### PR TITLE
Quick fix for old-skool Jabber on S2S

### DIFF
--- a/src/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/src/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -674,7 +674,8 @@ public class ServerDialback {
             for (int eventType = xpp.getEventType(); eventType != XmlPullParser.START_TAG;) {
                 eventType = xpp.next();
             }
-            if (xpp.getAttributeValue("", "version").equals("1.0")) {
+            if ((xpp.getAttributeValue("", "version") != null) &&
+                (xpp.getAttributeValue("", "version").equals("1.0"))) {
                 Document doc;
                 try {
                     doc = reader.parseDocument();


### PR DESCRIPTION
This will fix a bug with connections to any large, broken providers who use entirely unencrypted sessions using a legacy protocol and are too unresponsive to fix it.

Can't imagine there's many of those though.
