### PR TITLE
Allow users to specifiy custom classes to map credentials from certificates

### DIFF
--- a/src/java/org/jivesoftware/openfire/clearspace/ClearspaceX509TrustManager.java
+++ b/src/java/org/jivesoftware/openfire/clearspace/ClearspaceX509TrustManager.java
@@ -77,7 +77,7 @@ public class ClearspaceX509TrustManager implements X509TrustManager {
         if (verify) {
             int nSize = x509Certificates.length;
 
-            List<String> peerIdentities = CertificateManager.getPeerIdentities(x509Certificates[0]);
+            List<String> peerIdentities = CertificateManager.getServerPeerIdentities(x509Certificates[0]);
 
             if (getBooleanProperty("clearspace.certificate.verify.chain", true)) {
                 // Working down the chain, for every certificate in the chain,

--- a/src/java/org/jivesoftware/openfire/clearspace/ClearspaceX509TrustManager.java
+++ b/src/java/org/jivesoftware/openfire/clearspace/ClearspaceX509TrustManager.java
@@ -77,7 +77,7 @@ public class ClearspaceX509TrustManager implements X509TrustManager {
         if (verify) {
             int nSize = x509Certificates.length;
 
-            List<String> peerIdentities = CertificateManager.getServerPeerIdentities(x509Certificates[0]);
+            List<String> peerIdentities = CertificateManager.getServerIdentities(x509Certificates[0]);
 
             if (getBooleanProperty("clearspace.certificate.verify.chain", true)) {
                 // Working down the chain, for every certificate in the chain,

--- a/src/java/org/jivesoftware/openfire/net/ClientTrustManager.java
+++ b/src/java/org/jivesoftware/openfire/net/ClientTrustManager.java
@@ -189,7 +189,7 @@ public class ClientTrustManager implements X509TrustManager {
         if (verify) {
             int nSize = x509Certificates.length;
 
-            List<String> peerIdentities = CertificateManager.getClientPeerIdentities(x509Certificates[0]);
+            List<String> peerIdentities = CertificateManager.getClientIdentities(x509Certificates[0]);
 
             if (JiveGlobals.getBooleanProperty("xmpp.client.certificate.verify.chain", true)) {
                 // Working down the chain, for every certificate in the chain,

--- a/src/java/org/jivesoftware/openfire/net/ClientTrustManager.java
+++ b/src/java/org/jivesoftware/openfire/net/ClientTrustManager.java
@@ -189,7 +189,7 @@ public class ClientTrustManager implements X509TrustManager {
         if (verify) {
             int nSize = x509Certificates.length;
 
-            List<String> peerIdentities = CertificateManager.getPeerIdentities(x509Certificates[0]);
+            List<String> peerIdentities = CertificateManager.getClientPeerIdentities(x509Certificates[0]);
 
             if (JiveGlobals.getBooleanProperty("xmpp.client.certificate.verify.chain", true)) {
                 // Working down the chain, for every certificate in the chain,

--- a/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -590,7 +590,7 @@ public class SASLAuthentication {
                 authenticationFailed(session, Failure.NOT_AUTHORIZED);
                 return Status.failed;
             }
-            principals.addAll(CertificateManager.getClientPeerIdentities((X509Certificate)trusted));
+            principals.addAll(CertificateManager.getClientIdentities((X509Certificate)trusted));
 
             if(principals.size() == 1) {
                 principal = principals.get(0);
@@ -640,7 +640,7 @@ public class SASLAuthentication {
     }
     
     public static boolean verifyCertificate(X509Certificate trustedCert, String hostname) {
-        for (String identity : CertificateManager.getServerPeerIdentities(trustedCert)) {
+        for (String identity : CertificateManager.getServerIdentities(trustedCert)) {
             // Verify that either the identity is the same as the hostname, or for wildcarded
             // identities that the hostname ends with .domainspecified or -is- domainspecified.
             if ((identity.startsWith("*.")

--- a/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -590,7 +590,7 @@ public class SASLAuthentication {
                 authenticationFailed(session, Failure.NOT_AUTHORIZED);
                 return Status.failed;
             }
-            principals.addAll(CertificateManager.getPeerIdentities((X509Certificate)trusted));
+            principals.addAll(CertificateManager.getClientPeerIdentities((X509Certificate)trusted));
 
             if(principals.size() == 1) {
                 principal = principals.get(0);
@@ -640,7 +640,7 @@ public class SASLAuthentication {
     }
     
     public static boolean verifyCertificate(X509Certificate trustedCert, String hostname) {
-        for (String identity : CertificateManager.getPeerIdentities(trustedCert)) {
+        for (String identity : CertificateManager.getServerPeerIdentities(trustedCert)) {
             // Verify that either the identity is the same as the hostname, or for wildcarded
             // identities that the hostname ends with .domainspecified or -is- domainspecified.
             if ((identity.startsWith("*.")

--- a/src/java/org/jivesoftware/util/CertificateManager.java
+++ b/src/java/org/jivesoftware/util/CertificateManager.java
@@ -49,7 +49,6 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.CollectionCertStoreParameters;
 import java.security.cert.PKIXBuilderParameters;
-import java.security.cert.TrustAnchor;
 import java.security.cert.X509CertSelector;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -58,11 +57,11 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.StringTokenizer;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -70,7 +69,6 @@ import java.util.regex.Pattern;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1TaggedObject;
-import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.DERObjectIdentifier;
@@ -87,11 +85,13 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.PEMDecryptorProvider;
 import org.bouncycastle.openssl.PEMEncryptedKeyPair;
-import org.bouncycastle.openssl.PasswordFinder;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 import org.bouncycastle.x509.X509V3CertificateGenerator;
+import org.jivesoftware.util.cert.CertificateIdentityMapping;
+import org.jivesoftware.util.cert.CNCertificateIdentityMapping;
+import org.jivesoftware.util.cert.SANCertificateIdentityMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,9 +105,6 @@ public class CertificateManager {
 
 	private static final Logger Log = LoggerFactory.getLogger(CertificateManager.class);
 
-    private static final String OTHERNAME_XMPP_OID = "1.3.6.1.5.5.7.8.5";
-
-    private static Pattern cnPattern = Pattern.compile("(?i)(cn=)([^,]*)");
     private static Pattern valuesPattern = Pattern.compile("(?i)(=)([^,]*)");
 
     private static Provider provider = new BouncyCastleProvider();
@@ -119,9 +116,35 @@ public class CertificateManager {
 
     private static List<CertificateEventListener> listeners = new CopyOnWriteArrayList<CertificateEventListener>();
 
+    private static List<CertificateIdentityMapping> certIdentityMapping = new ArrayList<CertificateIdentityMapping>();
+    
     static {
         // Add the BC provider to the list of security providers
         Security.addProvider(provider);
+        
+        String classList = JiveGlobals.getProperty("provider.certIdentityMapping.classList");
+        if (classList != null) {
+        	StringTokenizer st = new StringTokenizer(classList, " ,\t\n\r\f");
+            while (st.hasMoreTokens()) {
+                String s_provider = st.nextToken();
+                try {
+                    Class c_provider = ClassUtils.forName(s_provider);
+                    CertificateIdentityMapping provider =
+                            (CertificateIdentityMapping)(c_provider.newInstance());
+                    Log.debug("CertificateManager: Loaded " + s_provider);
+                    certIdentityMapping.add(provider);
+                }
+                catch (Exception e) {
+                    Log.error("CertificateManager: Error loading CertificateIdentityMapping: " + s_provider + "\n" + e);
+                }
+            }
+        }
+        
+        if (certIdentityMapping.isEmpty()) {
+        	Log.debug("CertificateManager: No CertificateIdentityMapping's found. Loading default mappings");
+        	certIdentityMapping.add(new SANCertificateIdentityMapping());
+        	certIdentityMapping.add(new CNCertificateIdentityMapping());
+        }
     }
 
     /**
@@ -346,101 +369,15 @@ public class CertificateManager {
      * @return the identities of the remote server as defined in the specified certificate.
      */
     public static List<String> getPeerIdentities(X509Certificate x509Certificate) {
-        // Look the identity in the subjectAltName extension if available
-        List<String> names = getSubjectAlternativeNames(x509Certificate);
-        if (names.isEmpty()) {
-            String name = x509Certificate.getSubjectDN().getName();
-            Matcher matcher = cnPattern.matcher(name);
-            // Create an array with the detected identities
-            names = new ArrayList<String>();
-            while (matcher.find()) {
-                names.add(matcher.group(2));
-            }
-        }
+    	
+    	List<String> names = new ArrayList<String>();
+    	for (CertificateIdentityMapping mapping : certIdentityMapping) {
+    		List<String> identities = mapping.mapIdentity(x509Certificate);
+    		Log.debug("CertificateManager: " + mapping.name() + " returned " + identities.toString());
+    		names.addAll(identities);
+    	}
+
         return names;
-    }
-
-    /**
-     * Returns the JID representation of an XMPP entity contained as a SubjectAltName extension
-     * in the certificate. If none was found then return <tt>null</tt>.
-     *
-     * @param certificate the certificate presented by the remote entity.
-     * @return the JID representation of an XMPP entity contained as a SubjectAltName extension
-     *         in the certificate. If none was found then return <tt>null</tt>.
-     */
-    private static List<String> getSubjectAlternativeNames(X509Certificate certificate) {
-        List<String> identities = new ArrayList<String>();
-        try {
-            Collection<List<?>> altNames = certificate.getSubjectAlternativeNames();
-            // Check that the certificate includes the SubjectAltName extension
-            if (altNames == null) {
-                return Collections.emptyList();
-            }
-            // Use the type OtherName to search for the certified server name
-            for (List<?> item : altNames) {
-                Integer type = (Integer) item.get(0);
-                if (type == 0) {
-                    // Type OtherName found so return the associated value
-                    try {
-                        // Value is encoded using ASN.1 so decode it to get the server's identity
-                        ASN1InputStream decoder = new ASN1InputStream((byte[]) item.get(1));
-                        Object object = decoder.readObject();
-                        ASN1Sequence otherNameSeq = null;
-                        if (object != null && object instanceof ASN1Sequence) {
-                        	otherNameSeq = (ASN1Sequence) object;
-                        } else {
-                        	continue;
-                        }
-                        // Check the object identifier
-                        ASN1ObjectIdentifier objectId = (ASN1ObjectIdentifier) otherNameSeq.getObjectAt(0);
-                    	Log.debug("Parsing otherName for subject alternative names: " + objectId.toString() );
-
-                        if ( !OTHERNAME_XMPP_OID.equals(objectId.getId())) {
-                            // Not a XMPP otherName
-                            Log.debug("Ignoring non-XMPP otherName, " + objectId.getId());
-                            continue;
-                        }
-
-                        // Get identity string
-                        try {
-                        	final String identity;
-	                        ASN1Encodable o = otherNameSeq.getObjectAt(1);
-	                        if (o instanceof DERTaggedObject) {
-	                        	ASN1TaggedObject ato = DERTaggedObject.getInstance(o);
-	                        	Log.debug("... processing DERTaggedObject: " + ato.toString());
-	                        	// TODO: there's bound to be a better way...
-	                        	identity = ato.toString().substring(ato.toString().lastIndexOf(']')+1).trim();
-	                        } else {
-	                        	DERUTF8String derStr = DERUTF8String.getInstance(o);
-		                        identity = derStr.getString();
-	                        }
-	                        if (identity != null && identity.length() > 0) {
-	                            // Add the decoded server name to the list of identities
-	                            identities.add(identity);
-	                        }
-	                        decoder.close();
-                        } catch (IllegalArgumentException ex) {
-                        	// OF-517: othername formats are extensible. If we don't recognize the format, skip it.
-                        	Log.debug("Cannot parse altName, likely because of unknown record format.", ex);
-                        }
-                    }
-                    catch (UnsupportedEncodingException e) {
-                        // Ignore
-                    }
-                    catch (IOException e) {
-                        // Ignore
-                    }
-                    catch (Exception e) {
-                        Log.error("Error decoding subjectAltName", e);
-                    }
-                }
-                // Other types are not applicable for XMPP, so silently ignore them
-            }
-        }
-        catch (CertificateParsingException e) {
-            Log.error("Error parsing SubjectAltName in certificate: " + certificate.getSubjectDN(), e);
-        }
-        return identities;
     }
 
     /**

--- a/src/java/org/jivesoftware/util/CertificateManager.java
+++ b/src/java/org/jivesoftware/util/CertificateManager.java
@@ -397,7 +397,10 @@ public class CertificateManager {
     	for (CertificateIdentityMapping mapping : clientCertMapping) {
     		List<String> identities = mapping.mapIdentity(x509Certificate);
     		Log.debug("CertificateManager: " + mapping.name() + " returned " + identities.toString());
-    		names.addAll(identities);
+    		if (!identities.isEmpty()) {
+    			names.addAll(identities);
+    			break;
+    		}
     	}
 
         return names;
@@ -420,7 +423,10 @@ public class CertificateManager {
     	for (CertificateIdentityMapping mapping : serverCertMapping) {
     		List<String> identities = mapping.mapIdentity(x509Certificate);
     		Log.debug("CertificateManager: " + mapping.name() + " returned " + identities.toString());
-    		names.addAll(identities);
+    		if (!identities.isEmpty()) {
+    			names.addAll(identities);
+    			break;
+    		}
     	}
 
         return names;

--- a/src/java/org/jivesoftware/util/CertificateManager.java
+++ b/src/java/org/jivesoftware/util/CertificateManager.java
@@ -116,9 +116,9 @@ public class CertificateManager {
 
     private static List<CertificateEventListener> listeners = new CopyOnWriteArrayList<CertificateEventListener>();
 
-    private static List<CertificateIdentityMapping> serverCertIdentityMapping = new ArrayList<CertificateIdentityMapping>();
+    private static List<CertificateIdentityMapping> serverCertMapping = new ArrayList<CertificateIdentityMapping>();
     
-    private static List<CertificateIdentityMapping> clientCertIdentityMapping = new ArrayList<CertificateIdentityMapping>();
+    private static List<CertificateIdentityMapping> clientCertMapping = new ArrayList<CertificateIdentityMapping>();
     
     static {
         // Add the BC provider to the list of security providers
@@ -134,7 +134,7 @@ public class CertificateManager {
                     CertificateIdentityMapping provider =
                             (CertificateIdentityMapping)(c_provider.newInstance());
                     Log.debug("CertificateManager: Loaded server identity mapping " + s_provider);
-                    serverCertIdentityMapping.add(provider);
+                    serverCertMapping.add(provider);
                 }
                 catch (Exception e) {
                     Log.error("CertificateManager: Error loading CertificateIdentityMapping: " + s_provider + "\n" + e);
@@ -142,10 +142,10 @@ public class CertificateManager {
             }
         }
         
-        if (serverCertIdentityMapping.isEmpty()) {
+        if (serverCertMapping.isEmpty()) {
         	Log.debug("CertificateManager: No server CertificateIdentityMapping's found. Loading default mappings");
-        	serverCertIdentityMapping.add(new SANCertificateIdentityMapping());
-        	serverCertIdentityMapping.add(new CNCertificateIdentityMapping());   	
+        	serverCertMapping.add(new SANCertificateIdentityMapping());
+        	serverCertMapping.add(new CNCertificateIdentityMapping());   	
         }
                 
         String clientCertMapList = JiveGlobals.getProperty("provider.clientCertIdentityMap.classList");
@@ -158,7 +158,7 @@ public class CertificateManager {
                     CertificateIdentityMapping provider =
                             (CertificateIdentityMapping)(c_provider.newInstance());
                     Log.debug("CertificateManager: Loaded client identity mapping " + s_provider);
-                    clientCertIdentityMapping.add(provider);
+                    clientCertMapping.add(provider);
                 }
                 catch (Exception e) {
                     Log.error("CertificateManager: Error loading CertificateIdentityMapping: " + s_provider + "\n" + e);
@@ -166,9 +166,9 @@ public class CertificateManager {
             }
         }
         
-        if (clientCertIdentityMapping.isEmpty()) {
+        if (clientCertMapping.isEmpty()) {
         	Log.debug("CertificateManager: No client CertificateIdentityMapping's found. Loading default mappings");
-        	clientCertIdentityMapping.add(new CNCertificateIdentityMapping());
+        	clientCertMapping.add(new CNCertificateIdentityMapping());
         }
     }
 
@@ -391,10 +391,10 @@ public class CertificateManager {
      * @param x509Certificate the certificate the holds the identities of the remote server.
      * @return the identities of the remote client as defined in the specified certificate.
      */
-    public static List<String> getClientPeerIdentities(X509Certificate x509Certificate) {
+    public static List<String> getClientIdentities(X509Certificate x509Certificate) {
     	
     	List<String> names = new ArrayList<String>();
-    	for (CertificateIdentityMapping mapping : clientCertIdentityMapping) {
+    	for (CertificateIdentityMapping mapping : clientCertMapping) {
     		List<String> identities = mapping.mapIdentity(x509Certificate);
     		Log.debug("CertificateManager: " + mapping.name() + " returned " + identities.toString());
     		names.addAll(identities);
@@ -414,10 +414,10 @@ public class CertificateManager {
      * @param x509Certificate the certificate the holds the identities of the remote server.
      * @return the identities of the remote server as defined in the specified certificate.
      */
-    public static List<String> getServerPeerIdentities(X509Certificate x509Certificate) {
+    public static List<String> getServerIdentities(X509Certificate x509Certificate) {
     	
     	List<String> names = new ArrayList<String>();
-    	for (CertificateIdentityMapping mapping : serverCertIdentityMapping) {
+    	for (CertificateIdentityMapping mapping : serverCertMapping) {
     		List<String> identities = mapping.mapIdentity(x509Certificate);
     		Log.debug("CertificateManager: " + mapping.name() + " returned " + identities.toString());
     		names.addAll(identities);
@@ -484,7 +484,7 @@ public class CertificateManager {
             }
             else {
                 // Only accept certified domains that match the specified domain
-                for (String identity : getServerPeerIdentities(certificate)) {
+                for (String identity : getServerIdentities(certificate)) {
                     if (identity.endsWith(domain) && certificate.getPublicKey().getAlgorithm().equals(algorithm)) {
                         result = true;
                     }

--- a/src/java/org/jivesoftware/util/cert/CNCertificateIdentityMapping.java
+++ b/src/java/org/jivesoftware/util/cert/CNCertificateIdentityMapping.java
@@ -1,0 +1,49 @@
+package org.jivesoftware.util.cert;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Certificate identity mapping that uses the CommonName as the
+ * identity credentials
+ * 
+ * @author Victor Hong
+ *
+ */
+public class CNCertificateIdentityMapping implements CertificateIdentityMapping {
+
+	private static Pattern cnPattern = Pattern.compile("(?i)(cn=)([^,]*)");
+	
+	/**
+	 * Maps certificate CommonName as identity credentials
+	 * 
+	 * @param certificate
+	 * @return
+	 */
+	@Override
+	public List<String> mapIdentity(X509Certificate certificate) {
+        String name = certificate.getSubjectDN().getName();
+        Matcher matcher = cnPattern.matcher(name);
+        // Create an array with the detected identities
+        List<String> names = new ArrayList<String>();
+        while (matcher.find()) {
+            names.add(matcher.group(2));
+        }
+		
+		return names;
+	}
+
+	/**
+	 * Returns the short name of mapping
+	 * 
+	 * @return The short name of the mapping
+	 */
+	@Override
+	public String name() {
+		return "Common Name Mapping";
+	}
+
+}

--- a/src/java/org/jivesoftware/util/cert/CertificateIdentityMapping.java
+++ b/src/java/org/jivesoftware/util/cert/CertificateIdentityMapping.java
@@ -1,0 +1,29 @@
+package org.jivesoftware.util.cert;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+/**
+ * This is the interface used to map identity credentials from certificates.
+ * Users may implement this class to map authentication credentials (i.e. usernames)
+ * from certificate data (e.g. CommonName or SubjectAlternativeName) 
+ * 
+ * @author Victor Hong
+ *
+ */
+public interface CertificateIdentityMapping {
+	/**
+	 * Maps identities from X509Certificates
+	 * 
+	 * @param certificate The certificate from which to map identities
+	 * @return A list of identities mapped from the certificate 
+	 */
+	List<String> mapIdentity(X509Certificate certificate);
+	
+	/**
+	 * Returns the short name of the mapping
+	 * 
+	 * @return The short name of the mapping
+	 */
+	String name();
+}

--- a/src/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
+++ b/src/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
@@ -1,0 +1,129 @@
+package org.jivesoftware.util.cert;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.ASN1TaggedObject;
+import org.bouncycastle.asn1.DERTaggedObject;
+import org.bouncycastle.asn1.DERUTF8String;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Certificate identity mapping that uses XMPP-OtherName SubjectAlternativeName
+ * as the identity credentials
+ * 
+ * @author Victor Hong
+ *
+ */
+public class SANCertificateIdentityMapping implements CertificateIdentityMapping {
+	
+	private static final Logger Log = LoggerFactory.getLogger(SANCertificateIdentityMapping.class);
+
+    private static final String OTHERNAME_XMPP_OID = "1.3.6.1.5.5.7.8.5";
+    
+    /**
+     * Returns the JID representation of an XMPP entity contained as a SubjectAltName extension
+     * in the certificate. If none was found then return an empty list.
+     *
+     * @param certificate the certificate presented by the remote entity.
+     * @return the JID representation of an XMPP entity contained as a SubjectAltName extension
+     *         in the certificate. If none was found then return an empty list.
+     */
+	@Override
+	public List<String> mapIdentity(X509Certificate certificate) {
+		List<String> identities = new ArrayList<String>();
+        try {
+            Collection<List<?>> altNames = certificate.getSubjectAlternativeNames();
+            // Check that the certificate includes the SubjectAltName extension
+            if (altNames == null) {
+                return Collections.emptyList();
+            }
+            // Use the type OtherName to search for the certified server name
+            for (List<?> item : altNames) {
+                Integer type = (Integer) item.get(0);
+                if (type == 0) {
+                    // Type OtherName found so return the associated value
+                    try {
+                        // Value is encoded using ASN.1 so decode it to get the server's identity
+                        ASN1InputStream decoder = new ASN1InputStream((byte[]) item.get(1));
+                        Object object = decoder.readObject();
+                        ASN1Sequence otherNameSeq = null;
+                        if (object != null && object instanceof ASN1Sequence) {
+                        	otherNameSeq = (ASN1Sequence) object;
+                        } else {
+                        	continue;
+                        }
+                        // Check the object identifier
+                        ASN1ObjectIdentifier objectId = (ASN1ObjectIdentifier) otherNameSeq.getObjectAt(0);
+                    	Log.debug("Parsing otherName for subject alternative names: " + objectId.toString() );
+
+                        if ( !OTHERNAME_XMPP_OID.equals(objectId.getId())) {
+                            // Not a XMPP otherName
+                            Log.debug("Ignoring non-XMPP otherName, " + objectId.getId());
+                            continue;
+                        }
+
+                        // Get identity string
+                        try {
+                        	final String identity;
+	                        ASN1Encodable o = otherNameSeq.getObjectAt(1);
+	                        if (o instanceof DERTaggedObject) {
+	                        	ASN1TaggedObject ato = DERTaggedObject.getInstance(o);
+	                        	Log.debug("... processing DERTaggedObject: " + ato.toString());
+	                        	// TODO: there's bound to be a better way...
+	                        	identity = ato.toString().substring(ato.toString().lastIndexOf(']')+1).trim();
+	                        } else {
+	                        	DERUTF8String derStr = DERUTF8String.getInstance(o);
+		                        identity = derStr.getString();
+	                        }
+	                        if (identity != null && identity.length() > 0) {
+	                            // Add the decoded server name to the list of identities
+	                            identities.add(identity);
+	                        }
+	                        decoder.close();
+                        } catch (IllegalArgumentException ex) {
+                        	// OF-517: othername formats are extensible. If we don't recognize the format, skip it.
+                        	Log.debug("Cannot parse altName, likely because of unknown record format.", ex);
+                        }
+                    }
+                    catch (UnsupportedEncodingException e) {
+                        // Ignore
+                    }
+                    catch (IOException e) {
+                        // Ignore
+                    }
+                    catch (Exception e) {
+                        Log.error("Error decoding subjectAltName", e);
+                    }
+                }
+                // Other types are not applicable for XMPP, so silently ignore them
+            }
+        }
+        catch (CertificateParsingException e) {
+            Log.error("Error parsing SubjectAltName in certificate: " + certificate.getSubjectDN(), e);
+        }
+        return identities;
+	}
+
+	/**
+	 * Returns the short name of mapping
+	 * 
+	 * @return The short name of the mapping
+	 */
+	@Override
+	public String name() {
+		return "Subject Alternative Name Mapping";
+	}
+
+}

--- a/src/web/security-keystore.jsp
+++ b/src/web/security-keystore.jsp
@@ -210,7 +210,7 @@
                 String a = (String) aliases.nextElement();
                 X509Certificate c = (X509Certificate) keyStore.getCertificate(a);
                 StringBuffer identities = new StringBuffer();
-                for (String identity : CertificateManager.getServerPeerIdentities(c)) {
+                for (String identity : CertificateManager.getServerIdentities(c)) {
                     identities.append(identity).append(", ");
                 }
                 if (identities.length() > 0) {

--- a/src/web/security-keystore.jsp
+++ b/src/web/security-keystore.jsp
@@ -210,7 +210,7 @@
                 String a = (String) aliases.nextElement();
                 X509Certificate c = (X509Certificate) keyStore.getCertificate(a);
                 StringBuffer identities = new StringBuffer();
-                for (String identity : CertificateManager.getPeerIdentities(c)) {
+                for (String identity : CertificateManager.getServerPeerIdentities(c)) {
                     identities.append(identity).append(", ");
                 }
                 if (identities.length() > 0) {


### PR DESCRIPTION
Resubmitting this pull request from a different branch. See [here](https://github.com/igniterealtime/Openfire/pull/225).

"This change allows users to specify classes in the Openfire properties (similar to AuthorizationManager) to map different identity credentials from certificates. This change is useful during client authentication with certificates (mutual authentication) in order to provide different credentials to the AuthorizationMapping (e.g. full subject distinguished name instead of only common name).

This change is taking code out of CertificateManager.java and moving it into CNCertificateIdentityMapping and SANCertificateIdentityMapping which implement a new CertificateIdentityMapping interface. In CertificateManager it fell back to the CN if the SAN did not have any XMPP OIDs present. In this pull request it is currently adding CN to any list of identities that might have come from the SAN field. Most code appears to only use the first identity but if there is a concern about this change then the pull request can be updated to break out of the identity mapper loop when the first identity mapper returned a non-empty list of identities."