### PR TITLE
Fixes to javadocs to allow rpmbuild to work

### DIFF
--- a/src/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -867,7 +867,7 @@ public class HttpSession extends LocalClientSession {
      * by the 'requests' attribute in the connection manager's Session Creation Response.
      * However the client MAY make one additional request if it is to pause or terminate a session.
      *
-     * @see <a href="http://www.xmpp.org/extensions/xep-0124.html#overactive">overactive</a>.
+     * @see <a href="http://www.xmpp.org/extensions/xep-0124.html#overactive">overactive</a>
      * @param isPoll true if the session is using polling.
      * @throws HttpBindException if the connection has violated a facet of the HTTP binding
      *         protocol.

--- a/src/java/org/jivesoftware/util/HttpClientWithTimeoutFeedFetcher.java
+++ b/src/java/org/jivesoftware/util/HttpClientWithTimeoutFeedFetcher.java
@@ -208,7 +208,7 @@ public class HttpClientWithTimeoutFeedFetcher extends AbstractFeedFetcher {
      * @param urlStr
      * @param method
      * @param feed
-     * @return
+     * @return SyndFeedInfo
      * @throws MalformedURLException
      */
     private SyndFeedInfo buildSyndFeedInfo(URL feedUrl, String urlStr, HttpMethod method, SyndFeed feed, int statusCode) throws MalformedURLException {
@@ -253,7 +253,7 @@ public class HttpClientWithTimeoutFeedFetcher extends AbstractFeedFetcher {
     /**
 	 * @param urlStr
 	 * @param method
-	 * @return
+	 * @return SyndFeed or None
 	 * @throws IOException
 	 * @throws HttpException
 	 * @throws FetcherException

--- a/src/java/org/jivesoftware/util/XMPPDateTimeFormat.java
+++ b/src/java/org/jivesoftware/util/XMPPDateTimeFormat.java
@@ -158,7 +158,7 @@ public class XMPPDateTimeFormat {
      * CCYY-MM-DDThh:mm:ss.sssZ
      * 
      * @param date
-     * @return
+     * @return String
      */
     public static String format(Date date) {
         return FAST_FORMAT.format(date);
@@ -170,7 +170,7 @@ public class XMPPDateTimeFormat {
      * CCYYMMDDThh:mm:ss
      * 
      * @param date
-     * @return
+     * @return String
      */
     public static String formatOld(Date date) {
         return FAST_FORMAT_OLD.format(date);


### PR DESCRIPTION
On my linux system, the 'ant installer.rpm' build target would fail
due to javadoc issues.  I simply attempted to correct these by making
trivial character replacements.  I suspect there is a more robust
solution, but this worked-for-me.
