### PR TITLE
FIXED:  typo

### DIFF
--- a/src/plugins/ofmeet/src/java/org/jitsi/jicofo/BridgeSelector.java
+++ b/src/plugins/ofmeet/src/java/org/jitsi/jicofo/BridgeSelector.java
@@ -123,7 +123,7 @@ public class BridgeSelector
         else
         {
             logger.warn("No pub-sub node mapped for " + bridgeJid
-                        + " statistics will not be tracked fro this instance.");
+                        + " statistics will not be tracked for this instance.");
         }
 
         bridges.put(bridgeJid, new BridgeState(bridgeJid));


### PR DESCRIPTION
FIXED:  typo

1. 'for' was 'fro' (Line 126)