### PR TITLE
HazelcastClusterNodeInfo communication has big delay.

### DIFF
--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cluster/HazelcastClusterNodeInfo.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cluster/HazelcastClusterNodeInfo.java
@@ -45,6 +45,7 @@ public class HazelcastClusterNodeInfo implements ClusterNodeInfo {
 
     public HazelcastClusterNodeInfo(Member member, Long joinedTime) {
         hostname = member.getSocketAddress().getHostName();
+        hostname = member.getSocketAddress().getHostString();
         nodeID = NodeID.getInstance(StringUtils.getBytes(member.getUuid()));
         this.joinedTime = joinedTime;
         seniorMember = ClusterManager.getSeniorClusterMember().equals(StringUtils.getBytes(member.getUuid()));


### PR DESCRIPTION
Using getHostString() to benefit from not attempting a reverse lookup.
Or will cause very big delay if the ip address doese not have configured
host name.