### PR TITLE
OF-883: Compensate for new half-duplex close of TCP channel in MINA

### DIFF
--- a/src/java/org/jivesoftware/openfire/nio/ConnectionHandler.java
+++ b/src/java/org/jivesoftware/openfire/nio/ConnectionHandler.java
@@ -108,6 +108,14 @@ public abstract class ConnectionHandler extends IoHandlerAdapter {
     }
 
     @Override
+    public void inputClosed( IoSession session ) throws Exception {
+        // Get the connection for this session
+        Connection connection = (Connection) session.getAttribute(CONNECTION);
+        // Inform the connection that it was closed
+        connection.close();
+    }
+
+    @Override
 	public void sessionClosed(IoSession session) throws Exception {
         // Get the connection for this session
         Connection connection = (Connection) session.getAttribute(CONNECTION);

--- a/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
+++ b/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
@@ -222,7 +222,7 @@ public class NIOConnection implements Connection {
     			return;
     		}
             try {
-                deliverRawText(flashClient ? "</flash:stream>" : "</stream:stream>", false);
+                deliverRawText(flashClient ? "</flash:stream>" : "</stream:stream>", true);
             } catch (Exception e) {
                 // Ignore
             }
@@ -235,7 +235,7 @@ public class NIOConnection implements Connection {
     	// OF-881: Notify any close listeners after the synchronized block has completed. 
     	notifyCloseListeners(); // clean up session, etc.
     	
-        ioSession.close(false); // async via MINA
+        ioSession.close(true); // sync via MINA
     }
 
     public void systemShutdown() {


### PR DESCRIPTION
MINA 2.0.8 introduces support for half-duplex close of TCP channels (see DIRMINA-785).
As part of this change, IoHandlers got a new method. The default behavior of the
IoHandlerAdapter closes the MINA session when this handler is triggered. However,
without an Openfire-specific extension (in ConnectionHandler), this fails to close
Openfire-maintained resources. As a result, CPUs could start to spin in NIO code,
resulting in 100% CPU cycles.

To fix this issue, ConnectionHandler now overrides the default functionality and
triggers a normal closure of the session (both in Openfire as well as MINA context).

Additionally, to prevent the CPU spin, MINA sessions need to be closed synchronously
(as opposed to the async closure Openfire had up until now). I cannot quite explain
the need for this change, other than a suspision of race conditions in the async
setup.