### PR TITLE
Change OF min version to 3.9.4

### DIFF
--- a/src/plugins/hazelcast/plugin.xml
+++ b/src/plugins/hazelcast/plugin.xml
@@ -7,5 +7,5 @@
     <author>Tom Evans</author>
     <version>1.3.1</version>
     <date>10/15/2014</date>
-    <minServerVersion>3.10.0</minServerVersion>
+    <minServerVersion>3.9.4</minServerVersion>
 </plugin>

--- a/src/plugins/ofmeet/plugin.xml
+++ b/src/plugins/ofmeet/plugin.xml
@@ -7,7 +7,7 @@
     <author></author>
     <version>0.0.2</version>
     <date>11/30/2014</date>
-    <minServerVersion>3.10.0</minServerVersion>
+    <minServerVersion>3.9.4</minServerVersion>
     
     <adminconsole>
         <tab id="tab-ofmeet" name="${plugin.title}" url="ofmeet-summary.jsp" description="${plugin.description}">

--- a/src/plugins/xmldebugger/plugin.xml
+++ b/src/plugins/xmldebugger/plugin.xml
@@ -10,7 +10,7 @@
     <author>Jive Software</author>
     <version>1.4.0</version>
     <date>10/20/2014</date>
-    <minServerVersion>3.10.0</minServerVersion>
+    <minServerVersion>3.9.4</minServerVersion>
 
    <adminconsole>
       <tab id="tab-server">


### PR DESCRIPTION
Since OF 3.9.3 has a bug whereby it thinks 3.10.0 is older than 3.9.3,
this causes a problem as OF 3.9.3 will attempt to install plugins that
it can not run.  This change puts the 3.10.0 plugins at a release that
will not happen, which keeps them affectively from getting installed.
