### PR TITLE
Do not synchronize on isClosed()

### DIFF
--- a/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
+++ b/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
@@ -116,7 +116,7 @@ public class NIOConnection implements Connection {
      * keep this flag to avoid using the connection between #close was used and the socket is actually
      * closed.
      */
-    private State state;
+    private volatile State state;
     
     /**
      * Lock used to ensure the integrity of the underlying IoSession (refer to
@@ -288,7 +288,7 @@ public class NIOConnection implements Connection {
         session = owner;
     }
 
-    public synchronized boolean isClosed() {
+    public boolean isClosed() {
         return state == State.CLOSED;
     }
 
@@ -297,7 +297,7 @@ public class NIOConnection implements Connection {
     }
 
     public void deliver(Packet packet) throws UnauthorizedException {
-        if (isClosed()) {
+        if (state != State.RUNNING) {
         	// OF-857: Do not allow the backup deliverer to recurse
         	if (backupDeliverer == null) {
         		Log.error("Failed to deliver packet: " + packet.toXML());


### PR DESCRIPTION
There is a deadlock while reading the state variable if close() is running.

This switches the state to be volatile instead - it's only written to inside
the lengthy close() lock, so this should be reasonable.