### PR TITLE
Don't return incorrect-encoding when receiving '='

### DIFF
--- a/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -84,7 +84,8 @@ public class SASLAuthentication {
 	private static final Logger Log = LoggerFactory.getLogger(SASLAuthentication.class);
 
     // http://stackoverflow.com/questions/8571501/how-to-check-whether-the-string-is-base64-encoded-or-not
-    private static final Pattern BASE64_ENCODED = Pattern.compile("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$");
+    // plus an extra regex alternative to catch a single equals sign ('=', see RFC 6120 6.4.2)
+    private static final Pattern BASE64_ENCODED = Pattern.compile("^(=|([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==))$");
 
     /**
      * The utf-8 charset for decoding and encoding Jabber packet streams.


### PR DESCRIPTION
when performing SASL authentication.

Since 3eadecb67daddbcaeb1dc76ec578ed0f70e96ad8 Openfire would return
incorrect-encoding when a SASL auth packet would contain just a single
equals sign ('='). But this is correct (client) behavior according to
RFC 6120 6.4.2.

Related to OF-736

07:25:42 PM SENT (2109957412): <stream:stream xmlns='jabber:client' to='igniterealtime.org' xmlns:stream='http://etherx.jabber.org/streams' version='1.0'>
07:25:42 PM RCV  (2109957412): <?xml version='1.0' encoding='UTF-8'?><stream:stream xmlns:stream="http://etherx.jabber.org/streams" xmlns="jabber:client" from="igniterealtime.org" id="1d96e3b3" xml:lang="en" version="1.0">
07:25:43 PM RCV  (2109957412): stream:features<starttls xmlns="urn:ietf:params:xml:ns:xmpp-tls"></starttls><mechanisms xmlns="urn:ietf:params:xml:ns:xmpp-sasl"><mechanism>DIGEST-MD5</mechanism><mechanism>JIVE-SHAREDSECRET</mechanism><mechanism>PLAIN</mechanism><mechanism>ANONYMOUS</mechanism><mechanism>CRAM-MD5</mechanism></mechanisms><compression xmlns="http://jabber.org/features/compress"><method>zlib</method></compression><auth xmlns="http://jabber.org/features/iq-auth"/><register xmlns="http://jabber.org/features/iq-register"/>/stream:features
07:25:43 PM SENT (2109957412): <auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='DIGEST-MD5'>=</auth>
07:25:43 PM RCV  (2109957412): <failure
xmlns="urn:ietf:params:xml:ns:xmpp-sasl"><incorrect-encoding/></failure>
