### PR TITLE
Update admin.tld to use the latest taglib version.

### DIFF
--- a/src/web/WEB-INF/admin.tld
+++ b/src/web/WEB-INF/admin.tld
@@ -1,19 +1,18 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<taglib xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+            http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
+        version="2.1">
+    <tlib-version>1.2</tlib-version>
+    <short-name>Tag Library for Openfire</short-name>
+    <description>Tab Library for Openfire Admin Console</description>
+    <uri>admin</uri>
 
-<!DOCTYPE taglib PUBLIC "-//Sun Microsystems, Inc.//DTD JSP Tag Library 1.1//EN"
-    "http://java.sun.com/j2ee/dtds/web-jsptaglibrary_1_1.dtd">
-
-<taglib>
-	<tlibversion>1.0</tlibversion>
-	<jspversion>1.1</jspversion>
-	<shortname>Tag Library for Openfire 2.0</shortname>
-	<uri>admin</uri>
-	<info>Tab Library for Openfire Admin Console</info>
-	<tag>
-		<name>tabs</name>
-		<tagclass>org.jivesoftware.admin.TabsTag</tagclass>
-        <bodycontent>JSP</bodycontent>
-		<info />
+    <tag>
+        <name>tabs</name>
+        <tag-class>org.jivesoftware.admin.TabsTag</tag-class>
+        <body-content>JSP</body-content>
         <attribute>
             <name>css</name>
             <required>false</required>
@@ -42,9 +41,8 @@
     </tag>
     <tag>
         <name>subnavbar</name>
-        <tagclass>org.jivesoftware.admin.SubnavTag</tagclass>
-        <bodycontent>JSP</bodycontent>
-        <info />
+        <tag-class>org.jivesoftware.admin.SubnavTag</tag-class>
+        <body-content>JSP</body-content>
         <attribute>
             <name>css</name>
             <required>false</required>
@@ -67,10 +65,9 @@
         </attribute>
     </tag>
     <tag>
-		<name>sidebar</name>
-		<tagclass>org.jivesoftware.admin.SidebarTag</tagclass>
-        <bodycontent>JSP</bodycontent>
-		<info />
+        <name>sidebar</name>
+        <tag-class>org.jivesoftware.admin.SidebarTag</tag-class>
+        <body-content>JSP</body-content>
         <attribute>
             <name>css</name>
             <required>false</required>
@@ -96,12 +93,11 @@
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
-	</tag>
-	<tag>
-		<name>subsidebar</name>
-		<tagclass>org.jivesoftware.admin.SubSidebarTag</tagclass>
-        <bodycontent>JSP</bodycontent>
-		<info />
+    </tag>
+    <tag>
+        <name>subsidebar</name>
+        <tag-class>org.jivesoftware.admin.SubSidebarTag</tag-class>
+        <body-content>JSP</body-content>
         <attribute>
             <name>css</name>
             <required>false</required>
@@ -122,12 +118,11 @@
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
-	</tag>
+    </tag>
     <tag>
         <name>infobox</name>
-        <tagclass>org.jivesoftware.admin.InfoboxTag</tagclass>
-        <bodycontent>JSP</bodycontent>
-        <info />
+        <tag-class>org.jivesoftware.admin.InfoboxTag</tag-class>
+        <body-content>JSP</body-content>
         <attribute>
             <name>type</name>
             <required>true</required>
@@ -136,9 +131,8 @@
     </tag>
     <tag>
         <name>ASN1DER</name>
-        <tagclass>org.jivesoftware.admin.ASN1DERTag</tagclass>
-        <bodycontent>JSP</bodycontent>
-        <info />
+        <tag-class>org.jivesoftware.admin.ASN1DERTag</tag-class>
+        <body-content>JSP</body-content>
         <attribute>
             <name>value</name>
             <required>true</required>


### PR DESCRIPTION
This is related to the JSP upgrade.

Some tags have changed after moving from the DTD to the XSD.
See also https://blogs.oracle.com/jluehe/entry/validate_your_tag_library_descriptor