### PR TITLE
OF-631 Reduce salt size to fit database

### DIFF
--- a/src/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -277,7 +277,7 @@ public class DefaultAuthProvider implements AuthProvider {
         }
         
         // Store the salt and salted password so SCRAM-SHA-1 SASL auth can be used later.
-        byte[] saltShaker = new byte[32];
+        byte[] saltShaker = new byte[24];
         random.nextBytes(saltShaker);
         String salt = DatatypeConverter.printBase64Binary(saltShaker);
 

--- a/src/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/src/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -332,7 +332,7 @@ public class ScramSha1SaslServer implements SaslServer {
             return salt;
         } catch (UserNotFoundException | UnsupportedOperationException | ConnectionException | InternalUnauthenticatedException e) {
             Log.warn("Exception in SCRAM.getSalt():", e);
-            byte[] salt = new byte[32];
+            byte[] salt = new byte[24];
             random.nextBytes(salt);
             return salt;
         }


### PR DESCRIPTION
The salt size was 32, and the database column was a VARCHAR(32).

However, the salt was base64 encoded prior to insertion, and this caused it to
be too large. Therefore this patch reduces the size to 24 bytes, which expands
to 8 units of three bytes encoded as four characters, hence 32 characters total.