### PR TITLE
OF-866: Prevent "session not found" errors

### DIFF
--- a/src/java/org/jivesoftware/openfire/SessionManager.java
+++ b/src/java/org/jivesoftware/openfire/SessionManager.java
@@ -548,10 +548,10 @@ public class SessionManager extends BasicModule implements ClusterEventListener 
      * @param session the session that was authenticated.
      */
     public void addSession(LocalClientSession session) {
-        // Remove the pre-Authenticated session but remember to use the temporary ID as the key
-        localSessionManager.getPreAuthenticatedSessions().remove(session.getStreamID().toString());
         // Add session to the routing table (routing table will know session is not available yet)
         routingTable.addClientRoute(session.getAddress(), session);
+        // Remove the pre-Authenticated session but remember to use the temporary ID as the key
+        localSessionManager.getPreAuthenticatedSessions().remove(session.getStreamID().toString());
         SessionEventDispatcher.EventType event = session.getAuthToken().isAnonymous() ?
                 SessionEventDispatcher.EventType.anonymous_session_created :
                 SessionEventDispatcher.EventType.session_created;


### PR DESCRIPTION
Fixes an intermittent race condition observed under high load by adding a newly authenticated session into the core routing table before removing it from the list of pre-authenticated sessions.