### PR TITLE
Initial xep-0198 message ack implementation

### DIFF
--- a/src/conf/openfire.xml
+++ b/src/conf/openfire.xml
@@ -34,13 +34,25 @@
     </network>
     -->
 
-    <!-- SPDY  Protocol is npn. 
-    	(note: npn does not work with Java 8) 
+    <!-- SPDY  Protocol is npn.
+    	(note: npn does not work with Java 8)
     	add -Xbootclasspath/p:/OPENFIRE_HOME/lib/npn-boot.jar to .vmoptions file    -->
 
-    <!--     
-    <spdy> 
-    	<protocol>npn</protocol> 
-    </spdy> 
+    <!--
+    <spdy>
+    	<protocol>npn</protocol>
+    </spdy>
     -->
+
+	<!-- XEP-0198 properties -->
+    <stream>
+    	<management>
+    		<!-- Whether stream management is offered to clients by server. -->
+    		<active>true</active>
+    		<!-- Number of stanzas sent to client before a stream management
+    			 acknowledgement request is made. -->
+    		<requestFrequency>5</requestFrequency>
+    	</management>
+    </stream>
+
 </jive>

--- a/src/java/org/jivesoftware/openfire/OfflineMessageStore.java
+++ b/src/java/org/jivesoftware/openfire/OfflineMessageStore.java
@@ -210,14 +210,18 @@ public class OfflineMessageStore extends BasicModule implements UserEventListene
                             xmlReader.read(new StringReader(msgXML)).getRootElement());
                 }
 
-                // Add a delayed delivery (XEP-0203) element to the message.
-                Element delay = message.addChildElement("delay", "urn:xmpp:delay");
-                delay.addAttribute("from", XMPPServer.getInstance().getServerInfo().getXMPPDomain());
-                delay.addAttribute("stamp", XMPPDateTimeFormat.format(creationDate));
-                // Add a legacy delayed delivery (XEP-0091) element to the message. XEP is obsolete and support should be dropped in future.
-                delay = message.addChildElement("x", "jabber:x:delay");
-                delay.addAttribute("from", XMPPServer.getInstance().getServerInfo().getXMPPDomain());
-                delay.addAttribute("stamp", XMPPDateTimeFormat.formatOld(creationDate));
+                // if there is already a delay stamp, we shouldn't add another.
+                Element delaytest = message.getChildElement("delay", "urn:xmpp:delay");
+                if (delaytest == null) {
+                    // Add a delayed delivery (XEP-0203) element to the message.
+                    Element delay = message.addChildElement("delay", "urn:xmpp:delay");
+                    delay.addAttribute("from", XMPPServer.getInstance().getServerInfo().getXMPPDomain());
+                    delay.addAttribute("stamp", XMPPDateTimeFormat.format(creationDate));
+                    // Add a legacy delayed delivery (XEP-0091) element to the message. XEP is obsolete and support should be dropped in future.
+                    delay = message.addChildElement("x", "jabber:x:delay");
+                    delay.addAttribute("from", XMPPServer.getInstance().getServerInfo().getXMPPDomain());
+                    delay.addAttribute("stamp", XMPPDateTimeFormat.formatOld(creationDate));
+                }
                 messages.add(message);
             }
             // Check if the offline messages loaded should be deleted, and that there are

--- a/src/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -28,6 +28,7 @@ import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.http.FlashCrossDomainServlet;
 import org.jivesoftware.openfire.session.LocalSession;
 import org.jivesoftware.openfire.session.Session;
+import org.jivesoftware.openfire.streammanagement.StreamManager;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.LocaleUtils;
 import org.jivesoftware.util.StringUtils;
@@ -182,13 +183,28 @@ public abstract class StanzaHandler {
                 // resource binding and session establishment (to client sessions only)
                 waitingCompressionACK = true;
             }
+        } else if(isStreamManagementStanza(doc)) {
+        	switch(tag) {
+        		case "enable":
+        			session.enableStreamMangement(doc);
+        			break;
+        		case "r":
+        			session.getStreamManager().sendServerAcknowledgement();
+        			break;
+        		case "a":
+        			session.getStreamManager().processClientAcknowledgement(doc);
+        			break;
+        		default:
+        			process(doc);
+        			break;
+        	}
         }
         else {
             process(doc);
         }
     }
 
-    private void process(Element doc) throws UnauthorizedException {
+	private void process(Element doc) throws UnauthorizedException {
         if (doc == null) {
             return;
         }
@@ -535,6 +551,16 @@ public abstract class StanzaHandler {
         sb.append("</stream:features>");
         connection.deliverRawText(sb.toString());
     }
+
+	/**
+	 * Determines whether stanza's namespace matches XEP-0198 namespace
+	 * @param stanza Stanza to be checked
+	 * @return whether stanza's namespace matches XEP-0198 namespace
+	 */
+	private boolean isStreamManagementStanza(Element stanza) {
+		return StreamManager.NAMESPACE_V2.equals(stanza.getNamespace().getStringValue()) ||
+				StreamManager.NAMESPACE_V3.equals(stanza.getNamespace().getStringValue());
+	}
 
     private String geStreamHeader() {
         StringBuilder sb = new StringBuilder(200);

--- a/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -21,6 +21,7 @@
 package org.jivesoftware.openfire.session;
 
 import java.net.UnknownHostException;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -867,7 +868,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
         if(streamManager.isEnabled()) {
         	streamManager.incrementServerSentStanzas();
         	// Temporarily store packet until delivery confirmed
-        	streamManager.getUnacknowledgedServerStanzas().put(streamManager.getServerSentStanzas(), packet.createCopy());
+        	streamManager.getUnacknowledgedServerStanzas().addLast(new StreamManager.UnackedPacket(new Date(), packet.createCopy()));
 	        if(getNumServerPackets() % JiveGlobals.getLongProperty("stream.management.requestFrequency", 5) == 0) {
 	        	streamManager.sendServerRequest();
 	        }

--- a/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -38,6 +38,7 @@ import org.jivesoftware.openfire.net.SSLConfig;
 import org.jivesoftware.openfire.net.SocketConnection;
 import org.jivesoftware.openfire.privacy.PrivacyList;
 import org.jivesoftware.openfire.privacy.PrivacyListManager;
+import org.jivesoftware.openfire.streammanagement.StreamManager;
 import org.jivesoftware.openfire.user.PresenceEventDispatcher;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.util.JiveGlobals;
@@ -801,10 +802,16 @@ public class LocalClientSession extends LocalSession implements ClientSession {
             }
         }
         else {
-            // If the session has been authenticated then offer resource binding
+            // If the session has been authenticated then offer resource binding,
             // and session establishment
             sb.append("<bind xmlns=\"urn:ietf:params:xml:ns:xmpp-bind\"/>");
             sb.append("<session xmlns=\"urn:ietf:params:xml:ns:xmpp-session\"><optional/></session>");
+
+            // Offer XEP-0198 stream management capabilities if enabled.
+            if(JiveGlobals.getBooleanProperty("stream.management.active", true)) {
+            	sb.append(String.format("<sm xmlns='%s'/>", StreamManager.NAMESPACE_V2));
+            	sb.append(String.format("<sm xmlns='%s'/>", StreamManager.NAMESPACE_V3));
+            }
         }
         return sb.toString();
     }
@@ -854,7 +861,17 @@ public class LocalClientSession extends LocalSession implements ClientSession {
 
     @Override
 	public void deliver(Packet packet) throws UnauthorizedException {
+
         conn.deliver(packet);
+
+        if(streamManager.isEnabled()) {
+        	streamManager.incrementServerSentStanzas();
+        	// Temporarily store packet until delivery confirmed
+        	streamManager.getUnacknowledgedServerStanzas().put(streamManager.getServerSentStanzas(), packet.createCopy());
+	        if(getNumServerPackets() % JiveGlobals.getLongProperty("stream.management.requestFrequency", 5) == 0) {
+	        	streamManager.sendServerRequest();
+	        }
+        }
     }
 
     @Override

--- a/src/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -98,7 +98,7 @@ public abstract class LocalSession implements Session {
     /**
      * XEP-0198 Stream Manager
      */
-    protected StreamManager streamManager = null;
+    protected final StreamManager streamManager;
 
     /**
      * Creates a session with an underlying connection and permission protection.
@@ -432,7 +432,7 @@ public abstract class LocalSession implements Session {
 
     /**
      * Enables stream management for session
-     * @param enable XEP-0198 <enable/> stanza
+     * @param enable XEP-0198 <enable/> element
      */
     public void enableStreamMangement(Element enable) {
 

--- a/src/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import javax.net.ssl.SSLSession;
 
+import org.dom4j.Element;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.StreamID;
@@ -33,7 +34,7 @@ import org.jivesoftware.openfire.interceptor.InterceptorManager;
 import org.jivesoftware.openfire.interceptor.PacketRejectedException;
 import org.jivesoftware.openfire.net.SocketConnection;
 import org.jivesoftware.openfire.net.TLSStreamHandler;
-import org.jivesoftware.openfire.spi.RoutingTableImpl;
+import org.jivesoftware.openfire.streammanagement.StreamManager;
 import org.jivesoftware.util.LocaleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,6 +96,11 @@ public abstract class LocalSession implements Session {
 	private final Map<String, Object> sessionData = new HashMap<String, Object>();
 
     /**
+     * XEP-0198 Stream Manager
+     */
+    protected StreamManager streamManager = null;
+
+    /**
      * Creates a session with an underlying connection and permission protection.
      *
      * @param serverName domain of the XMPP server where the new session belongs.
@@ -111,6 +117,7 @@ public abstract class LocalSession implements Session {
         String id = streamID.getID();
         this.address = new JID(null, serverName, id, true);
         this.sessionManager = SessionManager.getInstance();
+        this.streamManager = new StreamManager(conn);
     }
 
     /**
@@ -209,6 +216,7 @@ public abstract class LocalSession implements Session {
     public void incrementClientPacketCount() {
         clientPacketCount++;
         lastActiveDate = System.currentTimeMillis();
+        streamManager.incrementServerProcessedStanzas();
     }
 
     /**
@@ -277,6 +285,14 @@ public abstract class LocalSession implements Session {
         synchronized (sessionData) {
             sessionData.remove(key);
         }
+    }
+
+    /**
+     * Get XEP-0198 Stream manager for session
+     * @return
+     */
+    public StreamManager getStreamManager() {
+    	return streamManager;
     }
 
     public void process(Packet packet) {
@@ -413,4 +429,27 @@ public abstract class LocalSession implements Session {
         }
         return "NONE";
     }
+
+    /**
+     * Enables stream management for session
+     * @param enable XEP-0198 <enable/> stanza
+     */
+    public void enableStreamMangement(Element enable) {
+
+    	// Do nothing if already enabled
+    	if(streamManager.isEnabled()) {
+    		return;
+    	}
+
+		streamManager.setNamespace(enable.getNamespace().getStringValue());
+
+    	// Ensure that resource binding has occurred
+    	if(getAddress().getResource() == null) {
+    		streamManager.sendUnexpectedError();
+    		return;
+    	}
+
+    	streamManager.setEnabled(true);
+	}
+
 }

--- a/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -1,0 +1,238 @@
+package org.jivesoftware.openfire.streammanagement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dom4j.Element;
+import org.jivesoftware.openfire.Connection;
+import org.xmpp.packet.Packet;
+
+/**
+ * XEP-0198 Stream Manager.
+ * Handles client/server messages acknowledgement.
+ *
+ * @author jonnyheavey
+ */
+public class StreamManager {
+
+    /**
+     * Stanza namespaces
+     */
+    public static final String NAMESPACE_V2 = "urn:xmpp:sm:2";
+    public static final String NAMESPACE_V3 = "urn:xmpp:sm:3";
+
+	/**
+	 * Connection (stream) to client for the session the manager belongs to
+	 */
+	private Connection connection;
+
+	/**
+	 * Whether Stream Management is enabled for session
+	 * the manager belongs to.
+	 */
+	private boolean enabled;
+
+    /**
+     * Namespace to be used in stanzas sent to client (depending on XEP-0198 version used by client)
+     */
+    private String namespace;
+
+    /**
+     * Count of how many stanzas/packets
+     * have been sent from the server to the client (not necessarily processed)
+     */
+    private long serverSentStanzas = 0;
+
+    /**
+     * Count of how many stanzas/packets
+     * sent from the client that the server has processed
+     */
+    private long serverProcessedStanzas = 0;
+
+    /**
+ 	 * Count of how many stanzas/packets
+     * sent from the server that the client has processed
+     */
+    private long clientProcessedStanzas = 0;
+
+    /**
+     * Collection of stanzas/packets sent to client that haven't been acknowledged.
+     */
+    private Map<Long, Packet> unacknowledgedServerStanzas = new HashMap<Long, Packet>();
+
+    public StreamManager(Connection connection) {
+    	this.setConnection(connection);
+    }
+
+    /**
+     * Sends XEP-0198 acknowledgement <a /> to client from server
+     */
+	public void sendServerAcknowledgement() {
+		if(isEnabled()) {
+			String ack = String.format("<a xmlns='%s' h='%s' />", getNamespace(), getServerProcessedStanzas());
+			getConnection().deliverRawText(ack);
+		}
+	}
+
+	/**
+     * Sends XEP-0198 request <r /> to client from server
+	 */
+	public void sendServerRequest() {
+		if(isEnabled()) {
+			String request = String.format("<r xmlns='%s' />", getNamespace());
+			getConnection().deliverRawText(request);
+		}
+	}
+
+	/**
+	 * Send an error if a XEP-0198 stanza is received at an unexpected time.
+	 * e.g. before resource-binding has completed.
+	 */
+	public void sendUnexpectedError() {
+		StringBuilder sb = new StringBuilder(340);
+		sb.append(String.format("<failed xmlns='%s'>", getNamespace()));
+		sb.append("<unexpected-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>");
+		sb.append("</failed>");
+		getConnection().deliverRawText(sb.toString());
+	}
+
+	/**
+	 * Receive and process acknowledgement packet from client
+	 * @param ack XEP-0198 acknowledgement <a /> stanza to process
+	 */
+	public void processClientAcknowledgement(Element ack) {
+		if(isEnabled()) {
+			if(ack.attribute("h") != null) {
+				long count = Long.valueOf(ack.attributeValue("h"));
+				// Remove stanzas from temporary storage as now acknowledged
+				Map<Long,Packet> unacknowledgedStanzas = getUnacknowledgedServerStanzas();
+				long i = getClientProcessedStanzas();
+				while(i <= count) {
+					if(unacknowledgedStanzas.containsKey(i)) {
+						unacknowledgedStanzas.remove(i);
+					}
+					i++;
+				}
+
+				setClientProcessedStanzas(count);
+			}
+		}
+	}
+
+	/**
+	 * Get connection (stream) for the session
+	 * @return
+	 */
+	public Connection getConnection() {
+		return connection;
+	}
+
+	/**
+	 * Set connection for the session
+	 * @param connection
+	 */
+	public void setConnection(Connection connection) {
+		this.connection = connection;
+	}
+
+	/**
+	 * Determines whether Stream Management enabled for session this
+	 * manager belongs to.
+	 * @return
+	 */
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	/**
+	 * Sets whether Stream Management enabled for session this
+	 * manager belongs to.
+	 * @param enabled
+	 */
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+
+		if(enabled) {
+	    	String enabledStanza = String.format("<enabled xmlns='%s'/>", getNamespace());
+	    	getConnection().deliverRawText(enabledStanza);
+		}
+	}
+
+	/**
+	 * Retrieve configured XEP-0198 namespace
+	 * @return
+	 */
+	public String getNamespace() {
+		return namespace;
+	}
+
+	/**
+	 * Configure XEP-0198 namespace
+	 * @param namespace
+	 */
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+	/**
+	 * Retrieves number of stanzas sent to client by server.
+	 * @return
+	 */
+	public long getServerSentStanzas() {
+		return serverSentStanzas;
+	}
+
+	/**
+	 * Increments the count of stanzas sent to client by server.
+	 */
+	public void incrementServerSentStanzas() {
+		this.serverSentStanzas++;
+	}
+
+	/**
+	 * Retrieve the number of stanzas processed by the server since
+	 * Stream Management was enabled.
+	 * @return
+	 */
+	public long getServerProcessedStanzas() {
+		return serverProcessedStanzas;
+	}
+
+	/**
+	 * Increments the count of stanzas processed by the server since
+	 * Stream Management was enabled.
+	 */
+	public void incrementServerProcessedStanzas() {
+		if(isEnabled()) {
+			this.serverProcessedStanzas++;
+		}
+	}
+
+	/**
+	 * Retrieve the number of stanzas processed by the client since
+	 * Stream Management was enabled.
+	 * @return
+	 */
+	public long getClientProcessedStanzas() {
+		return clientProcessedStanzas;
+	}
+
+	/**
+	 * Sets the count of stanzas processed by the client since
+	 * Stream Management was enabled.
+	 */
+	public void setClientProcessedStanzas(long count) {
+		if(count >= clientProcessedStanzas) {
+			clientProcessedStanzas = count;
+		}
+	}
+
+	/**
+	 * Retrieves all unacknowledged stanzas sent to client from server.
+	 * @return
+	 */
+	public Map<Long, Packet> getUnacknowledgedServerStanzas() {
+		return unacknowledgedServerStanzas;
+	}
+
+}

--- a/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.dom4j.Element;
 import org.jivesoftware.openfire.Connection;
 import org.xmpp.packet.Packet;
+import org.xmpp.packet.PacketError;
 
 /**
  * XEP-0198 Stream Manager.
@@ -24,7 +25,7 @@ public class StreamManager {
 	/**
 	 * Connection (stream) to client for the session the manager belongs to
 	 */
-	private Connection connection;
+	private final Connection connection;
 
 	/**
 	 * Whether Stream Management is enabled for session
@@ -61,7 +62,7 @@ public class StreamManager {
     private Map<Long, Packet> unacknowledgedServerStanzas = new HashMap<Long, Packet>();
 
     public StreamManager(Connection connection) {
-    	this.setConnection(connection);
+    	this.connection = connection;
     }
 
     /**
@@ -91,9 +92,9 @@ public class StreamManager {
 	public void sendUnexpectedError() {
 		StringBuilder sb = new StringBuilder(340);
 		sb.append(String.format("<failed xmlns='%s'>", getNamespace()));
-		sb.append("<unexpected-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>");
+		sb.append(new PacketError(PacketError.Condition.unexpected_request).toXML());
 		sb.append("</failed>");
-		getConnection().deliverRawText(sb.toString());
+		getConnection().deliverRawText(sb.toString());	
 	}
 
 	/**
@@ -125,14 +126,6 @@ public class StreamManager {
 	 */
 	public Connection getConnection() {
 		return connection;
-	}
-
-	/**
-	 * Set connection for the session
-	 * @param connection
-	 */
-	public void setConnection(Connection connection) {
-		this.connection = connection;
 	}
 
 	/**


### PR DESCRIPTION
This patch adds a basic, non-resumable, XEP-0198 acking solution. It will
redirect "lost" messages to offline storage, but does not attempt to suspend
the session, so will not allow any resumptions.