### PR TITLE
Fix ConcurrentModificationException in kickPresence

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -2088,7 +2088,7 @@ public class LocalMUCRoom implements MUCRoom {
      */
     private void kickPresence(Presence kickPresence, JID actorJID) {
         // Get the role(s) to kick
-        List<MUCRole> occupants = occupantsByNickname.get(kickPresence.getFrom().getResource().toLowerCase());
+        List<MUCRole> occupants = new ArrayList<MUCRole>(occupantsByNickname.get(kickPresence.getFrom().getResource().toLowerCase()));
         for (MUCRole kickedRole : occupants) {
             kickPresence = kickPresence.createCopy();
             // Add the actor's JID that kicked this user from the room


### PR DESCRIPTION
Openfire 3.9.2 is throwing a ConcurrentModificationException when using the "kick" button in the admin panel to remove a user from a group chat room.

java.util.ConcurrentModificationException
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:859)
    at java.util.ArrayList$Itr.next(ArrayList.java:831)
    at org.jivesoftware.openfire.muc.spi.LocalMUCRoom.kickPresence(LocalMUCRoom.java:2092)
    at org.jivesoftware.openfire.muc.spi.LocalMUCRoom.kickOccupant(LocalMUCRoom.java:2072)
    at org.jivesoftware.openfire.admin.muc_002droom_002doccupants_jsp._jspService(muc_002droom_002doccupants_jsp.java:99)
    at org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:97)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)

This patch fixes the exception by working off a copy of the list.
