### PR TITLE
Subscribe with Response Unsubscribed Causes Roster Push to Responding Client

### DIFF
--- a/src/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
+++ b/src/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
@@ -210,7 +210,7 @@ public class PresenceSubscribeHandler extends BasicModule implements ChannelHand
                         // Send the presence of the local user to the remote user. The remote user
                         // subscribed to the presence of the local user and the local user accepted
                         JID prober = localServer.isLocal(recipientJID) ? recipientJID.asBareJID() : recipientJID;
-                        if (presenceManager.canProbePresence(prober, senderJID.toString())){
+                        if (presenceManager.canProbePresence(prober, senderJID.getNode())){
                             presenceManager.probePresence(prober, senderJID);
                             PresenceEventDispatcher.subscribedToPresence(recipientJID, senderJID);
                         }

--- a/src/java/org/jivesoftware/openfire/roster/Roster.java
+++ b/src/java/org/jivesoftware/openfire/roster/Roster.java
@@ -420,7 +420,7 @@ public class Roster implements Cacheable, Externalizable {
         // broadcast roster update
         // Do not push items with a state of "None + Pending In"
         if (item.getSubStatus() != RosterItem.SUB_NONE ||
-                item.getRecvStatus() != RosterItem.RECV_SUBSCRIBE) {
+                item.getRecvStatus() != RosterItem.RECV_SUBSCRIBE && !isSubscriptionRejected(item)) {
             broadcast(item, true);
         }
         /*if (item.getSubStatus() == RosterItem.SUB_BOTH || item.getSubStatus() == RosterItem.SUB_TO) {
@@ -428,6 +428,18 @@ public class Roster implements Cacheable, Externalizable {
         }*/
         // Fire event indicating that a roster item has been updated
         RosterEventDispatcher.contactUpdated(this, item);
+    }
+
+    /**
+     * Returns true if roster item represents a rejected subscription request.
+     *
+     * @param item The roster item.
+     * @return True, if the roster item represents a rejected subscription request.
+     */
+    private static boolean isSubscriptionRejected(RosterItem item) {
+        return item.getSubStatus() == RosterItem.SUB_NONE &&
+                item.getRecvStatus() == RosterItem.RECV_NONE &&
+                item.getAskStatus() == RosterItem.AskType.NONE;
     }
 
     /**
@@ -553,7 +565,7 @@ public class Roster implements Cacheable, Externalizable {
             }
             // Do not push items with a state of "None + Pending In"
             if (item.getSubStatus() != RosterItem.SUB_NONE ||
-                    item.getRecvStatus() != RosterItem.RECV_SUBSCRIBE) {
+                    item.getRecvStatus() != RosterItem.RECV_SUBSCRIBE && !isSubscriptionRejected(item)) {
                 roster.addItem(item.getJid(), item.getNickname(), ask, sub, groups);
             }
         }


### PR DESCRIPTION
This should fix OF-317.

During testing also discovered an UserNotFoundException thrown by canProbePresence, because it was passed the JID instead of the username.