### PR TITLE
OF-560: Remove pack200 decompression on startup

### DIFF
--- a/src/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/src/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -21,12 +21,10 @@
 package org.jivesoftware.openfire.container;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -49,8 +47,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.jar.JarOutputStream;
-import java.util.jar.Pack200;
 import java.util.zip.ZipFile;
 
 import org.dom4j.Attribute;
@@ -1134,64 +1130,11 @@ public class PluginManager {
                 }
                 zipFile.close();
 
-                // The lib directory of the plugin may contain Pack200 versions of the JAR
-                // file. If so, unpack them.
-                unpackArchives(new File(dir, "lib"));
             }
             catch (Exception e) {
                 Log.error(e.getMessage(), e);
             }
         }
-
-        /**
-         * Converts any pack files in a directory into standard JAR files. Each
-         * pack file will be deleted after being converted to a JAR. If no
-         * pack files are found, this method does nothing.
-         *
-         * @param libDir the directory containing pack files.
-         */
-        private void unpackArchives(File libDir) {
-            // Get a list of all packed files in the lib directory.
-            File [] packedFiles = libDir.listFiles(new FilenameFilter() {
-                public boolean accept(File dir, String name) {
-                    return name.endsWith(".pack");
-                }
-            });
-
-            if (packedFiles == null) {
-                // Do nothing since no .pack files were found
-                return;
-            }
-
-            // Unpack each.
-            for (File packedFile : packedFiles) {
-                try {
-                    String jarName = packedFile.getName().substring(0,
-                            packedFile.getName().length() - ".pack".length());
-                    // Delete JAR file with same name if it exists (could be due to upgrade
-                    // from old Openfire release).
-                    File jarFile = new File(libDir, jarName);
-                    if (jarFile.exists()) {
-                        jarFile.delete();
-                    }
-
-                    InputStream in = new BufferedInputStream(new FileInputStream(packedFile));
-                    JarOutputStream out = new JarOutputStream(new BufferedOutputStream(
-                            new FileOutputStream(new File(libDir, jarName))));
-                    Pack200.Unpacker unpacker = Pack200.newUnpacker();
-                    // Call the unpacker
-                    unpacker.unpack(in, out);
-
-                    in.close();
-                    out.close();
-                    packedFile.delete();
-                }
-                catch (Exception e) {
-                    Log.error(e.getMessage(), e);
-                }
-            }
-        }
-
     }
 
     /**


### PR DESCRIPTION
The PR #44 has splitted into two parts. This part remove the pack200 decompression of the .pack libraries on server startup.

TODO: If both parts (This one and PR #69) has been merged into the master, the pack200.jar should be deleted as well.
