### PR TITLE
OF-909: Include ack in BOSH response body element

### DIFF
--- a/src/java/org/jivesoftware/openfire/http/HttpBindServlet.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpBindServlet.java
@@ -348,14 +348,6 @@ public class HttpBindServlet extends HttpServlet {
         sendLegacyError(context, error, null);
     }
 
-    protected static String createEmptyBody(boolean terminate)
-    {
-        final Element body = DocumentHelper.createElement("body");
-        if (terminate) { body.addAttribute("type", "terminate"); }
-        body.addNamespace("", "http://jabber.org/protocol/httpbind");
-        return body.asXML();
-    }
-
     protected static String createErrorBody(String type, String condition) {
         final Element body = DocumentHelper.createElement("body");
         body.addNamespace("", "http://jabber.org/protocol/httpbind");

--- a/src/java/org/jivesoftware/openfire/http/HttpBindServlet.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpBindServlet.java
@@ -299,9 +299,9 @@ public class HttpBindServlet extends HttpServlet {
         if (async) {
             response.getOutputStream().setWriteListener(new WriteListenerImpl(context, byteContent));
         } else {
-            // BOSH communication should not have Chunked encoding. Ensure that the
-            // buffer can hold the entire response to prevent chunking.
-            context.getResponse().setBufferSize(byteContent.length);
+            // BOSH communication should not use Chunked encoding.
+            // This is prevented by explicitly setting the Content-Length header.
+            context.getResponse().setContentLength(byteContent.length);
             context.getResponse().getOutputStream().write(byteContent);
             context.getResponse().getOutputStream().flush();
             context.complete();

--- a/src/java/org/jivesoftware/openfire/http/HttpConnection.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpConnection.java
@@ -122,9 +122,9 @@ public class HttpConnection {
         }
 
         if (body == null) {
-            body = HttpBindServlet.createEmptyBody(false);
+            body = getSession().createEmptyBody(false);
         }
-        HttpBindServlet.respond(this.getSession(), this.context, body, async);
+        HttpBindServlet.respond(getSession(), this.context, body, async);
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -710,7 +710,7 @@ public class HttpSession extends LocalClientSession {
                 try {
                     // If onTimeout does not result in a complete(), the container falls back to default behavior.
                     // This is why this body is to be delivered in a non-async fashion.
-                    connection.deliverBody(createEmptyBody(), false);
+                    connection.deliverBody(createEmptyBody(false), false);
                     setLastResponseEmpty(true);
 
                     // This connection timed out we need to increment the request count
@@ -1014,13 +1014,8 @@ public class HttpSession extends LocalClientSession {
 
     private String createDeliverable(Collection<Deliverable> elements) {
         StringBuilder builder = new StringBuilder();
-        builder.append("<body xmlns='" + "http://jabber.org/protocol/httpbind" + "'");
-
-        long ack = getLastAcknowledged();
-        if(ack > lastRequestID)
-            builder.append(" ack='").append(ack).append("'");
-
-        builder.append(">");
+        builder.append("<body xmlns='http://jabber.org/protocol/httpbind' ack='")
+        		.append(getLastAcknowledged()).append("'>");
 
         setLastResponseEmpty(elements.size() == 0);
         synchronized (elements) {
@@ -1095,20 +1090,12 @@ public class HttpSession extends LocalClientSession {
    		});
     }
 
-    private String createEmptyBody() {
-        Element body = DocumentHelper.createElement("body");
-        body.addNamespace("", "http://jabber.org/protocol/httpbind");
-        long ack = getLastAcknowledged();
-        if(ack > lastRequestID)
-        	body.addAttribute("ack", String.valueOf(ack));
-        return body.asXML();
-    }
-
-    protected static String createEmptyBody(boolean terminate)
+    protected String createEmptyBody(boolean terminate)
     {
         final Element body = DocumentHelper.createElement("body");
         if (terminate) { body.addAttribute("type", "terminate"); }
         body.addNamespace("", "http://jabber.org/protocol/httpbind");
+        body.addAttribute("ack", String.valueOf(getLastAcknowledged()));
         return body.asXML();
     }
 


### PR DESCRIPTION
Per spec, the ack attribute in the response <body/> allows a BOSH client
to verify that sent stanzas with the corresponding rid(s) have been
successfully received by the server.

This PR will merge to master. See #210 for corresponding change for the 3.10 branch.