### PR TITLE
More S2S fixes

### DIFF
--- a/src/java/org/jivesoftware/openfire/SessionManager.java
+++ b/src/java/org/jivesoftware/openfire/SessionManager.java
@@ -391,12 +391,12 @@ public class SessionManager extends BasicModule implements ClusterEventListener 
      * @return the newly created {@link IncomingServerSession}.
      * @throws UnauthorizedException if the local server has not been initialized yet.
      */
-    public LocalIncomingServerSession createIncomingServerSession(Connection conn, StreamID id)
+    public LocalIncomingServerSession createIncomingServerSession(Connection conn, StreamID id, String fromDomain)
             throws UnauthorizedException {
         if (serverName == null) {
             throw new UnauthorizedException("Server not initialized");
         }
-        LocalIncomingServerSession session = new LocalIncomingServerSession(serverName, conn, id);
+        LocalIncomingServerSession session = new LocalIncomingServerSession(serverName, conn, id, fromDomain);
         conn.init(session);
         // Register to receive close notification on this session so we can
         // remove its route from the sessions set

--- a/src/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/src/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -431,7 +431,7 @@ public class ServerDialback {
                         Log.debug("ServerDialback: RS - Validation of remote domain for incoming session from {} to {} was successful.", hostname, recipient);
                         // Create a server Session for the remote server
                         LocalIncomingServerSession session = sessionManager.
-                                createIncomingServerSession(connection, streamID);
+                                createIncomingServerSession(connection, streamID, hostname);
                         // Add the validated domain as a valid domain
                         session.addValidatedDomain(hostname);
                         // Set the domain or subdomain of the local server used when


### PR DESCRIPTION
Kim 'Zash' Alvefur commented that an empty authzid in EXTERNAL wasn't working.

This patch adds this handling, and also changes authorization checks from a
domain.contains() to a domain.equals().
