### PR TITLE
Fix 'RFC 6121 8.5.1. No Such User' for IQ stanzas

### DIFF
--- a/src/java/org/jivesoftware/openfire/IQRouter.java
+++ b/src/java/org/jivesoftware/openfire/IQRouter.java
@@ -327,6 +327,16 @@ public class IQRouter extends BasicModule {
                 routingTable.routePacket(recipientJID, packet, false);
                 return;
             }
+
+            // RFC 6121 8.5.1.  No Such User http://xmpp.org/rfcs/rfc6121.html#rules-localpart-nosuchuser
+            // If the 'to' address specifies a bare JID <localpart@domainpart> or full JID <localpart@domainpart/resourcepart> where the domainpart of the JID matches a configured domain that is serviced by the server itself, the server MUST proceed as follows.
+            // If the user account identified by the 'to' attribute does not exist, how the stanza is processed depends on the stanza type.
+            if (recipientJID != null && recipientJID.getNode() != null && serverName.equals(recipientJID.getDomain()) && !userManager.isRegisteredUser(recipientJID.getNode()) && (IQ.Type.set == packet.getType() || IQ.Type.get == packet.getType())) {
+                // For an IQ stanza, the server MUST return a <service-unavailable/> stanza error to the sender.
+                sendErrorPacket(packet, PacketError.Condition.service_unavailable);
+                return;
+            }
+
             if (isLocalServer(recipientJID)) {
                 // Let the server handle the Packet
                 Element childElement = packet.getChildElement();


### PR DESCRIPTION
IQ stanzas, which were routed to a non-existent user were falsely replied to with an IQ-result (e.g. ping).
This fix checks for the existence of the user and returns an error, in case the user does not exist.

Related to OF-810.
I discovered this bug, while checking Openfire for RFC 6121 compliance.

If anybody thinks this deserves its own Jira issue, please comment.
