### PR TITLE
Fix NPE when handling routing failures

### DIFF
--- a/src/java/org/jivesoftware/openfire/IQRouter.java
+++ b/src/java/org/jivesoftware/openfire/IQRouter.java
@@ -433,6 +433,12 @@ public class IQRouter extends BasicModule {
             Log.error("Cannot reply an IQ error to another IQ error: " + originalPacket.toXML());
             return;
         }
+        if (originalPacket.getFrom() == null) {
+        	if (Log.isDebugEnabled()) {
+        		Log.debug("Original IQ has no sender for reply; dropped: " + originalPacket.toXML());
+        	}
+            return;
+        }
         IQ reply = IQ.createResultIQ(originalPacket);
         reply.setChildElement(originalPacket.getChildElement().createCopy());
         reply.setError(condition);


### PR DESCRIPTION
Avoids NPE by dropping (and optionally logging) error response stanzas
if the original packet has no sender JID.