### PR TITLE
OF-859: Pubsub fix; misc cleanup

### DIFF
--- a/src/java/org/jivesoftware/database/SequenceManager.java
+++ b/src/java/org/jivesoftware/database/SequenceManager.java
@@ -70,8 +70,8 @@ public class SequenceManager {
 
     static {
         new SequenceManager(JiveConstants.ROSTER, 5);
-        new SequenceManager(JiveConstants.OFFLINE, 1);
-        new SequenceManager(JiveConstants.MUC_ROOM, 1);
+        new SequenceManager(JiveConstants.OFFLINE, 5);
+        new SequenceManager(JiveConstants.MUC_ROOM, 5);
     }
 
     /**
@@ -237,7 +237,7 @@ public class SequenceManager {
         }
 
         if (!success) {
-            Log.error("WARNING: failed to obtain next ID block due to " +
+            Log.warn("WARNING: failed to obtain next ID block due to " +
                     "thread contention. Trying again...");
             // Call this method again, but sleep briefly to try to avoid thread contention.
             try {

--- a/src/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -31,7 +31,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.dom4j.Element;
 import org.jivesoftware.openfire.SessionManager;
-import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.pubsub.cluster.AffiliationTask;
 import org.jivesoftware.openfire.pubsub.cluster.CancelSubscriptionTask;
@@ -57,7 +56,6 @@ import org.xmpp.packet.Message;
  * @author Matt Tucker
  */
 public abstract class Node {
-	public static final String PUBSUB_SVC_ID = XMPPServer.getInstance().getPubSubModule().getServiceID();
 
     /**
      * Reference to the publish and subscribe service.

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceManager.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceManager.java
@@ -1627,9 +1627,6 @@ public class PubSubPersistenceManager {
             DbConnectionManager.closeConnection(rs, pstmt, con);
         }
 
-        if (results.size() == 0)
-			return Collections.emptyList();
-
         return results;
     }
 

--- a/src/java/org/jivesoftware/openfire/pubsub/PublishedItem.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PublishedItem.java
@@ -136,7 +136,7 @@ public class PublishedItem implements Serializable {
     	if (node == null) {
 			synchronized (this) {
 				if (node == null) {
-					if (Node.PUBSUB_SVC_ID.equals(serviceId))
+					if (XMPPServer.getInstance().getPubSubModule().getServiceID().equals(serviceId))
 					{
 						node = (LeafNode) XMPPServer.getInstance().getPubSubModule().getNode(nodeId);
 					}

--- a/src/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
@@ -43,7 +43,7 @@ public abstract class NodeTask implements ClusterTask
 
 	public PubSubService getService()
 	{
-		if (Node.PUBSUB_SVC_ID.equals(serviceId))
+		if (XMPPServer.getInstance().getPubSubModule().getServiceID().equals(serviceId))
 			return XMPPServer.getInstance().getPubSubModule();
 		else
 		{

--- a/src/java/org/jivesoftware/util/LocaleUtils.java
+++ b/src/java/org/jivesoftware/util/LocaleUtils.java
@@ -370,9 +370,13 @@ public class LocaleUtils {
     public static String getLocalizedString(String key) {
         Locale locale = JiveGlobals.getLocale();
 
-        ResourceBundle bundle = ResourceBundle.getBundle(resourceBaseName, locale);
-
-        return getLocalizedString(key, locale, null, bundle);
+        try {
+        	ResourceBundle bundle = ResourceBundle.getBundle(resourceBaseName, locale);
+        	return getLocalizedString(key, locale, null, bundle);
+        } catch (MissingResourceException mre) {
+        	Log.error(mre.getMessage());
+        	return key;
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes a problem with a static final reference in the Node.class. It
also addresses a couple of minor issues discovered during pubsub
testing:
- PubSubPersistenceManager should return an editable collection rather
  than a read-only collection for published items
- SequenceManager defaults should use a blocksize of 5 for frequently
  used tables
- LocaleUtils should catch and log a MissingResourceException and return
  the key in lieu of the missing value (by convention)
