### PR TITLE
Update web.xml schema namespaces to version 3.1 (Java EE 7)

### DIFF
--- a/src/plugins/clientControl/src/web/WEB-INF/web-custom.xml
+++ b/src/plugins/clientControl/src/web/WEB-INF/web-custom.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
     <!-- Servlets -->
     <servlet>
         <servlet-name>SparkDownload</servlet-name>

--- a/src/plugins/fastpath/src/web/WEB-INF/web-custom.xml
+++ b/src/plugins/fastpath/src/web/WEB-INF/web-custom.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
     <!-- Servlets -->
     <servlet>
         <servlet-name>ImageServlet</servlet-name>

--- a/src/plugins/gojara/src/web/WEB-INF/web-custom.xml
+++ b/src/plugins/gojara/src/web/WEB-INF/web-custom.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+		 version="3.1">
 	<!-- Servlets -->
 	<servlet>
 		<servlet-name>stats</servlet-name>

--- a/src/plugins/jmxweb/src/WEB-INF/web.xml
+++ b/src/plugins/jmxweb/src/WEB-INF/web.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee"
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
 
   <display-name>JSON JMX Agent</display-name>
 

--- a/src/plugins/kraken/src/web/WEB-INF/web-custom.xml
+++ b/src/plugins/kraken/src/web/WEB-INF/web-custom.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
-
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
 
     <!-- Servlets -->
     <servlet>
-        <servlet-name>dwr-invoker</servlet-name>
-        <display-name>DWR Servlet</display-name>
         <description>Direct Web Remoter Servlet</description>
+        <display-name>DWR Servlet</display-name>
+        <servlet-name>dwr-invoker</servlet-name>
         <servlet-class>net.sf.kraken.web.GatewayDWR</servlet-class>
         <init-param>
             <param-name>LogLevel</param-name>

--- a/src/plugins/monitoring/src/web/WEB-INF/web-custom.xml
+++ b/src/plugins/monitoring/src/web/WEB-INF/web-custom.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
     <!-- Servlets -->
     <servlet>
         <servlet-name>GraphServlet</servlet-name>
@@ -8,9 +10,9 @@
     </servlet>
 
     <servlet>
-        <servlet-name>dwr-invoker</servlet-name>
-        <display-name>DWR Servlet</display-name>
         <description>Direct Web Remoter Servlet</description>
+        <display-name>DWR Servlet</display-name>
+        <servlet-name>dwr-invoker</servlet-name>
         <servlet-class>org.jivesoftware.openfire.reporting.MonitoringDWR</servlet-class>
         <init-param>
             <param-name>logLevel</param-name>

--- a/src/plugins/mucservice/src/web/WEB-INF/web-custom.xml
+++ b/src/plugins/mucservice/src/web/WEB-INF/web-custom.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+		 version="3.1">
 	<!-- Servlets -->
 	<servlet>
 		<servlet-name>JerseyWrapper</servlet-name>

--- a/src/plugins/ofmeet/src/WEB-INF/web.xml
+++ b/src/plugins/ofmeet/src/WEB-INF/web.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee"
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+		 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+		 version="3.1">
 
 	<servlet>
 		<servlet-name>proxy</servlet-name>

--- a/src/plugins/presence/src/web/WEB-INF/web-custom.xml
+++ b/src/plugins/presence/src/web/WEB-INF/web-custom.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
     <!-- Servlets -->
     <servlet>
         <servlet-name>PresenceStatusServlet</servlet-name>

--- a/src/plugins/restAPI/src/web/WEB-INF/web-custom.xml
+++ b/src/plugins/restAPI/src/web/WEB-INF/web-custom.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+		 version="3.1">
 	<!-- Servlets -->
 	<servlet>
 		<servlet-name>JerseyWrapper</servlet-name>

--- a/src/plugins/userservice/src/web/WEB-INF/web-custom.xml
+++ b/src/plugins/userservice/src/web/WEB-INF/web-custom.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
     <!-- Servlets -->
     <servlet>
         <servlet-name>JerseyWrapper</servlet-name>

--- a/src/spank/WEB-INF/web.xml
+++ b/src/spank/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="2.4"
-         xmlns="http://java.sun.com/xml/ns/j2ee"
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
 
 </web-app>

--- a/src/web/WEB-INF/web.xml
+++ b/src/web/WEB-INF/web.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<web-app
-        xmlns="http://java.sun.com/xml/ns/j2ee"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-        version="2.4">
-
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
     <display-name>Openfire</display-name>
 
     <!--  OF-902 use HttpOnly for session cookie -->
@@ -161,13 +159,6 @@
         <servlet-name>dwr-invoker</servlet-name>
         <url-pattern>/dwr/*</url-pattern>
     </servlet-mapping>
-
-    <jsp-config>
-        <taglib>
-            <taglib-uri>admin</taglib-uri>
-            <taglib-location>/WEB-INF/admin.tld</taglib-location>
-        </taglib>
-    </jsp-config>
 
 </web-app>
 


### PR DESCRIPTION
Old version 2.4 was J2EE 1.4

Also remove <taglib> from web.xml. This was required in JSP 1.2, but is no longer in JSP 2.0 (Servlet API 2.4) and gives warnings since it has been removed from the XSD.
See http://wiki.metawerx.net/wiki/RemovingTaglibFromWeb.xml