### PR TITLE
Update protocol support documentation.

### DIFF
--- a/documentation/docs/protocol-support.html
+++ b/documentation/docs/protocol-support.html
@@ -24,8 +24,8 @@
 
 <p>Openfire provides full support for the
 <acronym title="Extensible Messaging and Presence Protocol">XMPP</acronym>
-protocol defined by <a href="http://www.xmpp.org/specs/rfc3920.html">RFC 3920</a> and
-<a href="http://www.xmpp.org/specs/rfc3921.html">RFC 3921</a>. In addition to full
+protocol defined by <a href="http://xmpp.org/rfcs/rfc6120.html">RFC 6120</a> and
+<a href="http://xmpp.org/rfcs/rfc6121.html">RFC 6121</a>. In addition to full
 XMPP support, Openfire also provides support for numerous extensions to XMPP
 that are defined through the
 <acronym title="XMPP Enhancement Proposals">XEP</acronym> process at
@@ -35,21 +35,20 @@ release.</p>
 
 <p>This document is broken down into the following sections:</p>
 <ul>
-  <li><a href="#basic">Basic IM Protocol Suite Support</a></li>
-  <li><a href="#intermediate">Intermediate IM Protocol Suite Support</a></li>
+  <li><a href="#core">Core XMPP Server Compliance Support</a></li>
+  <li><a href="#advanced">Advanced XMPP Server Compliance Support</a></li>
   <li><a href="#jeps">List of XEPs Supported</a></li>
   <li><a href="#footnotes">Footnotes</a></li>
 </ul>
 
 <br>
 
-<a name="basic"></a>
-<h2>Basic IM Protocol Suite Support</h2>
+<a name="core"></a>
+<h2>Core XMPP Server Compliance Support</h2>
 
-<p>The basic suite includes full support of the XMPP RFC's as well as the most common extensions.
+<p>The core compliance level includes full support of the XMPP RFC's as well as the most common extensions.
 The table below details the level of support for the requirements set by
-<a href="http://www.xmpp.org/extensions/xep-0073.html">XEP-0073: Basic IM Protocol
-Suite</a>.</p>
+<a href="http://www.xmpp.org/extensions/xep-0302.html">XEP-0302: XMPP Compliance Suites 2012</a>.</p>
 
 <table class="dbtable">
 <tr>
@@ -57,37 +56,31 @@ Suite</a>.</p>
 
   <th width="35%">Supported</th>
 </tr><tr>
-  <td><a href="http://www.xmpp.org/specs/rfc3920.html">RFC 3920</a>: XMPP Core</td>
+  <td><a href="http://xmpp.org/rfcs/rfc6120.html">RFC 6120</a>: XMPP Core</td>
     <td class="supported">Yes</td>
 </tr><tr>
-  <td><a href="http://www.xmpp.org/specs/rfc3921.html">RFC 3921</a>: XMPP IM</td>
+  <td><a href="http://xmpp.org/rfcs/rfc6121.html">RFC 6121</a>: XMPP IM</td>
   <td class="supported">Yes</td>
-
+</tr><tr>
+  <td><a href="http://xmpp.org/rfcs/rfc6122.html">RFC 6122</a>: XMPP ADDR</td>
+  <td class="supported">Yes</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0030.html">XEP-0030</a>: Service Discovery</td>
   <td class="supported">Yes</td>
 </tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0077.html">XEP-0077</a>: In-Band Registration</td>
-  <td class="supported">Yes</td>
-</tr><tr>
-
-  <td><a href="http://www.xmpp.org/extensions/xep-0078.html">XEP-0078</a>: Non-SASL Authentication</td>
-  <td class="supported">Yes</td>
-</tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0086.html">XEP-0086</a>: Error Condition Mappings</td>
+  <td><a href="http://www.xmpp.org/extensions/xep-0114.html">XEP-0114</a>: Jabber Component Protocol</td>
   <td class="supported">Yes</td>
 </tr>
 </table>
 
 <br>
 
-<a name="intermediate"></a>
-<h2>Intermediate IM Protocol Suite Support</h2>
+<a name="advanced"></a>
+<h2>Advanced XMPP Server Compliance Support</h2>
 
-<p>The intermediate suite includes the full basic suite as well as more advanced features in common use
+<p>The advanced compliance level includes the full basic suite as well as more advanced features in common use
 by XMPP clients. The table below details the level of support for the requirements set by
-<a href="http://www.xmpp.org/extensions/xep-0117.html">XEP-0117: Intermediate IM Protocol
-Suite</a>.</p>
+<a href="http://www.xmpp.org/extensions/xep-0302.html">XMPP Compliance Suites 2012</a>.</p>
 
 <table class="dbtable">
 <tr>
@@ -95,36 +88,29 @@ Suite</a>.</p>
   <th width="35%">Supported</th>
 
 </tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0073.html">XEP-0073</a>: Basic IM Protocol Suite</td>
+  <td><a href="http://www.xmpp.org/extensions/xep-0115.html">XEP-0115</a>: Entity Capabilities</td>
   <td class="supported">Yes</td>
 </tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0004.html">XEP-0004</a>: Data Forms</td>
-  <td class="supported">Yes</td>
-</tr><tr>
-
-  <td><a href="http://www.xmpp.org/extensions/xep-0020.html">XEP-0020</a>: Feature Negotiation</td>
+  <td><a href="http://www.xmpp.org/extensions/xep-0191.html">XEP-0191</a>: Blocking Command</td>
   <td class="unsupported">No</td>
+</tr><tr>
+  <td><a href="http://www.xmpp.org/extensions/xep-0124.html">XEP-0124</a>: Bidirectional-streams Over Synchronous HTTP (BOSH)</td>
+  <td class="supported">Yes</td>
+</tr><tr>
+  <td><a href="http://www.xmpp.org/extensions/xep-0206.html">XEP-0206</a>: XMPP Over BOSH</td>
+  <td class="supported">Yes</td>
+</tr><tr>
+  <td><a href="http://www.xmpp.org/extensions/xep-0054.html">XEP-0054</a>: vcard-temp</td>
+  <td class="supported">Yes</td>
+</tr><tr>
+  <td><a href="http://www.xmpp.org/extensions/xep-0163.html">XEP-0163</a>: Personal Eventing Protocol</td>
+  <td class="supported">Yes</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0045.html">XEP-0045</a>: Multi-User Chat</td>
   <td class="supported">Yes</td>
 </tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0047.html">XEP-0047</a>: In-Band Bytestreams</td>
-
-  <td class="supported">Yes</td>
-</tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0065.html">XEP-0065</a>: SOCKS5 Bytestreams</td>
-  <td class="supported">Yes</td>
-</tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0071.html">XEP-0071</a>: XHTML-IM</td>
-  <td class="supported">Yes [<a href="#fn1">1</a>]</td>
-
-</tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0096.html">XEP-0096</a>: File Transfer</td>
-  <td class="supported">Yes</td>
-</tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0115.html">XEP-0115</a>: Entity Capabilities</td>
-  <td class="supported">Yes</td>
-
+  <td><a href="http://www.xmpp.org/extensions/xep-0198.html">XEP-0198</a>: Stream Management</td>
+  <td class="supported">Partial</td>
 </tr>
 </table>
 <br>
@@ -132,107 +118,82 @@ Suite</a>.</p>
 <a name="jeps"></a>
 <h2>List of XEPs Supported</h2>
 
-<p>The table below lists all XEPs supported by Openfire and indicates which XEPs are part of the
-<a href="#basic">Basic</a> or <a href="#intermediate">Intermediate</a> Protocol Suites listed above.
+<p>The table below lists all XEPs supported by Openfire.
 XEPs that only require client-side support are omitted.</p>
 
 <table class="dbtable">
 <tr>
   <th>Specification</th>
-  <th>Suite</th>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0004.html">XEP-0004</a>: Data Forms</td>
-  <td>Intermediate</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0012.html">XEP-0012</a>: Last Activity</td>
-  <td>-</td>
  </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0013.html">XEP-0013</a>: Flexible Offline Message Retrieval</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0030.html">XEP-0030</a>: Service Discovery</td>
-  <td>Basic</td>
 </tr><tr>
  <td><a href="http://www.xmpp.org/extensions/xep-0033.html">XEP-0033</a>: Extended Stanza Addressing</td>
- <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0045.html">XEP-0045</a>: Multi-User Chat</td>
-  <td>Intermediate</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0049.html">XEP-0049</a>: Private XML Storage</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0050.html">XEP-0050</a>: Ad-Hoc Commands</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0054.html">XEP-0054</a>: vcard-temp</td>
-  <td>-</td>
 </tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0055.html">XEP-0055</a>: Jabber Search [<a href="#fn3">2</a>]</td>
-  <td>-</td>
+  <td><a href="http://www.xmpp.org/extensions/xep-0055.html">XEP-0055</a>: Jabber Search [<a href="#fn1">1</a>]</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0059.html">XEP-0059</a>: Result Set Management</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0060.html">XEP-0060</a>: Publish-Subscribe</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0065.html">XEP-0065</a>: SOCKS5 Bytestreams</td>
-  <td>Intermediate</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0077.html">XEP-0077</a>: In-Band Registration</td>
-  <td>Basic</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0078.html">XEP-0078</a>: Non-SASL Authentication</td>
-  <td>Basic</td>
 </tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0082.html">XEP-0082</a>: Jabber Date and Time Profiles</td>
-  <td>-</td>
+  <td><a href="http://www.xmpp.org/extensions/xep-0082.html">XEP-0082</a>: XMPP Date and Time Profiles</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0086.html">XEP-0086</a>: Error Condition Mappings</td>
-  <td>Basic</td>
 </tr><tr>
-  <td><a href="http://www.xmpp.org/extensions/xep-0090.html">XEP-0090</a>: Entity Time</td>
-  <td>-</td>
+  <td><a href="http://www.xmpp.org/extensions/xep-0090.html">XEP-0090</a>: Legacy Entity Time</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0091.html">XEP-0091</a>: Legacy Delayed Delivery</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0092.html">XEP-0092</a>: Software Version</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0096.html">XEP-0096</a>: File Transfer</td>
-  <td>Intermediate</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0106.html">XEP-0106</a>: JID Escaping</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0114.html">XEP-0114</a>: Jabber Component Protocol</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0115.html">XEP-0115</a>: Entity Capabilities</td>
-  <td>Intermediate</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0124.html">XEP-0124</a>: HTTP Binding</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0126.html">XEP-0126</a>: Invisibility</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0128.html">XEP-0128</a>: Service Discovery Extensions</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0138.html">XEP-0138</a>: Stream Compression</td>
-  <td>-</td>
+</tr><tr>
+  <td><a href="http://www.xmpp.org/extensions/xep-0160.html">XEP-0160</a>: Best Practices for Handling Offline Messages</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0163.html">XEP-0163</a>: Personal Eventing via Pubsub</td>
-  <td>-</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0175.html">XEP-0175</a>: Best Practices for Use of SASL ANONYMOUS</td>
-  <td>-</td>
+</tr><tr>
+  <td><a href="http://www.xmpp.org/extensions/xep-0198.html">XEP-0198</a>: Stream Management (<i>partial</i>)</td>
+</tr><tr>
+  <td><a href="http://www.xmpp.org/extensions/xep-0202.html">XEP-0202</a>: Entity Time</td>
 </tr><tr>
   <td><a href="http://www.xmpp.org/extensions/xep-0203.html">XEP-0203</a>: Delayed Delivery</td>
-  <td>-</td>
+</tr><tr>
+  <td><a href="http://www.xmpp.org/extensions/xep-0280.html">XEP-0280</a>: Message Carbons</td>
 </tr>
 </table>
 <br>
@@ -241,9 +202,7 @@ XEPs that only require client-side support are omitted.</p>
 <a name="footnotes"></a>
 <h2>Footnotes</h2>
 
- [<a name="fn1">1</a>] Some requirements of <u>XEP-0117: Intermediate IM Protocol Suite</u> do not pertain to servers.
- <br>
- [<a name="fn3">2</a>] Support for <u>XEP-0055: Jabber Search</u> is provided by the <a href="http://www.igniterealtime.org/projects/openfire/plugins.jsp">Search plugin</a>.
+ [<a name="fn1">1</a>] Support for <u>XEP-0055: Jabber Search</u> is provided by the <a href="http://www.igniterealtime.org/projects/openfire/plugins.jsp">Search plugin</a>.
  <br>
 
  


### PR DESCRIPTION
- Update old XMPP RFCs to the new one (e.g. 6120)
- Remove the obsolete reference to XEP-0073 and replace it with XEP-0302
- Get rid of the basic/intermediate terms as they are no longer in use in XEP-0302. Use Core and Advanced instead.
- Add XEP-0160, XEP-0198, XEP-0202, XEP-0280
- Correct "Entity Time" to "Legacy Entity Time"
- Correct "Jabber Date and Time Profiles" to "XMPP Date and Time Profiles"
