### PR TITLE
Make module loading driven by a file

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1176,6 +1176,7 @@
 
         <copy tofile="${target.solaris.root}/pkginfo" file="${basedir}/build/pkg/pkginfo" />
         <copy tofile="${target.solaris.root}/opt/openfire/resources/solaris/openfire.xml" file="${basedir}/build/solaris/openfire.xml" />
+        <copy tofile="${target.solaris.root}/opt/openfire/resources/solaris/modules.xml" file="${basedir}/build/solaris/modules.xml" />
         <copy tofile="${target.solaris.root}/checkinstall" file="${basedir}/build/solaris/checkinstall" />
         <copy tofile="${target.solaris.root}/postinstall" file="${basedir}/build/solaris/postinstall" />
         <copy tofile="${target.solaris.root}/preremove" file="${basedir}/build/solaris/preremove" />
@@ -1187,6 +1188,7 @@
 
         <replaceregexp file="${target.solaris.root}/Prototype" match="(.* .* .* .*) .* .*" replace="\1 daemon daemon" byline="true"/>
         <replaceregexp file="${target.solaris.root}/Prototype" match=".* (.* /opt/openfire/conf/openfire.xml=.* .* .* .*)" replace="e \1" byline="true"/>
+        <replaceregexp file="${target.solaris.root}/Prototype" match=".* (.* /opt/openfire/conf/modules.xml=.* .* .* .*)" replace="e \1" byline="true"/>
         <replaceregexp file="${target.solaris.root}/Prototype" match=".* (.* /opt/openfire/resources/security/keystore=.* .* .* .*)" replace="e \1" byline="true"/>
         <replaceregexp file="${target.solaris.root}/Prototype" match=".* (.* /opt/openfire/resources/security/truststore=.* .* .* .*)" replace="e \1" byline="true"/>
         <replaceregexp file="${target.solaris.root}/Prototype" match=".* (.* /opt/openfire/resources/security/client.truststore=.* .* .* .*)" replace="e \1" byline="true"/>

--- a/build/debian/openfire.conffiles
+++ b/build/debian/openfire.conffiles
@@ -1,4 +1,5 @@
 /etc/openfire/openfire.xml
+/etc/openfire/modules.xml
 /etc/openfire/security.xml
 /etc/openfire/security/keystore
 /etc/openfire/security/truststore

--- a/build/installer/openfire.install4j
+++ b/build/installer/openfire.install4j
@@ -50,6 +50,7 @@
       <fileEntry mountPoint="34" file="${compiler:RELEASE_FULL_PATH}/resources/security/truststore" overwrite="0" shared="false" mode="644" uninstallMode="1" />
       <fileEntry mountPoint="34" file="${compiler:RELEASE_FULL_PATH}/resources/security/keystore" overwrite="0" shared="false" mode="644" uninstallMode="1" />
       <fileEntry mountPoint="46" file="${compiler:RELEASE_FULL_PATH}/conf/openfire.xml" overwrite="0" shared="false" mode="644" uninstallMode="1" />
+      <fileEntry mountPoint="46" file="${compiler:RELEASE_FULL_PATH}/conf/modules.xml" overwrite="0" shared="false" mode="644" uninstallMode="1" />
       <fileEntry mountPoint="46" file="${compiler:RELEASE_FULL_PATH}/conf/security.xml" overwrite="0" shared="false" mode="644" uninstallMode="1" />
       <dirEntry mountPoint="1" file="${compiler:RELEASE_FULL_PATH}" overwrite="4" shared="false" mode="644" uninstallMode="0" excludeSuffixes="" dirMode="755">
         <exclude>

--- a/build/rpm/openfire.spec
+++ b/build/rpm/openfire.spec
@@ -113,6 +113,7 @@ exit 0
 %{homedir}/bin/embedded-db-viewer.sh
 %dir %{homedir}/conf
 %config(noreplace) %{homedir}/conf/openfire.xml
+%config(noreplace) %{homedir}/conf/modules.xml
 %config(noreplace) %{homedir}/conf/security.xml
 %config(noreplace) %{homedir}/conf/crowd.properties
 %dir %{homedir}/lib

--- a/src/conf/modules.xml
+++ b/src/conf/modules.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+     This file stores the modules that make up the implementation of Openfire.  Modules are loaded
+     in the order they are specified in this file (top to bottom).
+     
+     Don't modify this file unless you really know what you are doing 
+ -->
+ 
+<jive>
+  <!--  Boot Modules -->
+  <module interface="org.jivesoftware.openfire.RoutingTable" implementation="org.jivesoftware.openfire.spi.RoutingTableImpl" />
+  <module interface="org.jivesoftware.openfire.audit.AuditManager" implementation="org.jivesoftware.openfire.audit.spi.AuditManagerImpl" />
+  <module interface="org.jivesoftware.openfire.roster.RosterManager" implementation="org.jivesoftware.openfire.roster.RosterManager" />
+  <module interface="org.jivesoftware.openfire.PrivateStorage" implementation="org.jivesoftware.openfire.PrivateStorage" />
+  
+  <!--  Core Modules -->  
+  <module interface="org.jivesoftware.openfire.PresenceManager" implementation="org.jivesoftware.openfire.spi.PresenceManagerImpl" />
+  <module interface="org.jivesoftware.openfire.SessionManager" implementation="org.jivesoftware.openfire.SessionManager" />
+  <module interface="org.jivesoftware.openfire.PacketRouter" implementation="org.jivesoftware.openfire.spi.PacketRouterImpl" />
+  <module interface="org.jivesoftware.openfire.IQRouter" implementation="org.jivesoftware.openfire.IQRouter" />
+  <module interface="org.jivesoftware.openfire.MessageRouter" implementation="org.jivesoftware.openfire.MessageRouter" />
+  <module interface="org.jivesoftware.openfire.PresenceRouter" implementation="org.jivesoftware.openfire.PresenceRouter" />
+  <module interface="org.jivesoftware.openfire.MulticastRouter" implementation="org.jivesoftware.openfire.MulticastRouter" />
+  <module interface="org.jivesoftware.openfire.spi.PacketTransporterImpl" implementation="org.jivesoftware.openfire.spi.PacketTransporterImpl" />
+  <module interface="org.jivesoftware.openfire.PacketDeliverer" implementation="org.jivesoftware.openfire.spi.PacketDelivererImpl" />
+  <module interface="org.jivesoftware.openfire.transport.TransportHandler" implementation="org.jivesoftware.openfire.transport.TransportHandler" />
+  <module interface="org.jivesoftware.openfire.OfflineMessageStrategy" implementation="org.jivesoftware.openfire.OfflineMessageStrategy" />
+  <module interface="org.jivesoftware.openfire.OfflineMessageStore" implementation="org.jivesoftware.openfire.OfflineMessageStore" />
+  <module interface="org.jivesoftware.openfire.vcard.VCardManager" implementation="org.jivesoftware.openfire.vcard.VCardManager" />
+  
+  <!--  Standard Modules -->  
+  <module interface="org.jivesoftware.openfire.handler.IQBindHandler" implementation="org.jivesoftware.openfire.handler.IQBindHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQSessionEstablishmentHandler" implementation="org.jivesoftware.openfire.handler.IQSessionEstablishmentHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQAuthHandler" implementation="org.jivesoftware.openfire.handler.IQAuthHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQPingHandler" implementation="org.jivesoftware.openfire.handler.IQPingHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQPrivateHandler" implementation="org.jivesoftware.openfire.handler.IQPrivateHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQRegisterHandler" implementation="org.jivesoftware.openfire.handler.IQRegisterHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQRosterHandler" implementation="org.jivesoftware.openfire.handler.IQRosterHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQTimeHandler" implementation="org.jivesoftware.openfire.handler.IQTimeHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQEntityTimeHandler" implementation="org.jivesoftware.openfire.handler.IQEntityTimeHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQvCardHandler" implementation="org.jivesoftware.openfire.handler.IQvCardHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQVersionHandler" implementation="org.jivesoftware.openfire.handler.IQVersionHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQLastActivityHandler" implementation="org.jivesoftware.openfire.handler.IQLastActivityHandler" />
+  <module interface="org.jivesoftware.openfire.handler.PresenceSubscribeHandler" implementation="org.jivesoftware.openfire.handler.PresenceSubscribeHandler" />
+  <module interface="org.jivesoftware.openfire.handler.PresenceUpdateHandler" implementation="org.jivesoftware.openfire.handler.PresenceUpdateHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQOfflineMessagesHandler" implementation="org.jivesoftware.openfire.handler.IQOfflineMessagesHandler" />
+  <module interface="org.jivesoftware.openfire.pep.IQPEPHandler" implementation="org.jivesoftware.openfire.pep.IQPEPHandler" />
+  <module interface="org.jivesoftware.openfire.pep.IQPEPOwnerHandler" implementation="org.jivesoftware.openfire.pep.IQPEPOwnerHandler" />
+  <module interface="org.jivesoftware.openfire.net.MulticastDNSService" implementation="org.jivesoftware.openfire.net.MulticastDNSService" />
+  <module interface="org.jivesoftware.openfire.handler.IQSharedGroupHandler" implementation="org.jivesoftware.openfire.handler.IQSharedGroupHandler" />
+  <module interface="org.jivesoftware.openfire.commands.AdHocCommandHandler" implementation="org.jivesoftware.openfire.commands.AdHocCommandHandler" />
+  <module interface="org.jivesoftware.openfire.handler.IQPrivacyHandler" implementation="org.jivesoftware.openfire.handler.IQPrivacyHandler" />
+  <module interface="org.jivesoftware.openfire.filetransfer.DefaultFileTransferManager" implementation="org.jivesoftware.openfire.filetransfer.DefaultFileTransferManager" />
+  <module interface="org.jivesoftware.openfire.filetransfer.proxy.FileTransferProxy" implementation="org.jivesoftware.openfire.filetransfer.proxy.FileTransferProxy" />
+  <module interface="org.jivesoftware.openfire.mediaproxy.MediaProxyService" implementation="org.jivesoftware.openfire.mediaproxy.MediaProxyService" />
+  <module interface="org.jivesoftware.openfire.pubsub.PubSubModule" implementation="org.jivesoftware.openfire.pubsub.PubSubModule" />
+  <module interface="org.jivesoftware.openfire.disco.IQDiscoInfoHandler" implementation="org.jivesoftware.openfire.disco.IQDiscoInfoHandler" />
+  <module interface="org.jivesoftware.openfire.disco.IQDiscoItemsHandler" implementation="org.jivesoftware.openfire.disco.IQDiscoItemsHandler" />
+  <module interface="org.jivesoftware.openfire.update.UpdateManager" implementation="org.jivesoftware.openfire.update.UpdateManager" />
+  <module interface="org.jivesoftware.openfire.FlashCrossDomainHandler" implementation="org.jivesoftware.openfire.FlashCrossDomainHandler" />
+  <module interface="org.jivesoftware.openfire.component.InternalComponentManager" implementation="org.jivesoftware.openfire.component.InternalComponentManager" />
+  <module interface="org.jivesoftware.openfire.muc.MultiUserChatManager" implementation="org.jivesoftware.openfire.muc.MultiUserChatManager" />
+  <module interface="org.jivesoftware.openfire.clearspace.ClearspaceManager" implementation="org.jivesoftware.openfire.clearspace.ClearspaceManager" />
+  <module interface="org.jivesoftware.openfire.handler.IQMessageCarbonsHandler" implementation="org.jivesoftware.openfire.handler.IQMessageCarbonsHandler" />
+  <!--  
+        Load this module always last since we don't want to start listening for clients
+        before the rest of the modules have been started
+  -->
+  <module interface="org.jivesoftware.openfire.ConnectionManager" implementation="org.jivesoftware.openfire.spi.ConnectionManagerImpl" />
+</jive>


### PR DESCRIPTION
This change moves the list of modules to be loaded from hard coded in XMPPServer to defined in conf/modules.xml.  My motivation is to allow me to replace Openfire behavior defined in modules that can't be overridden or changed in a plugin.

There are two basic elements of the change.  First, the loadModules method has been updated to open the modules.xml file and pass the contents of the file to loadModule.  

The second part of the change is to modify the modules map to use a String as the key.  This allows for the modules to be looked up by the name they implement instead of the class that is actually implementing.

