### PR TITLE
OF-973: TLS negotiation failures should come in two flavors.

### DIFF
--- a/src/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/src/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -473,6 +473,16 @@ public class SocketConnection implements Connection {
         return backupDeliverer;
     }
 
+    /**
+     * Closes the connection without sending any data (not even a stream end-tag).
+     */
+    public void forceClose() {
+        close( true );
+    }
+
+    /**
+     * Closes the connection after trying to send a stream end tag.
+     */
     @Override
     public void close() {
         close( false );
@@ -484,7 +494,7 @@ public class SocketConnection implements Connection {
      * when sending data over the socket has taken a long time and we need to close the socket, discard
      * the connection and its session.
      */
-    private void close(boolean force) {   	
+    private void close(boolean force) {
     	if (state.compareAndSet(State.OPEN, State.CLOSED)) {
     		
             if (session != null) {
@@ -554,7 +564,7 @@ public class SocketConnection implements Connection {
                 Log.debug("Closing connection: " + this + " that started sending data at: " +
                         new Date(writeTimestamp));
             }
-            close(true); // force
+            forceClose();
             return true;
         }
         else {
@@ -567,7 +577,7 @@ public class SocketConnection implements Connection {
                 if (Log.isDebugEnabled()) {
                     Log.debug("Closing connection that has been idle: " + this);
                 }
-                close(true); // force
+                forceClose();
                 return true;
             }
         }

--- a/src/java/org/jivesoftware/openfire/net/SocketReadingMode.java
+++ b/src/java/org/jivesoftware/openfire/net/SocketReadingMode.java
@@ -87,9 +87,9 @@ abstract class SocketReadingMode {
             socketReader.connection.startTLS(false);
         }
         catch (SSLHandshakeException e) {
-            // RFC3620, section 5.4.3.2 "STARTTLS Failure" - close the socket *without* sending a <failure/> element.
+            // RFC3620, section 5.4.3.2 "STARTTLS Failure" - close the socket *without* sending any more data (<failure/> nor </stream>).
             Log.info( "STARTTLS negotiation (with: {}) failed.", socketReader.connection, e );
-            socketReader.connection.close();
+            socketReader.connection.forceClose();
             return false;
         }
         catch (IOException | RuntimeException e) {


### PR DESCRIPTION
When STARTTLS fails, there are two distinct types of failure. Each type should
be handled in a distinct manner.

Note that this commit applies a fix to the S2S code only. C2S may also need work.