### PR TITLE
Fix parsing logic of CDATA in  XMLLightweightParser

### DIFF
--- a/src/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
+++ b/src/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
@@ -311,6 +311,10 @@ class XMLLightweightParser {
                         status = XMLLightweightParser.OUTSIDE;
                         cdataOffset = 0;
                     }
+                } else if (cdataOffset == XMLLightweightParser.CDATA_END.length-1 && ch == XMLLightweightParser.CDATA_END[cdataOffset - 1]) {
+                	// if we are looking for the last CDATA_END char, and we instead found an extra ']' 
+                	// char, leave cdataOffset as is and proceed to the next char. This could be a case 
+                	// where the XML character data ends with multiple square braces. For Example ]]]>
                 } else {
                     cdataOffset = 0;
                 }


### PR DESCRIPTION
If a CDATA section ends with the sequence ]]]> (note the preceding square brace) the XMLLightweightParser was not correctly detecting the end of the CDATA section.  This fixes how the XMLLightweightParser handles CDATA sections that end with ]]]> 