### PR TITLE
Of 929

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 work/
+*.class
 
 # Ignore Intellij Idea project files
 *.iml

--- a/src/plugins/userCreation/src/java/org/jivesoftware/openfire/plugin/UserCreationPlugin.java
+++ b/src/plugins/userCreation/src/java/org/jivesoftware/openfire/plugin/UserCreationPlugin.java
@@ -1,8 +1,11 @@
 package org.jivesoftware.openfire.plugin;
 
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.math.RandomUtils;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
+import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.LocaleUtils;
 import org.jivesoftware.util.Log;
 import org.jivesoftware.openfire.SharedGroupException;
@@ -12,17 +15,23 @@ import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.openfire.roster.Roster;
 import org.jivesoftware.openfire.roster.RosterItem;
 import org.jivesoftware.openfire.roster.RosterManager;
+import org.jivesoftware.openfire.user.User;
 import org.jivesoftware.openfire.user.UserAlreadyExistsException;
 import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.openfire.vcard.VCardManager;
 import org.xmpp.packet.JID;
+import org.xmpp.packet.Message;
 import org.xmpp.packet.Presence;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by IntelliJ IDEA.
@@ -36,6 +45,7 @@ public class UserCreationPlugin implements Plugin {
     private static Hashtable<RosterItem.SubType, Map<String, Map<Presence.Type, Change>>> stateTable =
             new Hashtable<RosterItem.SubType, Map<String, Map<Presence.Type, Change>>>();
     private Element vCard;
+	public static final int DEFAULT_MAX_TIME_DEBUG = 30;
 
     static {
         Hashtable<Presence.Type, Change> subrTable;
@@ -282,6 +292,79 @@ public class UserCreationPlugin implements Plugin {
         }
         System.out.println("VCards created successfully: " + created);
     }
+    
+    public static final int NUMBER_CONVERSATION = 10;
+    public static final int NUMBER_MESSAGES = 10 ;//+ RandomUtils.nextInt(9);
+    
+	public void generateMessages() {
+		JiveGlobals.setProperty("conversation.maxTimeDebug", String.valueOf(DEFAULT_MAX_TIME_DEBUG));
+		XMPPServer server = XMPPServer.getInstance();
+		ExecutorService taskExecutor = Executors.newFixedThreadPool(8);
+
+		for (User user : UserManager.getInstance().getUsers()) {
+			final JID userJid = server.createJID(user.getUsername(), null);
+			System.out.println("Creating messages for user: " + userJid.getNode());
+			for (RosterItem ri : user.getRoster().getRosterItems()) {
+				final JID rosterItemJid = ri.getJid();
+
+				taskExecutor.execute(new Runnable() {
+					@Override
+					public void run() {
+						for (int j = 0; j < NUMBER_CONVERSATION; j++) {
+							String thread = RandomStringUtils.randomAlphanumeric(6);
+							for (int i = 0; i < NUMBER_MESSAGES; i++) {
+								if (i % 2 == 0) {
+									Message msg = new Message();
+									msg.setBody("Hello to " + rosterItemJid.getNode() + " from " + userJid.getNode() + ", conversation number " + j
+											+ " of " + NUMBER_CONVERSATION + ", message " + i + " of " + NUMBER_MESSAGES + " thread " + thread);
+									msg.setType(Message.Type.chat);
+									msg.setFrom(userJid);
+									msg.setTo(rosterItemJid);
+									msg.setThread(thread);
+									XMPPServer.getInstance().getMessageRouter().route(msg);
+									try {
+										/* otherwise monitoring plugin stores messages out of order */
+										Thread.sleep(1);
+									} catch (InterruptedException e) {
+										e.printStackTrace();
+									}
+								} else {
+									Message msg = new Message();
+									msg.setBody("Hello to " + userJid.getNode() + " from " + rosterItemJid.getNode() + ", conversation number " + j
+											+ " of " + NUMBER_CONVERSATION + ", message " + i + " of " + NUMBER_MESSAGES + " thread " + thread);
+									msg.setType(Message.Type.chat);
+									msg.setFrom(rosterItemJid);
+									msg.setTo(userJid);
+									msg.setThread(thread);
+									XMPPServer.getInstance().getMessageRouter().route(msg);
+									try {
+										/* otherwise monitoring plugin stores messages out of order */
+										Thread.sleep(1);
+									} catch (InterruptedException e) {
+										e.printStackTrace();
+									}
+								}
+							}
+							try {
+								Thread.sleep(DEFAULT_MAX_TIME_DEBUG);
+							} catch (InterruptedException e) {
+								e.printStackTrace();
+							}
+						}
+					}
+				});
+
+			}
+		}
+		taskExecutor.shutdown();
+		try {
+			taskExecutor.awaitTermination(2, TimeUnit.HOURS);
+			System.out.println("Conversation generation finished");
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		JiveGlobals.deleteProperty("conversation.maxTimeDebug");
+	}
 
     private Element getDefaultVCard() {
         if (vCard != null) {

--- a/src/plugins/userCreation/src/web/users-creation.jsp
+++ b/src/plugins/userCreation/src/web/users-creation.jsp
@@ -1,3 +1,4 @@
+<%@page import="org.jivesoftware.util.JiveGlobals"%>
 <%@ page import="org.jivesoftware.util.ParamUtils,
 				 org.jivesoftware.util.TaskEngine,
 				 org.jivesoftware.openfire.XMPPServer,
@@ -21,7 +22,8 @@
     String from = ParamUtils.getParameter(request, "from");
     String total = ParamUtils.getParameter(request, "total");
     String usersPerRoster = ParamUtils.getParameter(request, "usersPerRoster");
-
+    boolean generateMessages =  request.getParameter("messageGenerate") != null;
+    
     Map<String, String> errors = new HashMap<String, String>();
 
     boolean running = false;
@@ -31,8 +33,10 @@
         final int intFrom = Integer.parseInt(from);
         final int maxUsers = Integer.parseInt(total);
         final int usersRoster = Integer.parseInt(usersPerRoster) + 1;
+        final boolean boolGenerateMessages = generateMessages;
+
         if (maxUsers % usersRoster != 0 || maxUsers <= usersRoster) {
-            errors.put("arguments", "");
+        	errors.put("arguments", ""); 
         }
 
         if (errors.isEmpty()) {
@@ -43,6 +47,10 @@
                     plugin.createUsers(userPrefix, intFrom, maxUsers);
                     plugin.populateRosters(userPrefix, intFrom, maxUsers, usersRoster);
                     plugin.createVCards(userPrefix, intFrom, maxUsers);
+                    if (boolGenerateMessages) {
+                    	plugin.generateMessages();
+                    }
+                    
                 }
             });
             running = true;
@@ -92,7 +100,7 @@
         <tr class="c1">
             <td width="1%" colspan="2" nowrap>
                 User prefix:
-                &nbsp;<input type="text" name="prefix" value="<%=(prefix != null ? prefix : "") %>" size="30" maxlength="75"/>
+                &nbsp;<input type="text" name="prefix" value="<%=(prefix != null ? prefix : "user") %>" size="30" maxlength="75"/>
 	        </td>
         </tr>
         <tr class="c1">
@@ -104,20 +112,25 @@
         <tr class="c1">
             <td width="1%" colspan="2" nowrap>
                 Total users:
-                &nbsp;<input type="text" name="total" value="<%=(total != null ? total : "1000") %>" size="5" maxlength="15"/>
+                &nbsp;<input type="text" name="total" value="<%=(total != null ? total : "20") %>" size="5" maxlength="15"/>
 	        </td>
         </tr>
         <tr class="c1">
             <td width="1%" colspan="2" nowrap>
                 Contacts in roster:
-                &nbsp;<input type="text" name="usersPerRoster" value="<%=(usersPerRoster != null ? usersPerRoster : "30") %>" size="5" maxlength="15"/>
+                &nbsp;<input type="text" name="usersPerRoster" value="<%=(usersPerRoster != null ? usersPerRoster : "9") %>" size="5" maxlength="15"/>
 	        </td>
         </tr>
-            <tr class="c1">
-                <td width="1%" colspan="2" nowrap>
-                    <input type="submit" name="Create"/>
-                </td>
-            </tr>
+        <tr>
+            <td colspan="2" width="90%"><label class="jive-label" for="messageGenerate">Generate chat messages:</label><br>
+            Generates dummy chat messages between users. Useful for testing message archiving.</td>
+            <td><input type="checkbox" id="messageGenerate" name="messageGenerate" <%= "checked" %> /></td>
+      	</tr>	
+        <tr class="c1">
+            <td width="1%" colspan="2" nowrap>
+                <input type="submit" name="Create"/>
+            </td>
+        </tr>
         </table>
         </div>
     </fieldset>


### PR DESCRIPTION
As per here:
https://igniterealtime.org/issues/browse/OF-929

I was looking for a way to quickly generate a test Openfire environment populated with users, roster entries and messages.

Jive had a plugin already which did the first two. It now does number three as well, generating plenty of test data for the monitoring plugin..
