### PR TITLE
Delete web.xml.startup.servlet

### DIFF
--- a/src/web/WEB-INF/web.xml.startup.servlet
+++ b/src/web/WEB-INF/web.xml.startup.servlet
@@ -1,5 +1,0 @@
-<servlet>
-    <servlet-name>XMPPBootServlet</servlet-name>
-    <servlet-class>org.jivesoftware.messenger.XMPPBootServlet</servlet-class>
-    <load-on-startup>1</load-on-startup>
-</servlet>


### PR DESCRIPTION
Most likely not needed. It references a non-existent class.