### PR TITLE
OF-857: Properly configure Jetty connectors

### DIFF
--- a/src/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
+++ b/src/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
@@ -121,10 +121,11 @@ public class AdminConsolePlugin implements Plugin {
         if (adminPort > 0) {
 			httpConfig = new HttpConfiguration();
 
-            httpConnector = new ServerConnector(adminServer, -1, serverThreads);
         	// Do not send Jetty info in HTTP headers
 			httpConfig.setSendServerVersion( false );
-            httpConnector.addConnectionFactory(new HttpConnectionFactory(httpConfig));
+            httpConnector = new ServerConnector(adminServer, null, null, null, -1, serverThreads, 
+            		new HttpConnectionFactory(httpConfig));
+
             // Listen on a specific network interface if it has been set.
             String bindInterface = getBindInterface();
             httpConnector.setHost(bindInterface);
@@ -165,9 +166,8 @@ public class AdminConsolePlugin implements Plugin {
 					HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpsConfig);
 					SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(sslContextFactory, org.eclipse.jetty.http.HttpVersion.HTTP_1_1.toString());
 
-                	httpsConnector = new ServerConnector(adminServer, -1, serverThreads);
-                	httpsConnector.addConnectionFactory(sslConnectionFactory);
-                	httpsConnector.addConnectionFactory(httpConnectionFactory);
+                	httpsConnector = new ServerConnector(adminServer, null, null, null, -1, serverThreads, 
+                			sslConnectionFactory, httpConnectionFactory);
 				}
 
                 String bindInterface = getBindInterface();

--- a/src/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -200,8 +200,8 @@ public final class HttpBindManager {
         if (port > 0) {
 			HttpConfiguration httpConfig = new HttpConfiguration();
 			configureProxiedConnector(httpConfig);
-            ServerConnector connector = new ServerConnector(httpBindServer, -1, bindThreads);
-            connector.addConnectionFactory(new HttpConnectionFactory(httpConfig));
+            ServerConnector connector = new ServerConnector(httpBindServer, null, null, null, -1, bindThreads, 
+            		new HttpConnectionFactory(httpConfig));
 
             // Listen on a specific network interface if it has been set.
             connector.setHost(getBindInterface());
@@ -253,9 +253,8 @@ public final class HttpBindManager {
 					sslConnector = new HTTPSPDYServerConnector(httpBindServer, sslContextFactory);
 				} else {
 
-					sslConnector = new ServerConnector(httpBindServer, -1, bindThreads); 
-					sslConnector.addConnectionFactory(new SslConnectionFactory(sslContextFactory, "http/1.1"));
-					sslConnector.addConnectionFactory(new HttpConnectionFactory(httpsConfig));
+					sslConnector = new ServerConnector(httpBindServer, null, null, null, -1, bindThreads, 
+							new SslConnectionFactory(sslContextFactory, "http/1.1"), new HttpConnectionFactory(httpsConfig)); 
 				}
                 sslConnector.setHost(getBindInterface());
                 sslConnector.setPort(securePort);


### PR DESCRIPTION
Update for earlier fix to properly construct and initialize HTTP/S connectors using configurable resource limits.
