### PR TITLE
Simplify and shorten pubsub message id

### DIFF
--- a/src/java/org/jivesoftware/openfire/pep/PEPService.java
+++ b/src/java/org/jivesoftware/openfire/pep/PEPService.java
@@ -37,7 +37,6 @@ import org.jivesoftware.openfire.entitycaps.EntityCapabilities;
 import org.jivesoftware.openfire.entitycaps.EntityCapabilitiesManager;
 import org.jivesoftware.openfire.pubsub.CollectionNode;
 import org.jivesoftware.openfire.pubsub.DefaultNodeConfiguration;
-import org.jivesoftware.openfire.pubsub.LeafNode;
 import org.jivesoftware.openfire.pubsub.Node;
 import org.jivesoftware.openfire.pubsub.NodeSubscription;
 import org.jivesoftware.openfire.pubsub.PendingSubscriptionsCommand;
@@ -331,7 +330,7 @@ public class PEPService implements PubSubService, Cacheable {
         message.setFrom(getAddress());
         for (JID jid : jids) {
             message.setTo(jid);
-            message.setID(node.getNodeID() + "__" + jid.toBareJID() + "__" + StringUtils.randomString(5));
+            message.setID(StringUtils.randomString(8));
             router.route(message);
         }
     }
@@ -340,7 +339,7 @@ public class PEPService implements PubSubService, Cacheable {
     public void sendNotification(Node node, Message message, JID recipientJID) {
         message.setTo(recipientJID);
         message.setFrom(getAddress());
-        message.setID(node.getNodeID() + "__" + recipientJID.toBareJID() + "__" + StringUtils.randomString(5));
+        message.setID(StringUtils.randomString(8));
 
         // If the recipient subscribed with a bare JID and this PEPService can retrieve
         // presence information for the recipient, collect all of their full JIDs and

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -723,8 +723,7 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
         message.setFrom(getAddress());
         for (JID jid : jids) {
             message.setTo(jid);
-            message.setID(
-                    node.getNodeID() + "__" + jid.toBareJID() + "__" + StringUtils.randomString(5));
+            message.setID(StringUtils.randomString(8));
             router.route(message);
         }
     }
@@ -738,8 +737,7 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
     public void sendNotification(Node node, Message message, JID jid) {
         message.setFrom(getAddress());
         message.setTo(jid);
-        message.setID(
-                node.getNodeID() + "__" + jid.toBareJID() + "__" + StringUtils.randomString(5));
+        message.setID(StringUtils.randomString(8));
         router.route(message);
     }
 


### PR DESCRIPTION
The specification (XEP-0060) recommends generating unique message ids
within a pubsub instance to aid troubleshooting for notification
delivery issues when needed. This replaces a ridiculously long and
inefficient string concatenation with something a bit more tidy and
concise.