### PR TITLE
OF-767: Add jdk8 to the accepted jdk versions

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -227,6 +227,7 @@
                     <contains string="${ant.java.version}" substring="1.5"/>
                     <contains string="${ant.java.version}" substring="1.6"/>
                     <contains string="${ant.java.version}" substring="1.7"/>
+                    <contains string="${ant.java.version}" substring="1.8"/>
                 </or>
             </not>
         </condition>


### PR DESCRIPTION
Without such simple line ant break a build with jdk8 with following message:
BUILD FAILED
.... /Openfire/build/build.xml:234: Must use JDK 1.5.x or higher to build Openfire
