### PR TITLE
OF-943: Timeout issues on synchronous cluster tasks

### DIFF
--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -333,7 +333,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
         		for (Future<Object> future : futures.values()) {
         			long start = System.nanoTime();
         			result.add(future.get(nanosLeft, TimeUnit.NANOSECONDS));
-        			nanosLeft = (System.nanoTime() - start);
+        			nanosLeft = nanosLeft - (System.nanoTime() - start);
         		}
         	} catch (TimeoutException te) {
         		logger.error("Failed to execute cluster task within " + MAX_CLUSTER_EXECUTION_TIME + " seconds", te);


### PR DESCRIPTION
Details: https://community.igniterealtime.org/message/252259#252259

----

(Transcription in case the link becomes broken)

Hi! I've been dealing with the same problem as other, with Hazelcast reporting that it failed to execute cluster tasks in the set timeout period. As others, I have also seen that the expected timeout time had indeed not elapsed, and that sometimes the cluster nodes appear as not available from the clustering page in the admin console. Finally, I have also seen messages being lost and synchronization on clients connected to servers sometimes failing, and I am assuming that this last part is just a symptom of the same problem.
 
A colleague of mine spotted this in the hazelcast plugin source code.
 
Class: ClusteredCacheFactory

```java
/*01.*/ public Collection<Object> doSynchronousClusterTask(ClusterTask task, boolean includeLocalMember) {  
/*02.*/     if (cluster == null) { return Collections.emptyList(); }  
/*03.*/     Set<Member> members = new HashSet<Member>();  
/*04.*/     Member current = cluster.getLocalMember();  
/*05.*/     for(Member member : cluster.getMembers()) {  
/*06.*/         if (includeLocalMember || (!member.getUuid().equals(current.getUuid()))) {  
/*07.*/             members.add(member);  
/*08.*/         }  
/*09.*/     }  
/*10.*/     Collection<Object> result = new ArrayList<Object>();  
/*11.*/     if (members.size() > 0) {  
/*12.*/         // Asynchronously execute the task on the other cluster members  
/*13.*/         try {  
/*14.*/             logger.debug("Executing MultiTask: " + task.getClass().getName());  
/*15.*/             Map<Member, Future<Object>> futures = hazelcast.getExecutorService(HAZELCAST_EXECUTOR_SERVICE_NAME)  
/*16.*/                 .submitToMembers(new CallableTask<Object>(task), members);  
/*17.*/             long nanosLeft = TimeUnit.SECONDS.toNanos(MAX_CLUSTER_EXECUTION_TIME*members.size());  
/*18.*/             for (Future<Object> future : futures.values()) {  
/*19.*/                 long start = System.nanoTime();  
/*20.*/                 result.add(future.get(nanosLeft, TimeUnit.NANOSECONDS));  
/*21.*/                 nanosLeft = (System.nanoTime() - start);  
/*22.*/             }  
/*23.*/         } catch (TimeoutException te) {  
/*24.*/             logger.error("Failed to execute cluster task within " + MAX_CLUSTER_EXECUTION_TIME + " seconds", te);  
/*25.*/         } catch (Exception e) {  
/*26.*/             logger.error("Failed to execute cluster task", e);  
/*27.*/         }  
/*28.*/     } else {  
/*29.*/         logger.warn("No cluster members selected for cluster task " + task.getClass().getName());  
/*30.*/     }  
/*31.*/     return result;  
/*32.*/ } 
```

This is the implementation that several cluster tasks will use to be executed across the cluster itself.
 
Pay attention to lines 17 and 21 of the snippet I pasted above. The `nanosLeft` variable is supposed to keep track of how many nanoseconds are missing until the timeout period expired, using that for the timeout value of the future result (line 20), but on line 21, the current value of `nanosLeft` is not considered at all. The new value for the time left is going to be `System.nanoTime() - start`, which basically is how much time the last future value took to get (lines 19, 21).
 
At this point, I understand that having multiple nodes may have some tasks failing, and with a higher number of nodes, the possibility of these tasks failing are higher.
 
My setup has two nodes, and the tasks sometimes fail and sometimes doesn't. Considering what I just described, I think that tasks succeed when the second member can execute the task in a lower time than the first node, and the tasks fail otherwise.
 
My question for the Openfire community is: is the behavior I'm describing correct? Have we detected a bug in the Hazelcast clustering plugin?
 
Note that the hazelcast clustering plugin has been published with these changes about 7 months ago (according to GitHub), and I think that if this has been the case, the community would have been in an uproar for an implementation that fails 50% of the time. So, I believe that I may be missing part of the picture.