### PR TITLE
OF-122: Fix inconsistent MUC subject handling

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -2010,10 +2010,6 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
     public void changeSubject(Message packet, MUCRole role) throws ForbiddenException {
         if ((canOccupantsChangeSubject() && role.getRole().compareTo(MUCRole.Role.visitor) < 0) ||
                 MUCRole.Role.moderator == role.getRole()) {
-            // Do nothing if the new subject is the same as the existing one
-            if (packet.getSubject().equals(subject)) {
-                return;
-            }
             // Set the new subject to the room
             subject = packet.getSubject();
             MUCPersistenceManager.updateRoomSubject(this);
@@ -2024,10 +2020,8 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             // Fire event signifying that the room's subject has changed.
             MUCEventDispatcher.roomSubjectChanged(getJID(), role.getUserAddress(), subject);
 
-            if (!"local-only".equals(packet.getID())) {
-	            // Let other cluster nodes that the room has been updated
-	            CacheFactory.doClusterTask(new RoomUpdatedEvent(this));
-            }
+            // Let other cluster nodes that the room has been updated
+	        CacheFactory.doClusterTask(new RoomUpdatedEvent(this));
         }
         else {
             throw new ForbiddenException();

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
@@ -271,9 +271,7 @@ public class LocalMUCUser implements MUCUser {
                 }
                 else {
                     try {
-                        if (packet.getSubject() != null && packet.getSubject().trim().length() > 0 &&
-                                Message.Type.groupchat == packet.getType() &&
-                                (packet.getBody() == null || packet.getBody().trim().length() == 0)) {
+                        if (role.getChatRoom().getRoomHistory().isSubjectChangeRequest(packet)) {
                             // An occupant is trying to change the room's subject
                             role.getChatRoom().changeSubject(packet, role);
 

--- a/src/web/muc-room-edit-form.jsp
+++ b/src/web/muc-room-edit-form.jsp
@@ -269,7 +269,6 @@
                 message.setSubject(roomSubject);
                 message.setFrom(room.getRole().getRoleAddress());
                 message.setTo(room.getRole().getRoleAddress());
-                message.setID("local-only");
                 room.changeSubject(message, room.getRole());
             }
 


### PR DESCRIPTION
Ensure that the MUC room subject is set correctly from initial request and upon subsequent reload.

Initial testing looks good, but would welcome additional validation and testing with various XMPP clients if possible.