### PR TITLE
OF-830: Properly handle LDAP search filters

### DIFF
--- a/src/java/org/jivesoftware/openfire/ldap/LdapAuthorizationMapping.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapAuthorizationMapping.java
@@ -107,7 +107,8 @@ public class LdapAuthorizationMapping implements AuthorizationMapping {
             }
             constraints.setReturningAttributes(new String[] { usernameField });
 
-            NamingEnumeration answer = ctx.search("", princSearchFilter, new String[] {principal},
+            NamingEnumeration answer = ctx.search("", princSearchFilter, 
+            		new String[] {LdapManager.sanitizeSearchFilter(principal)},
                     constraints);
             Log.debug("LdapAuthorizationMapping: ... search finished");
             if (answer == null || !answer.hasMoreElements()) {

--- a/src/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
@@ -165,7 +165,7 @@ public class LdapGroupProvider extends AbstractGroupProvider {
         StringBuilder filter = new StringBuilder();
         filter.append("(&");
         filter.append(MessageFormat.format(manager.getGroupSearchFilter(), "*"));
-        filter.append("(").append(key).append("=").append(value);
+        filter.append("(").append(key).append("=").append(LdapManager.sanitizeSearchFilter(value));
         filter.append("))");
         if (Log.isDebugEnabled()) {
             Log.debug("Trying to find group names using query: " + filter.toString());
@@ -188,13 +188,11 @@ public class LdapGroupProvider extends AbstractGroupProvider {
         if (query == null || "".equals(query)) {
             return Collections.emptyList();
         }
-        // Make the query be a wildcard search by default. So, if the user searches for
-        // "Test", make the search be "Test*" instead.
-        if (!query.endsWith("*")) {
-            query = query + "*";
-        }
         StringBuilder filter = new StringBuilder();
-        filter.append("(").append(manager.getGroupNameField()).append("=").append(query).append(")");
+        // Make the query be a wildcard search by default. So, if the user searches for
+        // "Test", make the sanitized search be "Test*" instead.
+        filter.append("(").append(manager.getGroupNameField()).append("=")
+        		.append(LdapManager.sanitizeSearchFilter(query)).append("*)");
         // Perform the LDAP query
         return manager.retrieveList(
                 manager.getGroupNameField(),

--- a/src/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
@@ -255,11 +255,6 @@ public class LdapUserProvider implements UserProvider {
         if (!searchFields.keySet().containsAll(fields)) {
             throw new IllegalArgumentException("Search fields " + fields + " are not valid.");
         }
-        // Make the query be a wildcard search by default. So, if the user searches for
-        // "John", make the search be "John*" instead.
-        if (!query.endsWith("*")) {
-            query = query + "*";
-        }
         StringBuilder filter = new StringBuilder();
         //Add the global search filter so only those users the directory administrator wants to include
         //are returned from the directory
@@ -271,7 +266,10 @@ public class LdapUserProvider implements UserProvider {
         }
         for (String field:fields) {
             String attribute = searchFields.get(field);
-            filter.append("(").append(attribute).append("=").append(query).append(")");
+            // Make the query be a wildcard search by default. So, if the user searches for
+            // "John", make the sanitized search be "John*" instead.
+            filter.append("(").append(attribute).append("=")
+            	.append(LdapManager.sanitizeSearchFilter(query)).append("*)");
         }
         if (fields.size() > 1) {
             filter.append(")");

--- a/src/test/java/org/jivesoftware/util/LDAPTest.java
+++ b/src/test/java/org/jivesoftware/util/LDAPTest.java
@@ -9,10 +9,12 @@
  */
 package org.jivesoftware.util;
 
+import static org.junit.Assert.assertTrue;
+
+import javax.naming.ldap.Rdn;
+
 import org.jivesoftware.openfire.ldap.LdapManager;
 import org.junit.Test;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Daniel Henninger
@@ -34,6 +36,47 @@ public class LDAPTest {
         before = "ou=jive,dc=test,dc=jive,dc=com";
         after = "ou=\"jive\",dc=\"test\",dc=\"jive\",dc=\"com\"";
         converted = LdapManager.getEnclosedDN(before);
+        assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
+    }
+
+    @Test
+    public void testRdnEscapeValue() {
+        String before = "Jive Software, Inc";
+        String after = "Jive Software\\, Inc";
+        String converted = Rdn.escapeValue(before);
+        assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
+        
+        before = "Test.User; (+1)";
+        after = "Test.User\\; (\\+1)";
+        converted = Rdn.escapeValue(before);
+        assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
+        
+        before = "Wildcard *";
+        after = "Wildcard *";
+        converted = Rdn.escapeValue(before);
+        assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
+        
+        before = "Group/Section";
+        after = "Group/Section";
+        converted = Rdn.escapeValue(before);
+        assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
+    }
+
+    @Test
+    public void testSanitizeSearchFilter() {
+        String before = "Test.User; (+1)";
+        String after = "Test.User; \\28+1\\29";
+        String converted = LdapManager.sanitizeSearchFilter(before);
+        assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
+
+        before = "Wildcard *";
+        after = "Wildcard \\2a";
+        converted = LdapManager.sanitizeSearchFilter(before);
+        assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
+        
+        before = "~ Group|Section & Teams!";
+        after = "\\7e Group\\7cSection \\26 Teams\\21";
+        converted = LdapManager.sanitizeSearchFilter(before);
         assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
     }
 }


### PR DESCRIPTION
Updated LDAP components to escape special characters in user and group
search filters, including JID (un)escaping where appropriate.
