### PR TITLE
Add openjdk headless dependency to avoid installing X libraries

### DIFF
--- a/build/debian/control
+++ b/build/debian/control
@@ -9,7 +9,7 @@ Homepage: http://www.igniterealtime.org
 Package: openfire
 Section: net
 Priority: optional
-Pre-Depends: openjdk-7-jre | oracle-java7-jre
+Pre-Depends: openjdk-7-jre-headless | openjdk-7-jre | oracle-java7-jre
 Architecture: all
 Description: A high performance XMPP (Jabber) server.
  Openfire is an instant messaging server that implements the XMPP


### PR DESCRIPTION
When installing openfire 3.10 JRE 7 is required - that's good and I think it was one of my past PRs.
On one of my servers the installation fails because openjre is installed in headless (without X libraries) mode.

This PR adds the headless JRE to the dependencies as well.
```
# dpkg -i openfire_3.10.0_all.deb 
dpkg: regarding openfire_3.10.0_all.deb containing openfire, pre-dependency problem:
 openfire pre-depends on openjdk-7-jre | oracle-java7-jre
  openjdk-7-jre is not installed.
  oracle-java7-jre is not installed.
```