### PR TITLE
fix enabling https admin port without http enabled

### DIFF
--- a/src/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
+++ b/src/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
@@ -165,7 +165,8 @@ public class AdminConsolePlugin implements Plugin {
 					httpsConnector = new HTTPSPDYServerConnector(adminServer, sslContextFactory);
 
 				} else {
-					HttpConfiguration httpsConfig = new HttpConfiguration(httpConfig);
+					HttpConfiguration httpsConfig = new HttpConfiguration();
+					httpsConfig.setSendServerVersion( false );
 					httpsConfig.setSecureScheme("https");
 					httpsConfig.setSecurePort(adminSecurePort);
 					httpsConfig.addCustomizer(new SecureRequestCustomizer());


### PR DESCRIPTION
If the http admin port is disabled enabling https fails because it tries to copy from an uninitialized httpd configuration. An exception is generated and the server runs but you have no admin interfaces.

The only httpd configuration parameter that might have needed to be copied is setSendServerVersion. This just makes a new 'empty' connection and sets that parameter before continuing on as usual.

According to the documentation you're supposed to be able to use https admin without http admin. This situation appears to be a side effect of some code changes later on where someone just forgot to consider this.

More info here in my bug report:
https://igniterealtime.jiveon.com/message/241471
