### PR TITLE
OF-943: Fix timeout issues in HZ plugin

### DIFF
--- a/src/plugins/hazelcast/changelog.html
+++ b/src/plugins/hazelcast/changelog.html
@@ -44,6 +44,12 @@
 Hazelcast Clustering Plugin Changelog
 </h1>
 
+<p><b>2.1.2</b> -- September 16, 2015</p>
+<p>Bug fix:</p>
+<ul>
+     <li><a href="http://issues.igniterealtime.org/browse/OF-943">OF-943</a>: Fix intermittent timeout issues for synchronous remote task execution</li>
+</ul>
+
 <p><b>2.1.1</b> -- August 11, 2015</p>
 <p>Bug fix:</p>
 <ul>

--- a/src/plugins/hazelcast/plugin.xml
+++ b/src/plugins/hazelcast/plugin.xml
@@ -5,7 +5,7 @@
     <name>${plugin.name}</name>
     <description>${plugin.description}</description>
     <author>Tom Evans</author>
-    <version>2.1.1</version>
-    <date>08/11/2015</date>
+    <version>2.1.2</version>
+    <date>09/16/2015</date>
     <minServerVersion>3.9.4</minServerVersion>
 </plugin>


### PR DESCRIPTION
This PR updates the plugin metatdata to prepare a release for the timeout bug fix which was previously committed (via PR#288).