### PR TITLE
Ignore project files of Eclipse and Intellij Idea IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
 target/
 work/
+
+# Ignore Intellij Idea project files
+*.iml
+*.ipr
+.idea
+atlassian-ide-plugin.xml
+
+# Ignore Eclipse project files
+.settings
+.project
+.classpath


### PR DESCRIPTION
Let's ignore local project files of the IDE. Then it's easier to identify new files in the 'changes' view.
