### PR TITLE
OF-819 IQs of type error get falsely routed to IQ.createResult() which r...

### DIFF
--- a/src/java/org/jivesoftware/openfire/IQRouter.java
+++ b/src/java/org/jivesoftware/openfire/IQRouter.java
@@ -120,8 +120,7 @@ public class IQRouter extends BasicModule {
                                     "urn:ietf:params:xml:ns:xmpp-bind"
                                             .equals(packet.getChildElement().getNamespaceURI())))) {
                 handle(packet);
-            }
-            else {
+            } else if (packet.getType() == IQ.Type.get || packet.getType() == IQ.Type.set) {
                 IQ reply = IQ.createResultIQ(packet);
                 reply.setChildElement(packet.getChildElement().createCopy());
                 reply.setError(PacketError.Condition.not_authorized);


### PR DESCRIPTION
...esults in an Exception and connection termination

This can happen, if the session is in wrong status (e.g. if the user has not yet authenticated) and the client responds with an error IQ.
Only reply to an IQ if it is type get or set.
