### PR TITLE
Deprecate ConcurrentHashSet in favor of Collections.newSetFromMap().

### DIFF
--- a/src/java/org/jivesoftware/admin/AuthCheckFilter.java
+++ b/src/java/org/jivesoftware/admin/AuthCheckFilter.java
@@ -22,8 +22,10 @@ package org.jivesoftware.admin;
 
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.util.Collections;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -35,7 +37,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.jivesoftware.util.ConcurrentHashSet;
 import org.jivesoftware.util.WebManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,7 @@ public class AuthCheckFilter implements Filter {
 
 	private static final Logger Log = LoggerFactory.getLogger(AuthCheckFilter.class);
 
-    private static Set<String> excludes = new ConcurrentHashSet<String>();
+    private static Set<String> excludes = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 
     private ServletContext context;
     private String defaultLoginPage;

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -34,7 +34,6 @@ import org.jivesoftware.openfire.forward.Forwarded;
 import org.jivesoftware.openfire.handler.PresenceUpdateHandler;
 import org.jivesoftware.openfire.server.OutgoingSessionPromise;
 import org.jivesoftware.openfire.session.*;
-import org.jivesoftware.util.ConcurrentHashSet;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.cache.Cache;
 import org.jivesoftware.util.cache.CacheFactory;
@@ -43,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import org.xmpp.packet.*;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 
 /**
@@ -194,7 +194,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                             jids = new HashSet<String>();
                         }
                         else {
-                            jids = new ConcurrentHashSet<String>();
+                            jids = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
                         }
                     }
                     jids.add(route.toString());

--- a/src/java/org/jivesoftware/util/ConcurrentHashSet.java
+++ b/src/java/org/jivesoftware/util/ConcurrentHashSet.java
@@ -27,7 +27,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * This class implements the <tt>Set</tt> interface, backed by a ConcurrentHashMap instance.
  *
  * @author Matt Tucker
+ * @deprecated Use {@code Collections.newSetFromMap(new ConcurrentHashMap<E, Boolean>())} instead.
  */
+@Deprecated
 public class ConcurrentHashSet<E> extends AbstractSet<E> implements Set<E>, Cloneable,
         java.io.Serializable
 {

--- a/src/plugins/fastpath/src/java/org/jivesoftware/xmpp/workgroup/WorkgroupPresence.java
+++ b/src/plugins/fastpath/src/java/org/jivesoftware/xmpp/workgroup/WorkgroupPresence.java
@@ -25,15 +25,16 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.dom4j.Element;
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.openfire.fastpath.util.TaskEngine;
-import org.jivesoftware.util.ConcurrentHashSet;
 import org.jivesoftware.util.FastDateFormat;
 import org.jivesoftware.util.JiveConstants;
 import org.jivesoftware.util.XMPPDateTimeFormat;
@@ -84,7 +85,7 @@ public class WorkgroupPresence {
      * to susbcribe to the workgroup presence. The temporary subscription will be removed
      * when an unavailable presence is sent to the workgroup.
      */
-    private final Set<JID> listeners = new ConcurrentHashSet<JID>();
+    private final Set<JID> listeners = Collections.newSetFromMap(new ConcurrentHashMap<JID, Boolean>());
 
     /**
      * Holds the bare JID address of all the users that subscribed to the presence of the

--- a/src/plugins/fastpath/src/java/org/jivesoftware/xmpp/workgroup/dispatcher/RoundRobinDispatcher.java
+++ b/src/plugins/fastpath/src/java/org/jivesoftware/xmpp/workgroup/dispatcher/RoundRobinDispatcher.java
@@ -22,18 +22,20 @@ package org.jivesoftware.xmpp.workgroup.dispatcher;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.jivesoftware.openfire.fastpath.util.TaskEngine;
 import org.jivesoftware.openfire.fastpath.util.WorkgroupUtils;
 import org.jivesoftware.util.BeanUtils;
 import org.jivesoftware.util.ClassUtils;
-import org.jivesoftware.util.ConcurrentHashSet;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.NotFoundException;
 import org.jivesoftware.xmpp.workgroup.AgentSession;
@@ -82,7 +84,7 @@ public class RoundRobinDispatcher implements Dispatcher, AgentSessionListener {
      *
      * Let's the server route offer responses to the correct offer.
      */
-    private ConcurrentHashSet<Offer> offers = new ConcurrentHashSet<Offer>();
+    private Set<Offer> offers = Collections.newSetFromMap(new ConcurrentHashMap<Offer, Boolean>());
 
     /**
      * Creates a new dispatcher for the queue. The dispatcher will have a Timer with a unique task

--- a/src/plugins/gojara/src/java/org/jivesoftware/openfire/plugin/gojara/messagefilter/MainInterceptor.java
+++ b/src/plugins/gojara/src/java/org/jivesoftware/openfire/plugin/gojara/messagefilter/MainInterceptor.java
@@ -1,11 +1,13 @@
 package org.jivesoftware.openfire.plugin.gojara.messagefilter;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.dom4j.Element;
 import org.dom4j.Node;
@@ -19,7 +21,6 @@ import org.jivesoftware.openfire.plugin.gojara.sessions.TransportSessionManager;
 import org.jivesoftware.openfire.plugin.gojara.utils.XpathHelper;
 import org.jivesoftware.openfire.roster.RosterManager;
 import org.jivesoftware.openfire.session.Session;
-import org.jivesoftware.util.ConcurrentHashSet;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +42,7 @@ import org.xmpp.packet.Presence;
 public class MainInterceptor implements PacketInterceptor {
 
 	private static final Logger Log = LoggerFactory.getLogger(MainInterceptor.class);
-	private Set<String> activeTransports = new ConcurrentHashSet<String>();
+	private Set<String> activeTransports = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 	/**
 	 * For referencing the abstract remote Processors
 	 */


### PR DESCRIPTION
ConcurrentHashSet seems to be a relict from earlier Java times.

Since Java 1.6 the preferred method to create a "ConcurrentHashSet" is to use Collections.newSetFromMap(new ConcurrentHashMap<?, ?>())

I suggest to delete ConcurrentHashSet.java at latest with Openfire 4.