### PR TITLE
OF-974: Migrate cache content

### DIFF
--- a/src/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/src/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -732,12 +732,13 @@ public class CacheFactory {
     @SuppressWarnings("unchecked")
 	public static synchronized void joinedCluster() {
         cacheFactoryStrategy = clusteredCacheFactoryStrategy;
-        // Loop through local caches and switch them to clustered cache (purge content)
+        // Loop through local caches and switch them to clustered cache (copy content)
         for (Cache cache : getAllCaches()) {
             // skip local-only caches
             if (localOnly.contains(cache.getName())) continue;
             CacheWrapper cacheWrapper = ((CacheWrapper) cache);
             Cache clusteredCache = cacheFactoryStrategy.createCache(cacheWrapper.getName());
+            clusteredCache.putAll(cache);
             cacheWrapper.setWrappedCache(clusteredCache);
         }
         clusteringStarting = false;
@@ -753,12 +754,13 @@ public class CacheFactory {
         clusteringStarted = false;
         cacheFactoryStrategy = localCacheFactoryStrategy;
 
-        // Loop through clustered caches and change them to local caches (purge content)
+        // Loop through clustered caches and change them to local caches (copy content)
         for (Cache cache : getAllCaches()) {
             // skip local-only caches
             if (localOnly.contains(cache.getName())) continue;
             CacheWrapper cacheWrapper = ((CacheWrapper) cache);
             Cache standaloneCache = cacheFactoryStrategy.createCache(cacheWrapper.getName());
+            standaloneCache.putAll(cache);
             cacheWrapper.setWrappedCache(standaloneCache);
     	}
         log.info("Clustering stopped; cache migration complete");


### PR DESCRIPTION
When switch to/from clustered deployment, ensure that critical cached
items such as components and remote servers are not inadvertently
dropped from the cache.