### PR TITLE
Clean plugins directory when calling Ant "plugins" target.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1191,6 +1191,8 @@
 
     <!-- plugins =============================================================================== -->
     <target name="plugins" description="Builds all plugins" depends="anttasks">
+        <antcall target="clean-plugins"/>
+
         <tstamp>
             <format property="buildJavaDate" pattern="MMM dd, yyyy"/>
         </tstamp>


### PR DESCRIPTION
Don't know why, but it fixes the issue described here:
https://community.igniterealtime.org/thread/55868

org.apache.jasper.JasperException: XML parsing error on file /WEB-INF/web.xml