### PR TITLE
fixed MySQL Error 1093 in monitoring plugin ConversationManager & added description

### DIFF
--- a/src/plugins/monitoring/changelog.html
+++ b/src/plugins/monitoring/changelog.html
@@ -44,6 +44,11 @@
 Monitoring Plugin Changelog
 </h1>
 
+<p><b>1.4.6</b> -- Aug 11, 2015</p>
+<ul>
+	<li>Added support for XEP-0313: Message Archive Management</li>
+</ul>
+
 <p><b>1.4.4</b> -- Oct 28, 2014</p>
 <ul>
 	<li>Fixed request conversations and messages</li>

--- a/src/plugins/monitoring/plugin.xml
+++ b/src/plugins/monitoring/plugin.xml
@@ -5,8 +5,8 @@
     <name>Monitoring Service</name>
     <description>Monitors conversations and statistics of the server.</description>
     <author>Jive Software</author>
-    <version>1.4.5</version>
-    <date>10/28/2014</date>
+    <version>1.4.6</version>
+    <date>11/08/2015</date>
     <minServerVersion>3.9.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>3</databaseVersion>

--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -86,7 +86,7 @@ public class ConversationManager implements Startable, ComponentEventListener{
 	private static final String UPDATE_CONVERSATION = "UPDATE ofConversation SET lastActivity=?, messageCount=? WHERE conversationID=?";
 	private static final String UPDATE_PARTICIPANT = "UPDATE ofConParticipant SET leftDate=? WHERE conversationID=? AND bareJID=? AND jidResource=? AND joinedDate=?";
 	private static final String INSERT_MESSAGE = "INSERT INTO ofMessageArchive(messageID, conversationID, fromJID, fromJIDResource, toJID, toJIDResource, sentDate, body, stanza) "
-			+ "VALUES ((SELECT COUNT(*) FROM ofMessageArchive),?,?,?,?,?,?,?,?)";
+			+ "VALUES (?,?,?,?,?,?,?,?,?)";
 	private static final String CONVERSATION_COUNT = "SELECT COUNT(*) FROM ofConversation";
 	private static final String MESSAGE_COUNT = "SELECT COUNT(*) FROM ofMessageArchive";
 	private static final String DELETE_CONVERSATION_1 = "DELETE FROM ofMessageArchive WHERE conversationID=?";
@@ -988,14 +988,15 @@ public class ConversationManager implements Startable, ComponentEventListener{
 					ArchivedMessage message;
 					int count = 0;
 					while ((message = messageQueue.poll()) != null) {
-						pstmt.setLong(1, message.getConversationID());
-						pstmt.setString(2, message.getFromJID().toBareJID());
-						pstmt.setString(3, message.getFromJID().getResource());
-						pstmt.setString(4, message.getToJID().toBareJID());
-						pstmt.setString(5, message.getToJID().getResource());
-						pstmt.setLong(6, message.getSentDate().getTime());
-						DbConnectionManager.setLargeTextField(pstmt, 7, message.getBody());
-						DbConnectionManager.setLargeTextField(pstmt, 8, message.getStanza());
+						pstmt.setInt(1, getArchivedMessageCount());
+						pstmt.setLong(2, message.getConversationID());
+						pstmt.setString(3, message.getFromJID().toBareJID());
+						pstmt.setString(4, message.getFromJID().getResource());
+						pstmt.setString(5, message.getToJID().toBareJID());
+						pstmt.setString(6, message.getToJID().getResource());
+						pstmt.setLong(7, message.getSentDate().getTime());
+						DbConnectionManager.setLargeTextField(pstmt, 8, message.getBody());
+						DbConnectionManager.setLargeTextField(pstmt, 9, message.getStanza());
 						if (DbConnectionManager.isBatchUpdatesSupported()) {
 							pstmt.addBatch();
 						} else {

--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -986,9 +986,12 @@ public class ConversationManager implements Startable, ComponentEventListener{
 
 					pstmt = con.prepareStatement(INSERT_MESSAGE);
 					ArchivedMessage message;
+					
+					int msgCount = getArchivedMessageCount();
+					
 					int count = 0;
 					while ((message = messageQueue.poll()) != null) {
-						pstmt.setInt(1, getArchivedMessageCount());
+						pstmt.setInt(1, ++msgCount);
 						pstmt.setLong(2, message.getConversationID());
 						pstmt.setString(3, message.getFromJID().toBareJID());
 						pstmt.setString(4, message.getFromJID().getResource());


### PR DESCRIPTION
1) add new monitoring plugin description
2) fix MySQL Error 1093(can't modify the same table which is used in the SELECT part) in ConversationManager