### PR TITLE
Fix XEP-0012 logic.

### DIFF
--- a/src/java/org/jivesoftware/openfire/PresenceManager.java
+++ b/src/java/org/jivesoftware/openfire/PresenceManager.java
@@ -98,7 +98,7 @@ public interface PresenceManager {
      * Returns true if the the prober is allowed to see the presence of the probee.
      *
      * @param prober the user that is trying to probe the presence of another user.
-     * @param probee the username of the uset that is being probed.
+     * @param probee the username of the user that is being probed.
      * @return true if the the prober is allowed to see the presence of the probee.
      * @throws UserNotFoundException If the probee does not exist in the local server or the prober
      *         is not present in the roster of the probee.

--- a/src/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
@@ -337,6 +337,9 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
 
     @Override
     public boolean canProbePresence(JID prober, String probee) throws UserNotFoundException {
+        if (probee.equals(prober.getNode()) && XMPPServer.getInstance().isLocal(prober)) {
+            return true;
+        }
         RosterItem item = rosterManager.getRoster(probee).getRosterItem(prober);
         return item.getSubStatus() == RosterItem.SUB_FROM
                 || item.getSubStatus() == RosterItem.SUB_BOTH;


### PR DESCRIPTION
If a query has no 'to' attribute it should be treated on behalf of the sender.
It should not be treated as if it were targeted to the server (and return the server uptime).

The former logic also threw an UserNotFoundException, if the user queried itself, because the user was not on his own roster.
 I've fixed that in the canProbePresence method.

 Fixes issue OF-982