### PR TITLE
OF-949: Catch parsing errors for offline messages

### DIFF
--- a/src/java/org/jivesoftware/openfire/OfflineMessageStore.java
+++ b/src/java/org/jivesoftware/openfire/OfflineMessageStore.java
@@ -206,8 +206,13 @@ public class OfflineMessageStore extends BasicModule implements UserEventListene
                     if (matcher.find()) {
                         msgXML = matcher.replaceAll("");
                     }
-                    message = new OfflineMessage(creationDate,
+                    try {
+                    	message = new OfflineMessage(creationDate,
                             xmlReader.read(new StringReader(msgXML)).getRootElement());
+                    } catch (DocumentException de) {
+                    	Log.error("Failed to route packet (offline message): " + msgXML, de);
+                    	continue; // skip and process remaining offline messages
+                    }
                 }
 
                 // if there is already a delay stamp, we shouldn't add another.


### PR DESCRIPTION
Detect offline messages that fail to parse; write to error log before
discarding as undeliverable. This will unblock the offline message queue
for future (valid) messages addressed to the affected user.