### PR TITLE
Disable SSLv3 for socket connections to avoid POODLE vulnerability.

### DIFF
--- a/src/java/org/jivesoftware/openfire/nio/ConnectionHandler.java
+++ b/src/java/org/jivesoftware/openfire/nio/ConnectionHandler.java
@@ -38,6 +38,8 @@ import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
 import org.xmpp.packet.StreamError;
 
+import javax.net.ssl.SSLHandshakeException;
+
 /**
  * A ConnectionHandler is responsible for creating new sessions, destroying sessions and delivering
  * received XML stanzas to the proper StanzaHandler.
@@ -146,6 +148,9 @@ public abstract class ConnectionHandler extends IoHandlerAdapter {
         if (cause instanceof IOException) {
             // TODO Verify if there were packets pending to be sent and decide what to do with them
             Log.info("ConnectionHandler reports IOException for session: " + session, cause);
+            if (cause instanceof SSLHandshakeException) {
+                session.close(true);
+            }
         }
         else if (cause instanceof ProtocolDecoderException) {
             Log.warn("Closing session due to exception: " + session, cause);
@@ -157,7 +162,7 @@ public abstract class ConnectionHandler extends IoHandlerAdapter {
             } else {
             	error = new StreamError(StreamError.Condition.internal_server_error);
             }
-            
+
             final Connection connection = (Connection) session.getAttribute(CONNECTION);
             connection.deliverRawText(error.toXML());
             session.close(true);

--- a/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
+++ b/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
@@ -367,6 +367,8 @@ public class NIOConnection implements Connection {
 
         SslFilter filter = new SslFilter(tlsContext);
         filter.setUseClientMode(clientMode);
+        // Disable SSLv3 due to POODLE vulnerability.
+        filter.setEnabledProtocols(new String[]{"TLSv1", "TLSv1.1", "TLSv1.2"});
         if (authentication == ClientAuth.needed) {
             filter.setNeedClientAuth(true);
         }


### PR DESCRIPTION
This is my take to disable SSLv3 for socket connections on port 5222. (There was another PR for admin console and BOSH). See OF-861.

I've tested it with a client, which only supports SSLv3 and it will receive the following exception during handshake then:
javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure
