### PR TITLE
Prevent sessions in admin console from showing UnknownHostException

### DIFF
--- a/src/web/component-session-details.jsp
+++ b/src/web/component-session-details.jsp
@@ -151,9 +151,13 @@
             <fmt:message key="session.details.hostname" />
         </td>
         <td>
-            <%= StringUtils.escapeHTMLTags(componentSession.getHostAddress()) %>
-            /
-            <%= StringUtils.escapeHTMLTags(componentSession.getHostName()) %>
+            <% try { %>
+                <%= StringUtils.escapeHTMLTags(componentSession.getHostAddress()) %>
+                /
+                <%= StringUtils.escapeHTMLTags(componentSession.getHostName()) %>
+            <% } catch (java.net.UnknownHostException e) { %>
+                Invalid session/connection
+            <% } %>
         </td>
     </tr>
 </tbody>

--- a/src/web/server-session-details.jsp
+++ b/src/web/server-session-details.jsp
@@ -22,7 +22,7 @@
                  org.jivesoftware.openfire.session.OutgoingServerSession,
                  org.jivesoftware.util.JiveGlobals,
                  org.jivesoftware.util.ParamUtils,
-                java.text.NumberFormat"
+                 java.text.NumberFormat"
     errorPage="error.jsp"
 %>
 <%@ page import="java.util.Calendar" %>
@@ -99,14 +99,18 @@
             <fmt:message key="server.session.details.hostname" />
         </td>
         <td>
-        <% if (!inSessions.isEmpty()) { %>
-            <%= inSessions.get(0).getHostAddress() %>
-            /
-            <%= inSessions.get(0).getHostName() %>
-        <% } else if (outSession != null) { %>
-            <%= outSession.getHostAddress() %>
-            /
-            <%= outSession.getHostName() %>
+        <% try {
+            if (!inSessions.isEmpty()) { %>
+                <%= inSessions.get(0).getHostAddress() %>
+                /
+                <%= inSessions.get(0).getHostName() %>
+	        <% } else if (outSession != null) { %>
+	            <%= outSession.getHostAddress() %>
+	            /
+	            <%= outSession.getHostName() %>
+	        <% }
+	       } catch (java.net.UnknownHostException e) { %>
+                Invalid session/connection
         <% } %>
         </td>
     </tr>

--- a/src/web/session-details.jsp
+++ b/src/web/session-details.jsp
@@ -281,9 +281,13 @@
             <fmt:message key="session.details.hostname" />
         </td>
         <td>
-            <%= currentSess.getHostAddress() %>
-            /
-            <%= currentSess.getHostName() %>
+            <% try { %>
+                <%= currentSess.getHostAddress() %>
+                /
+                <%= currentSess.getHostName() %>
+            <% } catch (java.net.UnknownHostException e) { %>
+                Invalid session/connection
+            <% } %>
         </td>
     </tr>
 </tbody>

--- a/src/web/session-row.jspf
+++ b/src/web/session-row.jspf
@@ -168,7 +168,11 @@
     </td>
 
     <td width="1%" nowrap>
-        <%= sess.getHostAddress() %>
+        <% try { %>
+            <%= sess.getHostAddress() %>
+        <% } catch (java.net.UnknownHostException e) { %>
+            Invalid session/connection
+        <% } %>
     </td>
 
     <td width="1%" nowrap align="center" style="border-right:1px #ccc solid;">


### PR DESCRIPTION
Updated JSP pages around sessions to prevent them from blowing up when an UnknownHostException is thrown and show 'Invalid session/connection' instead. The user can then manually remove those sessions.