### PR TITLE
restAPI: make group affiliations per room visible

### DIFF
--- a/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -20,6 +20,8 @@ import org.jivesoftware.openfire.muc.ForbiddenException;
 import org.jivesoftware.openfire.muc.MUCRole;
 import org.jivesoftware.openfire.muc.MUCRoom;
 import org.jivesoftware.openfire.muc.NotAllowedException;
+import org.jivesoftware.openfire.group.ConcurrentGroupList;
+import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.plugin.rest.utils.MUCRoomUtils;
 import org.jivesoftware.openfire.plugin.rest.utils.UserUtils;
 import org.jivesoftware.util.AlreadyExistsException;
@@ -52,7 +54,7 @@ public class MUCRoomController {
 	 *            the room search
 	 * @return the chat rooms
 	 */
-	public MUCRoomEntities getChatRooms(String serviceName, String channelType, String roomSearch) {
+	public MUCRoomEntities getChatRooms(String serviceName, String channelType, String roomSearch, boolean expand) {
 		List<MUCRoom> rooms = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(serviceName)
 				.getChatRooms();
 
@@ -66,9 +68,9 @@ public class MUCRoomController {
 			}
 
 			if (channelType.equals(MUCChannelType.ALL)) {
-				mucRoomEntities.add(convertToMUCRoomEntity(chatRoom));
+				mucRoomEntities.add(convertToMUCRoomEntity(chatRoom, expand));
 			} else if (channelType.equals(MUCChannelType.PUBLIC) && chatRoom.isPublicRoom()) {
-				mucRoomEntities.add(convertToMUCRoomEntity(chatRoom));
+				mucRoomEntities.add(convertToMUCRoomEntity(chatRoom, expand));
 			}
 		}
 
@@ -86,7 +88,7 @@ public class MUCRoomController {
 	 * @throws ServiceException
 	 *             the service exception
 	 */
-	public MUCRoomEntity getChatRoom(String roomName, String serviceName) throws ServiceException {
+	public MUCRoomEntity getChatRoom(String roomName, String serviceName, boolean expand) throws ServiceException {
 		MUCRoom chatRoom = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(serviceName)
 				.getChatRoom(roomName);
 
@@ -94,7 +96,7 @@ public class MUCRoomController {
 			throw new ServiceException("Could not find the chat room", roomName, ExceptionType.ROOM_NOT_FOUND, Response.Status.NOT_FOUND);
 		}
 
-		MUCRoomEntity mucRoomEntity = convertToMUCRoomEntity(chatRoom);
+		MUCRoomEntity mucRoomEntity = convertToMUCRoomEntity(chatRoom, expand);
 		return mucRoomEntity;
 	}
 
@@ -305,7 +307,7 @@ public class MUCRoomController {
 	 *            the room
 	 * @return the MUC room entity
 	 */
-	public MUCRoomEntity convertToMUCRoomEntity(MUCRoom room) {
+	public MUCRoomEntity convertToMUCRoomEntity(MUCRoom room, boolean expand) {
 		MUCRoomEntity mucRoomEntity = new MUCRoomEntity(room.getNaturalLanguageName(), room.getName(),
 				room.getDescription());
 
@@ -325,10 +327,35 @@ public class MUCRoomController {
 		mucRoomEntity.setMembersOnly(room.isMembersOnly());
 		mucRoomEntity.setModerated(room.isModerated());
 
-		mucRoomEntity.setOwners(MUCRoomUtils.convertJIDsToStringList(room.getOwners()));
-		mucRoomEntity.setAdmins(MUCRoomUtils.convertJIDsToStringList(room.getAdmins()));
-		mucRoomEntity.setMembers(MUCRoomUtils.convertJIDsToStringList(room.getMembers()));
-		mucRoomEntity.setOutcasts(MUCRoomUtils.convertJIDsToStringList(room.getOutcasts()));
+		ConcurrentGroupList<JID> owners = new ConcurrentGroupList<JID>(room.getOwners());
+		ConcurrentGroupList<JID> admins = new ConcurrentGroupList<JID>(room.getAdmins());
+		ConcurrentGroupList<JID> members = new ConcurrentGroupList<JID>(room.getMembers());
+		ConcurrentGroupList<JID> outcasts = new ConcurrentGroupList<JID>(room.getOutcasts());
+
+		if (expand) {
+			for(Group ownerGroup : owners.getGroups()) {
+				owners.addAllAbsent(ownerGroup.getAll());
+			}
+			for(Group adminGroup : admins.getGroups()) {
+				admins.addAllAbsent(adminGroup.getAll());
+			}
+			for(Group memberGroup : members.getGroups()) {
+				members.addAllAbsent(memberGroup.getAll());
+			}
+			for(Group outcastGroup : outcasts.getGroups()) {
+				outcasts.addAllAbsent(outcastGroup.getAll());
+			}
+		}
+
+		mucRoomEntity.setOwners(MUCRoomUtils.convertJIDsToStringList(owners));
+		mucRoomEntity.setAdmins(MUCRoomUtils.convertJIDsToStringList(admins));
+		mucRoomEntity.setMembers(MUCRoomUtils.convertJIDsToStringList(members));
+		mucRoomEntity.setOutcasts(MUCRoomUtils.convertJIDsToStringList(outcasts));
+
+		mucRoomEntity.setOwnerGroups(MUCRoomUtils.convertGroupsToStringList(owners.getGroups()));
+		mucRoomEntity.setAdminGroups(MUCRoomUtils.convertGroupsToStringList(admins.getGroups()));
+		mucRoomEntity.setMemberGroups(MUCRoomUtils.convertGroupsToStringList(members.getGroups()));
+		mucRoomEntity.setOutcastGroups(MUCRoomUtils.convertGroupsToStringList(outcasts.getGroups()));
 
 		mucRoomEntity.setBroadcastPresenceRoles(room.getRolesToBroadcastPresence());
 

--- a/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/entity/MUCRoomEntity.java
+++ b/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/entity/MUCRoomEntity.java
@@ -13,7 +13,7 @@ import javax.xml.bind.annotation.XmlType;
 		"modificationDate", "maxUsers", "persistent", "publicRoom", "registrationEnabled", "canAnyoneDiscoverJID",
 		"canOccupantsChangeSubject", "canOccupantsInvite", "canChangeNickname", "logEnabled",
 		"loginRestrictedToNickname", "membersOnly", "moderated", "broadcastPresenceRoles", "owners", "admins",
-		"members", "outcasts" })
+		"members", "outcasts", "ownerGroups", "adminGroups", "memberGroups", "outcastGroups" })
 public class MUCRoomEntity {
 
 	private String roomName;
@@ -42,12 +42,16 @@ public class MUCRoomEntity {
 	private List<String> broadcastPresenceRoles;
 
 	private List<String> owners;
+	private List<String> ownerGroups;
 
 	private List<String> admins;
+	private List<String> adminGroups;
 
 	private List<String> members;
+	private List<String> memberGroups;
 
 	private List<String> outcasts;
+	private List<String> outcastGroups;
 
 	public MUCRoomEntity() {
 	}
@@ -245,8 +249,18 @@ public class MUCRoomEntity {
 		return owners;
 	}
 
+	@XmlElementWrapper(name = "ownerGroups")
+	@XmlElement(name = "ownerGroup")
+	public List<String> getOwnerGroups() {
+		return ownerGroups;
+	}
+
 	public void setOwners(List<String> owners) {
 		this.owners = owners;
+	}
+
+	public void setOwnerGroups(List<String> ownerGroups) {
+		this.ownerGroups = ownerGroups;
 	}
 
 	@XmlElementWrapper(name = "members")
@@ -255,8 +269,18 @@ public class MUCRoomEntity {
 		return members;
 	}
 
+	@XmlElementWrapper(name = "memberGroups")
+	@XmlElement(name = "memberGroup")
+	public List<String> getmemberGroups() {
+		return memberGroups;
+	}
+
 	public void setMembers(List<String> members) {
 		this.members = members;
+	}
+
+	public void setMemberGroups(List<String> memberGroups) {
+		this.memberGroups = memberGroups;
 	}
 
 	@XmlElementWrapper(name = "outcasts")
@@ -265,8 +289,18 @@ public class MUCRoomEntity {
 		return outcasts;
 	}
 
+	@XmlElementWrapper(name = "outcastGroups")
+	@XmlElement(name = "outcastGroup")
+	public List<String> getoutcastGroups() {
+		return outcastGroups;
+	}
+
 	public void setOutcasts(List<String> outcasts) {
 		this.outcasts = outcasts;
+	}
+
+	public void setOutcastGroups(List<String> outcastGroups) {
+		this.outcastGroups = outcastGroups;
 	}
 
 	@XmlElementWrapper(name = "admins")
@@ -275,8 +309,18 @@ public class MUCRoomEntity {
 		return admins;
 	}
 
+	@XmlElementWrapper(name = "adminGroups")
+	@XmlElement(name = "adminGroup")
+	public List<String> getadminGroups() {
+		return adminGroups;
+	}
+
 	public void setAdmins(List<String> admins) {
 		this.admins = admins;
+	}
+
+	public void setAdminGroups(List<String> adminGroups) {
+		this.adminGroups = adminGroups;
 	}
 
 }

--- a/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomService.java
+++ b/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomService.java
@@ -27,16 +27,18 @@ public class MUCRoomService {
 	@Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
 	public MUCRoomEntities getMUCRooms(@DefaultValue("conference") @QueryParam("servicename") String serviceName,
 			@DefaultValue(MUCChannelType.PUBLIC) @QueryParam("type") String channelType,
-			@QueryParam("search") String roomSearch) {
-		return MUCRoomController.getInstance().getChatRooms(serviceName, channelType, roomSearch);
+			@QueryParam("search") String roomSearch,
+			@DefaultValue("false") @QueryParam("expandGroups") Boolean expand) {
+		return MUCRoomController.getInstance().getChatRooms(serviceName, channelType, roomSearch, expand);
 	}
 	
 	@GET
 	@Path("/{roomName}")
 	@Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
 	public MUCRoomEntity getMUCRoomJSON2(@PathParam("roomName") String roomName,
-			@DefaultValue("conference") @QueryParam("servicename") String serviceName) throws ServiceException {
-		return MUCRoomController.getInstance().getChatRoom(roomName, serviceName);
+			@DefaultValue("conference") @QueryParam("servicename") String serviceName,
+			@DefaultValue("false") @QueryParam("expandGroups") Boolean expand) throws ServiceException {
+		return MUCRoomController.getInstance().getChatRoom(roomName, serviceName, expand);
 	}
 
 

--- a/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/utils/MUCRoomUtils.java
+++ b/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/utils/MUCRoomUtils.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.jivesoftware.openfire.group.Group;
 import org.xmpp.packet.JID;
 
 /**
@@ -20,6 +21,7 @@ public class MUCRoomUtils {
 
 	/**
 	 * Convert jids to string list.
+	 * In case the jid is not bare (=it is a group jid) exclude it
 	 *
 	 * @param jids
 	 *            the jids
@@ -29,7 +31,21 @@ public class MUCRoomUtils {
 		List<String> result = new ArrayList<String>();
 
 		for (JID jid : jids) {
-			result.add(jid.toBareJID());
+			if (jid.getResource() == null) result.add(jid.toBareJID());
+		}
+		return result;
+	}
+
+	/**
+	 * Convert groups to string list
+	 * @param groups
+	 * 			the groups
+	 * @return the array list of the group names
+	 */
+	public static List<String> convertGroupsToStringList(Collection<Group> groups) {
+		List<String> result = new ArrayList<String>();
+		for (Group group : groups) {
+			result.add(group.getName());
 		}
 		return result;
 	}


### PR DESCRIPTION
This patch shows which groups have one of the affiliations
admin|member|owner|outcast.
In case the new query parameter expandGroups is set to true, the group
member's jids are added to the explicit jids.