### PR TITLE
Really route to all resources

### DIFF
--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -534,24 +534,20 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             return false;
         }
 
-        // Get the highest priority sessions for normal processing.
-        List<ClientSession> highestPrioritySessions = getHighestPrioritySessions(nonNegativePrioritySessions);
-
-        // Deliver to each session if property route.really-all-resources is true
-        if (JiveGlobals.getBooleanProperty("route.really-all-resources", false)) {
-            for (ClientSession session : nonNegativePrioritySessions) {
-                session.process(packet);
-            }
-            return true;
-        }
-
         // Check for message carbons enabled sessions and send the message to them.
         for (ClientSession session : nonNegativePrioritySessions) {
             // Deliver to each session, if is message carbons enabled.
             if (shouldCarbonCopyToResource(session, packet, isPrivate)) {
                 session.process(packet);
+            // Deliver to each session if property route.really-all-resources is true
+            // (in case client does not support carbons)
+            } else if (JiveGlobals.getBooleanProperty("route.really-all-resources", false)) {
+                session.process(packet);
             }
         }
+
+        // Get the highest priority sessions for normal processing.
+        List<ClientSession> highestPrioritySessions = getHighestPrioritySessions(nonNegativePrioritySessions);
 
         if (highestPrioritySessions.size() == 1) {
             // Found only one session so deliver message (if it hasn't already been processed because it has message carbons enabled)


### PR DESCRIPTION
Hello!

This adds option to actually route all messages to all clients connected with same username. It fixes the problem that there are some clients which don't have option to specify priority or does not support carbon copies.

It actually implements this feature requested: 
https://vanity-igniterealtime.jiveon.com/message/193376
