### PR TITLE
Support mock testing

### DIFF
--- a/src/java/org/jivesoftware/database/SchemaManager.java
+++ b/src/java/org/jivesoftware/database/SchemaManager.java
@@ -71,13 +71,6 @@ public class SchemaManager {
     private static final int DATABASE_VERSION = 22;
 
     /**
-     * Creates a new Schema manager.
-     */
-    SchemaManager() {
-
-    }
-
-    /**
      * Checks the Openfire database schema to ensure that it's installed and up to date.
      * If the schema isn't present or up to date, an automatic update will be attempted.
      *

--- a/src/java/org/jivesoftware/openfire/commands/SessionData.java
+++ b/src/java/org/jivesoftware/openfire/commands/SessionData.java
@@ -59,7 +59,7 @@ public class SessionData {
      */
     private int stage;
 
-    protected SessionData(String sessionid, JID owner) {
+    public SessionData(String sessionid, JID owner) {
         this.id = sessionid;
         this.creationStamp = System.currentTimeMillis();
         this.stage = -1;


### PR DESCRIPTION
Remove "private" default constructor to enable subclasses, mock testing, etc. Separate commits for SchemaManager and SessionData classes in case these need to be cherry-picked later.