### PR TITLE
OF-855: Ensure valid connection for session packets

### DIFF
--- a/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -854,8 +854,13 @@ public class LocalClientSession extends LocalSession implements ClientSession {
 
     @Override
 	public void deliver(Packet packet) throws UnauthorizedException {
-        if (conn != null && !conn.isClosed()) {
+        if (conn != null) {
             conn.deliver(packet);
+        } else {
+        	// invalid session; clean up and retry delivery (offline)
+        	Log.error("Failed to deliver packet to invalid session (no connection); will retry");
+        	sessionManager.removeSession(this);
+        	XMPPServer.getInstance().getPacketDeliverer().deliver(packet);
         }
     }
 


### PR DESCRIPTION
Check the underlying connection for a given session before delivering a
packet; if the connection is missing, clean up session and resend packet