### PR TITLE
Replace deprecated toURL() with toURI().toURL() as per the JavaDoc

### DIFF
--- a/src/java/org/jivesoftware/openfire/container/PluginClassLoader.java
+++ b/src/java/org/jivesoftware/openfire/container/PluginClassLoader.java
@@ -66,25 +66,25 @@ public class PluginClassLoader extends URLClassLoader {
             // Add classes directory to classpath.
             File classesDir = new File(directory, "classes");
             if (classesDir.exists()) {
-                addURL(classesDir.toURL());
+                addURL(classesDir.toURI().toURL());
             }
 
             // Add i18n directory to classpath.
             File databaseDir = new File(directory, "database");
             if(databaseDir.exists()){
-                addURL(databaseDir.toURL());
+                addURL(databaseDir.toURI().toURL());
             }
 
             // Add i18n directory to classpath.
             File i18nDir = new File(directory, "i18n");
             if(i18nDir.exists()){
-                addURL(i18nDir.toURL());
+                addURL(i18nDir.toURI().toURL());
             }
 
             // Add web directory to classpath.
             File webDir = new File(directory, "web");
             if(webDir.exists()){
-                addURL(webDir.toURL());
+                addURL(webDir.toURI().toURL());
             }
 
             // Add lib directory to classpath.

--- a/src/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/src/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -409,7 +409,7 @@ public class PluginManager {
 
                         if (classes.exists()) {
                             dev.setClassesDir(classes);
-                            pluginLoader.addURLFile(classes.getAbsoluteFile().toURL());
+                            pluginLoader.addURLFile(classes.getAbsoluteFile().toURI().toURL());
                         }
                     }
                 }

--- a/src/java/org/jivesoftware/openfire/launcher/Launcher.java
+++ b/src/java/org/jivesoftware/openfire/launcher/Launcher.java
@@ -595,7 +595,7 @@ public class Launcher {
                     // Just for fun. Show no matter what for two seconds.
                     Thread.sleep(2000);
 
-                    copy(plugin.toURL(), tempPluginsFile);
+                    copy(plugin.toURI().toURL(), tempPluginsFile);
 
                     // If successfull, rename to real plugin name.
                     tempPluginsFile.renameTo(realPluginsFile);


### PR DESCRIPTION
The toURL() method is deprecated and should be replaced with toURI().toURL() as described by the JavaDoc.
