### PR TITLE
Send initial presence to the generating resource.

### DIFF
--- a/src/java/org/jivesoftware/openfire/SessionManager.java
+++ b/src/java/org/jivesoftware/openfire/SessionManager.java
@@ -594,7 +594,12 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
             routingTable.addClientRoute(session.getAddress(), session);
             // Broadcast presence between the user's resources
             broadcastPresenceOfOtherResource(session);
-            broadcastPresenceToOtherResources(session.getAddress(), presence);
+
+            // RFC 6121 § 4.4.2.
+            // The user's server MUST also send the presence stanza to all of the user's available resources (including the resource that generated the presence notification in the first place).
+            Presence selfPresence = presence.createCopy();
+            selfPresence.setTo(session.getAddress());
+            routingTable.routePacket(session.getAddress(), selfPresence, false);
         }
     }
 


### PR DESCRIPTION
This is for OF-454, which got fixed insufficiently in my opinion.
As per my tests, the broadcastPresenceToOtherResources (introduced with 3.9.0) made presences delivered twice to the other resources. I guess because normal presence routing logic already took care about routing to other resources.

However, it still didn't send initial presence to the generating resource (RFC 6121 § 4.4.2.).

I guess this is a critical part and there was some discussion in OF-454, so please review mindfully and merge with care.
I did some tests and it behaves as expected, but I'd like to have some other opinions/tests.