### PR TITLE
OF-888: Fix outgoing S2S packet delivery failure

### DIFF
--- a/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -637,6 +637,14 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
     private void returnErrorToSender(Packet packet) {
         RoutingTable routingTable = XMPPServer.getInstance().getRoutingTable();
         try {
+        	// OF-888 (outgoing S2S failure) Prevent recursion for failed delivery of error response packet
+        	String el = "ext";
+        	String ns = getClass().getName();
+        	if (packet.deleteExtension(el, ns)) {
+                Log.warn("Failed to route error to sender; remote server not found. Original packet: " + packet);
+                return;
+        	}
+        	packet.addExtension(new PacketExtension(el, ns));
             if (packet instanceof IQ) {
             	if (((IQ) packet).isResponse()) {
             		Log.debug("XMPP specs forbid us to respond with an IQ error to: " + packet.toXML());

--- a/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -62,6 +62,7 @@ import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 import org.xmpp.packet.Packet;
 import org.xmpp.packet.PacketError;
+import org.xmpp.packet.PacketExtension;
 import org.xmpp.packet.Presence;
 
 import com.jcraft.jzlib.JZlib;


### PR DESCRIPTION
Prevent recursion when attempting to send an error response packet via S2S to a non-responsive remote domain.