### PR TITLE
Doesn't filter iq results that needs to be delivered to local muc users.

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
@@ -368,10 +368,6 @@ public class LocalMUCUser implements MUCUser {
     }
 
     public void process(IQ packet) {
-        // Ignore IQs of type ERROR sent to a room
-        if (IQ.Type.error == packet.getType()) {
-            return;
-        }
         lastPacketTime = System.currentTimeMillis();
         JID recipient = packet.getTo();
         String group = recipient.getNode();
@@ -386,7 +382,8 @@ public class LocalMUCUser implements MUCUser {
             if (role == null) {
                 sendErrorPacket(packet, PacketError.Condition.not_authorized);
             }
-            else if (IQ.Type.result == packet.getType()) {
+            else if (IQ.Type.result == packet.getType()
+                    || IQ.Type.error == packet.getType()) {
                 // Only process IQ result packet if it's a private packet sent to another
                 // room occupant
                 if (packet.getTo().getResource() != null) {


### PR DESCRIPTION
Doesn't filter iq results that needs to be delivered to local muc users. This one reverts a fix for https://igniterealtime.org/issues/browse/OF-772 (https://github.com/igniterealtime/Openfire/commit/b94b52e5e7ee32359fbe5a4747a9c67610203849). But iq queries and results between muc users are correct and there is no need to filter them.
