### PR TITLE
Revert fix for OF-874 because it introduced a critical regression.

### DIFF
--- a/src/java/org/jivesoftware/openfire/SessionManager.java
+++ b/src/java/org/jivesoftware/openfire/SessionManager.java
@@ -88,7 +88,7 @@ import org.xmpp.packet.Presence;
  *
  * @author Derek DeMoro
  */
-public class SessionManager extends BasicModule implements ClusterEventListener, ServerItemsProvider, DiscoInfoProvider, DiscoItemsProvider {
+public class SessionManager extends BasicModule implements ClusterEventListener/*, ServerItemsProvider, DiscoInfoProvider, DiscoItemsProvider */{
 
 	private static final Logger Log = LoggerFactory.getLogger(SessionManager.class);
 
@@ -1171,7 +1171,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener,
         conflictLimit = limit;
         JiveGlobals.setProperty("xmpp.session.conflict-limit", Integer.toString(conflictLimit));
     }
-
+    /*
     @Override
     public Iterator<DiscoServerItem> getItems() {
         return Arrays.asList(new DiscoServerItem(serverAddress, null, null, null, this, this)).iterator();
@@ -1215,7 +1215,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener,
             return Collections.emptyIterator();
         }
     }
-
+    */
     private class ClientSessionListener implements ConnectionCloseListener {
         /**
          * Handle a session that just closed.
@@ -1374,7 +1374,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener,
         sessionInfoCache = CacheFactory.createCache(C2S_INFO_CACHE_NAME);
         // Listen to cluster events
         ClusterManager.addListener(this);
-        server.getIQDiscoItemsHandler().addServerItemsProvider(this);
+        //server.getIQDiscoItemsHandler().addServerItemsProvider(this);
     }
 
 

--- a/src/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/src/java/org/jivesoftware/openfire/XMPPServer.java
@@ -540,6 +540,7 @@ public class XMPPServer {
         loadModule(PrivateStorage.class.getName());
         // Load core modules
         loadModule(PresenceManagerImpl.class.getName());
+        loadModule(SessionManager.class.getName());
         loadModule(PacketRouterImpl.class.getName());
         loadModule(IQRouter.class.getName());
         loadModule(MessageRouter.class.getName());
@@ -579,8 +580,6 @@ public class XMPPServer {
         loadModule(PubSubModule.class.getName());
         loadModule(IQDiscoInfoHandler.class.getName());
         loadModule(IQDiscoItemsHandler.class.getName());
-        // SessionManager registers to IQDiscoItemsHandler, therefore load it after it.
-        loadModule(SessionManager.class.getName());
         loadModule(UpdateManager.class.getName());
         loadModule(FlashCrossDomainHandler.class.getName());
         loadModule(InternalComponentManager.class.getName());


### PR DESCRIPTION
Appearently there can only be one ServerItemsProvider. What happened here is that disco#items requests were now routed to SessionManager, which returned an empty result, which means service discovery fails.

It seems like Openfire can only host items for the whole server, not for single users, so the real fix needs some more investigation.

Original commit: 9c904ce569f1ce4facbab700a7be94318b5e4a3f