### PR TITLE
Prevent NoClassDefFoundError during Openfire start.

### DIFF
--- a/src/java/org/jivesoftware/openfire/starter/ServerStarter.java
+++ b/src/java/org/jivesoftware/openfire/starter/ServerStarter.java
@@ -20,8 +20,7 @@
 
 package org.jivesoftware.openfire.starter;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jivesoftware.util.Log;
 
 import java.io.File;
 /**
@@ -46,8 +45,6 @@ import java.io.File;
  * @author Iain Shigeoka
  */
 public class ServerStarter {
-
-    private static final Logger Log = LoggerFactory.getLogger(ServerStarter.class);
 
     /**
      * Default to this location if one has not been specified


### PR DESCRIPTION
f81c28b replaced org.jivesoftware.util.Log with org.slf4j.Logger.
This commit partially reverts this.

Apparently the build process produces an additional startup.jar, which contains the ServerStarter class. However, it doesn't add slf4j-api.jar to the classpath or manifest.
Because Openfire's classpath, lib folder and build structure is pretty confusing (e.g. slf4j-api.jar gets merged into a new openfire.jar, there's an extra JiveClassLoader, etc...), it's hard to solve this in a reasonable way at the moment.