### PR TITLE
byte[].equals() should probably be Arrays.equals()

### DIFF
--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1044,7 +1044,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         	serverLock.lock();
 	    	List<String> remoteServerDomains = new ArrayList<>();
 	    	for (Map.Entry<String, byte[]> entry : serversCache.entrySet()) {
-	    		if (entry.getValue().equals(nodeID)) {
+	    		if (Arrays.equals(entry.getValue(), nodeID)) {
 	    			remoteServerDomains.add(entry.getKey());
 	    		}
 	    	}


### PR DESCRIPTION
This is highlighted as "probably a bug" in my IDE.

E.g. `new byte[]{1}.equals(new byte[]{1})` is always false.
But `Arrays.equals(new byte[]{1}, new byte[]{1});` is true.