### PR TITLE
OF-857: Improve thread pool management

### DIFF
--- a/src/java/org/jivesoftware/openfire/http/HttpSessionManager.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpSessionManager.java
@@ -88,7 +88,7 @@ public class HttpSessionManager {
         
         int maxPoolSize = JiveGlobals.getIntProperty("xmpp.httpbind.worker.threads", 
 				// use deprecated property as default (shared with ConnectionManagerImpl)
-				JiveGlobals.getIntProperty("xmpp.client.processing.threads", 16));
+				JiveGlobals.getIntProperty("xmpp.client.processing.threads", 8));
         int keepAlive = JiveGlobals.getIntProperty("xmpp.httpbind.worker.timeout", 60);
 
         sendPacketPool = new ThreadPoolExecutor(getCorePoolSize(maxPoolSize), maxPoolSize, keepAlive, TimeUnit.SECONDS, 


### PR DESCRIPTION
Update default QTP configuration for admin console and BOSH connectors;
added new configuration property "adminConsole.serverThreads" with a
default of 2
