### PR TITLE
fix XML Schema instance namespace in two XML Schema files.

### DIFF
--- a/src/plugins/jmxweb/src/hawtio/app/wiki/exemplar/camel-blueprint.xml
+++ b/src/plugins/jmxweb/src/hawtio/app/wiki/exemplar/camel-blueprint.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:xsi="http://www.w3c.org/2001/XMLSchema-instance"
            xsi:schemaLocation="
            http://www.osgi.org/xmlns/blueprint/v1.0.0
            http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">

--- a/src/plugins/userImportExport/classes/wildfire-user-schema.xsd.xml
+++ b/src/plugins/userImportExport/classes/wildfire-user-schema.xsd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+<xs:schema xmlns:xs="http://www.w3c.org/2001/XMLSchema" elementFormDefault="qualified">
    <xs:element name="Openfire">
       <xs:complexType>
          <xs:sequence>


### PR DESCRIPTION
There was a typo. The XML Schema instance namespace should be "www.w3c.org", not "www.w3.org".
- src/plugins/userImportExport/classes/wildfire-user-schema.xsd.xml
- src/plugins/jmxweb/src/hawtio/app/wiki/exemplar/camel-blueprint.xml

(from http://www.w3.org/2001/XMLSchema to http://www.w3c.org/2001/XMLSchema)