### PR TITLE
Fix NPE when accessing AuditManager module

### DIFF
--- a/src/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/src/java/org/jivesoftware/openfire/XMPPServer.java
@@ -1216,7 +1216,7 @@ public class XMPPServer {
      * @return the <code>AuditManager</code> registered with this server.
      */
     public AuditManager getAuditManager() {
-        return (AuditManager) modules.get(AuditManagerImpl.class.getName());
+        return (AuditManager) modules.get(AuditManager.class.getName());
     }
 
     /**


### PR DESCRIPTION
Not sure when this got changed, but the module loader uses the interface class name as a key, not the implementation class name.