### PR TITLE
OF-473: Revert original patch

### DIFF
--- a/src/java/org/jivesoftware/openfire/roster/Roster.java
+++ b/src/java/org/jivesoftware/openfire/roster/Roster.java
@@ -159,8 +159,6 @@ public class Roster implements Cacheable, Externalizable {
                     if (group.isUser(jid)) {
                         item.addSharedGroup(group);
                         itemGroups.add(group);
-                        item.setNickname(UserNameManager.getUserName(jid));
-                        broadcast(item, true);
                     } else {
                         item.addInvisibleSharedGroup(group);
                     }


### PR DESCRIPTION
Received reports of unexpected roster caching caused by this change (not
verified). Additional investigation is needed to determine whether/how
to fix original issue reported via OF-473.