### PR TITLE
OF-805 [MUC] OF does not return all affiliated users when requesting mul...

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/IQAdminHandler.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/IQAdminHandler.java
@@ -134,13 +134,15 @@ public class IQAdminHandler {
         // Check if the client is requesting or changing the list of moderators/members/etc.
         if (!hasJID && !hasNick) {
             // The client is requesting the list of moderators/members/participants/outcasts
+
+            // Create the result that will hold an item for each
+            // moderator/member/participant/outcast
+            Element result = reply.setChildElement("query", "http://jabber.org/protocol/muc#admin");
+
             for (Object anItem : itemsList) {
                 item = (Element) anItem;
                 affiliation = item.attributeValue("affiliation");
                 roleAttribute = item.attributeValue("role");
-                // Create the result that will hold an item for each
-                // moderator/member/participant/outcast
-                Element result = reply.setChildElement("query", "http://jabber.org/protocol/muc#admin");
 
                 Element metaData;
                 if ("outcast".equals(affiliation)) {


### PR DESCRIPTION
...tiple affiliations

When requesting:
<iq type="get" to="6ace0fd2f59f13c2484336dd06b4462a@bizmanager.msz006" id="getRoomMemberList">
<query xmlns="http://jabber.org/protocol/muc#admin">
<item affiliation="member"/>
<item affiliation="owner"/>
<item affiliation="admin"/>
</query>
</iq>

Openfire does only return admins (the last requested affiliation).
This fix rectifies this.
