### PR TITLE
OF-629: Here Lies XMPP Session

### DIFF
--- a/src/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -178,6 +178,7 @@ public class HttpSession extends LocalClientSession {
 
         Element session = DocumentHelper.createElement(new QName("session",
                 new Namespace("", "urn:ietf:params:xml:ns:xmpp-session")));
+        session.addElement("optional");
         elements.add(session);
         return elements;
     }

--- a/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -804,7 +804,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
             // If the session has been authenticated then offer resource binding
             // and session establishment
             sb.append("<bind xmlns=\"urn:ietf:params:xml:ns:xmpp-bind\"/>");
-            sb.append("<session xmlns=\"urn:ietf:params:xml:ns:xmpp-session\"/>");
+            sb.append("<session xmlns=\"urn:ietf:params:xml:ns:xmpp-session\"><optional/></session>");
         }
         return sb.toString();
     }


### PR DESCRIPTION
Update the advertised stream features to mark the xmpp-session capability as optional (per
http://tools.ietf.org/html/draft-cridland-xmpp-session-01). Current implementation is already no-op.
