### PR TITLE
Update StatsAction.java

### DIFF
--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/reporting/stats/StatsAction.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/reporting/stats/StatsAction.java
@@ -179,12 +179,19 @@ public class StatsAction {
         format.setMaximumFractionDigits(0);
         if(lows.length > 0) {
             if(type == Statistic.Type.count) {
-                low = String.valueOf((int) lows[0]);
+                double result = 0;
+                for (int i = 0; i < lows.length; i++ ) {
+                        result += lows[i];
+                }
+                low = String.valueOf((int) result);
             }
             else {
-                double l = lows[0];
-                if(Double.isNaN(l)) {
-                    l = 0;
+                double l = 0;
+                for (int i = 0; i < lows.length; i++ ) {
+                        if(Double.isNaN(lows[i])) {
+                                lows[i] = 0;
+                        }
+                        l += lows[i];
                 }
                 low = format.format(l);
             }
@@ -195,12 +202,19 @@ public class StatsAction {
         String high;
         if(highs.length > 0) {
             if(type == Statistic.Type.count) {
-                high = String.valueOf((int) highs[0]);
+                double result = 0;
+                for (int i=0; i < highs.length; i++ ) {
+                        result += highs[i];
+                }
+                high = String.valueOf((int) result);
             }
             else {
-                double h= highs[0];
-                if(Double.isNaN(h)) {
-                    h = 0;
+                double h= 0;
+                for (int i = 0; i < highs.length; i++) {
+                        if(Double.isNaN(highs[i])) {
+                                highs[i] = 0;
+                        }
+                        h += highs[i];
                 }
                 high = format.format(h);
             }


### PR DESCRIPTION
The Server traffic statstics in quick stats are incorrect and inconsistent compared with All Reports page.
The problem is in the calculation of Low and High Values.
The StatsViewer.getMin() and getMax() will return two values for high and low for server_bytes_in and server_bytes_out respectively.
The StatsAction.getLowAndHigh(String key,  long[] timePeriod) does not take that into account and always precesses the first element in the array. Modified so that it sums the values of all the elements of the array.
