### PR TITLE
OF-946: Help Java to find the correct Security Provider

### DIFF
--- a/src/java/org/jivesoftware/openfire/keystore/IdentityStoreConfig.java
+++ b/src/java/org/jivesoftware/openfire/keystore/IdentityStoreConfig.java
@@ -49,7 +49,7 @@ public class IdentityStoreConfig extends CertificateStoreConfig
 
         try
         {
-            keyFactory = KeyManagerFactory.getInstance( KeyManagerFactory.getDefaultAlgorithm(), PROVIDER );
+            keyFactory = KeyManagerFactory.getInstance( KeyManagerFactory.getDefaultAlgorithm() );
             keyFactory.init( store, password.toCharArray() );
         }
         catch ( UnrecoverableKeyException | NoSuchAlgorithmException | KeyStoreException ex )

--- a/src/web/user-roster-add.jsp
+++ b/src/web/user-roster-add.jsp
@@ -173,7 +173,7 @@
 		</tr>
 		<tr>
 			<td width="1%" nowrap>
-				<label for="nicknametf"><fmt:message key="user.roster.nickname" />:</label>
+				<label for="nicknametf"><fmt:message key="user.roster.nickname" />:</label></td>
 			<td width="99%">
 				<input type="text" name="nickname" size="30" maxlength="255" value="<%= ((nickname!=null) ? StringUtils.escapeForXML(nickname) : "") %>"
 				 id="nicknametf">


### PR DESCRIPTION
For some reason, the default validation fails to iterate over all providers and will fail if the default
provider does not support the algorithm of the chain. To work around this issue, the code now iterates over each provider explicitly, returning success when at least one provider validates the chain successfully.
This replaces an earlier attempt to fix this issue by explicitly naming one (and just one) provider.