### PR TITLE
Make code more readable by using StandardCharsets.UTF_8.

### DIFF
--- a/src/java/org/jivesoftware/openfire/SessionPacketRouter.java
+++ b/src/java/org/jivesoftware/openfire/SessionPacketRouter.java
@@ -25,8 +25,6 @@ import org.jivesoftware.openfire.net.SASLAuthentication;
 import org.jivesoftware.openfire.session.LocalClientSession;
 import org.xmpp.packet.*;
 
-import java.io.UnsupportedEncodingException;
-
 /**
  * Handles the routing of packets to a particular session. It will invoke all of the appropriate
  * interceptors, before and after having the server process the message.
@@ -60,7 +58,7 @@ public class SessionPacketRouter implements PacketRouter {
     }
 
     public void route(Element wrappedElement)
-            throws UnsupportedEncodingException, UnknownStanzaException {
+            throws UnknownStanzaException {
         String tag = wrappedElement.getName();
         if ("auth".equals(tag) || "response".equals(tag)) {
             SASLAuthentication.handle(session, wrappedElement);

--- a/src/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -20,7 +20,6 @@
 
 package org.jivesoftware.openfire.auth;
 
-import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -239,7 +238,7 @@ public class DefaultAuthProvider implements AuthProvider {
                    saltedPassword = ScramUtils.createSaltedPassword(saltShaker, testPassword, iterations);
                    clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
                    testStoredKey = MessageDigest.getInstance("SHA-1").digest(clientKey);
-            } catch(SaslException | NoSuchAlgorithmException | UnsupportedEncodingException e) {
+            } catch(SaslException | NoSuchAlgorithmException e) {
                 Log.warn("Unable to check SCRAM values for PLAIN authentication.");
                 return false;
             }
@@ -285,7 +284,7 @@ public class DefaultAuthProvider implements AuthProvider {
                clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
                storedKey = MessageDigest.getInstance("SHA-1").digest(clientKey);
                serverKey = ScramUtils.computeHmac(saltedPassword, "Server Key");
-       } catch (SaslException | NoSuchAlgorithmException | UnsupportedEncodingException e) {
+       } catch (SaslException | NoSuchAlgorithmException e) {
            Log.warn("Unable to persist values for SCRAM authentication.");
        }
    

--- a/src/java/org/jivesoftware/openfire/auth/ScramUtils.java
+++ b/src/java/org/jivesoftware/openfire/auth/ScramUtils.java
@@ -20,7 +20,6 @@
 
 package org.jivesoftware.openfire.auth;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -28,8 +27,6 @@ import java.security.NoSuchAlgorithmException;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.security.sasl.SaslException;
-
-import org.jivesoftware.util.JiveGlobals;
 
 /**
  * A utility class that provides methods that are useful for dealing with
@@ -62,7 +59,7 @@ public class ScramUtils {
     }
     
     public static byte[] computeHmac(final byte[] key, final String string)
-            throws SaslException, UnsupportedEncodingException {
+            throws SaslException {
         Mac mac = createSha1Hmac(key);
         mac.update(string.getBytes(StandardCharsets.US_ASCII));
         return mac.doFinal();

--- a/src/java/org/jivesoftware/openfire/group/GroupJID.java
+++ b/src/java/org/jivesoftware/openfire/group/GroupJID.java
@@ -1,6 +1,6 @@
 package org.jivesoftware.openfire.group;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.util.StringUtils;
@@ -127,13 +127,7 @@ public class GroupJID extends JID {
 	 * @return The group name
 	 */
 	private static String decodeNode(String node) {
-		try {
-			return new String(StringUtils.decodeBase32(node), "UTF-8");
-		} catch (UnsupportedEncodingException uee) {
-			// this shouldn't happen, but ...
-			Log.error("Unexpected encoding exception", uee);
-			return null;
-		}
+		return new String(StringUtils.decodeBase32(node), StandardCharsets.UTF_8);
 	}
 
     /**

--- a/src/java/org/jivesoftware/openfire/http/HttpBindServlet.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpBindServlet.java
@@ -22,6 +22,7 @@ package org.jivesoftware.openfire.http;
 import java.io.*;
 import java.net.InetAddress;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 
@@ -295,7 +296,7 @@ public class HttpBindServlet extends HttpServlet {
             System.out.println(new Date() + ": HTTP SENT(" + session.getStreamID().getID() + "): " + content);
         }
 
-        final byte[] byteContent = content.getBytes("UTF-8");
+        final byte[] byteContent = content.getBytes(StandardCharsets.UTF_8);
         if (async) {
             response.getOutputStream().setWriteListener(new WriteListenerImpl(context, byteContent));
         } else {

--- a/src/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -21,7 +21,6 @@ package org.jivesoftware.openfire.http;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.cert.Certificate;
@@ -653,11 +652,6 @@ public class HttpSession extends LocalClientSession {
             for (Element packet : packetsToSend.remove()) {
                 try {
                     router.route(packet);
-                }
-                catch (UnsupportedEncodingException e) {
-                    Log.error(
-                            "Client provided unsupported encoding type in auth request",
-                            e);
                 }
                 catch (UnknownStanzaException e) {
                     Log.error("Client provided unknown packet type", e);

--- a/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -20,8 +20,8 @@
 
 package org.jivesoftware.openfire.ldap;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -2239,16 +2238,11 @@ public class LdapManager {
                     }
                     else if (c >= 0x080) { 
                         // higher-order 2, 3 and 4-byte UTF-8 chars
-                        try {
-                            byte[] utf8bytes = String.valueOf(c).getBytes("UTF8");
-                            for (byte b: utf8bytes)
-                            {
-                            	result.append(String.format("\\%02x", b));
-                            }
-                        } catch (UnsupportedEncodingException e) {
-                            // ignore
+                        byte[] utf8bytes = String.valueOf(c).getBytes(StandardCharsets.UTF_8);
+                        for (byte b : utf8bytes) {
+                            result.append(String.format("\\%02x", b));
                         }
-            		}
+                    }
                 }
             }
             return result.toString();

--- a/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -20,8 +20,8 @@
 
 package org.jivesoftware.openfire.net;
 
-import java.io.UnsupportedEncodingException;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.Security;
 import java.security.cert.Certificate;
@@ -86,11 +86,6 @@ public class SASLAuthentication {
     // http://stackoverflow.com/questions/8571501/how-to-check-whether-the-string-is-base64-encoded-or-not
     // plus an extra regex alternative to catch a single equals sign ('=', see RFC 6120 6.4.2)
     private static final Pattern BASE64_ENCODED = Pattern.compile("^(=|([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==))$");
-
-    /**
-     * The utf-8 charset for decoding and encoding Jabber packet streams.
-     */
-    protected static String CHARSET = "UTF-8";
 
     private static final String SASL_NAMESPACE = "xmlns=\"urn:ietf:params:xml:ns:xmpp-sasl\"";
 
@@ -232,9 +227,8 @@ public class SASLAuthentication {
      * @param doc the stanza sent by the authenticating entity.
      * @return value that indicates whether the authentication has finished either successfully
      *         or not or if the entity is expected to send a response to a challenge.
-     * @throws UnsupportedEncodingException If UTF-8 charset is not supported.
      */
-    public static Status handle(LocalSession session, Element doc) throws UnsupportedEncodingException {
+    public static Status handle(LocalSession session, Element doc) {
         Status status;
         String mechanism;
         if (doc.getNamespace().asXML().equals(SASL_NAMESPACE)) {
@@ -511,8 +505,7 @@ public class SASLAuthentication {
         }
     }
 
-    private static Status doExternalAuthentication(LocalSession session, Element doc)
-            throws UnsupportedEncodingException {
+    private static Status doExternalAuthentication(LocalSession session, Element doc) {
         // At this point the connection has already been secured using TLS
 
         if (session instanceof IncomingServerSession) {
@@ -524,7 +517,7 @@ public class SASLAuthentication {
                 return Status.needResponse;
             }
     
-            hostname = new String(StringUtils.decodeBase64(hostname), CHARSET);
+            hostname = new String(StringUtils.decodeBase64(hostname), StandardCharsets.UTF_8);
             if (hostname.length() == 0) {
                 hostname = null;
             }
@@ -569,7 +562,7 @@ public class SASLAuthentication {
             Log.debug("SASLAuthentication: EXTERNAL authentication via SSL certs for c2s connection");
             
             // This may be null, we will deal with that later
-            String username = new String(StringUtils.decodeBase64(doc.getTextTrim()), CHARSET);
+            String username = new String(StringUtils.decodeBase64(doc.getTextTrim()), StandardCharsets.UTF_8);
             String principal = "";
             ArrayList<String> principals = new ArrayList<String>();
             Connection connection = session.getConnection();
@@ -669,9 +662,7 @@ public class SASLAuthentication {
         return false;
     }
 
-    private static Status doSharedSecretAuthentication(LocalSession session, Element doc)
-            throws UnsupportedEncodingException
-    {
+    private static Status doSharedSecretAuthentication(LocalSession session, Element doc) {
         String secretDigest;
         String response = doc.getTextTrim();
         if (response == null || response.length() == 0) {
@@ -681,7 +672,7 @@ public class SASLAuthentication {
         }
 
         // Parse data and obtain username & password
-        String data = new String(StringUtils.decodeBase64(response), CHARSET);
+        String data = new String(StringUtils.decodeBase64(response), StandardCharsets.UTF_8);
         StringTokenizer tokens = new StringTokenizer(data, "\0");
         tokens.nextToken();
         secretDigest = tokens.nextToken();

--- a/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
+++ b/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
@@ -28,9 +28,9 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.util.concurrent.locks.ReentrantLock;
@@ -76,11 +76,6 @@ public class NIOConnection implements Connection {
 	private static final Logger Log = LoggerFactory.getLogger(NIOConnection.class);
 
     public enum State { RUNNING, CLOSING, CLOSED }
-
-    /**
-     * The utf-8 charset for decoding and encoding XMPP packet streams.
-     */
-    public static final String CHARSET = "UTF-8";
 
     private LocalSession session;
     private IoSession ioSession;
@@ -361,7 +356,7 @@ public class NIOConnection implements Connection {
             try {
                 //Charset charset = Charset.forName(CHARSET);
                 //buffer.putString(text, charset.newEncoder());
-                buffer.put(text.getBytes(CHARSET));
+                buffer.put(text.getBytes(StandardCharsets.UTF_8));
                 if (flashClient) {
                     buffer.put((byte) '\0');
                 }
@@ -523,7 +518,7 @@ public class NIOConnection implements Connection {
 
         @Override
 		protected CharsetEncoder initialValue() {
-            return Charset.forName(CHARSET).newEncoder()
+            return StandardCharsets.UTF_8.newEncoder()
 				.onMalformedInput(CodingErrorAction.REPORT)
 				.onUnmappableCharacter(CodingErrorAction.REPORT);
         }

--- a/src/java/org/jivesoftware/openfire/sasl/SaslServerPlainImpl.java
+++ b/src/java/org/jivesoftware/openfire/sasl/SaslServerPlainImpl.java
@@ -21,10 +21,10 @@
 package org.jivesoftware.openfire.sasl;
 
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslServer;
 import javax.security.sasl.SaslException;
@@ -105,7 +105,7 @@ public class SaslServerPlainImpl implements SaslServer {
         }
         try {
             if(response.length != 0) {
-                String data = new String(response, "UTF8");
+                String data = new String(response, StandardCharsets.UTF_8);
                 StringTokenizer tokens = new StringTokenizer(data, "\0");
                 if (tokens.countTokens() > 2) {
                     username = tokens.nextToken();
@@ -141,9 +141,6 @@ public class SaslServerPlainImpl implements SaslServer {
                 }
                 return null;
             }
-        } catch (UnsupportedEncodingException e) {
-            aborted = true;
-            throw new SaslException("UTF8 not available on platform", e);
         } catch (UnsupportedCallbackException e) {
             aborted = true;
             throw new SaslException("PLAIN authentication failed for: "+username, e);

--- a/src/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/src/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -20,8 +20,6 @@
 
 package org.jivesoftware.openfire.sasl;
 
-
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -211,7 +209,7 @@ public class ScramSha1SaslServer implements SaslServer {
             }
             return ("v=" + DatatypeConverter.printBase64Binary(serverSignature))
             		.getBytes(StandardCharsets.US_ASCII);
-        } catch (UnsupportedEncodingException | UserNotFoundException | NoSuchAlgorithmException e) {
+        } catch (UserNotFoundException | NoSuchAlgorithmException e) {
             throw new SaslException(e.getMessage(), e);
         }
     }

--- a/src/java/org/jivesoftware/util/AesEncryptor.java
+++ b/src/java/org/jivesoftware/util/AesEncryptor.java
@@ -1,6 +1,6 @@
 package org.jivesoftware.util;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.Security;
 
@@ -60,9 +60,7 @@ public class AesEncryptor implements Encryptor {
 	public String encrypt(String value)
 	{
 		if (value == null) { return null; }
-		byte [] bytes = null;
-		try { bytes = value.getBytes("UTF-8"); }
-		catch (UnsupportedEncodingException uee) { bytes = value.getBytes(); }
+		byte [] bytes = value.getBytes(StandardCharsets.UTF_8);
 		return Base64.encodeBytes( cipher(bytes, getKey(), Cipher.ENCRYPT_MODE) );
 	}
 
@@ -75,10 +73,7 @@ public class AesEncryptor implements Encryptor {
 		if (value == null) { return null; }
 		byte [] bytes = cipher(Base64.decode(value), getKey(), Cipher.DECRYPT_MODE);
 		if (bytes == null) { return null; }
-		String result = null;
-		try { result = new String(bytes,"UTF-8"); }
-		catch (UnsupportedEncodingException uee) { result = new String(bytes); }
-		return result;
+		return new String(bytes, StandardCharsets.UTF_8);
 	}
 
 	/**
@@ -144,9 +139,7 @@ public class AesEncryptor implements Encryptor {
 			cipherKey = null; 
 			return;
 		}
-		byte [] bytes = null;
-		try { bytes = key.getBytes("UTF-8"); }
-		catch (UnsupportedEncodingException uee) { bytes = key.getBytes(); }
+		byte [] bytes = key.getBytes(StandardCharsets.UTF_8);
 		setKey(editKey(bytes));
 	}
 

--- a/src/java/org/jivesoftware/util/StringUtils.java
+++ b/src/java/org/jivesoftware/util/StringUtils.java
@@ -19,8 +19,14 @@
 
 package org.jivesoftware.util;
 
-import java.io.UnsupportedEncodingException;
+import org.apache.commons.codec.binary.Base32;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
 import java.net.IDN;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.BreakIterator;
@@ -35,13 +41,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
-
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
-
-import org.apache.commons.codec.binary.Base32;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Utility class to perform common String manipulation algorithms.
@@ -387,13 +386,7 @@ public class StringUtils {
      * @return a hashed version of the passed-in String
      */
     public static String hash(String data, String algorithm) {
-        try {
-            return hash(data.getBytes("UTF-8"), algorithm);
-        }
-        catch (UnsupportedEncodingException e) {
-            Log.error(e.getMessage(), e);
-        }
-        return data;
+        return hash(data.getBytes(StandardCharsets.UTF_8), algorithm);
     }
 
     /**
@@ -539,13 +532,7 @@ public class StringUtils {
      * @return a base64 encoded String.
      */
     public static String encodeBase64(String data) {
-        byte[] bytes = null;
-        try {
-            bytes = data.getBytes("UTF-8");
-        }
-        catch (UnsupportedEncodingException uee) {
-            Log.error(uee.getMessage(), uee);
-        }
+        byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
         return encodeBase64(bytes);
     }
 
@@ -580,13 +567,7 @@ public class StringUtils {
      * @return a base32 encoded String.
      */
     public static String encodeBase32(String data) {
-        byte[] bytes = null;
-        try {
-            bytes = data == null ? null : data.getBytes("UTF-8");
-        }
-        catch (UnsupportedEncodingException uee) {
-            Log.error(uee.getMessage(), uee);
-        }
+        byte[] bytes = data == null ? null : data.getBytes(StandardCharsets.UTF_8);
         return encodeBase32(bytes);
     }
 
@@ -1239,35 +1220,22 @@ public class StringUtils {
 	}
 	
 	/**
-	 * Returns the UTF-8 bytes for the given String, suppressing
-	 * UnsupportedEncodingException (in lieu of log message)
+	 * Returns the UTF-8 bytes for the given String.
 	 * 
 	 * @param input The source string
 	 * @return The UTF-8 encoding for the given string
 	 */
 	public static byte[] getBytes(String input) {
-		try {
-			return input.getBytes("UTF-8");
-		} catch (UnsupportedEncodingException uee) {
-			Log.warn("Unable to encode string using UTF-8: " + input);
-			return input.getBytes(); // default encoding
-		}
+        return input.getBytes(StandardCharsets.UTF_8);
 	}
 	
 	/**
-	 * Returns the UTF-8 String for the given byte array, suppressing
-	 * UnsupportedEncodingException (in lieu of log message)
+	 * Returns the UTF-8 String for the given byte array.
 	 * 
 	 * @param input The source byte array
 	 * @return The UTF-8 encoded String for the given byte array
 	 */
 	public static String getString(byte[] input) {
-		try {
-			return new String(input, "UTF-8");
-		} catch (UnsupportedEncodingException uee) {
-			String result = new String(input); // default encoding
-			Log.warn("Unable to decode byte array using UTF-8: " + result);
-			return result;
-		}
+        return new String(input, StandardCharsets.UTF_8);
 	}
 }

--- a/src/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
+++ b/src/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
@@ -1,7 +1,6 @@
 package org.jivesoftware.util.cert;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -96,9 +95,6 @@ public class SANCertificateIdentityMapping implements CertificateIdentityMapping
                         	// OF-517: othername formats are extensible. If we don't recognize the format, skip it.
                         	Log.debug("Cannot parse altName, likely because of unknown record format.", ex);
                         }
-                    }
-                    catch (UnsupportedEncodingException e) {
-                        // Ignore
                     }
                     catch (IOException e) {
                         // Ignore

--- a/src/plugins/websocket/src/java/org/jivesoftware/openfire/websocket/StreamManagementPacketRouter.java
+++ b/src/plugins/websocket/src/java/org/jivesoftware/openfire/websocket/StreamManagementPacketRouter.java
@@ -55,7 +55,7 @@ public class StreamManagementPacketRouter extends SessionPacketRouter {
 	}
 
 	@Override
-	public void route(Element wrappedElement) throws UnsupportedEncodingException, UnknownStanzaException {
+	public void route(Element wrappedElement) throws UnknownStanzaException {
 		
         String tag = wrappedElement.getName();
 		if (StreamManager.NAMESPACE_V3.equals(wrappedElement.getNamespace().getStringValue())) {

--- a/src/test/java/org/jivesoftware/openfire/group/GroupJIDTest.java
+++ b/src/test/java/org/jivesoftware/openfire/group/GroupJIDTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.UnsupportedEncodingException;
-
 import org.jivesoftware.util.StringUtils;
 import org.junit.Test;
 import org.xmpp.packet.JID;
@@ -13,7 +11,7 @@ import org.xmpp.packet.JID;
 public class GroupJIDTest {
 
 	@Test
-	public void testBase32Encoding() throws UnsupportedEncodingException {
+	public void testBase32Encoding() {
 		
 		String testGroupName = "Test Group (1)";
 		String testDomainName = "localhost";


### PR DESCRIPTION
- Use String.getBytes(Charset) instead of String.getBytes(String)
- Use new String(byte[], Charset) instead of new String(byte[], String)
-> Get rid of UnsupportedEncodingException.
-> Less try-catch blocks.