### PR TITLE
Add PropertyHandler and used it at some points to clarify the usage.

### DIFF
--- a/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -523,9 +523,7 @@ public class SASLAuthentication {
             // Check if certificate validation is disabled for s2s
             // Flag that indicates if certificates of the remote server should be validated.
             // Disabling certificate validation is not recommended for production environments.
-            boolean verify =
-                    JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true);
-            if (!verify) {
+            if (!ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY.get()) {
                 authenticationSuccessful(session, hostname, null);
                 return Status.authenticated;
             }

--- a/src/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
@@ -25,7 +25,6 @@ import org.jivesoftware.openfire.PacketRouter;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.openfire.session.LocalIncomingServerSession;
-import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
@@ -109,9 +108,9 @@ public class ServerStanzaHandler extends StanzaHandler {
 	void startTLS() throws Exception {
         // TODO Finish implementation. We need to get the name of the remote server if we want to validate certificates of the remote server that requested TLS
 
-        boolean needed = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true) &&
-                JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY, true) &&
-                !JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false);
+        boolean needed = ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY.get() &&
+                ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY.get() &&
+                !ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS.get();
         connection.startTLS(false, "IMPLEMENT_ME", needed ? Connection.ClientAuth.needed : Connection.ClientAuth.wanted);
     }
     @Override

--- a/src/java/org/jivesoftware/openfire/net/ServerTrustManager.java
+++ b/src/java/org/jivesoftware/openfire/net/ServerTrustManager.java
@@ -32,7 +32,6 @@ import javax.net.ssl.X509TrustManager;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.util.CertificateManager;
-import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,8 +100,7 @@ public class ServerTrustManager implements X509TrustManager {
 
         // Flag that indicates if certificates of the remote server should be validated. Disabling
         // certificate validation is not recommended for production environments.
-        boolean verify = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true);
-        if (verify) {
+        if (ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY.get()) {
             int nSize = x509Certificates.length;
             if (Log.isDebugEnabled()) {
                 Log.debug("Certificate chain:");
@@ -113,7 +111,7 @@ public class ServerTrustManager implements X509TrustManager {
 
             List<String> peerIdentities = CertificateManager.getPeerIdentities(x509Certificates[0]);
 
-            if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY, true)) {
+            if (ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY.get()) {
                 Log.debug("Verifying certificate chain...");
 
                 // Working down the chain, for every certificate in the chain,
@@ -148,7 +146,7 @@ public class ServerTrustManager implements X509TrustManager {
                 }
             }
 
-            if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_ROOT_VERIFY, true)) {
+            if (ConnectionSettings.Server.TLS_CERTIFICATE_ROOT_VERIFY.get()) {
                 Log.debug("Verifying certificate chain root certificate...");
                 // Verify that the the last certificate in the chain was issued
                 // by a third-party that the client trusts.
@@ -157,8 +155,7 @@ public class ServerTrustManager implements X509TrustManager {
                     trusted = trustStore.getCertificateAlias(x509Certificates[nSize - 1]) != null;
                     // Keep track if the other peer presented a self-signed certificate
                     connection.setUsingSelfSignedCertificate(!trusted && nSize == 1);
-                    if (!trusted && nSize == 1 && JiveGlobals
-                            .getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false))
+                    if (!trusted && nSize == 1 && ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS.get())
                     {
                         Log.warn("Accepting self-signed certificate of remote server: " +
                                 peerIdentities);
@@ -193,7 +190,7 @@ public class ServerTrustManager implements X509TrustManager {
                 throw new CertificateException("target verification failed of " + peerIdentities);
             }
 
-            if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY_VALIDITY, true)) {
+            if (ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY_VALIDITY.get()) {
                 Log.debug("Verifying certificate chain validity (by date)...");
 
                 // For every certificate in the chain, verify that the certificate
@@ -211,7 +208,7 @@ public class ServerTrustManager implements X509TrustManager {
     }
 
     public X509Certificate[] getAcceptedIssuers() {
-        if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false)) {
+        if (ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS.get()) {
             // Answer an empty list since we accept any issuer
             return new X509Certificate[0];
         }

--- a/src/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
@@ -22,7 +22,6 @@ package org.jivesoftware.openfire.net;
 
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.session.ConnectionSettings;
-import org.jivesoftware.util.JiveGlobals;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
@@ -140,10 +139,9 @@ public class TLSStreamHandler {
         }
         else if (needClientAuth) {
             // Only REQUIRE client authentication if we are fully verifying certificates
-            if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true) &&
-                    JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY, true) &&
-                    !JiveGlobals
-                            .getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false))
+            if (ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY.get() &&
+                    ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY.get() &&
+                    !ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS.get())
             {
                 tlsEngine.setNeedClientAuth(true);
             }

--- a/src/java/org/jivesoftware/openfire/nio/ClientConnectionHandler.java
+++ b/src/java/org/jivesoftware/openfire/nio/ClientConnectionHandler.java
@@ -60,7 +60,7 @@ public class ClientConnectionHandler extends ConnectionHandler {
 
     @Override
 	int getMaxIdleTime() {
-        return JiveGlobals.getIntProperty(ConnectionSettings.Client.IDLE_TIMEOUT, 6 * 60 * 1000) / 1000;
+        return ConnectionSettings.Client.IDLE_TIMEOUT.get() / 1000;
     }
 
 	/**
@@ -87,8 +87,7 @@ public class ClientConnectionHandler extends ConnectionHandler {
     public void sessionIdle(IoSession session, IdleStatus status) throws Exception {
     	super.sessionIdle(session, status);
     	
-    	final boolean doPing = JiveGlobals.getBooleanProperty(ConnectionSettings.Client.KEEP_ALIVE_PING, true);
-        if (doPing && session.getIdleCount(status) == 1) {
+        if (ConnectionSettings.Client.KEEP_ALIVE_PING.get() && session.getIdleCount(status) == 1) {
             final ClientStanzaHandler handler = (ClientStanzaHandler) session.getAttribute(HANDLER);
             final JID entity = handler.getAddress();
             

--- a/src/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/src/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -101,8 +101,8 @@ public class OutgoingSessionPromise implements RoutableChannelHandler {
         serversCache = CacheFactory.createCache(RoutingTableImpl.S2S_CACHE_NAME);
         routingTable = XMPPServer.getInstance().getRoutingTable();
         // Create a pool of threads that will process queued packets.
-        int maxThreads = JiveGlobals.getIntProperty(ConnectionSettings.Server.QUEUE_MAX_THREADS, 20);
-        int queueSize = JiveGlobals.getIntProperty(ConnectionSettings.Server.QUEUE_SIZE, 50);
+        int maxThreads = ConnectionSettings.Server.QUEUE_MAX_THREADS.get();
+        int queueSize = ConnectionSettings.Server.QUEUE_SIZE.get();
         if (maxThreads < 10) {
             // Ensure that the max number of threads in the pool is at least 10
             maxThreads = 10;

--- a/src/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/src/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -129,7 +129,7 @@ public class ServerDialback {
      * @return true if server dialback is enabled.
      */
     public static boolean isEnabled() {
-        return JiveGlobals.getBooleanProperty(ConnectionSettings.Server.DIALBACK_ENABLED, true);
+        return ConnectionSettings.Server.DIALBACK_ENABLED.get();
     }
 
     /**
@@ -144,7 +144,7 @@ public class ServerDialback {
      * certificate.
      */
     public static boolean isEnabledForSelfSigned() {
-        return JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false);
+        return ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS.get();
     }
 
     /**
@@ -159,7 +159,7 @@ public class ServerDialback {
      * certificate.
      */
     public static void setEnabledForSelfSigned(boolean enabled) {
-        JiveGlobals.setProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, Boolean.toString(enabled));
+        ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS.set(enabled);
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/src/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -1,5 +1,15 @@
 package org.jivesoftware.openfire.session;
 
+import org.jivesoftware.openfire.Connection;
+import org.jivesoftware.openfire.ConnectionManager;
+import org.jivesoftware.openfire.server.RemoteServerManager;
+import org.jivesoftware.util.property.BooleanProperty;
+import org.jivesoftware.util.property.EnumProperty;
+import org.jivesoftware.util.property.IntegerProperty;
+import org.jivesoftware.util.property.StringProperty;
+
+import static org.jivesoftware.util.property.Property.of;
+
 public final class ConnectionSettings {
 
     private ConnectionSettings() {
@@ -7,19 +17,21 @@ public final class ConnectionSettings {
 
     public static final class Client {
 
-        public static final String SOCKET_ACTIVE = "xmpp.socket.plain.active";
-        public static final String PORT = "xmpp.socket.plain.port";
-        public static final String IDLE_TIMEOUT = "xmpp.client.idle";
-        public static final String KEEP_ALIVE_PING = "xmpp.client.idle.ping";
+        public static final BooleanProperty SOCKET_ACTIVE = of("xmpp.socket.plain.active", true);
+        public static final IntegerProperty PORT = of("xmpp.socket.plain.port", ConnectionManager.DEFAULT_PORT);
+        public static final IntegerProperty IDLE_TIMEOUT = of("xmpp.client.idle", 6*60*1000);
+        public static final BooleanProperty KEEP_ALIVE_PING = of("xmpp.client.idle.ping", true);
 
-        public static final String TLS_POLICY = "xmpp.client.tls.policy";
-        public static final String OLD_SSLPORT = "xmpp.socket.ssl.port";
-        public static final String ENABLE_OLD_SSLPORT = "xmpp.socket.ssl.active";
-        public static final String AUTH_PER_CLIENTCERT_POLICY = "xmpp.client.cert.policy";
+        public static final EnumProperty<Connection.TLSPolicy> TLS_POLICY =
+                of("xmpp.client.tls.policy", Connection.TLSPolicy.optional);
+        public static final IntegerProperty OLD_SSLPORT = of("xmpp.socket.ssl.port", ConnectionManager.DEFAULT_SSL_PORT);
+        public static final BooleanProperty ENABLE_OLD_SSLPORT = of("xmpp.socket.ssl.active", false);
+        public static final StringProperty AUTH_PER_CLIENTCERT_POLICY = of("xmpp.client.cert.policy", "disabled");
 
-        public static final String COMPRESSION_SETTINGS = "xmpp.client.compression.policy";
-        public static final String LOGIN_ALLOWED = "xmpp.client.login.allowed";
-        public static final String LOGIN_ANONYM_ALLOWED = "xmpp.client.login.allowedAnonym";
+        public static final EnumProperty<Connection.CompressionPolicy> COMPRESSION_SETTINGS =
+                of("xmpp.client.compression.policy", Connection.CompressionPolicy.optional);
+        public static final StringProperty LOGIN_ALLOWED = of("xmpp.client.login.allowed", "");
+        public static final StringProperty LOGIN_ANONYM_ALLOWED = of("xmpp.client.login.allowedAnonym", "");
 
         private Client() {
         }
@@ -27,44 +39,46 @@ public final class ConnectionSettings {
 
     public static final class Server {
 
-        public static final String SOCKET_ACTIVE = "xmpp.server.socket.active";
-        public static final String PORT = "xmpp.server.socket.port";
-        public static final String REMOTE_SERVER_PORT = "xmpp.server.socket.remotePort";
-        public static final String SOCKET_READ_TIMEOUT = "xmpp.server.read.timeout";
+        public static final BooleanProperty SOCKET_ACTIVE = of("xmpp.server.socket.active", true);
+        public static final IntegerProperty PORT = of("xmpp.server.socket.port", ConnectionManager.DEFAULT_SERVER_PORT);
+        public static final IntegerProperty REMOTE_SERVER_PORT = of("xmpp.server.socket.remotePort", ConnectionManager.DEFAULT_SERVER_PORT);
+        public static final IntegerProperty SOCKET_READ_TIMEOUT = of("xmpp.server.read.timeout", 120000);
 
-        public static final String QUEUE_MAX_THREADS = "xmpp.server.outgoing.max.threads";
-        public static final String QUEUE_SIZE = "xmpp.server.outgoing.queue";
+        public static final IntegerProperty QUEUE_MAX_THREADS = of("xmpp.server.outgoing.max.threads", 20);
+        public static final IntegerProperty QUEUE_SIZE = of("xmpp.server.outgoing.queue", 50);
 
-        public static final String DIALBACK_ENABLED = "xmpp.server.dialback.enabled";
-        public static final String TLS_ENABLED = "xmpp.server.tls.enabled";
-        public static final String TLS_ACCEPT_SELFSIGNED_CERTS = "xmpp.server.certificate.accept-selfsigned";
-        public static final String TLS_CERTIFICATE_VERIFY = "xmpp.server.certificate.verify";
-        public static final String TLS_CERTIFICATE_VERIFY_VALIDITY = "xmpp.server.certificate.verify.validity";
-        public static final String TLS_CERTIFICATE_ROOT_VERIFY = "xmpp.server.certificate.verify.root";
-        public static final String TLS_CERTIFICATE_CHAIN_VERIFY = "xmpp.server.certificate.verify.chain";
+        public static final BooleanProperty DIALBACK_ENABLED = of("xmpp.server.dialback.enabled", true);
+        public static final BooleanProperty TLS_ENABLED = of("xmpp.server.tls.enabled", true);
+        public static final BooleanProperty TLS_ACCEPT_SELFSIGNED_CERTS = of("xmpp.server.certificate.accept-selfsigned", false);
+        public static final BooleanProperty TLS_CERTIFICATE_VERIFY = of("xmpp.server.certificate.verify", true);
+        public static final BooleanProperty TLS_CERTIFICATE_VERIFY_VALIDITY = of("xmpp.server.certificate.verify.validity", true);
+        public static final BooleanProperty TLS_CERTIFICATE_ROOT_VERIFY = of("xmpp.server.certificate.verify.root", true);
+        public static final BooleanProperty TLS_CERTIFICATE_CHAIN_VERIFY = of("xmpp.server.certificate.verify.chain", true);
 
-        public static final String COMPRESSION_SETTINGS = "xmpp.server.compression.policy";
+        public static final EnumProperty<Connection.CompressionPolicy> COMPRESSION_SETTINGS =
+                of("xmpp.server.compression.policy", Connection.CompressionPolicy.disabled);
 
-        public static final String PERMISSION_SETTINGS = "xmpp.server.permission";
+        public static final EnumProperty<RemoteServerManager.PermissionPolicy> PERMISSION_SETTINGS = of("xmpp.server.permission", RemoteServerManager.PermissionPolicy.blacklist);
 
         private Server() {
         }
     }
 
     public static final class Multiplex {
-        public static final String SOCKET_ACTIVE = "xmpp.multiplex.socket.active";
-        public static final String PORT = "xmpp.multiplex.socket.port";
+        public static final BooleanProperty SOCKET_ACTIVE = of("xmpp.multiplex.socket.active", false);
+        public static final IntegerProperty PORT = of("xmpp.multiplex.socket.port", ConnectionManager.DEFAULT_MULTIPLEX_PORT);
 
-        public static final String TLS_POLICY = "xmpp.multiplex.tls.policy";
-        public static final String COMPRESSION_SETTINGS = "xmpp.multiplex.compression.policy";
+        public static final EnumProperty<Connection.TLSPolicy> TLS_POLICY =
+                of("xmpp.multiplex.tls.policy", Connection.TLSPolicy.disabled);
+        public static final EnumProperty<Connection.CompressionPolicy> COMPRESSION_SETTINGS =
+                of("xmpp.multiplex.compression.policy", Connection.CompressionPolicy.disabled);
 
         private Multiplex() {
         }
     }
 
     public static final class Component {
-        public static final String SOCKET_ACTIVE = "xmpp.component.socket.active";
-        public static final String PORT = "xmpp.component.socket.port";
-
+        public static final BooleanProperty SOCKET_ACTIVE = of("xmpp.component.socket.active", false);
+        public static final IntegerProperty PORT = of("xmpp.component.socket.port", ConnectionManager.DEFAULT_COMPONENT_PORT);
     }
 }

--- a/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -40,7 +40,6 @@ import org.jivesoftware.openfire.privacy.PrivacyList;
 import org.jivesoftware.openfire.privacy.PrivacyListManager;
 import org.jivesoftware.openfire.user.PresenceEventDispatcher;
 import org.jivesoftware.openfire.user.UserNotFoundException;
-import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.LocaleUtils;
 import org.jivesoftware.util.cache.Cache;
 import org.slf4j.Logger;
@@ -117,13 +116,13 @@ public class LocalClientSession extends LocalSession implements ClientSession {
 
     static {
         // Fill out the allowedIPs with the system property
-        String allowed = JiveGlobals.getProperty(ConnectionSettings.Client.LOGIN_ALLOWED, "");
+        final String allowed = ConnectionSettings.Client.LOGIN_ALLOWED.get();
         StringTokenizer tokens = new StringTokenizer(allowed, ", ");
         while (tokens.hasMoreTokens()) {
             String address = tokens.nextToken().trim();
             allowedIPs.put(address, "");
         }
-        String allowedAnonym = JiveGlobals.getProperty(ConnectionSettings.Client.LOGIN_ANONYM_ALLOWED, "");
+        final String allowedAnonym = ConnectionSettings.Client.LOGIN_ANONYM_ALLOWED.get();
         tokens = new StringTokenizer(allowedAnonym, ", ");
         while (tokens.hasMoreTokens()) {
             String address = tokens.nextToken().trim();
@@ -368,7 +367,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
     public static void setAllowedIPs(Map<String, String> allowed) {
         allowedIPs = allowed;
         if (allowedIPs.isEmpty()) {
-            JiveGlobals.deleteProperty(ConnectionSettings.Client.LOGIN_ALLOWED);
+            ConnectionSettings.Client.LOGIN_ALLOWED.delete();
         }
         else {
             // Iterate through the elements in the map.
@@ -380,7 +379,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
             while (iter.hasNext()) {
                 buf.append(", ").append(iter.next());
             }
-            JiveGlobals.setProperty(ConnectionSettings.Client.LOGIN_ALLOWED, buf.toString());
+            ConnectionSettings.Client.LOGIN_ALLOWED.set(buf.toString());
         }
     }
 
@@ -393,7 +392,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
     public static void setAllowedAnonymIPs(Map<String, String> allowed) {
         allowedAnonymIPs = allowed;
         if (allowedAnonymIPs.isEmpty()) {
-            JiveGlobals.deleteProperty(ConnectionSettings.Client.LOGIN_ANONYM_ALLOWED);
+            ConnectionSettings.Client.LOGIN_ANONYM_ALLOWED.delete();
         }
         else {
             // Iterate through the elements in the map.
@@ -405,7 +404,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
             while (iter.hasNext()) {
                 buf.append(", ").append(iter.next());
             }
-            JiveGlobals.setProperty(ConnectionSettings.Client.LOGIN_ANONYM_ALLOWED, buf.toString());
+            ConnectionSettings.Client.LOGIN_ANONYM_ALLOWED.set(buf.toString());
         }
     }
 
@@ -419,16 +418,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
      * @return whether TLS is mandatory, optional or is disabled.
      */
     public static SocketConnection.TLSPolicy getTLSPolicy() {
-        // Set the TLS policy stored as a system property
-        String policyName = JiveGlobals.getProperty(ConnectionSettings.Client.TLS_POLICY, Connection.TLSPolicy.optional.toString());
-        SocketConnection.TLSPolicy tlsPolicy;
-        try {
-            tlsPolicy = Connection.TLSPolicy.valueOf(policyName);
-        } catch (IllegalArgumentException e) {
-            Log.error("Error parsing xmpp.client.tls.policy: " + policyName, e);
-            tlsPolicy = Connection.TLSPolicy.optional;
-        }
-        return tlsPolicy;
+        return ConnectionSettings.Client.TLS_POLICY.get();
     }
 
     /**
@@ -441,7 +431,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
      * @param policy whether TLS is mandatory, optional or is disabled.
      */
     public static void setTLSPolicy(SocketConnection.TLSPolicy policy) {
-        JiveGlobals.setProperty(ConnectionSettings.Client.TLS_POLICY, policy.toString());
+        ConnectionSettings.Client.TLS_POLICY.set(policy);
     }
 
     /**
@@ -450,17 +440,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
      * @return whether compression is optional or is disabled.
      */
     public static SocketConnection.CompressionPolicy getCompressionPolicy() {
-        // Set the Compression policy stored as a system property
-        String policyName = JiveGlobals
-                .getProperty(ConnectionSettings.Client.COMPRESSION_SETTINGS, Connection.CompressionPolicy.optional.toString());
-        SocketConnection.CompressionPolicy compressionPolicy;
-        try {
-            compressionPolicy = Connection.CompressionPolicy.valueOf(policyName);
-        } catch (IllegalArgumentException e) {
-            Log.error("Error parsing xmpp.client.compression.policy: " + policyName, e);
-            compressionPolicy = Connection.CompressionPolicy.optional;
-        }
-        return compressionPolicy;
+        return ConnectionSettings.Client.COMPRESSION_SETTINGS.get();
     }
 
     /**
@@ -469,7 +449,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
      * @param policy whether compression is optional or is disabled.
      */
     public static void setCompressionPolicy(SocketConnection.CompressionPolicy policy) {
-        JiveGlobals.setProperty(ConnectionSettings.Client.COMPRESSION_SETTINGS, policy.toString());
+        ConnectionSettings.Client.COMPRESSION_SETTINGS.set(policy);
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
@@ -29,7 +29,6 @@ import org.jivesoftware.openfire.multiplex.ConnectionMultiplexerManager;
 import org.jivesoftware.openfire.multiplex.MultiplexerPacketDeliverer;
 import org.jivesoftware.openfire.net.SASLAuthentication;
 import org.jivesoftware.openfire.net.SocketConnection;
-import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
@@ -64,14 +63,10 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
 
     static {
         // Set the TLS policy stored as a system property
-        String policyName = JiveGlobals.getProperty(ConnectionSettings.Multiplex.TLS_POLICY,
-                Connection.TLSPolicy.disabled.toString());
-        tlsPolicy = Connection.TLSPolicy.valueOf(policyName);
+        tlsPolicy = ConnectionSettings.Multiplex.TLS_POLICY.get();
 
         // Set the Compression policy stored as a system property
-        policyName = JiveGlobals.getProperty(ConnectionSettings.Multiplex.COMPRESSION_SETTINGS,
-                Connection.CompressionPolicy.disabled.toString());
-        compressionPolicy = Connection.CompressionPolicy.valueOf(policyName);
+        compressionPolicy = ConnectionSettings.Multiplex.COMPRESSION_SETTINGS.get();
     }
 
     public static LocalConnectionMultiplexerSession createSession(String serverName, XmlPullParser xpp, Connection connection)
@@ -331,7 +326,7 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
      */
     public static void setTLSPolicy(SocketConnection.TLSPolicy policy) {
         tlsPolicy = policy;
-        JiveGlobals.setProperty(ConnectionSettings.Multiplex.TLS_POLICY, tlsPolicy.toString());
+        ConnectionSettings.Multiplex.TLS_POLICY.set(policy);
     }
 
     /**
@@ -350,7 +345,7 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
      */
     public static void setCompressionPolicy(SocketConnection.CompressionPolicy policy) {
         compressionPolicy = policy;
-        JiveGlobals.setProperty(ConnectionSettings.Multiplex.COMPRESSION_SETTINGS, compressionPolicy.toString());
+        ConnectionSettings.Multiplex.COMPRESSION_SETTINGS.set(policy);
     }
 
 }

--- a/src/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -156,11 +156,7 @@ public class LocalIncomingServerSession extends LocalSession implements Incoming
             }
 
             // Indicate the compression policy to use for this connection
-            String policyName = JiveGlobals.getProperty(ConnectionSettings.Server.COMPRESSION_SETTINGS,
-                    Connection.CompressionPolicy.disabled.toString());
-            Connection.CompressionPolicy compressionPolicy =
-                    Connection.CompressionPolicy.valueOf(policyName);
-            connection.setCompressionPolicy(compressionPolicy);
+            connection.setCompressionPolicy(ConnectionSettings.Server.COMPRESSION_SETTINGS.get());
 
             StringBuilder sb = new StringBuilder();
             
@@ -169,7 +165,7 @@ public class LocalIncomingServerSession extends LocalSession implements Incoming
             	// Don't offer stream-features to pre-1.0 servers, as it confuses them. Sending features to Openfire < 3.7.1 confuses it too - OF-443) 
                 sb.append("<stream:features>");
 
-	            if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ENABLED, true)) {
+	            if (ConnectionSettings.Server.TLS_ENABLED.get()) {
 	                sb.append("<starttls xmlns=\"urn:ietf:params:xml:ns:xmpp-tls\">");
 	                if (!ServerDialback.isEnabled()) {
 	                    // Server dialback is disabled so TLS is required

--- a/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -46,11 +46,9 @@ import org.jivesoftware.openfire.net.DNSUtil;
 import org.jivesoftware.openfire.net.MXParser;
 import org.jivesoftware.openfire.net.SocketConnection;
 import org.jivesoftware.openfire.server.OutgoingServerSocketReader;
-import org.jivesoftware.openfire.server.RemoteServerConfiguration;
 import org.jivesoftware.openfire.server.RemoteServerManager;
 import org.jivesoftware.openfire.server.ServerDialback;
 import org.jivesoftware.openfire.spi.BasicStreamIDFactory;
-import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -255,12 +253,12 @@ public class LocalOutgoingServerSession extends LocalSession implements Outgoing
             int port) {
 
         String localDomainName = XMPPServer.getInstance().getServerInfo().getXMPPDomain();
-        boolean useTLS = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ENABLED, true);
-        RemoteServerConfiguration configuration = RemoteServerManager.getConfiguration(hostname);
-        if (configuration != null) {
+        //boolean useTLS = ConnectionSettings.Server.TLS_ENABLED.get();
+        //RemoteServerConfiguration configuration = RemoteServerManager.getConfiguration(hostname);
+        //if (configuration != null) {
             // TODO Use the specific TLS configuration for this remote server
             //useTLS = configuration.isTLSEnabled();
-        }
+        //}
 
         // Connect to remote server using XMPP 1.0 (TLS + SASL EXTERNAL or TLS + server dialback or server dialback)
         String realHostname = null;
@@ -340,7 +338,7 @@ public class LocalOutgoingServerSession extends LocalSession implements Outgoing
                 Element features = reader.parseDocument().getRootElement();
                 if (features != null) {
                     // Check if TLS is enabled
-                    if (useTLS && features.element("starttls") != null) {
+                    if (ConnectionSettings.Server.TLS_ENABLED.get() && features.element("starttls") != null) {
                         // Secure the connection with TLS and authenticate using SASL
                         LocalOutgoingServerSession answer;
                         answer = secureAndAuthenticate(hostname, connection, reader, openingStream,
@@ -427,9 +425,9 @@ public class LocalOutgoingServerSession extends LocalSession implements Outgoing
         Element proceed = reader.parseDocument().getRootElement();
         if (proceed != null && proceed.getName().equals("proceed")) {
             log.debug("Negotiating TLS...");
-            boolean needed = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true) &&
-                    		 JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY, true) &&
-                    		 !JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false);
+            boolean needed = ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY.get() &&
+                    		 ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY.get() &&
+                    		 !ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS.get();
             connection.startTLS(true, hostname, needed ? Connection.ClientAuth.needed : Connection.ClientAuth.wanted);
             log.debug("TLS negotiation was successful.");
 
@@ -448,9 +446,7 @@ public class LocalOutgoingServerSession extends LocalSession implements Outgoing
             features = reader.parseDocument().getRootElement();
             if (features != null) {
                 // Check if we can use stream compression
-                String policyName = JiveGlobals.getProperty(ConnectionSettings.Server.COMPRESSION_SETTINGS, Connection.CompressionPolicy.disabled.toString());
-                Connection.CompressionPolicy compressionPolicy = Connection.CompressionPolicy.valueOf(policyName);
-                if (Connection.CompressionPolicy.optional == compressionPolicy) {
+                if (Connection.CompressionPolicy.optional == ConnectionSettings.Server.COMPRESSION_SETTINGS.get()) {
                     // Verify if the remote server supports stream compression
                     Element compression = features.element("compression");
                     if (compression != null) {

--- a/src/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
@@ -468,10 +468,10 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                         new java.security.SecureRandom());
 
                 SSLFilter sslFilter = new SSLFilter(sslContext);
-                if (JiveGlobals.getProperty(ConnectionSettings.Client.AUTH_PER_CLIENTCERT_POLICY,"disabled").equals("needed")) {
+                if ("needed".equals(ConnectionSettings.Client.AUTH_PER_CLIENTCERT_POLICY.get())) {
                     sslFilter.setNeedClientAuth(true);
                 }
-                else if(JiveGlobals.getProperty(ConnectionSettings.Client.AUTH_PER_CLIENTCERT_POLICY,"disabled").equals("wanted")) {
+                else if("wanted".equals(ConnectionSettings.Client.AUTH_PER_CLIENTCERT_POLICY.get())) {
                     sslFilter.setWantClientAuth(true);
                 }
                 sslSocketAcceptor.getFilterChain().addFirst("tls", sslFilter);
@@ -587,20 +587,20 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
             return;
         }
         if (enabled) {
-            JiveGlobals.setProperty(ConnectionSettings.Client.SOCKET_ACTIVE, "true");
+            ConnectionSettings.Client.SOCKET_ACTIVE.set(true);
             // Start the port listener for clients
             createClientListeners();
             startClientListeners(localIPAddress);
         }
         else {
-            JiveGlobals.setProperty(ConnectionSettings.Client.SOCKET_ACTIVE, "false");
+            ConnectionSettings.Client.SOCKET_ACTIVE.set(false);
             // Stop the port listener for clients
             stopClientListeners();
         }
     }
 
     public boolean isClientListenerEnabled() {
-        return JiveGlobals.getBooleanProperty(ConnectionSettings.Client.SOCKET_ACTIVE, true);
+        return ConnectionSettings.Client.SOCKET_ACTIVE.get();
     }
 
     public void enableClientSSLListener(boolean enabled) {
@@ -609,13 +609,13 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
             return;
         }
         if (enabled) {
-            JiveGlobals.setProperty(ConnectionSettings.Client.ENABLE_OLD_SSLPORT, "true");
+            ConnectionSettings.Client.ENABLE_OLD_SSLPORT.set(true);
             // Start the port listener for secured clients
             createClientSSLListeners();
             startClientSSLListeners(localIPAddress);
         }
         else {
-            JiveGlobals.setProperty(ConnectionSettings.Client.ENABLE_OLD_SSLPORT, "false");
+            ConnectionSettings.Client.ENABLE_OLD_SSLPORT.set(false);
             // Stop the port listener for secured clients
             stopClientSSLListeners();
         }
@@ -623,10 +623,9 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
 
     public boolean isClientSSLListenerEnabled() {
         try {
-            return JiveGlobals.getBooleanProperty(ConnectionSettings.Client.ENABLE_OLD_SSLPORT, false) && SSLConfig.getKeyStore().size() > 0;
-        } catch (KeyStoreException e) {
-            return false;
-        } catch (IOException e) {
+            return ConnectionSettings.Client.ENABLE_OLD_SSLPORT.get() && SSLConfig.getKeyStore().size() > 0;
+        } catch (KeyStoreException | IOException e) {
+            Log.warn("Exception on keystore occured: {}", e.getMessage(), e);
             return false;
         }
     }
@@ -637,20 +636,20 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
             return;
         }
         if (enabled) {
-            JiveGlobals.setProperty(ConnectionSettings.Component.SOCKET_ACTIVE, "true");
+            ConnectionSettings.Component.SOCKET_ACTIVE.set(true);
             // Start the port listener for external components
             createComponentListener();
             startComponentListener();
         }
         else {
-            JiveGlobals.setProperty(ConnectionSettings.Component.SOCKET_ACTIVE, "false");
+            ConnectionSettings.Component.SOCKET_ACTIVE.set(false);
             // Stop the port listener for external components
             stopComponentListener();
         }
     }
 
     public boolean isComponentListenerEnabled() {
-        return JiveGlobals.getBooleanProperty(ConnectionSettings.Component.SOCKET_ACTIVE, false);
+        return ConnectionSettings.Component.SOCKET_ACTIVE.get();
     }
 
     public void enableServerListener(boolean enabled) {
@@ -659,20 +658,20 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
             return;
         }
         if (enabled) {
-            JiveGlobals.setProperty(ConnectionSettings.Server.SOCKET_ACTIVE, "true");
+            ConnectionSettings.Server.SOCKET_ACTIVE.set(true);
             // Start the port listener for s2s communication
             createServerListener(localIPAddress);
             startServerListener();
         }
         else {
-            JiveGlobals.setProperty(ConnectionSettings.Server.SOCKET_ACTIVE, "false");
+            ConnectionSettings.Server.SOCKET_ACTIVE.set(false);
             // Stop the port listener for s2s communication
             stopServerListener();
         }
     }
 
     public boolean isServerListenerEnabled() {
-        return JiveGlobals.getBooleanProperty(ConnectionSettings.Server.SOCKET_ACTIVE, true);
+        return ConnectionSettings.Server.SOCKET_ACTIVE.get();
     }
 
     public void enableConnectionManagerListener(boolean enabled) {
@@ -681,20 +680,20 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
             return;
         }
         if (enabled) {
-            JiveGlobals.setProperty(ConnectionSettings.Multiplex.SOCKET_ACTIVE, "true");
+            ConnectionSettings.Multiplex.SOCKET_ACTIVE.set(true);
             // Start the port listener for s2s communication
             createConnectionManagerListener();
             startConnectionManagerListener(localIPAddress);
         }
         else {
-            JiveGlobals.setProperty(ConnectionSettings.Multiplex.SOCKET_ACTIVE, "false");
+            ConnectionSettings.Multiplex.SOCKET_ACTIVE.set(false);
             // Stop the port listener for s2s communication
             stopConnectionManagerListener();
         }
     }
 
     public boolean isConnectionManagerListenerEnabled() {
-        return JiveGlobals.getBooleanProperty(ConnectionSettings.Multiplex.SOCKET_ACTIVE, false);
+        return ConnectionSettings.Multiplex.SOCKET_ACTIVE.get();
     }
 
     public void setClientListenerPort(int port) {
@@ -702,7 +701,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
             // Ignore new setting
             return;
         }
-        JiveGlobals.setProperty(ConnectionSettings.Client.PORT, String.valueOf(port));
+        ConnectionSettings.Client.PORT.set(port);
         // Stop the port listener for clients
         stopClientListeners();
         if (isClientListenerEnabled()) {
@@ -717,7 +716,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
     }
 
     public int getClientListenerPort() {
-        return JiveGlobals.getIntProperty(ConnectionSettings.Client.PORT, DEFAULT_PORT);
+        return ConnectionSettings.Client.PORT.get();
     }
 
     public SocketAcceptor getSSLSocketAcceptor() {
@@ -729,7 +728,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
             // Ignore new setting
             return;
         }
-        JiveGlobals.setProperty(ConnectionSettings.Client.OLD_SSLPORT, String.valueOf(port));
+        ConnectionSettings.Client.OLD_SSLPORT.set(port);
         // Stop the port listener for secured clients
         stopClientSSLListeners();
         if (isClientSSLListenerEnabled()) {
@@ -740,7 +739,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
     }
 
     public int getClientSSLListenerPort() {
-        return JiveGlobals.getIntProperty(ConnectionSettings.Client.OLD_SSLPORT, DEFAULT_SSL_PORT);
+        return ConnectionSettings.Client.OLD_SSLPORT.get();
     }
 
     public void setComponentListenerPort(int port) {
@@ -748,7 +747,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
             // Ignore new setting
             return;
         }
-        JiveGlobals.setProperty(ConnectionSettings.Component.PORT, String.valueOf(port));
+        ConnectionSettings.Component.PORT.set(port);
         // Stop the port listener for external components
         stopComponentListener();
         if (isComponentListenerEnabled()) {
@@ -763,7 +762,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
     }
 
     public int getComponentListenerPort() {
-        return JiveGlobals.getIntProperty(ConnectionSettings.Component.PORT, DEFAULT_COMPONENT_PORT);
+        return ConnectionSettings.Component.PORT.get();
     }
 
     public void setServerListenerPort(int port) {
@@ -771,7 +770,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
             // Ignore new setting
             return;
         }
-        JiveGlobals.setProperty(ConnectionSettings.Server.PORT, String.valueOf(port));
+        ConnectionSettings.Server.PORT.set(port);
         // Stop the port listener for s2s communication
         stopServerListener();
         if (isServerListenerEnabled()) {
@@ -782,7 +781,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
     }
 
     public int getServerListenerPort() {
-        return JiveGlobals.getIntProperty(ConnectionSettings.Server.PORT, DEFAULT_SERVER_PORT);
+        return ConnectionSettings.Server.PORT.get();
     }
 
     public SocketAcceptor getMultiplexerSocketAcceptor() {
@@ -794,7 +793,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
             // Ignore new setting
             return;
         }
-        JiveGlobals.setProperty(ConnectionSettings.Multiplex.PORT, String.valueOf(port));
+        ConnectionSettings.Multiplex.PORT.set(port);
         // Stop the port listener for connection managers
         stopConnectionManagerListener();
         if (isConnectionManagerListenerEnabled()) {
@@ -805,7 +804,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
     }
 
     public int getConnectionManagerListenerPort() {
-        return JiveGlobals.getIntProperty(ConnectionSettings.Multiplex.PORT, DEFAULT_MULTIPLEX_PORT);
+        return ConnectionSettings.Multiplex.PORT.get();
     }
 
     // #####################################################################

--- a/src/java/org/jivesoftware/util/property/BooleanProperty.java
+++ b/src/java/org/jivesoftware/util/property/BooleanProperty.java
@@ -1,0 +1,15 @@
+package org.jivesoftware.util.property;
+
+import org.jivesoftware.util.JiveGlobals;
+
+public final class BooleanProperty extends Property<Boolean> {
+
+    BooleanProperty(String propertyKey, Boolean defaultValue) {
+        super(propertyKey, defaultValue);
+    }
+
+    @Override
+    public Boolean get() {
+        return JiveGlobals.getBooleanProperty(key, defaultValue);
+    }
+}

--- a/src/java/org/jivesoftware/util/property/EnumProperty.java
+++ b/src/java/org/jivesoftware/util/property/EnumProperty.java
@@ -1,0 +1,32 @@
+package org.jivesoftware.util.property;
+
+import org.jivesoftware.util.JiveGlobals;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class EnumProperty<E extends Enum<E>> extends Property<E> {
+
+    private static final Logger Log = LoggerFactory.getLogger(EnumProperty.class);
+
+    private Class<E> enumType;
+
+    EnumProperty(String propertyKey, E defaultValue) {
+        super(propertyKey, defaultValue);
+        this.enumType = defaultValue.getDeclaringClass();
+    }
+
+    @Override
+    public E get() {
+        try {
+            return Enum.valueOf(enumType, JiveGlobals.getProperty(key, String.valueOf(defaultValue)));
+        } catch (IllegalArgumentException e) {
+            Log.error("Error parsing {}: " + e.getMessage(), key, e);
+            return defaultValue;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return key + " = " + enumType.getSimpleName() + " : " + get();
+    }
+}

--- a/src/java/org/jivesoftware/util/property/IntegerProperty.java
+++ b/src/java/org/jivesoftware/util/property/IntegerProperty.java
@@ -1,0 +1,15 @@
+package org.jivesoftware.util.property;
+
+import org.jivesoftware.util.JiveGlobals;
+
+public class IntegerProperty extends Property<Integer> {
+
+    IntegerProperty(String propertyKey, Integer defaultValue) {
+        super(propertyKey, defaultValue);
+    }
+
+    @Override
+    public Integer get() {
+        return JiveGlobals.getIntProperty(key, defaultValue);
+    }
+}

--- a/src/java/org/jivesoftware/util/property/Property.java
+++ b/src/java/org/jivesoftware/util/property/Property.java
@@ -1,0 +1,77 @@
+package org.jivesoftware.util.property;
+
+import org.jivesoftware.util.JiveGlobals;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+public abstract class Property<T> {
+
+    protected final String key;
+
+    protected final T defaultValue;
+
+    protected final PropertyChangeSupport propChange = new PropertyChangeSupport( this );
+
+    public Property(String key, T defaultValue) {
+        this.key = key;
+        this.defaultValue = defaultValue;
+    }
+
+    public abstract T get();
+
+    public void set(T value) {
+        final T oldValue = get();
+        JiveGlobals.setProperty(key, String.valueOf(value));
+        propChange.firePropertyChange(key, oldValue, value);
+    }
+
+    public void delete() {
+        JiveGlobals.deleteProperty(key);
+    }
+
+    public void reset() {
+        set(defaultValue);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public T getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void addPropertyChangeListener(final PropertyChangeListener listener) {
+        propChange.addPropertyChangeListener(key, listener);
+    }
+
+    public void removePropertyChangeListener(final PropertyChangeListener listener) {
+        propChange.removePropertyChangeListener(key, listener);
+    }
+
+    public String toString() {
+        return key + " = " + String.valueOf(get());
+    }
+
+    /*
+     * Builder
+     */
+
+    public static BooleanProperty of(String propertyKey, boolean defaultValue) {
+        return new BooleanProperty(propertyKey, defaultValue);
+    }
+
+    public static StringProperty of(String propertyKey, String defaultValue) {
+        return new StringProperty(propertyKey, defaultValue);
+    }
+
+    public static IntegerProperty of(String propertyKey, int defaultValue) {
+        return new IntegerProperty(propertyKey, defaultValue);
+    }
+
+    public static <E extends Enum<E>> EnumProperty<E> of(String propertyKey, E defaultValue) {
+        return new EnumProperty<>(propertyKey, defaultValue);
+    }
+}
+

--- a/src/java/org/jivesoftware/util/property/StringProperty.java
+++ b/src/java/org/jivesoftware/util/property/StringProperty.java
@@ -1,0 +1,14 @@
+package org.jivesoftware.util.property;
+
+import org.jivesoftware.util.JiveGlobals;
+
+public final class StringProperty extends Property<String> {
+    StringProperty(String propertyKey, String defaultValue) {
+        super(propertyKey, defaultValue);
+    }
+
+    @Override
+    public String get() {
+        return JiveGlobals.getProperty(key, defaultValue);
+    }
+}

--- a/src/test/java/org/jivesoftware/util/property/EnumPropertyTest.java
+++ b/src/test/java/org/jivesoftware/util/property/EnumPropertyTest.java
@@ -1,0 +1,55 @@
+package org.jivesoftware.util.property;
+
+import org.jivesoftware.openfire.Connection;
+import org.junit.Test;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.security.cert.CRLReason;
+
+import static org.jivesoftware.util.property.Property.of;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EnumPropertyTest {
+
+    @Test
+    public void shouldBeInitializableWithClassicEnum() {
+        final EnumProperty<CRLReason> unit = of("keyThatIsNotInAPropertyStore", CRLReason.UNSPECIFIED);
+        assertEquals(CRLReason.UNSPECIFIED, unit.get());
+    }
+
+    @Test
+    public void shouldBeInitializableWithInnerEnum() {
+        final EnumProperty<Connection.CompressionPolicy> unit = of("keyThatIsNotInAPropertyStore", Connection.CompressionPolicy.optional);
+        assertEquals(Connection.CompressionPolicy.optional, unit.get());
+    }
+
+    @Test
+    public void valueShouldBeRenderedWithinToString() {
+        final EnumProperty<Connection.CompressionPolicy> unit = of("keyThatIsNotInAPropertyStore", Connection.CompressionPolicy.optional);
+        assertEquals("keyThatIsNotInAPropertyStore = CompressionPolicy : optional", unit.toString());
+    }
+
+    /**
+     * Ohh dear, we need a good and simple mocking framework for verification -  Like Mockito!!
+     */
+    @Test
+    public void shouldFirePropertyChangeListener() {
+        final TestHelper helper = new TestHelper();
+        final EnumProperty<Connection.CompressionPolicy> unit = of("keyThatIsNotInAPropertyStore", Connection.CompressionPolicy.optional);
+        unit.addPropertyChangeListener(new PropertyChangeListener() {
+            @Override
+            public void propertyChange(final PropertyChangeEvent evt) {
+                helper.propertyChangeFired = true;
+            }
+        });
+
+        unit.set(Connection.CompressionPolicy.disabled);
+        assertTrue(helper.propertyChangeFired);
+    }
+
+    private static class TestHelper {
+        public boolean propertyChangeFired = false;
+    }
+}

--- a/src/test/java/org/jivesoftware/util/property/IntegerPropertyTest.java
+++ b/src/test/java/org/jivesoftware/util/property/IntegerPropertyTest.java
@@ -1,0 +1,22 @@
+package org.jivesoftware.util.property;
+
+import org.junit.Test;
+
+
+import static org.jivesoftware.util.property.Property.of;
+import static org.junit.Assert.assertEquals;
+
+public class IntegerPropertyTest {
+
+    @Test
+    public void shouldBeInitializable() {
+        final IntegerProperty unit = of("keyThatIsNotInAPropertyStore", 42);
+        assertEquals(Integer.valueOf(42), unit.get());
+    }
+
+    @Test
+    public void valueShouldBeRenderedWithinToString() {
+        final IntegerProperty unit = of("keyThatIsNotInAPropertyStore", 42);
+        assertEquals("keyThatIsNotInAPropertyStore = 42", unit.toString());
+    }
+}

--- a/src/web/client-connections-settings.jsp
+++ b/src/web/client-connections-settings.jsp
@@ -89,11 +89,11 @@
 			response.sendRedirect("client-connections-settings.jsp?success=true");
 			
 			if (!idleDisco) {
-            	JiveGlobals.setProperty(ConnectionSettings.Client.IDLE_TIMEOUT, "-1");
+                ConnectionSettings.Client.IDLE_TIMEOUT.set(-1);
 			} else {
-            	JiveGlobals.setProperty(ConnectionSettings.Client.IDLE_TIMEOUT, String.valueOf(clientIdle));
+                ConnectionSettings.Client.IDLE_TIMEOUT.set(clientIdle);
 			}
-            JiveGlobals.setProperty(ConnectionSettings.Client.KEEP_ALIVE_PING, String.valueOf(pingIdleClients));
+            ConnectionSettings.Client.KEEP_ALIVE_PING.set(pingIdleClients);
             // Log the events
             webManager.logEvent("set server property " + ConnectionSettings.Client.IDLE_TIMEOUT,
                     ConnectionSettings.Client.IDLE_TIMEOUT + " = " + clientIdle);
@@ -106,8 +106,8 @@
         sslEnabled = connectionManager.isClientSSLListenerEnabled();
         port = connectionManager.getClientListenerPort();
         sslPort = connectionManager.getClientSSLListenerPort();
-        clientIdle = JiveGlobals.getIntProperty(ConnectionSettings.Client.IDLE_TIMEOUT, 6*60*1000);
-        pingIdleClients = JiveGlobals.getBooleanProperty(ConnectionSettings.Client.KEEP_ALIVE_PING, true);
+        clientIdle = ConnectionSettings.Client.IDLE_TIMEOUT.get();
+        pingIdleClients = ConnectionSettings.Client.KEEP_ALIVE_PING.get();
     }
 %>
 

--- a/src/web/ssl-settings.jsp
+++ b/src/web/ssl-settings.jsp
@@ -21,8 +21,7 @@
                  org.jivesoftware.openfire.ConnectionManager,
                  org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.openfire.server.ServerDialback,
-                 org.jivesoftware.openfire.session.LocalClientSession,
-                 org.jivesoftware.util.JiveGlobals"
+                 org.jivesoftware.openfire.session.LocalClientSession"
     errorPage="error.jsp"
 %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
@@ -86,15 +85,15 @@
 
             // Enable TLS and disable server dialback
             XMPPServer.getInstance().getConnectionManager().enableServerListener(true);
-            JiveGlobals.setProperty(ConnectionSettings.Server.TLS_ENABLED, "true");
-            JiveGlobals.setProperty(ConnectionSettings.Server.DIALBACK_ENABLED, "false");
+            ConnectionSettings.Server.TLS_ENABLED.set(true);
+            ConnectionSettings.Server.DIALBACK_ENABLED.set(false);
         } else if ("notreq".equals(serverSecurityRequired)) {
             // User selected that security for s2s is NOT required
 
             // Enable TLS and enable server dialback
             XMPPServer.getInstance().getConnectionManager().enableServerListener(true);
-            JiveGlobals.setProperty(ConnectionSettings.Server.TLS_ENABLED, "true");
-            JiveGlobals.setProperty(ConnectionSettings.Server.DIALBACK_ENABLED, "true");
+            ConnectionSettings.Server.TLS_ENABLED.set(true);
+            ConnectionSettings.Server.DIALBACK_ENABLED.set(true);
         } else if ("custom".equals(serverSecurityRequired)) {
             // User selected custom server authentication
 
@@ -105,24 +104,24 @@
                 XMPPServer.getInstance().getConnectionManager().enableServerListener(true);
 
                 // Enable or disable server dialback
-                JiveGlobals.setProperty(ConnectionSettings.Server.DIALBACK_ENABLED, dialbackEnabled ? "true" : "false");
+                ConnectionSettings.Server.DIALBACK_ENABLED.set(dialbackEnabled);
 
                 // Enable or disable TLS for s2s connections
-                JiveGlobals.setProperty(ConnectionSettings.Server.TLS_ENABLED, tlsEnabled ? "true" : "false");
+                ConnectionSettings.Server.TLS_ENABLED.set(tlsEnabled);
             } else {
                 XMPPServer.getInstance().getConnectionManager().enableServerListener(false);
                 // Disable server dialback
-                JiveGlobals.setProperty(ConnectionSettings.Server.DIALBACK_ENABLED, "false");
+                ConnectionSettings.Server.DIALBACK_ENABLED.set(false);
 
                 // Disable TLS for s2s connections
-                JiveGlobals.setProperty(ConnectionSettings.Server.TLS_ENABLED, "false");
+                ConnectionSettings.Server.TLS_ENABLED.set(false);
             }
         }
         ServerDialback.setEnabledForSelfSigned(selfSigned);
         success = true;
         // Log the event
-        webManager.logEvent("updated SSL configuration", ConnectionSettings.Server.DIALBACK_ENABLED + " = "+JiveGlobals.getProperty(ConnectionSettings.Server.DIALBACK_ENABLED)+
-                "\n"+ ConnectionSettings.Server.TLS_ENABLED+" = "+JiveGlobals.getProperty(ConnectionSettings.Server.TLS_ENABLED));
+        webManager.logEvent("updated SSL configuration", ConnectionSettings.Server.DIALBACK_ENABLED + " = "+ConnectionSettings.Server.DIALBACK_ENABLED.get()+
+                "\n"+ ConnectionSettings.Server.TLS_ENABLED+" = "+ConnectionSettings.Server.TLS_ENABLED.get());
     }
 
     // Set page vars
@@ -148,9 +147,8 @@
                 LocalClientSession.getTLSPolicy().toString();
     }
 
-    boolean tlsEnabled = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ENABLED, true);
-    boolean dialbackEnabled = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.DIALBACK_ENABLED, true);
-    if (tlsEnabled) {
+    final boolean dialbackEnabled = ConnectionSettings.Server.DIALBACK_ENABLED.get();
+    if (ConnectionSettings.Server.TLS_ENABLED.get()) {
         if (dialbackEnabled) {
             serverSecurityRequired = "notreq";
             dialback = "available";


### PR DESCRIPTION
Introduced PropertyHandler to hold the key and the default value of a property. They're responsible to read and transform the value - and vice versa to write it back.
The advantages:
- The compiler checks the types. It's impossible to store a wrong type into a property
- Enums are translated back in one line
- Default values are configured at one place
- Listeners realized with PropertyChangeSupport of java.beans

I used it for most of the connection properties. But feel free to use them for other properties too.
