### PR TITLE
OF-631: Implement SCRAM support

### DIFF
--- a/src/database/openfire_db2.sql
+++ b/src/database/openfire_db2.sql
@@ -3,6 +3,10 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR(64)     NOT NULL,
+  storedKey             VARCHAR(32),
+  serverKey             VARCHAR(32),
+  salt                  VARCHAR(32),
+  iterations            INTEGER,
   plainPassword         VARCHAR(32),
   encryptedPassword     VARCHAR(255),
   name                  VARCHAR(100),

--- a/src/database/openfire_hsqldb.sql
+++ b/src/database/openfire_hsqldb.sql
@@ -3,6 +3,10 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR(64)     NOT NULL,
+  storedKey             VARCHAR(32),
+  serverKey             VARCHAR(32),
+  salt                  VARCHAR(32),
+  iterations            INTEGER,
   plainPassword         VARCHAR(32),
   encryptedPassword     VARCHAR(255),
   name                  VARCHAR(100),

--- a/src/database/openfire_mysql.sql
+++ b/src/database/openfire_mysql.sql
@@ -3,6 +3,10 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR(64)     NOT NULL,
+  storedKey             VARCHAR(32),
+  serverKey             VARCHAR(32),
+  salt                  VARCHAR(32),
+  iterations            INTEGER,
   plainPassword         VARCHAR(32),
   encryptedPassword     VARCHAR(255),
   name                  VARCHAR(100),

--- a/src/database/openfire_oracle.sql
+++ b/src/database/openfire_oracle.sql
@@ -3,6 +3,10 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR2(64)     NOT NULL,
+  storedKey             VARCHAR(32),
+  serverKey             VARCHAR(32),
+  salt                  VARCHAR(32),
+  iterations            INTEGER,
   plainPassword         VARCHAR2(32),
   encryptedPassword     VARCHAR2(255),
   name                  VARCHAR2(100),

--- a/src/database/openfire_postgresql.sql
+++ b/src/database/openfire_postgresql.sql
@@ -5,6 +5,10 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR(64)     NOT NULL,
+  storedKey             VARCHAR(32),
+  serverKey             VARCHAR(32),
+  salt                  VARCHAR(32),
+  iterations            INTEGER,
   plainPassword         VARCHAR(32),
   encryptedPassword     VARCHAR(255),
   name                  VARCHAR(100),

--- a/src/database/openfire_sqlserver.sql
+++ b/src/database/openfire_sqlserver.sql
@@ -3,6 +3,10 @@
 
 CREATE TABLE ofUser (
   username              NVARCHAR(64)    NOT NULL,
+  storedKey             VARCHAR(32),
+  serverKey             VARCHAR(32),
+  salt                  VARCHAR(32),
+  iterations            INTEGER,
   plainPassword         NVARCHAR(32),
   encryptedPassword     NVARCHAR(255),
   name                  NVARCHAR(100),

--- a/src/database/openfire_sybase.sql
+++ b/src/database/openfire_sybase.sql
@@ -3,6 +3,10 @@
 
 CREATE TABLE ofUser (
   username              NVARCHAR(64)    NOT NULL,
+  storedKey             VARCHAR(32),
+  serverKey             VARCHAR(32),
+  salt                  VARCHAR(32),
+  iterations            INTEGER,
   plainPassword         NVARCHAR(32)    NULL,
   encryptedPassword     NVARCHAR(255)   NULL,
   name                  NVARCHAR(100)   NULL,

--- a/src/database/upgrade/22/openfire_db2.sql
+++ b/src/database/upgrade/22/openfire_db2.sql
@@ -1,0 +1,7 @@
+// add columns for SASL SCRAM-SHA-1
+ALTER TABLE ofUser ADD COLUMN storedKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN serverKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN salt VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN iterations INTEGER;
+
+UPDATE ofVersion SET version = 22 WHERE name = 'openfire';

--- a/src/database/upgrade/22/openfire_hsqldb.sql
+++ b/src/database/upgrade/22/openfire_hsqldb.sql
@@ -1,0 +1,7 @@
+// add columns for SASL SCRAM-SHA-1
+ALTER TABLE ofUser ADD COLUMN storedKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN serverKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN salt VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN iterations INTEGER;
+
+UPDATE ofVersion SET version = 22 WHERE name = 'openfire';

--- a/src/database/upgrade/22/openfire_mysql.sql
+++ b/src/database/upgrade/22/openfire_mysql.sql
@@ -1,0 +1,7 @@
+// add columns for SASL SCRAM-SHA-1
+ALTER TABLE ofUser ADD COLUMN storedKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN serverKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN salt VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN iterations INTEGER;
+
+UPDATE ofVersion SET version = 22 WHERE name = 'openfire';

--- a/src/database/upgrade/22/openfire_oracle.sql
+++ b/src/database/upgrade/22/openfire_oracle.sql
@@ -1,0 +1,9 @@
+// add columns for SASL SCRAM-SHA-1
+ALTER TABLE ofUser ADD COLUMN storedKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN serverKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN salt VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN iterations INTEGER;
+
+UPDATE ofVersion SET version = 22 WHERE name = 'openfire';
+
+COMMIT;

--- a/src/database/upgrade/22/openfire_postgresql.sql
+++ b/src/database/upgrade/22/openfire_postgresql.sql
@@ -1,0 +1,7 @@
+// add columns for SASL SCRAM-SHA-1
+ALTER TABLE ofUser ADD COLUMN storedKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN serverKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN salt VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN iterations INTEGER;
+
+UPDATE ofVersion SET version = 22 WHERE name = 'openfire';

--- a/src/database/upgrade/22/openfire_sqlserver.sql
+++ b/src/database/upgrade/22/openfire_sqlserver.sql
@@ -1,0 +1,7 @@
+// add columns for SASL SCRAM-SHA-1
+ALTER TABLE ofUser ADD COLUMN storedKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN serverKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN salt VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN iterations INTEGER;
+
+UPDATE ofVersion SET version = 22 WHERE name = 'openfire';

--- a/src/database/upgrade/22/openfire_sybase.sql
+++ b/src/database/upgrade/22/openfire_sybase.sql
@@ -1,0 +1,7 @@
+// add columns for SASL SCRAM-SHA-1
+ALTER TABLE ofUser ADD COLUMN storedKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN serverKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN salt VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN iterations INTEGER;
+
+UPDATE ofVersion SET version = 22 WHERE name = 'openfire';

--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -1959,6 +1959,9 @@ setup.profile.description=Choose the user and group system to use with the serve
 setup.profile.default=Default
 setup.profile.default_description=Store users and groups in the server database. This is the \
   best option for simple deployments.
+setup.profile.default.scramOnly=Only Hashed Passwords
+setup.profile.default.scramOnly_description=Store only non-reversible hashes of passwords in the database. \
+  This only supports PLAIN and SCRAM-SHA-1 capable clients.
 setup.profile.ldap=Directory Server (LDAP)
 setup.profile.ldap_description=Integrate with a directory server such as Active Directory or \
   OpenLDAP using the LDAP protocol. Users and groups are stored in the directory and treated \

--- a/src/java/org/jivesoftware/database/SchemaManager.java
+++ b/src/java/org/jivesoftware/database/SchemaManager.java
@@ -68,7 +68,7 @@ public class SchemaManager {
     /**
      * Current Openfire database schema version.
      */
-    private static final int DATABASE_VERSION = 21;
+    private static final int DATABASE_VERSION = 22;
 
     /**
      * Creates a new Schema manager.

--- a/src/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/src/java/org/jivesoftware/openfire/XMPPServer.java
@@ -49,6 +49,7 @@ import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.openfire.admin.AdminManager;
 import org.jivesoftware.openfire.audit.AuditManager;
 import org.jivesoftware.openfire.audit.spi.AuditManagerImpl;
+import org.jivesoftware.openfire.auth.ScramUtils;
 import org.jivesoftware.openfire.clearspace.ClearspaceManager;
 import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.cluster.NodeID;
@@ -420,6 +421,9 @@ public class XMPPServer {
                     JiveGlobals.setProperty(propName, JiveGlobals.getXMLProperty(propName));
                 }
             }
+            
+            // Set default SASL SCRAM-SHA-1 iteration count
+            JiveGlobals.setProperty("sasl.scram-sha-1.iteration-count", Integer.toString(ScramUtils.DEFAULT_ITERATION_COUNT));
 
             // Update certificates (if required)
             try {

--- a/src/java/org/jivesoftware/openfire/auth/AuthFactory.java
+++ b/src/java/org/jivesoftware/openfire/auth/AuthFactory.java
@@ -328,4 +328,9 @@ public class AuthFactory {
         }
         return cipher;
     }
+
+    public static boolean supportsScram() {
+        // TODO Auto-generated method stub
+        return authProvider.isScramSupported();
+    }
 }

--- a/src/java/org/jivesoftware/openfire/auth/AuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/AuthProvider.java
@@ -129,4 +129,6 @@ public interface AuthProvider {
      *         backend user store.
      */
     public boolean supportsPasswordRetrieval();
+
+    boolean isScramSupported();
 }

--- a/src/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
@@ -257,4 +257,10 @@ public class HybridAuthProvider implements AuthProvider {
     public boolean supportsPasswordRetrieval() {
         return false;
     }
+
+    @Override
+    public boolean isScramSupported() {
+        // TODO Auto-generated method stub
+        return false;
+    }
 }

--- a/src/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
@@ -409,4 +409,10 @@ public class JDBCAuthProvider implements AuthProvider {
             }
         }
     }
+
+    @Override
+    public boolean isScramSupported() {
+        // TODO Auto-generated method stub
+        return false;
+    }
 }

--- a/src/java/org/jivesoftware/openfire/auth/NativeAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/NativeAuthProvider.java
@@ -204,4 +204,10 @@ public class NativeAuthProvider implements AuthProvider {
     public boolean supportsPasswordRetrieval() {
         return false;
     }
+
+    @Override
+    public boolean isScramSupported() {
+        // TODO Auto-generated method stub
+        return false;
+    }
 }

--- a/src/java/org/jivesoftware/openfire/auth/POP3AuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/POP3AuthProvider.java
@@ -245,4 +245,8 @@ public class POP3AuthProvider implements AuthProvider {
     public boolean supportsPasswordRetrieval() {
         return false;
     }
+    
+    public boolean isScramSupported() {
+        return false;
+    }
 }

--- a/src/java/org/jivesoftware/openfire/auth/ScramUtils.java
+++ b/src/java/org/jivesoftware/openfire/auth/ScramUtils.java
@@ -1,0 +1,82 @@
+/**
+ * $RCSfile$
+ * $Revision: $
+ * $Date: $
+ *
+ * Copyright 2015 Surevine Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.auth;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import javax.security.sasl.SaslException;
+
+import org.jivesoftware.util.JiveGlobals;
+
+/**
+ * A utility class that provides methods that are useful for dealing with
+ * Salted Challenge Response Authentication Mechanism (SCRAM).
+ * 
+ * @author Richard Midwinter
+ */
+public class ScramUtils {
+	
+	public static final int DEFAULT_ITERATION_COUNT = 4096;
+
+	private ScramUtils() {}
+
+    public static byte[] createSaltedPassword(byte[] salt, String password, int iters) throws SaslException {
+        Mac mac = createSha1Hmac(password.getBytes(StandardCharsets.US_ASCII));
+        mac.update(salt);
+        mac.update(new byte[]{0, 0, 0, 1});
+        byte[] result = mac.doFinal();
+
+        byte[] previous = null;
+        for (int i = 1; i < iters; i++) {
+            mac.update(previous != null ? previous : result);
+            previous = mac.doFinal();
+            for (int x = 0; x < result.length; x++) {
+                result[x] ^= previous[x];
+            }
+        }
+
+        return result;
+    }
+    
+    public static byte[] computeHmac(final byte[] key, final String string)
+            throws SaslException, UnsupportedEncodingException {
+        Mac mac = createSha1Hmac(key);
+        mac.update(string.getBytes(StandardCharsets.US_ASCII));
+        return mac.doFinal();
+    }
+
+    public static Mac createSha1Hmac(final byte[] keyBytes)
+            throws SaslException {
+        try {
+            SecretKeySpec key = new SecretKeySpec(keyBytes, "HmacSHA1");
+            Mac mac = Mac.getInstance("HmacSHA1");
+            mac.init(key);
+            return mac;
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new SaslException(e.getMessage(), e);
+        }
+    }
+}

--- a/src/java/org/jivesoftware/openfire/clearspace/ClearspaceAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/clearspace/ClearspaceAuthProvider.java
@@ -131,4 +131,9 @@ public class ClearspaceAuthProvider implements AuthProvider {
     public boolean supportsPasswordRetrieval() {
         return false;
     }
+
+    @Override
+    public boolean isScramSupported() {
+        return false;
+    }
 }

--- a/src/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
@@ -109,4 +109,10 @@ public class CrowdAuthProvider implements AuthProvider {
 		return false;
 	}
 
+    @Override
+    public boolean isScramSupported() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
 }

--- a/src/java/org/jivesoftware/openfire/ldap/LdapAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapAuthProvider.java
@@ -160,4 +160,9 @@ public class LdapAuthProvider implements AuthProvider {
     public boolean supportsPasswordRetrieval() {
         return false;
     }
+
+    @Override
+    public boolean isScramSupported() {
+        return false;
+    }
 }

--- a/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -802,6 +802,11 @@ public class SASLAuthentication {
                     it.remove();
                 }
             }
+            else if (mech.equals("SCRAM-SHA-1")) {
+                if (!AuthFactory.supportsPasswordRetrieval() && !AuthFactory.supportsScram()) {
+                    it.remove();
+                }
+            }
             else if (mech.equals("ANONYMOUS")) {
                 // Check anonymous is supported
                 if (!XMPPServer.getInstance().getIQAuthHandler().isAnonymousAllowed()) {
@@ -832,6 +837,7 @@ public class SASLAuthentication {
             mechanisms.add("PLAIN");
             mechanisms.add("DIGEST-MD5");
             mechanisms.add("CRAM-MD5");
+            mechanisms.add("SCRAM-SHA-1");
             mechanisms.add("JIVE-SHAREDSECRET");
         }
         else {
@@ -843,6 +849,7 @@ public class SASLAuthentication {
                         mech.equals("PLAIN") ||
                         mech.equals("DIGEST-MD5") ||
                         mech.equals("CRAM-MD5") ||
+                        mech.equals("SCRAM-SHA-1") ||
                         mech.equals("GSSAPI") ||
                         mech.equals("EXTERNAL") ||
                         mech.equals("JIVE-SHAREDSECRET")) 

--- a/src/java/org/jivesoftware/openfire/sasl/SaslProvider.java
+++ b/src/java/org/jivesoftware/openfire/sasl/SaslProvider.java
@@ -34,10 +34,12 @@ public class SaslProvider extends Provider {
      * Constructs a the JiveSoftware SASL provider.
      */
     public SaslProvider() {
-        super("JiveSoftware", 1.0, "JiveSoftware SASL provider v1.0, implementing server mechanisms for: PLAIN, CLEARSPACE");
+        super("JiveSoftware", 1.0, "JiveSoftware SASL provider v1.0, implementing server mechanisms for: PLAIN, CLEARSPACE, SCRAM-SHA-1");
         // Add SaslServer supporting the PLAIN SASL mechanism
         put("SaslServerFactory.PLAIN", "org.jivesoftware.openfire.sasl.SaslServerFactoryImpl");
         // Add SaslServer supporting the Clearspace SASL mechanism
         put("SaslServerFactory.CLEARSPACE", "org.jivesoftware.openfire.sasl.SaslServerFactoryImpl");
+        // Add SaslServer supporting the SCRAM-SHA-1 SASL mechanism
+        put("SaslServerFactory.SCRAM-SHA-1", "org.jivesoftware.openfire.sasl.SaslServerFactoryImpl");
     }
 }

--- a/src/java/org/jivesoftware/openfire/sasl/SaslServerFactoryImpl.java
+++ b/src/java/org/jivesoftware/openfire/sasl/SaslServerFactoryImpl.java
@@ -38,9 +38,10 @@ import org.jivesoftware.openfire.clearspace.ClearspaceSaslServer;
 
 public class SaslServerFactoryImpl implements SaslServerFactory {
 
-    private static final String myMechs[] = { "PLAIN", "CLEARSPACE" };
+    private static final String myMechs[] = { "PLAIN", "CLEARSPACE", "SCRAM-SHA-1" };
     private static final int PLAIN = 0;
     private static final int CLEARSPACE = 1;
+    private static final int SCRAM_SHA_1 = 2;
 
     public SaslServerFactoryImpl() {
     }
@@ -69,6 +70,12 @@ public class SaslServerFactoryImpl implements SaslServerFactory {
                 throw new SaslException("CallbackHandler with support for AuthorizeCallback required");
             }
             return new ClearspaceSaslServer();
+        }
+        else if (mechanism.equals(myMechs[SCRAM_SHA_1])) {
+        	if (cbh == null) {
+                throw new SaslException("CallbackHandler with support for AuthorizeCallback required");
+        	}
+        	return new ScramSha1SaslServer();
         }
         return null;
     }

--- a/src/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/src/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -1,0 +1,342 @@
+/**
+ * $RCSfile$
+ * $Revision: $
+ * $Date: $
+ *
+ * Copyright 2015 Surevine Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.sasl;
+
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import javax.xml.bind.DatatypeConverter;
+
+import org.jivesoftware.openfire.auth.AuthFactory;
+import org.jivesoftware.openfire.auth.ConnectionException;
+import org.jivesoftware.openfire.auth.InternalUnauthenticatedException;
+import org.jivesoftware.openfire.auth.ScramUtils;
+import org.jivesoftware.openfire.user.UserManager;
+import org.jivesoftware.openfire.user.UserNotFoundException;
+
+/**
+ * Implements the SCRAM-SHA-1 server-side mechanism.
+ *
+ * @author Richard Midwinter
+ */
+public class ScramSha1SaslServer implements SaslServer {
+	
+	private static final Pattern
+			CLIENT_FIRST_MESSAGE = Pattern.compile("^(([pny])=?([^,]*),([^,]*),)(m?=?[^,]*,?n=([^,]*),r=([^,]*),?.*)$"),
+			CLIENT_FINAL_MESSAGE = Pattern.compile("(c=([^,]*),r=([^,]*)),p=(.*)$");
+
+    private String username;
+    private State state = State.INITIAL;
+    private String nonce;
+    private String serverFirstMessage;
+    private String clientFirstMessageBare;
+    private SecureRandom random = new SecureRandom();
+    
+    private enum State {
+    	INITIAL,
+    	IN_PROGRESS,
+    	COMPLETE;
+    }
+    
+    public ScramSha1SaslServer() {
+    }
+
+    /**
+     * Returns the IANA-registered mechanism name of this SASL server.
+     * ("SCRAM-SHA-1").
+     * @return A non-null string representing the IANA-registered mechanism name.
+     */
+    public String getMechanismName() {
+        return "SCRAM-SHA-1";
+    }
+
+    /**
+     * Evaluates the response data and generates a challenge.
+     *
+     * If a response is received from the client during the authentication
+     * process, this method is called to prepare an appropriate next
+     * challenge to submit to the client. The challenge is null if the
+     * authentication has succeeded and no more challenge data is to be sent
+     * to the client. It is non-null if the authentication must be continued
+     * by sending a challenge to the client, or if the authentication has
+     * succeeded but challenge data needs to be processed by the client.
+     * <tt>isComplete()</tt> should be called
+     * after each call to <tt>evaluateResponse()</tt>,to determine if any further
+     * response is needed from the client.
+     *
+     * @param response The non-null (but possibly empty) response sent
+     * by the client.
+     *
+     * @return The possibly null challenge to send to the client.
+     * It is null if the authentication has succeeded and there is
+     * no more challenge data to be sent to the client.
+     * @exception SaslException If an error occurred while processing
+     * the response or generating a challenge.
+     */
+    @Override
+    public byte[] evaluateResponse(final byte[] response) throws SaslException {
+        byte[] challenge;
+        switch (state) {
+            case INITIAL:
+                challenge = generateServerFirstMessage(response);
+                state = State.IN_PROGRESS;
+                break;
+            case IN_PROGRESS:
+                challenge = generateServerFinalMessage(response);
+                state = State.COMPLETE;
+                break;
+            case COMPLETE:
+                if (response == null || response.length == 0) {
+                    challenge = new byte[0];
+                    break;
+                }
+            default:
+                throw new SaslException("No response expected in state " + state);
+
+        }
+        return challenge;
+    }
+
+    /**
+     * First response returns:
+     *   - the nonce (client nonce appended with our own random UUID)
+     *   - the salt
+     *   - the number of iterations
+     */
+    private byte[] generateServerFirstMessage(final byte[] response) throws SaslException {
+        String clientFirstMessage = new String(response, StandardCharsets.US_ASCII);
+        
+        Matcher m = CLIENT_FIRST_MESSAGE.matcher(clientFirstMessage);
+        if (!m.matches()) {
+        	throw new SaslException("Invalid first client message");
+        }
+        
+//        String gs2Header = m.group(1);
+//        String gs2CbindFlag = m.group(2);
+//        String gs2CbindName = m.group(3);
+//        String authzId = m.group(4);
+        clientFirstMessageBare = m.group(5);
+        username = m.group(6);
+        String clientNonce = m.group(7);
+        
+        nonce = clientNonce + UUID.randomUUID().toString();
+
+        try {
+			serverFirstMessage = String.format("r=%s,s=%s,i=%d", nonce, DatatypeConverter.printBase64Binary(getSalt(username)),
+					getIterations(username));
+		} catch (UserNotFoundException e) {
+            throw new SaslException(e.getMessage(), e);
+		}
+        
+        return serverFirstMessage.getBytes(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Final response returns the server signature.
+     */
+    private byte[] generateServerFinalMessage(final byte[] response) throws SaslException {
+        String clientFinalMessage = new String(response, StandardCharsets.US_ASCII);
+        
+        Matcher m = CLIENT_FINAL_MESSAGE.matcher(clientFinalMessage);
+        if (!m.matches()) {
+        	throw new SaslException("Invalid client final message");
+        }
+
+        String clientFinalMessageWithoutProof = m.group(1);
+//        String channelBinding = m.group(2);
+        String clientNonce = m.group(3);
+        String proof = m.group(4);
+        
+        if (!nonce.equals(clientNonce)) {
+            throw new SaslException("Client final message has incorrect nonce value");
+        }
+
+        try {
+            String authMessage = clientFirstMessageBare + "," + serverFirstMessage + "," + clientFinalMessageWithoutProof;
+            byte[] storedKey = getStoredKey(username);
+            byte[] serverKey = getServerKey(username);
+
+            byte[] clientSignature = ScramUtils.computeHmac(storedKey, authMessage);
+            byte[] serverSignature = ScramUtils.computeHmac(serverKey, authMessage);
+            
+            byte[] clientKey = clientSignature.clone();
+            byte[] decodedProof = DatatypeConverter.parseBase64Binary(proof);
+            for (int i = 0; i < clientKey.length; i++) {
+            	clientKey[i] ^= decodedProof[i];
+            }
+
+            if (!Arrays.equals(storedKey, MessageDigest.getInstance("SHA-1").digest(clientKey))) {
+                throw new SaslException("Authentication failed");
+            }
+            return ("v=" + DatatypeConverter.printBase64Binary(serverSignature))
+            		.getBytes(StandardCharsets.US_ASCII);
+        } catch (UnsupportedEncodingException | UserNotFoundException | NoSuchAlgorithmException e) {
+            throw new SaslException(e.getMessage(), e);
+        }
+    }
+
+   /**
+      * Determines whether the authentication exchange has completed.
+      * This method is typically called after each invocation of
+      * <tt>evaluateResponse()</tt> to determine whether the
+      * authentication has completed successfully or should be continued.
+      * @return true if the authentication exchange has completed; false otherwise.
+      */
+    public boolean isComplete() {
+        return state == State.COMPLETE;
+    }
+
+    /**
+     * Reports the authorization ID in effect for the client of this
+     * session.
+     * This method can only be called if isComplete() returns true.
+     * @return The authorization ID of the client.
+     * @exception IllegalStateException if this authentication session has not completed
+     */
+    public String getAuthorizationID() {
+        if (isComplete()) {
+            return username;
+        } else {
+            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
+        }
+    }
+
+    /**
+     * Unwraps a byte array received from the client. SCRAM-SHA-1 supports no security layer.
+     * 
+     * @throws SaslException if attempted to use this method.
+     */
+    public byte[] unwrap(byte[] incoming, int offset, int len)
+        throws SaslException {
+    	if (isComplete()) {
+            throw new IllegalStateException("SCRAM-SHA-1 does not support integrity or privacy");
+        } else {
+            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
+        }
+    }
+
+    /**
+     * Wraps a byte array to be sent to the client. SCRAM-SHA-1 supports no security layer.
+     *
+     * @throws SaslException if attempted to use this method.
+     */
+    public byte[] wrap(byte[] outgoing, int offset, int len)
+        throws SaslException {
+    	if (isComplete()) {
+            throw new IllegalStateException("SCRAM-SHA-1 does not support integrity or privacy");
+        } else {
+            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
+        }
+    }
+
+    /**
+     * Retrieves the negotiated property.
+     * This method can be called only after the authentication exchange has
+     * completed (i.e., when <tt>isComplete()</tt> returns true); otherwise, an
+     * <tt>IllegalStateException</tt> is thrown.
+     *
+     * @param propName the property
+     * @return The value of the negotiated property. If null, the property was
+     * not negotiated or is not applicable to this mechanism.
+     * @exception IllegalStateException if this authentication exchange has not completed
+     */
+    public Object getNegotiatedProperty(String propName) {
+    	if (isComplete()) {
+            if (propName.equals(Sasl.QOP)) {
+                return "auth";
+            } else {
+                return null;
+            }
+        } else {
+            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
+        }
+    }
+
+     /**
+      * Disposes of any system resources or security-sensitive information
+      * the SaslServer might be using. Invoking this method invalidates
+      * the SaslServer instance. This method is idempotent.
+      * @throws SaslException If a problem was encountered while disposing
+      * the resources.
+      */
+    public void dispose() throws SaslException {
+        username = null;
+        state = State.INITIAL;
+    }
+    
+    /**
+     * Retrieve the salt from the database for a given username.
+     * 
+     * Returns a random salt if the user doesn't exist to mimic an invalid password. 
+     */
+    private byte[] getSalt(final String username) {
+        try {
+            String saltshaker = UserManager.getUserProvider().loadUser(username).getSalt();
+            byte[] salt;
+            if (saltshaker == null) {
+                String password = AuthFactory.getPassword(username);
+                AuthFactory.setPassword(username, password);
+                salt = DatatypeConverter.parseBase64Binary(UserManager.getUserProvider().loadUser(username).getSalt());
+            } else {
+                salt = DatatypeConverter.parseBase64Binary(saltshaker);
+            }
+            return salt;
+        } catch (UserNotFoundException | UnsupportedOperationException | ConnectionException | InternalUnauthenticatedException e) {
+            byte[] salt = new byte[32];
+            random.nextBytes(salt);
+            return salt;
+        }
+    }
+    
+    /**
+     * Retrieve the iteration count from the database for a given username.
+     */
+    private int getIterations(final String username) throws UserNotFoundException {
+    	return UserManager.getUserProvider().loadUser(username).getIterations();
+    }
+    
+    /**
+     * Retrieve the server key from the database for a given username.
+     */
+    private byte[] getServerKey(final String username) throws UserNotFoundException {
+    	return DatatypeConverter.parseBase64Binary(
+    			UserManager.getUserProvider().loadUser(username).getServerKey());
+    }
+    
+    /**
+     * Retrieve the stored key from the database for a given username.
+     */
+    private byte[] getStoredKey(final String username) throws UserNotFoundException {
+    	return DatatypeConverter.parseBase64Binary(
+    			UserManager.getUserProvider().loadUser(username).getStoredKey());
+    }
+}

--- a/src/java/org/jivesoftware/openfire/user/User.java
+++ b/src/java/org/jivesoftware/openfire/user/User.java
@@ -84,6 +84,10 @@ public class User implements Cacheable, Externalizable, Result {
     private static final String EMAIL_VISIBLE_PROPERTY = "email.visible";
 
     private String username;
+    private String salt;
+    private String storedKey;
+    private String serverKey;
+    private int iterations;
     private String name;
     private String email;
     private Date creationDate;
@@ -198,6 +202,38 @@ public class User implements Cacheable, Externalizable, Result {
 		} catch (InternalUnauthenticatedException e) {
             Log.error(e.getMessage(), e);
 		}
+    }
+    
+    public String getStoredKey() {
+    	return storedKey;
+    }
+    
+    public void setStoredKey(String storedKey) {
+    	this.storedKey = storedKey;
+    }
+    
+    public String getServerKey() {
+    	return serverKey;
+    }
+    
+    public void setServerKey(String serverKey) {
+    	this.serverKey = serverKey;
+    }
+    
+    public String getSalt() {
+    	return salt;
+    }
+    
+    public void setSalt(String salt) {
+    	this.salt = salt;
+    }
+    
+    public int getIterations() {
+    	return iterations;
+    }
+    
+    public void setIterations(int iterations) {
+    	this.iterations = iterations;
     }
 
     public String getName() {

--- a/src/web/setup/setup-admin-settings.jsp
+++ b/src/web/setup/setup-admin-settings.jsp
@@ -71,6 +71,11 @@
         if (password == null) {
             errors.put("password", "password");
         }
+        try {
+            AuthFactory.authenticate("admin", "admin");
+        } catch (Exception e) {
+            errors.put("password", "password");
+        }
         if (email == null) {
             errors.put("email", "email");
         }
@@ -248,14 +253,15 @@ function checkClick() {
 <%
     // If the current password is "admin", don't show the text box for them to type
     // the current password. This makes setup simpler for first-time users.
-    String currentPass = null;
+    boolean defaultPassword = false;
     try {
-        currentPass = AuthFactory.getPassword("admin");
+        AuthFactory.authenticate("admin", "admin");
+        defaultPassword = true;
     }
     catch (Exception e) {
         // Ignore.
     }
-    if ("admin".equals(currentPass)) {
+    if (defaultPassword) {
 %>
 <input type="hidden" name="password" value="admin">
 <%

--- a/src/web/setup/setup-profile-settings.jsp
+++ b/src/web/setup/setup-profile-settings.jsp
@@ -25,6 +25,8 @@
             JiveGlobals.getProperty("provider.auth.className"));
     boolean isCLEARSPACE = "org.jivesoftware.openfire.clearspace.ClearspaceAuthProvider".equals(
             JiveGlobals.getProperty("provider.auth.className"));
+    boolean scramOnly = JiveGlobals.getBooleanProperty("user.scramHashedPasswordOnly");
+    boolean requestedScramOnly = (request.getParameter("scramOnly") != null);
     boolean next = request.getParameter("continue") != null;
     if (next) {
         // Figure out where to send the user.
@@ -49,6 +51,9 @@
                     org.jivesoftware.openfire.security.DefaultSecurityAuditProvider.class.getName()));
             xmppSettings.put("provider.admin.className", JiveGlobals.getXMLProperty("provider.admin.className",
                     org.jivesoftware.openfire.admin.DefaultAdminProvider.class.getName()));
+            if (requestedScramOnly) {
+                JiveGlobals.setProperty("user.scramHashedPasswordOnly", "true");
+            }
 
             // Redirect
             response.sendRedirect("setup-admin-settings.jsp");
@@ -91,6 +96,15 @@
     <td>
         <label for="rb01"><b><fmt:message key="setup.profile.default" /></b></label><br>
 	    <fmt:message key="setup.profile.default_description" />
+    </td>
+</tr>
+<tr>
+    <td align="center" valign="top">
+        <input type="checkbox" name="scramOnly" value="scramOnly" id="rb01-0" <% if (scramOnly) { %>checked<% } %>>
+    </td>
+    <td>
+        <label for="rb01-0"><b><fmt:message key="setup.profile.default.scramOnly" /></b></label><br>
+	    <fmt:message key="setup.profile.default.scramOnly_description" />
     </td>
 </tr>
 <tr>


### PR DESCRIPTION
This implements the SCRAM-SHA1 mechanism, and includes extending the existing
DefaultAuthProvider to store the Scram hashes for faster authentication.

If user.scramHashedOnly is set to true, then only these non-reversable hashes
are stored (and thus security is increased in exchanged for removing support
for DIGEST-MD5 et al).