### PR TITLE
OF-873 Openfire MUST return an empty query if no items are found (disco#...

### DIFF
--- a/src/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
+++ b/src/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
@@ -195,13 +195,11 @@ public class IQDiscoItemsHandler extends IQHandler implements ServerFeaturesProv
                 // If the DiscoItemsProvider has no items for the requested name and node 
                 // then answer a not found error
                 reply.setChildElement(packet.getChildElement().createCopy());
-                reply.setError(PacketError.Condition.item_not_found);
             }
         }
         else {
             // If we didn't find a DiscoItemsProvider then answer a not found error
             reply.setChildElement(packet.getChildElement().createCopy());
-            reply.setError(PacketError.Condition.item_not_found);
         }
 
         return reply;


### PR DESCRIPTION
...items) instead of an error.