### PR TITLE
Upgrade debian package dependencies to openjdk7.

### DIFF
--- a/build/debian/control
+++ b/build/debian/control
@@ -2,14 +2,14 @@ Source: openfire
 Section: net
 Priority: optional
 Maintainer: Ignite Realtime Community <admin@igniterealtime.org>
-Build-Depends: debhelper (>= 5), cdbs, patchutils, sun-java6-jdk | oracle-j2sdk1.7 | openjdk-6-jdk | openjdk-7-jdk, ant
+Build-Depends: debhelper (>= 5), cdbs, patchutils, openjdk-7-jdk | oracle-j2sdk1.7 , ant
 Standards-Version: 3.7.2
 Homepage: http://www.igniterealtime.org
 
 Package: openfire
 Section: net
 Priority: optional
-Pre-Depends: sun-java6-jre | default-jre-headless | openjdk-6-jre | openjdk-7-jre | oracle-java7-jre
+Pre-Depends: openjdk-7-jre | oracle-java7-jre
 Architecture: all
 Description: A high performance XMPP (Jabber) server.
  Openfire is an instant messaging server that implements the XMPP

--- a/build/debian/rules
+++ b/build/debian/rules
@@ -13,7 +13,7 @@ ETCDIR := $(DEST)/etc/openfire
 LOGDIR := $(DEST)/var/log/openfire
 VARDIR := $(DEST)/var/lib/openfire
 
-JAVA_HOME ?= /usr/lib/jvm/java-6-sun
+JAVA_HOME ?= /usr/lib/jvm/java-7-openjdk-amd64
 DEB_ANT_BUILDFILE := build/build.xml
 DEB_ANT_CLEAN_TARGET := clean
 


### PR DESCRIPTION
Due the update of Openfire to Java7 the debian package should require this java-version as well. Otherwise the start of the application will fail on debian.
