### PR TITLE
OF-913 Treat lib/log4j.xml as a config file in installers

### DIFF
--- a/build/installer/openfire.install4j
+++ b/build/installer/openfire.install4j
@@ -44,6 +44,7 @@
       <mountPoint id="33" root="" location="resources" mode="755" />
       <mountPoint id="34" root="" location="resources/security" mode="755" />
       <mountPoint id="46" root="" location="conf" mode="755" />
+      <mountPoint id="47" root="" location="lib" mode="755" />
       <mountPoint id="1" root="" location="" mode="755" />
     </mountPoints>
     <entries>
@@ -51,10 +52,12 @@
       <fileEntry mountPoint="34" file="${compiler:RELEASE_FULL_PATH}/resources/security/keystore" overwrite="0" shared="false" mode="644" uninstallMode="1" />
       <fileEntry mountPoint="46" file="${compiler:RELEASE_FULL_PATH}/conf/openfire.xml" overwrite="0" shared="false" mode="644" uninstallMode="1" />
       <fileEntry mountPoint="46" file="${compiler:RELEASE_FULL_PATH}/conf/security.xml" overwrite="0" shared="false" mode="644" uninstallMode="1" />
+      <fileEntry mountPoint="47" file="${compiler:RELEASE_FULL_PATH}/lib/log4j.xml" overwrite="0" shared="false" mode="644" uninstallMode="1" />
       <dirEntry mountPoint="1" file="${compiler:RELEASE_FULL_PATH}" overwrite="4" shared="false" mode="644" uninstallMode="0" excludeSuffixes="" dirMode="755">
         <exclude>
           <entry location="conf/openfire.xml" launcher="false" />
           <entry location="conf/security.xml" launcher="false" />
+          <entry location="lib/log4j.xml" launcher="false" />
           <entry location="resources/security/keystore" launcher="false" />
           <entry location="resources/security/truststore" launcher="false" />
         </exclude>

--- a/build/osx/resources/postupgrade
+++ b/build/osx/resources/postupgrade
@@ -19,6 +19,10 @@ if [ -f /tmp/openfireInstallBackup/client.truststore ]; then
 	/bin/mv /tmp/openfireInstallBackup/client.truststore /usr/local/openfire/resources/security/client.truststore
 fi
 
+if [ -f /tmp/openfireInstallBackup/log4j.xml ]; then
+	/bin/mv /tmp/openfireInstallBackup/log4j.xml /usr/local/openfire/lib/log4j.xml
+fi
+
 OPENFIRE_HOME=/usr/local/openfire/
 OPENFIRE_GID=`cat /private/tmp/openfiregid`
 rm /private/tmp/openfiregid

--- a/build/osx/resources/preupgrade
+++ b/build/osx/resources/preupgrade
@@ -27,5 +27,8 @@ if [ -d /usr/local/openfire ]; then
 	if [ -f /usr/local/openfire/resources/security/client.truststore ]; then
 		/bin/cp /usr/local/openfire/resources/security/client.truststore /tmp/openfireInstallBackup/client.truststore
 	fi
+	if [ -f /usr/local/openfire/lib/log4j.xml ]; then
+		/bin/cp /usr/local/openfire/lib/log4j.xml /tmp/openfireInstallBackup/log4j.xml
+	fi
 
 fi

--- a/build/rpm/openfire.spec
+++ b/build/rpm/openfire.spec
@@ -117,7 +117,7 @@ exit 0
 %config(noreplace) %{homedir}/conf/crowd.properties
 %dir %{homedir}/lib
 %{homedir}/lib/*.jar
-%{homedir}/lib/log4j.xml
+%config(noreplace) %{homedir}/lib/log4j.xml
 %dir %{homedir}/logs
 %dir %{homedir}/plugins
 %{homedir}/plugins/search.jar

--- a/build/solaris/postinstall
+++ b/build/solaris/postinstall
@@ -25,6 +25,11 @@ if [ -f /tmp/openfireInstallBackup/client.truststore ]; then
 	/bin/chown daemon:daemon /opt/openfire/resources/security/client.truststore
 fi
 
+if [ -f /tmp/openfireInstallBackup/log4j.xml ]; then
+        /bin/mv /tmp/openfireInstallBackup/log4j.xml /opt/openfire/lib/log4j.xml
+	/bin/chown daemon:daemon /opt/openfire/lib/log4j.xml
+fi
+
 if [ -d "/tmp/openfireInstallBackup" ]; then
 	/bin/rm -rf /tmp/openfireInstallBackup
 fi

--- a/build/solaris/preremove
+++ b/build/solaris/preremove
@@ -20,6 +20,9 @@ if [ -d "/opt/openfire" ]; then
 	if [ -f /opt/openfire/resources/security/client.truststore ]; then
 		/bin/cp -f /opt/openfire/resources/security/client.truststore /tmp/openfireInstallBackup/client.truststore
 	fi
+	if [ -f /opt/openfire/lib/log4j.xml ]; then
+		/bin/cp -f /opt/openfire/lib/log4j.xml /tmp/openfireInstallBackup/log4j.xml
+	fi
 
 	if [ -x "/usr/sbin/svcadm" ]; then
 		/usr/sbin/svcadm disable openfire


### PR DESCRIPTION
Currently, if users make changes to the lib/log4j.xml file, these changes are over-written by the installers for subsequent releases.  I have made an attempt to correct this for all platforms but debian.