### PR TITLE
OF-983 Do not bounce packets while lock is held

### DIFF
--- a/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -590,17 +590,20 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
     @Override
 	boolean canProcess(Packet packet) {
         String senderDomain = packet.getFrom().getDomain();
+        boolean processed = true;
         if (!getAuthenticatedDomains().contains(senderDomain)) {
             synchronized (senderDomain.intern()) {
                 if (!getAuthenticatedDomains().contains(senderDomain) &&
                         !authenticateSubdomain(senderDomain, packet.getTo().getDomain())) {
                     // Return error since sender domain was not validated by remote server
-                    returnErrorToSender(packet);
-                    return false;
+                    processed = false;
                 }
             }
         }
-        return true;
+        if (!processed) {
+            returnErrorToSender(packet);
+        }
+        return processed;
     }
 
     @Override

--- a/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -592,7 +592,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
         String senderDomain = packet.getFrom().getDomain();
         boolean processed = true;
         if (!getAuthenticatedDomains().contains(senderDomain)) {
-            synchronized (senderDomain.intern()) {
+            synchronized (("Auth::" + senderDomain).intern()) {
                 if (!getAuthenticatedDomains().contains(senderDomain) &&
                         !authenticateSubdomain(senderDomain, packet.getTo().getDomain())) {
                     // Return error since sender domain was not validated by remote server


### PR DESCRIPTION
OF-983 appears to be caused by a complex bouncing process run while the
authentication check lock is held. This patch moves the actual bounce to
outside the synchronized block, so the code no longer deadlocks.

Untested, but based on the stack traces in OF-983 reports.