### PR TITLE
Removed chopping by @ character in the URL, to get MUC Plugin running

### DIFF
--- a/src/java/org/jivesoftware/admin/AuthCheckFilter.java
+++ b/src/java/org/jivesoftware/admin/AuthCheckFilter.java
@@ -86,11 +86,6 @@ public class AuthCheckFilter implements Filter {
         // in the URL and then the resulting url must exactly match the exclude rule. If the exclude ends with a "*"
         // character then the URL is allowed if it exactly matches everything before the * and there are no ".."
         // characters after the "*". All data in the URL before
-        // the "@" character is chopped.
-
-        if (url.contains("@")) {
-            url = url.substring(url.indexOf("@"));
-        }
 
         if (exclude.endsWith("*")) {
             if (url.startsWith(exclude.substring(0, exclude.length()-1))) {

--- a/src/test/java/org/jivesoftware/admin/AuthCheckFilterTest.java
+++ b/src/test/java/org/jivesoftware/admin/AuthCheckFilterTest.java
@@ -25,8 +25,6 @@ public class AuthCheckFilterTest {
 
         assertTrue(AuthCheckFilter.testURLPassesExclude("setup/setup-new.jsp","setup/setup-*"));
 
-        // Let's get crafty by using an "@" symbol
-        assertFalse(AuthCheckFilter.testURLPassesExclude("login.jsp?@another.jsp", "login.jsp"));
         assertFalse(AuthCheckFilter.testURLPassesExclude("another.jsp?login.jsp", "login.jsp"));
     }
 }


### PR DESCRIPTION
I don't see any reason why the URL need to be chopped at the @ char. 
If so, please let me know.

Additionally it breaks one functionality in the MUC Plugin (to add / remove user role from a channel) 
The MUC Plugin mentioned problem: https://community.igniterealtime.org/thread/53822