### PR TITLE
Remove dispensable logic in the IQOwnerHandler, which deals with MUC aff...

### DIFF
--- a/src/plugins/fastpath/src/java/org/jivesoftware/openfire/fastpath/providers/MonitorProvider.java
+++ b/src/plugins/fastpath/src/java/org/jivesoftware/openfire/fastpath/providers/MonitorProvider.java
@@ -107,7 +107,7 @@ public class MonitorProvider implements WorkgroupProvider {
                 iqPacket.setTo(roomName);
                 iqPacket.setFrom(workgroup.getFullJID());
 
-                Element query = iqPacket.setChildElement("query", "http://jabber.org/protocol/muc#owner");
+                Element query = iqPacket.setChildElement("query", "http://jabber.org/protocol/muc#admin");
                 Element item = query.addElement("item");
                 item.addAttribute("affiliation", "owner");
                 item.addAttribute("jid", packet.getFrom().toBareJID());

--- a/src/web/muc-room-affiliations.jsp
+++ b/src/web/muc-room-affiliations.jsp
@@ -82,22 +82,14 @@
                     userJID = username + rest.trim();
                 }
                 IQ iq = new IQ(IQ.Type.set);
-                if ("owner".equals(affiliation) || "admin".equals(affiliation)) {
-                    Element frag = iq.setChildElement("query", "http://jabber.org/protocol/muc#owner");
-                    Element item = frag.addElement("item");
-                    item.addAttribute("affiliation", affiliation);
-                    item.addAttribute("jid", userJID);
-                    // Send the IQ packet that will modify the room's configuration
-                    room.getIQOwnerHandler().handleIQ(iq, room.getRole());
-                }
-                else if ("member".equals(affiliation) || "outcast".equals(affiliation)) {
-                    Element frag = iq.setChildElement("query", "http://jabber.org/protocol/muc#admin");
-                    Element item = frag.addElement("item");
-                    item.addAttribute("affiliation", affiliation);
-                    item.addAttribute("jid", userJID);
-                    // Send the IQ packet that will modify the room's configuration
-                    room.getIQAdminHandler().handleIQ(iq, room.getRole());
-                }
+
+                Element frag = iq.setChildElement("query", "http://jabber.org/protocol/muc#admin");
+                Element item = frag.addElement("item");
+                item.addAttribute("affiliation", affiliation);
+                item.addAttribute("jid", userJID);
+                // Send the IQ packet that will modify the room's configuration
+                room.getIQAdminHandler().handleIQ(iq, room.getRole());
+
                 // Log the event
                 webManager.logEvent("set MUC affilation to "+affiliation+" for "+userJID+" in "+roomName, null);
                 // done, return


### PR DESCRIPTION
...iliation changes

MUC affiliations are managed in the #admin namespace, not in the #owner namespace.
This is already a minor contribution to OF-178 (Updating MUC to latest version).
