### PR TITLE
OF-855/OF-857 improvements

### DIFF
--- a/src/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -134,8 +134,7 @@ public class HttpSession extends LocalClientSession {
 
     public HttpSession(PacketDeliverer backupDeliverer, String serverName, InetAddress address,
                        StreamID streamID, long rid, HttpConnection connection) {
-        super(serverName, null, streamID);
-        conn = new HttpVirtualConnection(address);
+        super(serverName, new HttpVirtualConnection(address), streamID);
         this.isClosed = false;
         this.lastActivity = System.currentTimeMillis();
         this.lastRequestID = rid;

--- a/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -854,14 +854,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
 
     @Override
 	public void deliver(Packet packet) throws UnauthorizedException {
-        if (conn != null) {
-            conn.deliver(packet);
-        } else {
-        	// invalid session; clean up and retry delivery (offline)
-        	Log.error("Failed to deliver packet to invalid session (no connection); will retry");
-        	sessionManager.removeSession(this);
-        	XMPPServer.getInstance().getPacketDeliverer().deliver(packet);
-        }
+        conn.deliver(packet);
     }
 
     @Override

--- a/src/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
@@ -302,7 +302,7 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
 
     @Override
 	void deliver(Packet packet) throws UnauthorizedException {
-        if (conn != null && !conn.isClosed()) {
+        if (!conn.isClosed()) {
             conn.deliver(packet);
         }
     }

--- a/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -611,7 +611,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
 
     @Override
 	void deliver(Packet packet) throws UnauthorizedException {
-        if (conn != null && !conn.isClosed()) {
+        if (!conn.isClosed()) {
             conn.deliver(packet);
         }
     }

--- a/src/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -75,7 +75,7 @@ public abstract class LocalSession implements Session {
     /**
      * The connection that this session represents.
      */
-    protected Connection conn;
+    protected final Connection conn;
 
     protected SessionManager sessionManager;
 
@@ -101,6 +101,9 @@ public abstract class LocalSession implements Session {
      * @param streamID unique identifier for this session.
      */
     public LocalSession(String serverName, Connection connection, StreamID streamID) {
+        if (connection == null) {
+            throw new IllegalArgumentException("connection must not be null");
+        }
         conn = connection;
         this.streamID = streamID;
         this.serverName = serverName;
@@ -328,9 +331,7 @@ public abstract class LocalSession implements Session {
     abstract void deliver(Packet packet) throws UnauthorizedException;
 
     public void deliverRawText(String text) {
-        if (conn != null) {
-            conn.deliverRawText(text);
-        }
+        conn.deliverRawText(text);
     }
 
     /**
@@ -342,9 +343,7 @@ public abstract class LocalSession implements Session {
     public abstract String getAvailableStreamFeatures();
 
     public void close() {
-        if (conn != null) {
-            conn.close();
-        }
+        conn.close();
     }
 
     public boolean validate() {


### PR DESCRIPTION
I'm pretty sure that 4158dd77e4776fa263373e7cb83467ebd5cd3e6d is sound. 7bbfb9dbc49600ea8ffd02129909c152a2f73a72 should be too since I doubt that there is a case where Connection in the constructor is null. But since I don't longer have a Openfire instance to test I can't confirm it.