### PR TITLE
OF-839 Forwarded extension should not overwrite extension namespaces of ...

### DIFF
--- a/src/java/org/jivesoftware/openfire/forward/Forwarded.java
+++ b/src/java/org/jivesoftware/openfire/forward/Forwarded.java
@@ -19,7 +19,10 @@ public class Forwarded extends PacketExtension {
         for (Object element : copy.getElement().elements()) {
             if (element instanceof Element) {
                 Element el = (Element) element;
-                el.setQName(QName.get(el.getName(), "jabber:client"));
+                // Only set the "jabber:client" namespace if the namespace is empty (otherwise the resulting xml would look like <body xmlns=""/>)
+                if ("".equals(el.getNamespace().getStringValue())) {
+                    el.setQName(QName.get(el.getName(), "jabber:client"));
+                }
             }
         }
         element.add(copy.getElement());

--- a/src/test/java/org/jivesoftware/openfire/forward/ForwardTest.java
+++ b/src/test/java/org/jivesoftware/openfire/forward/ForwardTest.java
@@ -1,6 +1,7 @@
 package org.jivesoftware.openfire.forward;
 
 import org.junit.Test;
+import org.xmpp.forms.DataForm;
 import org.xmpp.packet.Message;
 
 import static org.junit.Assert.assertEquals;
@@ -15,12 +16,13 @@ public class ForwardTest {
         Message message = new Message();
         message.setType(Message.Type.chat);
         message.setBody("Tests");
+        message.addExtension(new DataForm(DataForm.Type.submit));
 
         Forwarded forwarded = new Forwarded(message);
         Forwarded forwarded2 = new Forwarded(message);
         String xml1 = forwarded.getElement().asXML();
         String xml2 = forwarded2.getElement().asXML();
-        assertEquals("<forwarded xmlns=\"urn:xmpp:forward:0\"><message xmlns=\"jabber:client\" type=\"chat\"><body>Tests</body></message></forwarded>", xml1);
-        assertEquals("<forwarded xmlns=\"urn:xmpp:forward:0\"><message xmlns=\"jabber:client\" type=\"chat\"><body>Tests</body></message></forwarded>", xml2);
+        assertEquals("<forwarded xmlns=\"urn:xmpp:forward:0\"><message xmlns=\"jabber:client\" type=\"chat\"><body>Tests</body><x xmlns=\"jabber:x:data\" type=\"submit\"/></message></forwarded>", xml1);
+        assertEquals("<forwarded xmlns=\"urn:xmpp:forward:0\"><message xmlns=\"jabber:client\" type=\"chat\"><body>Tests</body><x xmlns=\"jabber:x:data\" type=\"submit\"/></message></forwarded>", xml2);
     }
 }


### PR DESCRIPTION
...the forwarded message.

The Forwarded extension overwrote the namespace of message extensions. This fix rectifies this problem by only setting the jabber:client namespace if the namespace of the message child element had an empty namespace (thus belonging directly to the message).
