### PR TITLE
OF-810 RFC 6121 Routing Compliance Fix

### DIFF
--- a/src/java/org/jivesoftware/openfire/MessageRouter.java
+++ b/src/java/org/jivesoftware/openfire/MessageRouter.java
@@ -250,7 +250,13 @@ public class MessageRouter extends BasicModule {
         // If message was sent to an unavailable full JID of a user then retry using the bare JID
         if (serverName.equals(recipient.getDomain()) && recipient.getResource() != null &&
                 userManager.isRegisteredUser(recipient.getNode())) {
-            routingTable.routePacket(recipient.asBareJID(), packet, false);
+            Message msg = (Message)packet;
+            if (msg.getType().equals(Message.Type.chat)) {
+                routingTable.routePacket(recipient.asBareJID(), packet, false);
+            } else {
+                // Delegate to offline message strategy, which will either bounce or ignore the message depending on user settings.
+                messageStrategy.storeOffline((Message) packet);
+            }
         } else {
             // Just store the message offline
             messageStrategy.storeOffline((Message) packet);


### PR DESCRIPTION
This fix fixes the routing, which is described in RFC 6121 8.5.3.2.1.  Message

Misbehavior before: Every message addressed to a full JID, whose resource was not available was routed to the bare JID (as fallback). 8.5.3.2.1 specifies, that only chat messages should be routed to bare JID and other message types should either be ignored or bounced with an error.

Behavior now: non-chat messages are delegated to the offline message strategy, which decides, if the message should be ignored or bounced with an error, depending on the settings in offline-messages.jsp.
