### PR TITLE
Added more TLDs to a blacklist to prevent connection attempts

### DIFF
--- a/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -102,7 +102,8 @@ public class LocalOutgoingServerSession extends LocalSession implements Outgoing
      */
     private boolean usingServerDialback = true;
 
-    private static final List<String> TOP_LEVEL_DOMAINS = Arrays.asList("com", "net", "org", "gov", "edu");
+    private static final List<String> TOP_LEVEL_DOMAINS = Arrays.asList("com", "net", "org", "gov", "edu", "biz", "info",
+            "de", "at", "ch", "li", "uk", "fr", "pl", "nl", "cn", "eu");
 
     /**
      * Creates a new outgoing connection to the specified hostname if no one exists. The port of


### PR DESCRIPTION
In my logfiles I could see crazy attempts like this:
2014.05.04 01:51:57 org.jivesoftware.openfire.session.LocalOutgoingServerSession - Error trying to connect to remote server: eu(DNS lookup: eu:5269)
java.net.UnknownHostException: eu 

This patch put all blacklisted tlds to a list and extend the list by some europe country top level domains.
