### PR TITLE
Fix Rostermanager remove shane group admin exception

### DIFF
--- a/src/java/org/jivesoftware/openfire/roster/RosterManager.java
+++ b/src/java/org/jivesoftware/openfire/roster/RosterManager.java
@@ -487,8 +487,9 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
         }
     }
 
+    @Override
     public void adminRemoved(Group group, Map params) {
-        JID deletedUser = new JID((String) params.get("admin"));
+        JID deletedUser = new JID( (String) params.get("member"));
         // Do nothing if the user is still a member
         if (group.getMembers().contains(deletedUser)) {
             return;


### PR DESCRIPTION
Fix Rostermanager remove shane group admin exception

Management Console listener parameter error when deleting group administrator
