### PR TITLE
Move all property keys regarding connection settings into a one class

### DIFF
--- a/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -51,6 +51,7 @@ import org.jivesoftware.openfire.auth.AuthToken;
 import org.jivesoftware.openfire.auth.AuthorizationManager;
 import org.jivesoftware.openfire.lockout.LockOutManager;
 import org.jivesoftware.openfire.session.ClientSession;
+import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.openfire.session.IncomingServerSession;
 import org.jivesoftware.openfire.session.LocalClientSession;
 import org.jivesoftware.openfire.session.LocalIncomingServerSession;
@@ -549,7 +550,7 @@ public class SASLAuthentication {
             // Flag that indicates if certificates of the remote server should be validated.
             // Disabling certificate validation is not recommended for production environments.
             boolean verify =
-                    JiveGlobals.getBooleanProperty("xmpp.server.certificate.verify", true);
+                    JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true);
             if (!verify) {
                 authenticationSuccessful(session, hostname, null);
                 return Status.authenticated;

--- a/src/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
@@ -23,6 +23,7 @@ import org.dom4j.Element;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.PacketRouter;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
+import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.openfire.session.LocalIncomingServerSession;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
@@ -108,9 +109,9 @@ public class ServerStanzaHandler extends StanzaHandler {
 	void startTLS() throws Exception {
         // TODO Finish implementation. We need to get the name of the remote server if we want to validate certificates of the remote server that requested TLS
 
-        boolean needed = JiveGlobals.getBooleanProperty("xmpp.server.certificate.verify", true) &&
-                JiveGlobals.getBooleanProperty("xmpp.server.certificate.verify.chain", true) &&
-                !JiveGlobals.getBooleanProperty("xmpp.server.certificate.accept-selfsigned", false);
+        boolean needed = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true) &&
+                JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY, true) &&
+                !JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false);
         connection.startTLS(false, "IMPLEMENT_ME", needed ? Connection.ClientAuth.needed : Connection.ClientAuth.wanted);
     }
     @Override

--- a/src/java/org/jivesoftware/openfire/net/ServerTrustManager.java
+++ b/src/java/org/jivesoftware/openfire/net/ServerTrustManager.java
@@ -30,6 +30,7 @@ import java.util.List;
 import javax.net.ssl.X509TrustManager;
 
 import org.jivesoftware.openfire.Connection;
+import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.util.CertificateManager;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
@@ -100,7 +101,7 @@ public class ServerTrustManager implements X509TrustManager {
 
         // Flag that indicates if certificates of the remote server should be validated. Disabling
         // certificate validation is not recommended for production environments.
-        boolean verify = JiveGlobals.getBooleanProperty("xmpp.server.certificate.verify", true);
+        boolean verify = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true);
         if (verify) {
             int nSize = x509Certificates.length;
             if (Log.isDebugEnabled()) {
@@ -112,7 +113,7 @@ public class ServerTrustManager implements X509TrustManager {
 
             List<String> peerIdentities = CertificateManager.getPeerIdentities(x509Certificates[0]);
 
-            if (JiveGlobals.getBooleanProperty("xmpp.server.certificate.verify.chain", true)) {
+            if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY, true)) {
                 Log.debug("Verifying certificate chain...");
 
                 // Working down the chain, for every certificate in the chain,
@@ -147,7 +148,7 @@ public class ServerTrustManager implements X509TrustManager {
                 }
             }
 
-            if (JiveGlobals.getBooleanProperty("xmpp.server.certificate.verify.root", true)) {
+            if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_ROOT_VERIFY, true)) {
                 Log.debug("Verifying certificate chain root certificate...");
                 // Verify that the the last certificate in the chain was issued
                 // by a third-party that the client trusts.
@@ -157,7 +158,7 @@ public class ServerTrustManager implements X509TrustManager {
                     // Keep track if the other peer presented a self-signed certificate
                     connection.setUsingSelfSignedCertificate(!trusted && nSize == 1);
                     if (!trusted && nSize == 1 && JiveGlobals
-                            .getBooleanProperty("xmpp.server.certificate.accept-selfsigned", false))
+                            .getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false))
                     {
                         Log.warn("Accepting self-signed certificate of remote server: " +
                                 peerIdentities);
@@ -192,7 +193,7 @@ public class ServerTrustManager implements X509TrustManager {
                 throw new CertificateException("target verification failed of " + peerIdentities);
             }
 
-            if (JiveGlobals.getBooleanProperty("xmpp.server.certificate.verify.validity", true)) {
+            if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY_VALIDITY, true)) {
                 Log.debug("Verifying certificate chain validity (by date)...");
 
                 // For every certificate in the chain, verify that the certificate
@@ -210,7 +211,7 @@ public class ServerTrustManager implements X509TrustManager {
     }
 
     public X509Certificate[] getAcceptedIssuers() {
-        if (JiveGlobals.getBooleanProperty("xmpp.server.certificate.accept-selfsigned", false)) {
+        if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false)) {
             // Answer an empty list since we accept any issuer
             return new X509Certificate[0];
         }

--- a/src/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
@@ -21,6 +21,7 @@
 package org.jivesoftware.openfire.net;
 
 import org.jivesoftware.openfire.Connection;
+import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.util.JiveGlobals;
 
 import javax.net.ssl.SSLEngine;
@@ -139,10 +140,10 @@ public class TLSStreamHandler {
         }
         else if (needClientAuth) {
             // Only REQUIRE client authentication if we are fully verifying certificates
-            if (JiveGlobals.getBooleanProperty("xmpp.server.certificate.verify", true) &&
-                    JiveGlobals.getBooleanProperty("xmpp.server.certificate.verify.chain", true) &&
+            if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true) &&
+                    JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY, true) &&
                     !JiveGlobals
-                            .getBooleanProperty("xmpp.server.certificate.accept-selfsigned", false))
+                            .getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false))
             {
                 tlsEngine.setNeedClientAuth(true);
             }

--- a/src/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/src/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -35,6 +35,7 @@ import java.util.concurrent.locks.Lock;
 import org.jivesoftware.openfire.RoutableChannelHandler;
 import org.jivesoftware.openfire.RoutingTable;
 import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.openfire.session.LocalOutgoingServerSession;
 import org.jivesoftware.openfire.spi.RoutingTableImpl;
 import org.jivesoftware.util.JiveGlobals;
@@ -100,8 +101,8 @@ public class OutgoingSessionPromise implements RoutableChannelHandler {
         serversCache = CacheFactory.createCache(RoutingTableImpl.S2S_CACHE_NAME);
         routingTable = XMPPServer.getInstance().getRoutingTable();
         // Create a pool of threads that will process queued packets.
-        int maxThreads = JiveGlobals.getIntProperty("xmpp.server.outgoing.max.threads", 20);
-        int queueSize = JiveGlobals.getIntProperty("xmpp.server.outgoing.queue", 50);
+        int maxThreads = JiveGlobals.getIntProperty(ConnectionSettings.Server.QUEUE_MAX_THREADS, 20);
+        int queueSize = JiveGlobals.getIntProperty(ConnectionSettings.Server.QUEUE_SIZE, 50);
         if (maxThreads < 10) {
             // Ensure that the max number of threads in the pool is at least 10
             maxThreads = 10;

--- a/src/java/org/jivesoftware/openfire/server/RemoteServerManager.java
+++ b/src/java/org/jivesoftware/openfire/server/RemoteServerManager.java
@@ -29,6 +29,7 @@ import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.openfire.ConnectionManager;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.server.RemoteServerConfiguration.Permission;
+import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.cache.Cache;
@@ -109,7 +110,7 @@ public class RemoteServerManager {
     public static boolean canAccess(String domain) {
         // If s2s is disabled then it is not possible to send packets to remote servers or
         // receive packets from remote servers
-        if (!JiveGlobals.getBooleanProperty("xmpp.server.socket.active", true)) {
+        if (!JiveGlobals.getBooleanProperty(ConnectionSettings.Server.SOCKET_ACTIVE, true)) {
             return false;
         }
 
@@ -162,7 +163,7 @@ public class RemoteServerManager {
      *         data from a remote server.
      */
     public static int getSocketTimeout() {
-        return JiveGlobals.getIntProperty("xmpp.server.read.timeout", 120000);
+        return JiveGlobals.getIntProperty(ConnectionSettings.Server.SOCKET_READ_TIMEOUT, 120000);
     }
 
     /**
@@ -298,13 +299,13 @@ public class RemoteServerManager {
      * @return the remote port to connect for the specified remote server.
      */
     public static int getPortForServer(String domain) {
-        int port = JiveGlobals.getIntProperty("xmpp.server.socket.remotePort", ConnectionManager.DEFAULT_SERVER_PORT);
+        int port = JiveGlobals.getIntProperty(ConnectionSettings.Server.PORT, ConnectionManager.DEFAULT_SERVER_PORT);
         RemoteServerConfiguration config = getConfiguration(domain);
         if (config != null) {
             port = config.getRemotePort();
             if (port == 0) {
                 port = JiveGlobals
-                        .getIntProperty("xmpp.server.socket.remotePort", ConnectionManager.DEFAULT_SERVER_PORT);
+                        .getIntProperty(ConnectionSettings.Server.PORT, ConnectionManager.DEFAULT_SERVER_PORT);
             }
         }
         return port;
@@ -322,7 +323,7 @@ public class RemoteServerManager {
      */
     public static PermissionPolicy getPermissionPolicy() {
         try {
-            return PermissionPolicy.valueOf(JiveGlobals.getProperty("xmpp.server.permission",
+            return PermissionPolicy.valueOf(JiveGlobals.getProperty(ConnectionSettings.Server.PERMISSION_SETTINGS,
                     PermissionPolicy.blacklist.toString()));
         }
         catch (Exception e) {
@@ -341,7 +342,7 @@ public class RemoteServerManager {
      * @param policy the new PermissionPolicy to use.
      */
     public static void setPermissionPolicy(PermissionPolicy policy) {
-        JiveGlobals.setProperty("xmpp.server.permission", policy.toString());
+        JiveGlobals.setProperty(ConnectionSettings.Server.PERMISSION_SETTINGS, policy.toString());
         // Check if the connected servers can remain connected to the server
         for (String hostname : SessionManager.getInstance().getIncomingServers()) {
             if (!canAccess(hostname)) {

--- a/src/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/src/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -46,6 +46,7 @@ import org.jivesoftware.openfire.net.DNSUtil;
 import org.jivesoftware.openfire.net.MXParser;
 import org.jivesoftware.openfire.net.ServerTrafficCounter;
 import org.jivesoftware.openfire.net.SocketConnection;
+import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.openfire.session.IncomingServerSession;
 import org.jivesoftware.openfire.session.LocalIncomingServerSession;
 import org.jivesoftware.openfire.session.LocalOutgoingServerSession;
@@ -128,7 +129,7 @@ public class ServerDialback {
      * @return true if server dialback is enabled.
      */
     public static boolean isEnabled() {
-        return JiveGlobals.getBooleanProperty("xmpp.server.dialback.enabled", true);
+        return JiveGlobals.getBooleanProperty(ConnectionSettings.Server.DIALBACK_ENABLED, true);
     }
 
     /**
@@ -143,7 +144,7 @@ public class ServerDialback {
      * certificate.
      */
     public static boolean isEnabledForSelfSigned() {
-        return JiveGlobals.getBooleanProperty("xmpp.server.certificate.accept-selfsigned", false);
+        return JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false);
     }
 
     /**
@@ -158,7 +159,7 @@ public class ServerDialback {
      * certificate.
      */
     public static void setEnabledForSelfSigned(boolean enabled) {
-        JiveGlobals.setProperty("xmpp.server.certificate.accept-selfsigned", Boolean.toString(enabled));
+        JiveGlobals.setProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, Boolean.toString(enabled));
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/src/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -1,0 +1,52 @@
+package org.jivesoftware.openfire.session;
+
+public final class ConnectionSettings {
+
+    private ConnectionSettings() {
+    }
+
+    public static final class Client {
+
+        public static final String TLS_POLICY = "xmpp.client.tls.policy";
+
+        public static final String COMPRESSION_SETTINGS = "xmpp.client.compression.policy";
+        public static final String LOGIN_ALLOWED = "xmpp.client.login.allowed";
+        public static final String LOGIN_ANONYM_ALLOWED = "xmpp.client.login.allowedAnonym";
+
+        private Client() {
+        }
+    }
+
+    public static final class Server {
+
+        public static final String SOCKET_ACTIVE = "xmpp.server.socket.active";
+        public static final String PORT = "xmpp.server.socket.remotePort";
+        public static final String SOCKET_READ_TIMEOUT = "xmpp.server.read.timeout";
+
+        public static final String QUEUE_MAX_THREADS = "xmpp.server.outgoing.max.threads";
+        public static final String QUEUE_SIZE = "xmpp.server.outgoing.queue";
+
+        public static final String DIALBACK_ENABLED = "xmpp.server.dialback.enabled";
+        public static final String TLS_ENABLED = "xmpp.server.tls.enabled";
+        public static final String TLS_ACCEPT_SELFSIGNED_CERTS = "xmpp.server.certificate.accept-selfsigned";
+        public static final String TLS_CERTIFICATE_VERIFY = "xmpp.server.certificate.verify";
+        public static final String TLS_CERTIFICATE_VERIFY_VALIDITY = "xmpp.server.certificate.verify.validity";
+        public static final String TLS_CERTIFICATE_ROOT_VERIFY = "xmpp.server.certificate.verify.root";
+        public static final String TLS_CERTIFICATE_CHAIN_VERIFY = "xmpp.server.certificate.verify.chain";
+
+        public static final String COMPRESSION_SETTINGS = "xmpp.server.compression.policy";
+
+        public static final String PERMISSION_SETTINGS = "xmpp.server.permission";
+
+        private Server() {
+        }
+    }
+
+    public static final class Multiplex {
+        public static final String TLS_POLICY = "xmpp.multiplex.tls.policy";
+        public static final String COMPRESSION_SETTINGS = "xmpp.multiplex.compression.policy";
+
+        private Multiplex() {
+        }
+    }
+}

--- a/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -117,13 +117,13 @@ public class LocalClientSession extends LocalSession implements ClientSession {
 
     static {
         // Fill out the allowedIPs with the system property
-        String allowed = JiveGlobals.getProperty("xmpp.client.login.allowed", "");
+        String allowed = JiveGlobals.getProperty(ConnectionSettings.Client.LOGIN_ALLOWED, "");
         StringTokenizer tokens = new StringTokenizer(allowed, ", ");
         while (tokens.hasMoreTokens()) {
             String address = tokens.nextToken().trim();
             allowedIPs.put(address, "");
         }
-        String allowedAnonym = JiveGlobals.getProperty("xmpp.client.login.allowedAnonym", "");
+        String allowedAnonym = JiveGlobals.getProperty(ConnectionSettings.Client.LOGIN_ANONYM_ALLOWED, "");
         tokens = new StringTokenizer(allowedAnonym, ", ");
         while (tokens.hasMoreTokens()) {
             String address = tokens.nextToken().trim();
@@ -368,7 +368,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
     public static void setAllowedIPs(Map<String, String> allowed) {
         allowedIPs = allowed;
         if (allowedIPs.isEmpty()) {
-            JiveGlobals.deleteProperty("xmpp.client.login.allowed");
+            JiveGlobals.deleteProperty(ConnectionSettings.Client.LOGIN_ALLOWED);
         }
         else {
             // Iterate through the elements in the map.
@@ -380,7 +380,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
             while (iter.hasNext()) {
                 buf.append(", ").append(iter.next());
             }
-            JiveGlobals.setProperty("xmpp.client.login.allowed", buf.toString());
+            JiveGlobals.setProperty(ConnectionSettings.Client.LOGIN_ALLOWED, buf.toString());
         }
     }
 
@@ -393,7 +393,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
     public static void setAllowedAnonymIPs(Map<String, String> allowed) {
         allowedAnonymIPs = allowed;
         if (allowedAnonymIPs.isEmpty()) {
-            JiveGlobals.deleteProperty("xmpp.client.login.allowedAnonym");
+            JiveGlobals.deleteProperty(ConnectionSettings.Client.LOGIN_ANONYM_ALLOWED);
         }
         else {
             // Iterate through the elements in the map.
@@ -405,7 +405,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
             while (iter.hasNext()) {
                 buf.append(", ").append(iter.next());
             }
-            JiveGlobals.setProperty("xmpp.client.login.allowedAnonym", buf.toString());
+            JiveGlobals.setProperty(ConnectionSettings.Client.LOGIN_ANONYM_ALLOWED, buf.toString());
         }
     }
 
@@ -420,7 +420,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
      */
     public static SocketConnection.TLSPolicy getTLSPolicy() {
         // Set the TLS policy stored as a system property
-        String policyName = JiveGlobals.getProperty("xmpp.client.tls.policy", Connection.TLSPolicy.optional.toString());
+        String policyName = JiveGlobals.getProperty(ConnectionSettings.Client.TLS_POLICY, Connection.TLSPolicy.optional.toString());
         SocketConnection.TLSPolicy tlsPolicy;
         try {
             tlsPolicy = Connection.TLSPolicy.valueOf(policyName);
@@ -441,7 +441,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
      * @param policy whether TLS is mandatory, optional or is disabled.
      */
     public static void setTLSPolicy(SocketConnection.TLSPolicy policy) {
-        JiveGlobals.setProperty("xmpp.client.tls.policy", policy.toString());
+        JiveGlobals.setProperty(ConnectionSettings.Client.TLS_POLICY, policy.toString());
     }
 
     /**
@@ -452,7 +452,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
     public static SocketConnection.CompressionPolicy getCompressionPolicy() {
         // Set the Compression policy stored as a system property
         String policyName = JiveGlobals
-                .getProperty("xmpp.client.compression.policy", Connection.CompressionPolicy.optional.toString());
+                .getProperty(ConnectionSettings.Client.COMPRESSION_SETTINGS, Connection.CompressionPolicy.optional.toString());
         SocketConnection.CompressionPolicy compressionPolicy;
         try {
             compressionPolicy = Connection.CompressionPolicy.valueOf(policyName);
@@ -469,7 +469,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
      * @param policy whether compression is optional or is disabled.
      */
     public static void setCompressionPolicy(SocketConnection.CompressionPolicy policy) {
-        JiveGlobals.setProperty("xmpp.client.compression.policy", policy.toString());
+        JiveGlobals.setProperty(ConnectionSettings.Client.COMPRESSION_SETTINGS, policy.toString());
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
@@ -64,12 +64,12 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
 
     static {
         // Set the TLS policy stored as a system property
-        String policyName = JiveGlobals.getProperty("xmpp.multiplex.tls.policy",
+        String policyName = JiveGlobals.getProperty(ConnectionSettings.Multiplex.TLS_POLICY,
                 Connection.TLSPolicy.disabled.toString());
         tlsPolicy = Connection.TLSPolicy.valueOf(policyName);
 
         // Set the Compression policy stored as a system property
-        policyName = JiveGlobals.getProperty("xmpp.multiplex.compression.policy",
+        policyName = JiveGlobals.getProperty(ConnectionSettings.Multiplex.COMPRESSION_SETTINGS,
                 Connection.CompressionPolicy.disabled.toString());
         compressionPolicy = Connection.CompressionPolicy.valueOf(policyName);
     }
@@ -331,7 +331,7 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
      */
     public static void setTLSPolicy(SocketConnection.TLSPolicy policy) {
         tlsPolicy = policy;
-        JiveGlobals.setProperty("xmpp.multiplex.tls.policy", tlsPolicy.toString());
+        JiveGlobals.setProperty(ConnectionSettings.Multiplex.TLS_POLICY, tlsPolicy.toString());
     }
 
     /**
@@ -350,7 +350,7 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
      */
     public static void setCompressionPolicy(SocketConnection.CompressionPolicy policy) {
         compressionPolicy = policy;
-        JiveGlobals.setProperty("xmpp.multiplex.compression.policy", compressionPolicy.toString());
+        JiveGlobals.setProperty(ConnectionSettings.Multiplex.COMPRESSION_SETTINGS, compressionPolicy.toString());
     }
 
 }

--- a/src/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -156,7 +156,7 @@ public class LocalIncomingServerSession extends LocalSession implements Incoming
             }
 
             // Indicate the compression policy to use for this connection
-            String policyName = JiveGlobals.getProperty("xmpp.server.compression.policy",
+            String policyName = JiveGlobals.getProperty(ConnectionSettings.Server.COMPRESSION_SETTINGS,
                     Connection.CompressionPolicy.disabled.toString());
             Connection.CompressionPolicy compressionPolicy =
                     Connection.CompressionPolicy.valueOf(policyName);
@@ -169,7 +169,7 @@ public class LocalIncomingServerSession extends LocalSession implements Incoming
             	// Don't offer stream-features to pre-1.0 servers, as it confuses them. Sending features to Openfire < 3.7.1 confuses it too - OF-443) 
                 sb.append("<stream:features>");
 
-	            if (JiveGlobals.getBooleanProperty("xmpp.server.tls.enabled", true)) {
+	            if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ENABLED, true)) {
 	                sb.append("<starttls xmlns=\"urn:ietf:params:xml:ns:xmpp-tls\">");
 	                if (!ServerDialback.isEnabled()) {
 	                    // Server dialback is disabled so TLS is required

--- a/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -255,7 +255,7 @@ public class LocalOutgoingServerSession extends LocalSession implements Outgoing
             int port) {
 
         String localDomainName = XMPPServer.getInstance().getServerInfo().getXMPPDomain();
-        boolean useTLS = JiveGlobals.getBooleanProperty("xmpp.server.tls.enabled", true);
+        boolean useTLS = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ENABLED, true);
         RemoteServerConfiguration configuration = RemoteServerManager.getConfiguration(hostname);
         if (configuration != null) {
             // TODO Use the specific TLS configuration for this remote server
@@ -427,9 +427,9 @@ public class LocalOutgoingServerSession extends LocalSession implements Outgoing
         Element proceed = reader.parseDocument().getRootElement();
         if (proceed != null && proceed.getName().equals("proceed")) {
             log.debug("Negotiating TLS...");
-            boolean needed = JiveGlobals.getBooleanProperty("xmpp.server.certificate.verify", true) &&
-                    		 JiveGlobals.getBooleanProperty("xmpp.server.certificate.verify.chain", true) &&
-                    		 !JiveGlobals.getBooleanProperty("xmpp.server.certificate.accept-selfsigned", false);
+            boolean needed = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true) &&
+                    		 JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY, true) &&
+                    		 !JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false);
             connection.startTLS(true, hostname, needed ? Connection.ClientAuth.needed : Connection.ClientAuth.wanted);
             log.debug("TLS negotiation was successful.");
 
@@ -448,7 +448,7 @@ public class LocalOutgoingServerSession extends LocalSession implements Outgoing
             features = reader.parseDocument().getRootElement();
             if (features != null) {
                 // Check if we can use stream compression
-                String policyName = JiveGlobals.getProperty("xmpp.server.compression.policy", Connection.CompressionPolicy.disabled.toString());
+                String policyName = JiveGlobals.getProperty(ConnectionSettings.Server.COMPRESSION_SETTINGS, Connection.CompressionPolicy.disabled.toString());
                 Connection.CompressionPolicy compressionPolicy = Connection.CompressionPolicy.valueOf(policyName);
                 if (Connection.CompressionPolicy.optional == compressionPolicy) {
                     // Verify if the remote server supports stream compression

--- a/src/web/ssl-settings.jsp
+++ b/src/web/ssl-settings.jsp
@@ -26,6 +26,7 @@
     errorPage="error.jsp"
 %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
+<%@ page import="org.jivesoftware.openfire.session.ConnectionSettings" %>
 
 <%@ taglib uri="http://java.sun.com/jstl/core_rt" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jstl/fmt_rt" prefix="fmt" %>
@@ -85,15 +86,15 @@
 
             // Enable TLS and disable server dialback
             XMPPServer.getInstance().getConnectionManager().enableServerListener(true);
-            JiveGlobals.setProperty("xmpp.server.tls.enabled", "true");
-            JiveGlobals.setProperty("xmpp.server.dialback.enabled", "false");
+            JiveGlobals.setProperty(ConnectionSettings.Server.TLS_ENABLED, "true");
+            JiveGlobals.setProperty(ConnectionSettings.Server.DIALBACK_ENABLED, "false");
         } else if ("notreq".equals(serverSecurityRequired)) {
             // User selected that security for s2s is NOT required
 
             // Enable TLS and enable server dialback
             XMPPServer.getInstance().getConnectionManager().enableServerListener(true);
-            JiveGlobals.setProperty("xmpp.server.tls.enabled", "true");
-            JiveGlobals.setProperty("xmpp.server.dialback.enabled", "true");
+            JiveGlobals.setProperty(ConnectionSettings.Server.TLS_ENABLED, "true");
+            JiveGlobals.setProperty(ConnectionSettings.Server.DIALBACK_ENABLED, "true");
         } else if ("custom".equals(serverSecurityRequired)) {
             // User selected custom server authentication
 
@@ -104,23 +105,24 @@
                 XMPPServer.getInstance().getConnectionManager().enableServerListener(true);
 
                 // Enable or disable server dialback
-                JiveGlobals.setProperty("xmpp.server.dialback.enabled", dialbackEnabled ? "true" : "false");
+                JiveGlobals.setProperty(ConnectionSettings.Server.DIALBACK_ENABLED, dialbackEnabled ? "true" : "false");
 
                 // Enable or disable TLS for s2s connections
-                JiveGlobals.setProperty("xmpp.server.tls.enabled", tlsEnabled ? "true" : "false");
+                JiveGlobals.setProperty(ConnectionSettings.Server.TLS_ENABLED, tlsEnabled ? "true" : "false");
             } else {
                 XMPPServer.getInstance().getConnectionManager().enableServerListener(false);
                 // Disable server dialback
-                JiveGlobals.setProperty("xmpp.server.dialback.enabled", "false");
+                JiveGlobals.setProperty(ConnectionSettings.Server.DIALBACK_ENABLED, "false");
 
                 // Disable TLS for s2s connections
-                JiveGlobals.setProperty("xmpp.server.tls.enabled", "false");
+                JiveGlobals.setProperty(ConnectionSettings.Server.TLS_ENABLED, "false");
             }
         }
         ServerDialback.setEnabledForSelfSigned(selfSigned);
         success = true;
         // Log the event
-        webManager.logEvent("updated SSL configuration", "xmpp.server.dialback.enabled = "+JiveGlobals.getProperty("xmpp.server.dialback.enabled")+"\nxmpp.server.tls.enabled = "+JiveGlobals.getProperty("xmpp.server.tls.enabled"));
+        webManager.logEvent("updated SSL configuration", ConnectionSettings.Server.DIALBACK_ENABLED + " = "+JiveGlobals.getProperty(ConnectionSettings.Server.DIALBACK_ENABLED)+
+                "\n"+ ConnectionSettings.Server.TLS_ENABLED+" = "+JiveGlobals.getProperty(ConnectionSettings.Server.TLS_ENABLED));
     }
 
     // Set page vars
@@ -146,8 +148,8 @@
                 LocalClientSession.getTLSPolicy().toString();
     }
 
-    boolean tlsEnabled = JiveGlobals.getBooleanProperty("xmpp.server.tls.enabled", true);
-    boolean dialbackEnabled = JiveGlobals.getBooleanProperty("xmpp.server.dialback.enabled", true);
+    boolean tlsEnabled = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ENABLED, true);
+    boolean dialbackEnabled = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.DIALBACK_ENABLED, true);
     if (tlsEnabled) {
         if (dialbackEnabled) {
             serverSecurityRequired = "notreq";


### PR DESCRIPTION
To work on issues like OF-348 or OF-625, I've made some small refactorings. With this pull request I moved (hopefully) all property keys for connection settings into one class. 

(Currently the class holds only the keys. Maybe I would add the default values and property-getter/setter as well. - But with different pull requests to take baby-steps forward.)
