### PR TITLE
Add -Dhalt.on.plugin.error=true to travis ant script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: java
-script: ant -f build/build.xml openfire test plugins
+script: ant -Dhalt.on.plugin.error=true -f build/build.xml openfire test plugins


### PR DESCRIPTION
So that travis-CI will error out when a plugin fails to build.  The default
action is to silently ignore and continue building.