### PR TITLE
Generify ClusterTask interface

### DIFF
--- a/src/java/org/jivesoftware/openfire/cluster/GetBasicStatistics.java
+++ b/src/java/org/jivesoftware/openfire/cluster/GetBasicStatistics.java
@@ -37,7 +37,7 @@ import java.util.Map;
  *
  * @author Gaston Dombiak
  */
-public class GetBasicStatistics implements ClusterTask {
+public class GetBasicStatistics implements ClusterTask<Map<String, Object>> {
     public static final String NODE = "node";
     public static final String CLIENT = "client";
     public static final String INCOMING = "incoming";
@@ -48,7 +48,7 @@ public class GetBasicStatistics implements ClusterTask {
     private Map<String, Object> values;
 
     @Override
-    public Object getResult() {
+    public Map<String, Object> getResult() {
         return values;
     }
 

--- a/src/java/org/jivesoftware/openfire/component/NotifyComponentInfo.java
+++ b/src/java/org/jivesoftware/openfire/component/NotifyComponentInfo.java
@@ -36,7 +36,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class NotifyComponentInfo implements ClusterTask {
+public class NotifyComponentInfo implements ClusterTask<Void> {
     private IQ iq;
 
     public NotifyComponentInfo() {
@@ -47,7 +47,7 @@ public class NotifyComponentInfo implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/component/NotifyComponentRegistered.java
+++ b/src/java/org/jivesoftware/openfire/component/NotifyComponentRegistered.java
@@ -34,7 +34,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class NotifyComponentRegistered implements ClusterTask {
+public class NotifyComponentRegistered implements ClusterTask<Void> {
     private JID componentJID;
 
     public NotifyComponentRegistered() {
@@ -45,7 +45,7 @@ public class NotifyComponentRegistered implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/component/NotifyComponentUnregistered.java
+++ b/src/java/org/jivesoftware/openfire/component/NotifyComponentUnregistered.java
@@ -34,7 +34,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class NotifyComponentUnregistered implements ClusterTask {
+public class NotifyComponentUnregistered implements ClusterTask<Void> {
     private JID componentJID;
 
     public NotifyComponentUnregistered() {
@@ -45,7 +45,7 @@ public class NotifyComponentUnregistered implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/container/GetAdminConsoleInfoTask.java
+++ b/src/java/org/jivesoftware/openfire/container/GetAdminConsoleInfoTask.java
@@ -41,7 +41,7 @@ import java.util.Enumeration;
  *
  * @author Gaston Dombiak
  */
-public class GetAdminConsoleInfoTask implements ClusterTask {
+public class GetAdminConsoleInfoTask implements ClusterTask<GetAdminConsoleInfoTask> {
     private String bindInterface;
     private int adminPort;
     private int adminSecurePort;
@@ -49,7 +49,7 @@ public class GetAdminConsoleInfoTask implements ClusterTask {
 
 
     @Override
-    public Object getResult() {
+    public GetAdminConsoleInfoTask getResult() {
         return this;
     }
 

--- a/src/java/org/jivesoftware/openfire/container/IsPluginInstalledTask.java
+++ b/src/java/org/jivesoftware/openfire/container/IsPluginInstalledTask.java
@@ -33,7 +33,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class IsPluginInstalledTask implements ClusterTask {
+public class IsPluginInstalledTask implements ClusterTask<Boolean> {
     private String pluginName;
     private boolean installed;
 
@@ -48,7 +48,7 @@ public class IsPluginInstalledTask implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Boolean getResult() {
         return installed;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/AddAffiliation.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/AddAffiliation.java
@@ -34,7 +34,7 @@ import org.xmpp.packet.JID;
  *
  * @author Tom Evans
  */
-public class AddAffiliation extends MUCRoomTask {
+public class AddAffiliation extends MUCRoomTask<Void> {
     private JID bareJID;
     private MUCRole.Affiliation affiliation;
 
@@ -63,7 +63,7 @@ public class AddAffiliation extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/AddMember.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/AddMember.java
@@ -33,7 +33,7 @@ import org.xmpp.packet.JID;
  *
  * @author Gaston Dombiak
  */
-public class AddMember extends MUCRoomTask {
+public class AddMember extends MUCRoomTask<Void> {
     private JID bareJID;
     private String nickname;
 
@@ -62,7 +62,7 @@ public class AddMember extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/BroadcastMessageRequest.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/BroadcastMessageRequest.java
@@ -37,7 +37,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class BroadcastMessageRequest extends MUCRoomTask {
+public class BroadcastMessageRequest extends MUCRoomTask<Void> {
     private int occupants;
     private Message message;
 
@@ -59,7 +59,7 @@ public class BroadcastMessageRequest extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/BroadcastPresenceRequest.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/BroadcastPresenceRequest.java
@@ -38,7 +38,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class BroadcastPresenceRequest extends MUCRoomTask {
+public class BroadcastPresenceRequest extends MUCRoomTask<Void> {
     private Presence presence;
 
     private boolean isJoinPresence;
@@ -61,7 +61,7 @@ public class BroadcastPresenceRequest extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/ChangeNickname.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/ChangeNickname.java
@@ -38,7 +38,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class ChangeNickname extends MUCRoomTask {
+public class ChangeNickname extends MUCRoomTask<Void> {
     private String oldNick;
     private String newNick;
     private Presence presence;
@@ -66,7 +66,7 @@ public class ChangeNickname extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/DestroyRoomRequest.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/DestroyRoomRequest.java
@@ -35,7 +35,7 @@ import org.xmpp.packet.JID;
  *
  * @author Gaston Dombiak
  */
-public class DestroyRoomRequest extends MUCRoomTask {
+public class DestroyRoomRequest extends MUCRoomTask<Void> {
     private JID alternateJID; // Is allowed to be null!
     private String reason; // Is allowed to be null or empty!
 
@@ -55,7 +55,7 @@ public class DestroyRoomRequest extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/GetNewMemberRoomsRequest.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/GetNewMemberRoomsRequest.java
@@ -40,14 +40,14 @@ import java.util.List;
  *
  * @author Gaston Dombiak
  */
-public class GetNewMemberRoomsRequest implements ClusterTask {
+public class GetNewMemberRoomsRequest implements ClusterTask<List<RoomInfo>> {
     private List<RoomInfo> rooms;
 
     public GetNewMemberRoomsRequest() {
     }
 
     @Override
-    public Object getResult() {
+    public List<RoomInfo> getResult() {
         return rooms;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/GetNumberConnectedUsers.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/GetNumberConnectedUsers.java
@@ -34,11 +34,11 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class GetNumberConnectedUsers implements ClusterTask{
+public class GetNumberConnectedUsers implements ClusterTask<Integer> {
     private Integer count;
 
     @Override
-    public Object getResult() {
+    public Integer getResult() {
         return count;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/MUCRoomTask.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/MUCRoomTask.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gaston Dombiak
  */
-public abstract class MUCRoomTask implements ClusterTask {
+public abstract class MUCRoomTask<V> implements ClusterTask<V> {
 	
 	private static final Logger Log = LoggerFactory.getLogger(MUCRoomTask.class);
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/MUCServicePropertyClusterEventTask.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/MUCServicePropertyClusterEventTask.java
@@ -34,7 +34,7 @@ import java.io.ObjectOutput;
  *
  * @author Daniel Henninger
  */
-public class MUCServicePropertyClusterEventTask implements ClusterTask {
+public class MUCServicePropertyClusterEventTask implements ClusterTask<Void> {
     private Type event;
     private String service;
     private String key;
@@ -58,7 +58,7 @@ public class MUCServicePropertyClusterEventTask implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/OccupantAddedEvent.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/OccupantAddedEvent.java
@@ -39,7 +39,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class OccupantAddedEvent extends MUCRoomTask {
+public class OccupantAddedEvent extends MUCRoomTask<Void> {
     private Presence presence;
     private int role;
     private int affiliation;
@@ -119,7 +119,7 @@ public class OccupantAddedEvent extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/OccupantLeftEvent.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/OccupantLeftEvent.java
@@ -35,7 +35,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class OccupantLeftEvent extends MUCRoomTask {
+public class OccupantLeftEvent extends MUCRoomTask<Void> {
     private MUCRole role;
     private String nickname;
 
@@ -60,7 +60,7 @@ public class OccupantLeftEvent extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/RoomAvailableEvent.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/RoomAvailableEvent.java
@@ -35,7 +35,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class RoomAvailableEvent implements ClusterTask {
+public class RoomAvailableEvent implements ClusterTask<Void> {
     private LocalMUCRoom room;
 
     public RoomAvailableEvent() {
@@ -46,7 +46,7 @@ public class RoomAvailableEvent implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/RoomRemovedEvent.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/RoomRemovedEvent.java
@@ -35,7 +35,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class RoomRemovedEvent implements ClusterTask {
+public class RoomRemovedEvent implements ClusterTask<Void> {
     private LocalMUCRoom room;
 
     public RoomRemovedEvent() {
@@ -46,7 +46,7 @@ public class RoomRemovedEvent implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/RoomUpdatedEvent.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/RoomUpdatedEvent.java
@@ -33,7 +33,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class RoomUpdatedEvent extends MUCRoomTask {
+public class RoomUpdatedEvent extends MUCRoomTask<Void> {
     private LocalMUCRoom room;
 
     public RoomUpdatedEvent() {
@@ -45,7 +45,7 @@ public class RoomUpdatedEvent extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/SeniorMemberServicesRequest.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/SeniorMemberServicesRequest.java
@@ -42,14 +42,14 @@ import java.util.List;
  *
  * @author Daniel Henninger
  */
-public class SeniorMemberServicesRequest implements ClusterTask {
+public class SeniorMemberServicesRequest implements ClusterTask<List<ServiceInfo>> {
     private List<ServiceInfo> services;
 
     public SeniorMemberServicesRequest() {
     }
 
     @Override
-    public Object getResult() {
+    public List<ServiceInfo> getResult() {
         return services;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/ServiceAddedEvent.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/ServiceAddedEvent.java
@@ -40,7 +40,7 @@ import java.io.ObjectOutput;
  *
  * @author Daniel Henninger
  */
-public class ServiceAddedEvent implements ClusterTask {
+public class ServiceAddedEvent implements ClusterTask<Void> {
     private String subdomain;
     private String description;
     private Boolean isHidden;
@@ -55,7 +55,7 @@ public class ServiceAddedEvent implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/ServiceRemovedEvent.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/ServiceRemovedEvent.java
@@ -34,7 +34,7 @@ import java.io.ObjectOutput;
  *
  * @author Daniel Henninger
  */
-public class ServiceRemovedEvent implements ClusterTask {
+public class ServiceRemovedEvent implements ClusterTask<Void> {
     private String subdomain;
 
     public ServiceRemovedEvent() {
@@ -45,7 +45,7 @@ public class ServiceRemovedEvent implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/ServiceUpdatedEvent.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/ServiceUpdatedEvent.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Daniel Henninger
  */
-public class ServiceUpdatedEvent implements ClusterTask {
+public class ServiceUpdatedEvent implements ClusterTask<Void> {
 	
 	private static final Logger Log = LoggerFactory.getLogger(ServiceUpdatedEvent.class);
 
@@ -54,7 +54,7 @@ public class ServiceUpdatedEvent implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/UpdateHistoryStrategy.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/UpdateHistoryStrategy.java
@@ -37,7 +37,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class UpdateHistoryStrategy implements ClusterTask {
+public class UpdateHistoryStrategy implements ClusterTask<Void> {
     private String serviceName;
     private int type;
     private int maxNumber;
@@ -52,7 +52,7 @@ public class UpdateHistoryStrategy implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/UpdateOccupant.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/UpdateOccupant.java
@@ -38,7 +38,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class UpdateOccupant extends MUCRoomTask {
+public class UpdateOccupant extends MUCRoomTask<Void> {
     private Presence presence;
     private String nickname;
     private int role;
@@ -73,7 +73,7 @@ public class UpdateOccupant extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/UpdateOccupantRequest.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/UpdateOccupantRequest.java
@@ -39,7 +39,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class UpdateOccupantRequest extends MUCRoomTask {
+public class UpdateOccupantRequest extends MUCRoomTask<Element> {
     private Element answer;
     private String nickname;
     private int role;
@@ -74,7 +74,7 @@ public class UpdateOccupantRequest extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Element getResult() {
         return answer;
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/cluster/UpdatePresence.java
+++ b/src/java/org/jivesoftware/openfire/muc/cluster/UpdatePresence.java
@@ -37,7 +37,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class UpdatePresence extends MUCRoomTask {
+public class UpdatePresence extends MUCRoomTask<Void> {
     private Presence presence;
     private String nickname;
 
@@ -59,7 +59,7 @@ public class UpdatePresence extends MUCRoomTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/openfire/pubsub/cluster/FlushTask.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/cluster/FlushTask.java
@@ -8,7 +8,7 @@ import org.jivesoftware.openfire.pubsub.PubSubPersistenceManager;
 import org.jivesoftware.util.cache.ClusterTask;
 
 
-public class FlushTask implements ClusterTask
+public class FlushTask implements ClusterTask<Void>
 {
 	public FlushTask()
 	{
@@ -21,7 +21,7 @@ public class FlushTask implements ClusterTask
 	}
 
 	@Override
-	public Object getResult()
+	public Void getResult()
 	{
 		return null;
 	}

--- a/src/java/org/jivesoftware/openfire/pubsub/cluster/NodeChangeTask.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/cluster/NodeChangeTask.java
@@ -16,7 +16,7 @@ import org.jivesoftware.util.cache.ExternalizableUtil;
  * @author Robin Collier
  * 
  */
-public abstract class NodeChangeTask implements ClusterTask
+public abstract class NodeChangeTask implements ClusterTask<Void>
 {
 	private String nodeId;
 	transient private Node node;

--- a/src/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
@@ -12,7 +12,7 @@ import org.jivesoftware.util.cache.ClusterTask;
 import org.jivesoftware.util.cache.ExternalizableUtil;
 import org.xmpp.packet.JID;
 
-public abstract class NodeTask implements ClusterTask
+public abstract class NodeTask implements ClusterTask<Void>
 {
 
 	protected String nodeId;
@@ -53,7 +53,7 @@ public abstract class NodeTask implements ClusterTask
 	}
 
 	@Override
-	public Object getResult()
+	public Void getResult()
 	{
 		return null;
 	}

--- a/src/java/org/jivesoftware/openfire/session/GetSessionsCountTask.java
+++ b/src/java/org/jivesoftware/openfire/session/GetSessionsCountTask.java
@@ -33,7 +33,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class GetSessionsCountTask implements ClusterTask {
+public class GetSessionsCountTask implements ClusterTask<Integer> {
     private Boolean authenticated;
     private Integer count;
 
@@ -45,7 +45,7 @@ public class GetSessionsCountTask implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Integer getResult() {
         return count;
     }
 

--- a/src/java/org/jivesoftware/util/PropertyClusterEventTask.java
+++ b/src/java/org/jivesoftware/util/PropertyClusterEventTask.java
@@ -33,7 +33,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class PropertyClusterEventTask implements ClusterTask {
+public class PropertyClusterEventTask implements ClusterTask<Void> {
     private Type event;
     private String key;
     private String value;
@@ -54,7 +54,7 @@ public class PropertyClusterEventTask implements ClusterTask {
     }
 
     @Override
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/src/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -556,7 +556,7 @@ public class CacheFactory {
      *
      * @param task the task to be invoked on all other cluster members.
      */
-    public static void doClusterTask(final ClusterTask task) {
+    public static void doClusterTask(final ClusterTask<?> task) {
         cacheFactoryStrategy.doClusterTask(task);
     }
 
@@ -568,7 +568,7 @@ public class CacheFactory {
      * @param nodeID the byte array that identifies the target cluster member.
      * @throws IllegalStateException if requested node was not found or not running in a cluster. 
      */
-    public static void doClusterTask(final ClusterTask task, byte[] nodeID) {
+    public static void doClusterTask(final ClusterTask<?> task, byte[] nodeID) {
         cacheFactoryStrategy.doClusterTask(task, nodeID);
     }
 
@@ -582,7 +582,7 @@ public class CacheFactory {
      * @param includeLocalMember true to run the task on the local member, false otherwise
      * @return collection with the result of the execution.
      */
-    public static Collection<Object> doSynchronousClusterTask(ClusterTask task, boolean includeLocalMember) {
+    public static Collection<Object> doSynchronousClusterTask(ClusterTask<?> task, boolean includeLocalMember) {
         return cacheFactoryStrategy.doSynchronousClusterTask(task, includeLocalMember);
     }
 
@@ -595,7 +595,7 @@ public class CacheFactory {
      * @return result of remote operation or null if operation failed or operation returned null.
      * @throws IllegalStateException if requested node was not found or not running in a cluster.
      */
-    public static Object doSynchronousClusterTask(ClusterTask task, byte[] nodeID) {
+    public static Object doSynchronousClusterTask(ClusterTask<?> task, byte[] nodeID) {
         return cacheFactoryStrategy.doSynchronousClusterTask(task, nodeID);
     }
     

--- a/src/java/org/jivesoftware/util/cache/CacheFactoryStrategy.java
+++ b/src/java/org/jivesoftware/util/cache/CacheFactoryStrategy.java
@@ -114,7 +114,7 @@ public interface CacheFactoryStrategy {
      * 
      * @return Synchronized time for all cluster members
      */
-    public long getClusterTime();
+    long getClusterTime();
 
     	/**
      * Invokes a task on other cluster members in an asynchronous fashion. The task will not be
@@ -123,7 +123,7 @@ public interface CacheFactoryStrategy {
      *
      * @param task the task to be invoked on all other cluster members.
      */
-    void doClusterTask(final ClusterTask task);
+    void doClusterTask(final ClusterTask<?> task);
 
 
     /**
@@ -134,7 +134,7 @@ public interface CacheFactoryStrategy {
      * @param nodeID the byte array that identifies the target cluster member.
      * @throws IllegalStateException if requested node was not found.
      */
-    void doClusterTask(ClusterTask task, byte[] nodeID);
+    void doClusterTask(ClusterTask<?> task, byte[] nodeID);
 
     /**
      * Invokes a task on other cluster members synchronously and returns the result as a Collection
@@ -146,7 +146,7 @@ public interface CacheFactoryStrategy {
      * @param includeLocalMember true to run the task on the local member, false otherwise
      * @return collection with the result of the execution.
      */
-    Collection<Object> doSynchronousClusterTask(ClusterTask task, boolean includeLocalMember);
+    Collection<Object> doSynchronousClusterTask(ClusterTask<?> task, boolean includeLocalMember);
 
     /**
      * Invokes a task on a given cluster member synchronously and returns the result of
@@ -157,7 +157,7 @@ public interface CacheFactoryStrategy {
      * @return result of remote operation or null if operation failed or operation returned null.
      * @throws IllegalStateException if requested node was not found.
      */
-    Object doSynchronousClusterTask(ClusterTask task, byte[] nodeID);
+    Object doSynchronousClusterTask(ClusterTask<?> task, byte[] nodeID);
 
     /**
      * Updates the statistics of the specified caches and publishes them into

--- a/src/java/org/jivesoftware/util/cache/ClusterTask.java
+++ b/src/java/org/jivesoftware/util/cache/ClusterTask.java
@@ -22,12 +22,12 @@ package org.jivesoftware.util.cache;
 import java.io.Externalizable;
 
 /**
- * An interface to mix in Serializable and Runnable, which are both required for
- * sending invocable tasks across a cluster.
+ * An interface to mix in {@link Externalizable} and {@link Runnable}, which are both required for
+ * sending invokable tasks across a cluster.
  */
-public interface ClusterTask extends Runnable, Externalizable {
+public interface ClusterTask<V> extends Runnable, Externalizable {
 
-    public Object getResult();
+    V getResult();
 
 }
 

--- a/src/plugins/clustering/src/java/com/jivesoftware/openfire/session/DeliverRawTextTask.java
+++ b/src/plugins/clustering/src/java/com/jivesoftware/openfire/session/DeliverRawTextTask.java
@@ -36,7 +36,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class DeliverRawTextTask implements ClusterTask {
+public class DeliverRawTextTask implements ClusterTask<Void> {
     private SessionType sessionType;
     private JID address;
     private String streamID;
@@ -72,7 +72,7 @@ public class DeliverRawTextTask implements ClusterTask {
         this.text = text;
     }
 
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/plugins/clustering/src/java/com/jivesoftware/openfire/session/ProcessPacketTask.java
+++ b/src/plugins/clustering/src/java/com/jivesoftware/openfire/session/ProcessPacketTask.java
@@ -38,7 +38,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class ProcessPacketTask implements ClusterTask {
+public class ProcessPacketTask implements ClusterTask<Void> {
     private SessionType sessionType;
     private JID address;
     private String streamID;
@@ -74,7 +74,7 @@ public class ProcessPacketTask implements ClusterTask {
         this.packet = packet;
     }
 
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/plugins/clustering/src/java/com/jivesoftware/openfire/session/RemoteSessionTask.java
+++ b/src/plugins/clustering/src/java/com/jivesoftware/openfire/session/RemoteSessionTask.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Gaston Dombiak
  */
-public abstract class RemoteSessionTask implements ClusterTask {
+public abstract class RemoteSessionTask implements ClusterTask<Object> {
     protected Object result;
     protected Operation operation;
 

--- a/src/plugins/clustering/src/java/com/jivesoftware/util/cluster/BroadcastMessage.java
+++ b/src/plugins/clustering/src/java/com/jivesoftware/util/cluster/BroadcastMessage.java
@@ -34,7 +34,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class BroadcastMessage implements ClusterTask {
+public class BroadcastMessage implements ClusterTask<Void> {
 
     private Message packet;
 
@@ -46,7 +46,7 @@ public class BroadcastMessage implements ClusterTask {
         this.packet = packet;
     }
 
-    public Object getResult() {
+    public Void getResult() {
         // Not used since we are using #execute and not #query when using InvocationService
         return null;
     }

--- a/src/plugins/clustering/src/java/com/jivesoftware/util/cluster/RemotePacketExecution.java
+++ b/src/plugins/clustering/src/java/com/jivesoftware/util/cluster/RemotePacketExecution.java
@@ -36,7 +36,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class RemotePacketExecution implements ClusterTask {
+public class RemotePacketExecution implements ClusterTask<Void> {
 
     private JID receipient;
     private Packet packet;
@@ -49,7 +49,7 @@ public class RemotePacketExecution implements ClusterTask {
         this.packet = packet;
     }
 
-    public Object getResult() {
+    public Void getResult() {
         // Not used since we are using #execute and not #query when using InvocationService
         return null;
     }

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/DeliverRawTextTask.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/DeliverRawTextTask.java
@@ -36,7 +36,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class DeliverRawTextTask implements ClusterTask {
+public class DeliverRawTextTask implements ClusterTask<Void> {
     private SessionType sessionType;
     private JID address;
     private String streamID;
@@ -72,7 +72,7 @@ public class DeliverRawTextTask implements ClusterTask {
         this.text = text;
     }
 
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/ProcessPacketTask.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/ProcessPacketTask.java
@@ -38,7 +38,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class ProcessPacketTask implements ClusterTask {
+public class ProcessPacketTask implements ClusterTask<Void> {
     private SessionType sessionType;
     private JID address;
     private String streamID;
@@ -74,7 +74,7 @@ public class ProcessPacketTask implements ClusterTask {
         this.packet = packet;
     }
 
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/RemoteSessionTask.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/RemoteSessionTask.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Gaston Dombiak
  */
-public abstract class RemoteSessionTask implements ClusterTask {
+public abstract class RemoteSessionTask implements ClusterTask<Object> {
     protected Object result;
     protected Operation operation;
 

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -470,17 +470,17 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
         }
     }
 
-    private static class CallableTask<Object> implements Callable<Object>, Serializable {
-    	private ClusterTask task;
+    private static class CallableTask<V> implements Callable<V>, Serializable {
+    	private ClusterTask<V> task;
     	
-    	public CallableTask(ClusterTask task) {
+    	public CallableTask(ClusterTask<V> task) {
     		this.task = task;
     	}
 
-        public Object call() {
+        public V call() {
             task.run();
             logger.debug("CallableTask[" + task.getClass().getName() + "] result: " + task.getResult());
-            return (Object) task.getResult();
+            return task.getResult();
         }
     }
     

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cluster/BroadcastMessage.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cluster/BroadcastMessage.java
@@ -34,7 +34,7 @@ import org.xmpp.packet.Message;
  *
  * @author Gaston Dombiak
  */
-public class BroadcastMessage implements ClusterTask {
+public class BroadcastMessage implements ClusterTask<Void> {
 
     private Message packet;
 
@@ -46,7 +46,7 @@ public class BroadcastMessage implements ClusterTask {
         this.packet = packet;
     }
 
-    public Object getResult() {
+    public Void getResult() {
         // Not used since we are using #execute and not #query when using InvocationService
         return null;
     }

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cluster/NodeRuntimeStats.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cluster/NodeRuntimeStats.java
@@ -74,8 +74,8 @@ public class NodeRuntimeStats {
     /**
      * Encapsulates statistics and information about a cluster node.
      */
-    public static class NodeInfoTask implements ClusterTask {
-    	private Object result = null;
+    public static class NodeInfoTask implements ClusterTask<NodeInfo> {
+    	private NodeInfo result = null;
     	
 		public void run() {
             // Get runtime stats - mem and time:
@@ -93,10 +93,10 @@ public class NodeRuntimeStats {
 		}
 		
 		public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-			result = ExternalizableUtil.getInstance().readSerializable(in);
+			result = (NodeInfo) ExternalizableUtil.getInstance().readSerializable(in);
 		}
 
-		public Object getResult() { return result; }
+		public NodeInfo getResult() { return result; }
     	
     }
 

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cluster/RemotePacketExecution.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cluster/RemotePacketExecution.java
@@ -40,7 +40,7 @@ import org.xmpp.packet.Presence;
  *
  * @author Gaston Dombiak
  */
-public class RemotePacketExecution implements ClusterTask {
+public class RemotePacketExecution implements ClusterTask<Void> {
 
     private JID recipient;
     private Packet packet;
@@ -53,7 +53,7 @@ public class RemotePacketExecution implements ClusterTask {
         this.packet = packet;
     }
 
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationCountTask.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationCountTask.java
@@ -35,10 +35,10 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class GetConversationCountTask implements ClusterTask {
+public class GetConversationCountTask implements ClusterTask<Integer> {
     private int conversationCount;
 
-    public Object getResult() {
+    public Integer getResult() {
         return conversationCount;
     }
 

--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationTask.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationTask.java
@@ -37,7 +37,7 @@ import java.io.ObjectOutput;
  *
  * @author Gaston Dombiak
  */
-public class GetConversationTask implements ClusterTask {
+public class GetConversationTask implements ClusterTask<Conversation> {
     private long conversationID;
     private Conversation conversation;
 
@@ -48,7 +48,7 @@ public class GetConversationTask implements ClusterTask {
         this.conversationID = conversationID;
     }
 
-    public Object getResult() {
+    public Conversation getResult() {
         return conversation;
     }
 

--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationsTask.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/cluster/GetConversationsTask.java
@@ -37,10 +37,10 @@ import java.util.Collection;
  *
  * @author Gaston Dombiak
  */
-public class GetConversationsTask implements ClusterTask {
+public class GetConversationsTask implements ClusterTask<Collection<Conversation>> {
     private Collection<Conversation> conversations;
 
-    public Object getResult() {
+    public Collection<Conversation> getResult() {
         return conversations;
     }
 

--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/cluster/SendConversationEventsTask.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/cluster/SendConversationEventsTask.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gaston Dombiak
  */
-public class SendConversationEventsTask implements ClusterTask {
+public class SendConversationEventsTask implements ClusterTask<Void> {
 	
 	private static final Logger Log = LoggerFactory.getLogger(SendConversationEventsTask.class);
 			
@@ -56,7 +56,7 @@ public class SendConversationEventsTask implements ClusterTask {
         this.events = events;
     }
 
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 

--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/reporting/stats/GetStatistics.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/reporting/stats/GetStatistics.java
@@ -38,13 +38,13 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gaston Dombiak
  */
-public class GetStatistics implements ClusterTask {
+public class GetStatistics implements ClusterTask<Map<String, Double>> {
 	
 	private static final Logger Log = LoggerFactory.getLogger(GetStatistics.class);
 	
     private Map<String, Double> samples;
 
-    public Object getResult() {
+    public Map<String, Double> getResult() {
         return samples;
     }
 

--- a/src/plugins/packetFilter/src/java/org/jivesoftware/openfire/plugin/cluster/RulesUpdatedEvent.java
+++ b/src/plugins/packetFilter/src/java/org/jivesoftware/openfire/plugin/cluster/RulesUpdatedEvent.java
@@ -9,7 +9,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
 
-public class RulesUpdatedEvent implements ClusterTask {
+public class RulesUpdatedEvent implements ClusterTask<Void> {
 
 
 
@@ -17,7 +17,7 @@ public class RulesUpdatedEvent implements ClusterTask {
 
     }
 
-    public Object getResult() {
+    public Void getResult() {
         return null;
     }
 


### PR DESCRIPTION
in the same fashion as e.g. `java.util.concurrent.Callable`

Please note: I haven't tested its runtime behavior, but this change felt like a natural fit, especially due to the `CallableTask` class.

@tevans: Can you please review and maybe even test it or otherwise comment on it before merge?