### PR TITLE
fix getAuditedStartDate resetting startDate to null

### DIFF
--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
@@ -168,7 +168,7 @@ public class JdbcPersistenceManager implements PersistenceManager {
 	public Date getAuditedStartDate(Date startDate) {
 		long maxRetrievable = JiveGlobals.getIntProperty("conversation.maxRetrievable", ConversationManager.DEFAULT_MAX_RETRIEVABLE)
 				* JiveConstants.DAY;
-		Date result = null;
+		Date result;
 		if (maxRetrievable > 0) {
 			Date now = new Date();
 			Date maxRetrievableDate = new Date(now.getTime() - maxRetrievable);
@@ -176,6 +176,8 @@ public class JdbcPersistenceManager implements PersistenceManager {
 				result = maxRetrievableDate;
 			} else if (startDate.before(maxRetrievableDate)) {
 				result = maxRetrievableDate;
+			} else {
+				result = startDate;
 			}
 		}else{
                         result = startDate;


### PR DESCRIPTION
Currently, when conversation.maxRetrievable > 0 and startDate > maxRetrievableDate, result is set to null instead of startDate.