### PR TITLE
OF-921: Do not require restart to reload group memberships

### DIFF
--- a/src/java/org/jivesoftware/openfire/group/ConcurrentGroupList.java
+++ b/src/java/org/jivesoftware/openfire/group/ConcurrentGroupList.java
@@ -18,12 +18,6 @@ public class ConcurrentGroupList<T> extends CopyOnWriteArrayList<T> implements G
 
 	private static final long serialVersionUID = -8884698048047935327L;
 	
-	// This set is used to optimize group operations within this list.
-	// We only populate this set when it's needed to dereference the
-	// groups in the base list, but once it exists we keep it in sync
-	// via the various add/remove operations.
-	private transient Set<Group> groupsInList;
-	
 	public ConcurrentGroupList() {
 		super();
 	}
@@ -62,161 +56,16 @@ public class ConcurrentGroupList<T> extends CopyOnWriteArrayList<T> implements G
 	 */
 	@Override
 	public synchronized Set<Group> getGroups() {
-		if (groupsInList == null) {
-			groupsInList = new HashSet<Group>();
-			// add all the groups into the group set
-			Iterator<T> iterator = iterator();
-			while (iterator.hasNext()) {
-				T listItem = iterator.next();
-				Group group = Group.resolveFrom(listItem);
-				if (group != null) {
-					groupsInList.add(group);
-				};
-			}
+		Set<Group> groupsInList = new HashSet<Group>();
+		// add all the groups into the group set
+		Iterator<T> iterator = iterator();
+		while (iterator.hasNext()) {
+			T listItem = iterator.next();
+			Group group = Group.resolveFrom(listItem);
+			if (group != null) {
+				groupsInList.add(group);
+			};
 		}
 		return groupsInList;
 	}
-
-	/**
-	 * This method is called from several of the mutators to keep
-	 * the group set in sync with the full list. 
-	 * 
-	 * @param item The item to be added or removed if it is in the group set
-	 * @param addOrRemove True to add, false to remove
-	 * @return true if the given item is a group
-	 */
-	private synchronized boolean syncGroups(Object item, boolean addOrRemove) {
-		boolean result = false;
-		// only sync if the group list has been instantiated
-		if (groupsInList != null) {
-			Group group = Group.resolveFrom(item);
-			if (group != null) {
-				result = true;
-				if (addOrRemove == ADD) {
-					groupsInList.add(group);
-				} else if (addOrRemove == REMOVE) {
-					groupsInList.remove(group);
-				}
-			}
-		}
-		return result;
-	}
-	
-	// below are overrides for the various mutators
-	
-	@Override
-	public T set(int index, T element) {
-		T result = super.set(index, element);
-		syncGroups(element, ADD);
-		return result;
-	}
-
-	@Override
-	public boolean add(T e) {
-		boolean result = super.add(e);
-		syncGroups(e, ADD);
-		return result;
-	}
-
-	@Override
-	public void add(int index, T element) {
-		super.add(index, element);
-		syncGroups(element, ADD);
-	}
-
-	@Override
-	public T remove(int index) {
-		T result = super.remove(index);
-		syncGroups(result, REMOVE);
-		return result;
-	}
-
-	@Override
-	public boolean remove(Object o) {
-		boolean removed = super.remove(o);
-		if (removed) {
-			syncGroups(o, REMOVE);
-		}
-		return removed;
-	}
-
-	@Override
-	public boolean addIfAbsent(T e) {
-		boolean added = super.addIfAbsent(e);
-		if (added) {
-			syncGroups(e, ADD);
-		}
-		return added;
-	}
-
-	@Override
-	public boolean removeAll(Collection<?> c) {
-		boolean changed = super.removeAll(c);
-		if (changed) {
-			// drop the transient set, will be rebuilt when/if needed
-			synchronized(this) {
-				groupsInList = null;
-			}
-		}
-		return changed;
-	}
-
-	@Override
-	public boolean retainAll(Collection<?> c) {
-		boolean changed = super.retainAll(c);
-		if (changed) {
-			// drop the transient set, will be rebuilt when/if needed
-			synchronized(this) {
-				groupsInList = null;
-			}
-		}
-		return changed;
-	}
-
-	@Override
-	public int addAllAbsent(Collection<? extends T> c) {
-		int added = super.addAllAbsent(c);
-		if (added > 0) {
-			// drop the transient set, will be rebuilt when/if needed
-			synchronized(this) {
-				groupsInList = null;
-			}
-		}
-		return added;
-	}
-
-	@Override
-	public void clear() {
-		super.clear();
-		synchronized(this) {
-			groupsInList = null;
-		}
-	}
-
-	@Override
-	public boolean addAll(Collection<? extends T> c) {
-		boolean changed = super.addAll(c);
-		if (changed) {
-			// drop the transient set, will be rebuilt when/if needed
-			synchronized(this) {
-				groupsInList = null;
-			}
-		}
-		return changed;
-	}
-
-	@Override
-	public boolean addAll(int index, Collection<? extends T> c) {
-		boolean changed = super.addAll(index, c);
-		if (changed) {
-			// drop the transient set, will be rebuilt when/if needed
-			synchronized(this) {
-				groupsInList = null;
-			}
-		}
-		return changed;
-	}
-
-	private static final boolean ADD = true;
-	private static final boolean REMOVE = false;
 }

--- a/src/java/org/jivesoftware/openfire/group/ConcurrentGroupMap.java
+++ b/src/java/org/jivesoftware/openfire/group/ConcurrentGroupMap.java
@@ -19,14 +19,6 @@ public class ConcurrentGroupMap<K, V> extends ConcurrentHashMap<K, V>  implement
 
 	private static final long serialVersionUID = -2068242013524715293L;
 
-	// These sets are used to optimize group operations within this map.
-	// We only populate these sets when they are needed to dereference the
-	// groups in the base map, but once they exist we keep them in sync
-	// via the various put/remove operations.
-	private transient Set<Group> groupsFromKeys;
-	private transient Set<Group> groupsFromValues;
-	
-
 	/**
 	 * Returns true if the key list contains the given JID. If the JID
 	 * is not found in the key list, search the key list for groups and 
@@ -81,17 +73,15 @@ public class ConcurrentGroupMap<K, V> extends ConcurrentHashMap<K, V>  implement
 	 */
 	@Override
 	public synchronized Set<Group> getGroupsFromKeys() {
-		if (groupsFromKeys == null) {
-			groupsFromKeys = new HashSet<Group>();
-			// add all the groups into the group set
-			Iterator<K> iterator = keySet().iterator();
-			while (iterator.hasNext()) {
-				K key = iterator.next();
-				Group group = Group.resolveFrom(key);
-				if (group != null) {
-					groupsFromKeys.add(group);
-				};
-			}
+		Set<Group> groupsFromKeys = new HashSet<Group>();
+		// add all the groups into the group set
+		Iterator<K> iterator = keySet().iterator();
+		while (iterator.hasNext()) {
+			K key = iterator.next();
+			Group group = Group.resolveFrom(key);
+			if (group != null) {
+				groupsFromKeys.add(group);
+			};
 		}
 		return groupsFromKeys;
 	}
@@ -103,145 +93,16 @@ public class ConcurrentGroupMap<K, V> extends ConcurrentHashMap<K, V>  implement
 	 */
 	@Override
 	public synchronized Set<Group> getGroupsFromValues() {
-		if (groupsFromValues == null) {
-			groupsFromValues = new HashSet<Group>();
-			// add all the groups into the group set
-			Iterator<V> iterator = values().iterator();
-			while (iterator.hasNext()) {
-				V value = iterator.next();
-				Group group = Group.resolveFrom(value);
-				if (group != null) {
-					groupsFromValues.add(group);
-				};
-			}
+		Set<Group> groupsFromValues = new HashSet<Group>();
+		// add all the groups into the group set
+		Iterator<V> iterator = values().iterator();
+		while (iterator.hasNext()) {
+			V value = iterator.next();
+			Group group = Group.resolveFrom(value);
+			if (group != null) {
+				groupsFromValues.add(group);
+			};
 		}
 		return groupsFromValues;
 	}
-
-	/**
-	 * This method is called from several of the mutators to keep
-	 * the group set in sync with the keys in the map. 
-	 * 
-	 * @param item The item to be added or removed if it is in the group set
-	 * @param keyOrValue True for keys, false for values
-	 * @param addOrRemove True to add, false to remove
-	 * @return true if the given item is a group
-	 */
-	private synchronized boolean syncGroups(Object item, boolean keyOrValue, boolean addOrRemove) {
-		boolean result = false;
-		Set<Group> groupSet = (keyOrValue == KEYS) ? groupsFromKeys : groupsFromValues;
-		// only sync if the group list has been instantiated
-		if (groupSet != null) {
-			Group group = Group.resolveFrom(item);
-			if (group != null) {
-				result = true;
-				if (addOrRemove == ADD) {
-					groupSet.add(group);
-				} else if (addOrRemove == REMOVE) {
-					groupSet.remove(group);
-				}
-			}
-		}
-		return result;
-	}
-	
-	// below are overrides for the various mutators
-	
-	@Override
-	public V put(K key, V value) {
-		V priorValue = super.put(key, value);
-		syncGroups(value, VALUES, ADD);
-		if (priorValue == null) {
-			syncGroups(key, KEYS, ADD);
-		} else {
-			syncGroups(priorValue, VALUES, REMOVE);
-		}
-		return priorValue;
-	}
-
-
-	@Override
-	public V putIfAbsent(K key, V value) {
-		V priorValue = super.putIfAbsent(key, value);
-		// if the map already contains the key, there was no change
-		if (!value.equals(priorValue)) {
-			syncGroups(value, VALUES, ADD);
-			if (priorValue == null) {
-				syncGroups(key, KEYS, ADD);
-			} else {
-				syncGroups(priorValue, VALUES, REMOVE);
-			}
-		}
-		return priorValue;
-	}
-
-
-	@Override
-	public void putAll(Map<? extends K, ? extends V> m) {
-		super.putAll(m);
-		// drop the transient sets; will be rebuilt when/if needed
-		synchronized(this) {
-			groupsFromKeys = null;
-			groupsFromValues = null;
-		}
-	}
-
-
-	@Override
-	public V remove(Object key) {
-		V priorValue = super.remove(key);
-		if (priorValue != null) {
-			syncGroups(key, KEYS, REMOVE);
-			syncGroups(priorValue, VALUES, REMOVE);
-		}
-		return priorValue;
-	}
-
-
-	@Override
-	public boolean remove(Object key, Object value) {
-		boolean removed = super.remove(key, value);
-		if (removed) {
-			syncGroups(key, KEYS, REMOVE);
-			syncGroups(value, VALUES, REMOVE);
-		}
-		return removed;
-	}
-
-
-	@Override
-	public boolean replace(K key, V oldValue, V newValue) {
-		boolean replaced = super.replace(key, oldValue, newValue);
-		if (replaced) {
-			syncGroups(oldValue, VALUES, REMOVE);
-			syncGroups(newValue, VALUES, ADD);
-		}
-		return replaced;
-	}
-
-
-	@Override
-	public V replace(K key, V value) {
-		V priorValue = super.replace(key, value);
-		if (priorValue != null) {
-			syncGroups(value, VALUES, ADD);
-			syncGroups(priorValue, VALUES, REMOVE);
-		}
-		return priorValue;
-	}
-
-
-	@Override
-	public void clear() {
-		super.clear();
-		synchronized(this) {
-			groupsFromKeys = null;
-			groupsFromValues = null;
-		}
-	}
-
-	private static final boolean KEYS = true;
-	private static final boolean VALUES = false;
-	private static final boolean ADD = true;
-	private static final boolean REMOVE = false;
 }


### PR DESCRIPTION
This commit removes an additional group cache that could not be updated
anymore at runtime. It lets ConcurrentGroup(List|Map) use the ordinary
cache from GroupManager instead.
This way LDAP Groups can be updated after startup by simply removing the
cache.