### PR TITLE
fixed encrypted properties containing xml escaped data not saved correct...

### DIFF
--- a/src/java/org/jivesoftware/util/XMLProperties.java
+++ b/src/java/org/jivesoftware/util/XMLProperties.java
@@ -481,7 +481,7 @@ public class XMLProperties {
             	String propValue = StringEscapeUtils.escapeXml(value);
             	// check to see if the property is marked as encrypted
             	if (JiveGlobals.isPropertyEncrypted(name)) {
-            		propValue = JiveGlobals.getPropertyEncryptor().encrypt(propValue);
+            		propValue = JiveGlobals.getPropertyEncryptor().encrypt(value);
             		childElement.addAttribute(ENCRYPTED_ATTRIBUTE, "true");
             	}
                 childElement.setText(propValue);
@@ -642,7 +642,7 @@ public class XMLProperties {
         	String propValue = StringEscapeUtils.escapeXml(value);
         	// check to see if the property is marked as encrypted
         	if (JiveGlobals.isPropertyEncrypted(name)) {
-        		propValue = JiveGlobals.getPropertyEncryptor().encrypt(propValue);
+        		propValue = JiveGlobals.getPropertyEncryptor().encrypt(value);
         		element.addAttribute(ENCRYPTED_ATTRIBUTE, "true");
         	}
         	element.setText(propValue);


### PR DESCRIPTION
Encrypted properties containing data that needs xml escaping (eg a database password containing '&') are encryped in escaped form but decryption uses them directly. Encrypted properties do not need xml escaping.

Eg:
1. Install an mysql connection with the password 'pass&word'; password is saved as pass&amp;amp;word in properties.xml
2. Launch openfire
-> mysql connection is established correctly and password is now stored in encrypted form.
4. Restart openfire
5. Openfire startup fails due to incorrect database password (pass&amp;amp;word) is used.
