### PR TITLE
OF-857: Synchronize connection/session cleanup

### DIFF
--- a/src/java/org/jivesoftware/openfire/OfflineMessageStrategy.java
+++ b/src/java/org/jivesoftware/openfire/OfflineMessageStrategy.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 import org.xmpp.packet.PacketError;
+import org.xmpp.packet.PacketExtension;
 
 /**
  * Controls what is done with offline messages.
@@ -80,9 +81,11 @@ public class OfflineMessageStrategy extends BasicModule {
     public void storeOffline(Message message) {
         if (message != null) {
             // Do nothing if the message was sent to the server itself, an anonymous user or a non-existent user
+        	// Also ignore message carbons
             JID recipientJID = message.getTo();
             if (recipientJID == null || serverAddress.equals(recipientJID) ||
                     recipientJID.getNode() == null ||
+                    message.getExtension("received", "urn:xmpp:carbons:2") != null ||
                     !UserManager.getInstance().isRegisteredUser(recipientJID.getNode())) {
                 return;
             }

--- a/src/java/org/jivesoftware/openfire/SessionManager.java
+++ b/src/java/org/jivesoftware/openfire/SessionManager.java
@@ -641,7 +641,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener 
         JID searchJID = new JID(originatingResource.getNode(), originatingResource.getDomain(), null);
         List<JID> addresses = routingTable.getRoutes(searchJID, null);
         for (JID address : addresses) {
-        	if (originatingResource != address) {
+        	if (!originatingResource.equals(address)) {
 	            // Send the presence of the session whose presence has changed to
 	            // this user's other session(s)
 	            presence.setTo(address);

--- a/src/java/org/jivesoftware/openfire/SessionManager.java
+++ b/src/java/org/jivesoftware/openfire/SessionManager.java
@@ -641,10 +641,12 @@ public class SessionManager extends BasicModule implements ClusterEventListener 
         JID searchJID = new JID(originatingResource.getNode(), originatingResource.getDomain(), null);
         List<JID> addresses = routingTable.getRoutes(searchJID, null);
         for (JID address : addresses) {
-            // Send the presence of the session whose presence has changed to
-            // this other user's session
-            presence.setTo(address);
-            routingTable.routePacket(address, presence, false);
+        	if (originatingResource != address) {
+	            // Send the presence of the session whose presence has changed to
+	            // this user's other session(s)
+	            presence.setTo(address);
+	            routingTable.routePacket(address, presence, false);
+        	}
         }
     }
 

--- a/src/java/org/jivesoftware/openfire/nio/ClientConnectionHandler.java
+++ b/src/java/org/jivesoftware/openfire/nio/ClientConnectionHandler.java
@@ -50,7 +50,7 @@ public class ClientConnectionHandler extends ConnectionHandler {
 
     @Override
 	NIOConnection createNIOConnection(IoSession session) {
-        return new NIOConnection(session, XMPPServer.getInstance().getPacketDeliverer());
+        return new NIOConnection(session, new OfflinePacketDeliverer());
     }
 
     @Override

--- a/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
+++ b/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
@@ -215,8 +215,8 @@ public class NIOConnection implements Connection {
             if (session != null) {
                 session.setStatus(Session.STATUS_CLOSED);
             }
-            notifyCloseListeners(); // clean up session, etc.
             closed = true;
+            notifyCloseListeners(); // clean up session, etc.
     	}
         ioSession.close(false); // async via MINA
     }

--- a/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
+++ b/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
@@ -203,25 +203,22 @@ public class NIOConnection implements Connection {
     }
 
     public void close() {
-        boolean closedSuccessfully = false;
-        synchronized (this) {
-            if (!isClosed()) {
-                try {
-                    deliverRawText(flashClient ? "</flash:stream>" : "</stream:stream>", false);
-                } catch (Exception e) {
-                    // Ignore
-                }
-                if (session != null) {
-                    session.setStatus(Session.STATUS_CLOSED);
-                }
-                ioSession.close(false);
-                closed = true;
-                closedSuccessfully = true;
+    	synchronized(this) {
+    		if (isClosed()) {
+    			return;
+    		}
+            try {
+                deliverRawText(flashClient ? "</flash:stream>" : "</stream:stream>", false);
+            } catch (Exception e) {
+                // Ignore
             }
-        }
-        if (closedSuccessfully) {
-            notifyCloseListeners();
-        }
+            if (session != null) {
+                session.setStatus(Session.STATUS_CLOSED);
+            }
+            notifyCloseListeners(); // clean up session, etc.
+            closed = true;
+    	}
+        ioSession.close(false); // async via MINA
     }
 
     public void systemShutdown() {
@@ -248,11 +245,8 @@ public class NIOConnection implements Connection {
         session = owner;
     }
 
-    public boolean isClosed() {
-        if (session == null) {
-            return closed;
-        }
-        return session.getStatus() == Session.STATUS_CLOSED;
+    public synchronized boolean isClosed() {
+        return closed;
     }
 
     public boolean isSecure() {

--- a/src/java/org/jivesoftware/openfire/nio/OfflinePacketDeliverer.java
+++ b/src/java/org/jivesoftware/openfire/nio/OfflinePacketDeliverer.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2005-2015 Jive Software. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.nio;
+
+import org.jivesoftware.openfire.OfflineMessageStrategy;
+import org.jivesoftware.openfire.PacketDeliverer;
+import org.jivesoftware.openfire.PacketException;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.auth.UnauthorizedException;
+import org.jivesoftware.util.LocaleUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.IQ;
+import org.xmpp.packet.Message;
+import org.xmpp.packet.Packet;
+import org.xmpp.packet.Presence;
+
+/**
+ * Fallback method used by {@link org.jivesoftware.openfire.nio.NIOConnection} when a 
+ * connection fails to send a {@link Packet} (likely because it was closed). Message packets
+ * will be stored offline for later retrieval. IQ and Presence packets are dropped.<p>
+ *
+ * @author Tom Evans
+ */
+public class OfflinePacketDeliverer implements PacketDeliverer {
+
+	private static final Logger Log = LoggerFactory.getLogger(OfflinePacketDeliverer.class);
+
+	private OfflineMessageStrategy messageStrategy;
+
+    public OfflinePacketDeliverer() {
+        this.messageStrategy = XMPPServer.getInstance().getOfflineMessageStrategy();
+    }
+
+    @Override
+	public void deliver(Packet packet) throws UnauthorizedException, PacketException {
+    	
+        if (packet instanceof Message) {
+            messageStrategy.storeOffline((Message) packet);
+        }
+        else if (packet instanceof Presence) {
+            // presence packets are dropped silently
+        }
+        else if (packet instanceof IQ) {
+            // IQ packets are logged before being dropped
+            Log.warn(LocaleUtils.getLocalizedString("admin.error.routing") + "\n" + packet.toString());
+        }
+	}
+
+}


### PR DESCRIPTION
This patch is to prevent a stack overflow in certain exception cases
where a connection has been closed, but its corresponding session is
still present in the routing table. The patch synchronizes the internal
connection close logic before handing the connection back to mina to 
close the IoSession asynchronously.