### PR TITLE
DefaultUserProvider: Rethrow exception instead of silently logging it.

### DIFF
--- a/src/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
+++ b/src/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
@@ -163,8 +163,8 @@ public class DefaultUserProvider implements UserProvider {
                 pstmt.setString(5, StringUtils.dateToMillis(now));
                 pstmt.execute();
             }
-            catch (Exception e) {
-                Log.error(LocaleUtils.getLocalizedString("admin.error"), e);
+            catch (SQLException e) {
+                throw new RuntimeException(e);
             }
             finally {
                 DbConnectionManager.closeConnection(pstmt, con);


### PR DESCRIPTION
The reason is, that when calling the createUser() method, the caller thinks user creation succeeded, even if it might not.
This leads to unexpected behavior.

I've experienced that, when trying to create a user with a name of > 100 length:

com.mysql.jdbc.MysqlDataTruncation: Data truncation: Data too long for column 'name' at row 1
	at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:4230)
	at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:4164)
	at com.mysql.jdbc.MysqlIO.sendCommand(MysqlIO.java:2615)
	at com.mysql.jdbc.MysqlIO.sqlQueryDirect(MysqlIO.java:2776)
	at com.mysql.jdbc.ConnectionImpl.execSQL(ConnectionImpl.java:2838)
	at com.mysql.jdbc.PreparedStatement.executeInternal(PreparedStatement.java:2082)
	at com.mysql.jdbc.PreparedStatement.execute(PreparedStatement.java:1307)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.logicalcobwebs.proxool.ProxyStatement.invoke(ProxyStatement.java:100)
	at org.logicalcobwebs.proxool.ProxyStatement.intercept(ProxyStatement.java:57)
	at com.mysql.jdbc.Statement$$EnhancerByProxool$$cb3cdf02.execute(<generated>)
	at org.jivesoftware.openfire.user.DefaultUserProvider.createUser(DefaultUserProvider.java:164)