### PR TITLE
Replace deprecated org.jivesoftware.util.Log with org.slf4j.Logger

### DIFF
--- a/src/java/org/jivesoftware/admin/LdapGroupTester.java
+++ b/src/java/org/jivesoftware/admin/LdapGroupTester.java
@@ -20,8 +20,9 @@
 
 package org.jivesoftware.admin;
 
-import org.jivesoftware.util.Log;
 import org.jivesoftware.openfire.ldap.LdapManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.Attribute;
@@ -41,6 +42,8 @@ import java.util.Collection;
  * @author Gaston Dombiak
  */
 public class LdapGroupTester {
+
+    private static final Logger Log = LoggerFactory.getLogger(LdapGroupTester.class);
 
     private LdapManager manager;
 

--- a/src/java/org/jivesoftware/admin/LdapUserProfile.java
+++ b/src/java/org/jivesoftware/admin/LdapUserProfile.java
@@ -25,8 +25,9 @@ import org.dom4j.io.OutputFormat;
 import org.jivesoftware.openfire.ldap.LdapManager;
 import org.jivesoftware.openfire.ldap.LdapVCardProvider;
 import org.jivesoftware.util.JiveGlobals;
-import org.jivesoftware.util.Log;
 import org.jivesoftware.util.XMLWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -39,6 +40,8 @@ import java.util.Iterator;
  * @author Gaston Dombiak
  */
 public class LdapUserProfile {
+
+    private static final Logger Log = LoggerFactory.getLogger(LdapUserProfile.class);
 
     private String name = "";
     private String email = "";

--- a/src/java/org/jivesoftware/admin/LdapUserTester.java
+++ b/src/java/org/jivesoftware/admin/LdapUserTester.java
@@ -20,9 +20,10 @@
 
 package org.jivesoftware.admin;
 
-import org.jivesoftware.util.Log;
 import org.jivesoftware.util.Base64;
 import org.jivesoftware.openfire.ldap.LdapManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
 import javax.naming.NamingEnumeration;
@@ -41,6 +42,8 @@ import java.util.*;
  * @author Gaston Dombiak
  */
 public class LdapUserTester {
+
+    private static final Logger Log = LoggerFactory.getLogger(LdapUserTester.class);
 
     /**
      * Constants to access user properties

--- a/src/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
+++ b/src/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
@@ -21,14 +21,14 @@
 package org.jivesoftware.database;
 
 import org.jivesoftware.util.JiveGlobals;
-import org.jivesoftware.util.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.sql.DriverManager;
 import java.util.Properties;
 
@@ -41,6 +41,8 @@ import java.util.Properties;
  * @author Matt Tucker
  */
 public class EmbeddedConnectionProvider implements ConnectionProvider {
+
+    private static final Logger Log = LoggerFactory.getLogger(EmbeddedConnectionProvider.class);
 
     private Properties settings;
     private String serverURL;

--- a/src/java/org/jivesoftware/openfire/http/ResourceServlet.java
+++ b/src/java/org/jivesoftware/openfire/http/ResourceServlet.java
@@ -22,6 +22,8 @@ package org.jivesoftware.openfire.http;
 import org.jivesoftware.util.*;
 import org.jivesoftware.util.cache.Cache;
 import org.jivesoftware.util.cache.CacheFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -38,7 +40,10 @@ import java.io.*;
  * Combines and serves resources, such as javascript or css files.
  */
 public class ResourceServlet extends HttpServlet {
-//    private static String suffix = "";    // Set to "_src" to use source version
+
+    private static final Logger Log = LoggerFactory.getLogger(ResourceServlet.class);
+
+    //    private static String suffix = "";    // Set to "_src" to use source version
     private static long expiresOffset = 3600 * 24 * 10;	// 10 days util client cache expires
     private boolean debug = false;
     private boolean disableCompression = false;

--- a/src/java/org/jivesoftware/openfire/starter/ServerStarter.java
+++ b/src/java/org/jivesoftware/openfire/starter/ServerStarter.java
@@ -20,7 +20,8 @@
 
 package org.jivesoftware.openfire.starter;
 
-import org.jivesoftware.util.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 /**
@@ -45,6 +46,8 @@ import java.io.File;
  * @author Iain Shigeoka
  */
 public class ServerStarter {
+
+    private static final Logger Log = LoggerFactory.getLogger(ServerStarter.class);
 
     /**
      * Default to this location if one has not been specified


### PR DESCRIPTION
Most methods in org.jivesoftware.util.Log are deprecated, stating that org.slf4j.Logger should be used instead.

This PR uses org.slf4j.Logger in Openfire core now.