### PR TITLE
OF-903: Simplify backup packet delivery

### DIFF
--- a/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
+++ b/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
@@ -312,15 +312,7 @@ public class NIOConnection implements Connection {
 
     public void deliver(Packet packet) throws UnauthorizedException {
         if (state != State.RUNNING) {
-        	// OF-857: Do not allow the backup deliverer to recurse
-        	if (backupDeliverer == null) {
-        		Log.error("Failed to deliver packet: " + packet.toXML());
-        		throw new IllegalStateException("Connection closed");
-        	}
-        	// attempt to deliver via backup only once
-        	PacketDeliverer backup = backupDeliverer;
-            backupDeliverer = null;
-            backup.deliver(packet);
+        	backupDeliverer.deliver(packet);
         }
         else {
             boolean errorDelivering = false;


### PR DESCRIPTION
Original issue (OF-857) has been addressed by providing an alternate
packet deliverer (to offline storage). This additional logic was an
ill-advised "belt-and-suspenders" attempt to prevent the recursion which
was occurring before the backup deliverer was implemented.