### PR TITLE
OF-1004: Reduce complexity of connection configuration

### DIFF
--- a/src/i18n/openfire_i18n_cs_CZ.properties
+++ b/src/i18n/openfire_i18n_cs_CZ.properties
@@ -2466,3 +2466,15 @@ client.connections.settings.ping.footnote=The XMPP specification requires all cl
 		If a client does not support the XMPP Ping request, it must return an error (which in itself is a response too).        
 client.connections.settings.ping.enable=Send an XMPP Ping request to idle clients.
 client.connections.settings.ping.disable=Do not send XMPP Ping requests to idle clients.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_de.properties
+++ b/src/i18n/openfire_i18n_de.properties
@@ -2429,3 +2429,15 @@ client.connections.settings.ping.footnote=The XMPP specification requires all cl
 		If a client does not support the XMPP Ping request, it must return an error (which in itself is a response too).        
 client.connections.settings.ping.enable=Send an XMPP Ping request to idle clients.
 client.connections.settings.ping.disable=Do not send XMPP Ping requests to idle clients.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -3062,3 +3062,15 @@ client.connections.settings.ping.footnote=The XMPP specification requires all cl
 		If a client does not support the XMPP Ping request, it must return an error (which in itself is a response too).
 client.connections.settings.ping.enable=Send an XMPP Ping request to idle clients.
 client.connections.settings.ping.disable=Do not send XMPP Ping requests to idle clients.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_es.properties
+++ b/src/i18n/openfire_i18n_es.properties
@@ -2487,3 +2487,15 @@ client.connections.settings.ping.footnote=La especificaci\u00f3n de XMPP requeir
   solicitud. Si un cliente no soporta la solicitud XMPP Ping debe retornar error (lo cual tambi\u00e9n es una respuesta).
 client.connections.settings.ping.enable=Enviar una solicitud XMPP Ping a los clientes inactivos.
 client.connections.settings.ping.disable=No enviar una solicitud XMPP Ping a los clientes inactivos.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_fr.properties
+++ b/src/i18n/openfire_i18n_fr.properties
@@ -2042,3 +2042,15 @@ client.connections.settings.ping.footnote=The XMPP specification requires all cl
 		If a client does not support the XMPP Ping request, it must return an error (which in itself is a response too).        
 client.connections.settings.ping.enable=Send an XMPP Ping request to idle clients.
 client.connections.settings.ping.disable=Do not send XMPP Ping requests to idle clients.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_ja_JP.properties
+++ b/src/i18n/openfire_i18n_ja_JP.properties
@@ -2413,3 +2413,15 @@ client.connections.settings.ping.footnote=The XMPP specification requires all cl
 		If a client does not support the XMPP Ping request, it must return an error (which in itself is a response too).        
 client.connections.settings.ping.enable=Send an XMPP Ping request to idle clients.
 client.connections.settings.ping.disable=Do not send XMPP Ping requests to idle clients.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_nl.properties
+++ b/src/i18n/openfire_i18n_nl.properties
@@ -2433,3 +2433,15 @@ client.connections.settings.ping.footnote=De XMPP specificatie verplicht alle cl
 		is, waaraan Openfire kan zien dat de verbinding actief is).        
 client.connections.settings.ping.enable=Verstuur XMPP Ping verzoeken aan clienten die inactief zijn.
 client.connections.settings.ping.disable=Verstuur geen XMPP ping verzoeken.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_pl_PL.properties
+++ b/src/i18n/openfire_i18n_pl_PL.properties
@@ -2400,3 +2400,15 @@ client.connections.settings.ping.footnote=The XMPP specification requires all cl
 		If a client does not support the XMPP Ping request, it must return an error (which in itself is a response too).        
 client.connections.settings.ping.enable=Send an XMPP Ping request to idle clients.
 client.connections.settings.ping.disable=Do not send XMPP Ping requests to idle clients.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_pt_BR.properties
+++ b/src/i18n/openfire_i18n_pt_BR.properties
@@ -2433,3 +2433,15 @@ client.connections.settings.ping.footnote=The XMPP specification requires all cl
 		If a client does not support the XMPP Ping request, it must return an error (which in itself is a response too).        
 client.connections.settings.ping.enable=Send an XMPP Ping request to idle clients.
 client.connections.settings.ping.disable=Do not send XMPP Ping requests to idle clients.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_pt_PT.properties
+++ b/src/i18n/openfire_i18n_pt_PT.properties
@@ -2974,3 +2974,15 @@ client.connections.settings.ping.footnote=As defini\u00e7\u00f5es XMPP requerem 
 		Se o cliente n\u00e3o suportar o Ping XMPP, vai ter de devolver um erro (o que no fundo tambem \u00e9 uma resposta).        
 client.connections.settings.ping.enable=Enviar um Ping XMPP aos clientes para verifica\u00e7\u00e3o.
 client.connections.settings.ping.disable=N\u00e3o enviar Ping XMPP de verifica\u00e7\u00e3o.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_ru_RU.properties
+++ b/src/i18n/openfire_i18n_ru_RU.properties
@@ -1887,3 +1887,14 @@ xmpp.error.502=\u041E\u0448\u0438\u0431\u043A\u0430 \u0443\u0434\u0430\u043B\u04
 xmpp.error.503=\u0421\u043B\u0443\u0436\u0431\u0430 \u043D\u0435\u0434\u043E\u0441\u0442\u0443\u043F\u043D\u0430
 xmpp.error.504=\u0422\u0430\u0439\u043C-\u0430\u0443\u0442 \u0443\u0434\u0430\u043B\u0435\u043D\u043D\u043E\u0433\u043E \u0441\u0435\u0440\u0432\u0435\u0440\u0430
 xmpp.error.unknown=\u041D\u0435\u0438\u0437\u0432\u0435\u0441\u0442\u043D\u044B\u0439 \u043A\u043E\u0434 \u043E\u0448\u0438\u0431\u043A\u0438
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_sk.properties
+++ b/src/i18n/openfire_i18n_sk.properties
@@ -2269,3 +2269,15 @@ client.connections.settings.ping.footnote=The XMPP specification requires all cl
 		If a client does not support the XMPP Ping request, it must return an error (which in itself is a response too).        
 client.connections.settings.ping.enable=Send an XMPP Ping request to idle clients.
 client.connections.settings.ping.disable=Do not send XMPP Ping requests to idle clients.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/i18n/openfire_i18n_zh_CN.properties
+++ b/src/i18n/openfire_i18n_zh_CN.properties
@@ -2325,3 +2325,15 @@ client.connections.settings.ping.footnote=The XMPP specification requires all cl
 		If a client does not support the XMPP Ping request, it must return an error (which in itself is a response too).        
 client.connections.settings.ping.enable=Send an XMPP Ping request to idle clients.
 client.connections.settings.ping.disable=Do not send XMPP Ping requests to idle clients.
+
+# Connection type and mode
+connection-type.socket-s2s=server-to-server (federation)
+connection-type.socket-c2s=client-to-server
+connection-type.bosh-c2s=HTTP-binding (BOSH)
+connection-type.webadmin=admin console
+connection-type.component=external component
+connection-type.connection-manager=connection manager
+connection-type.unspecified=unspecified
+connection-mode.plain=plain text (with STARTSSL)
+connection-mode.legacy=encrypted (legacy-mode)
+connection-mode.unspecified=unspecified

--- a/src/java/org/jivesoftware/openfire/spi/ConnectionConfiguration.java
+++ b/src/java/org/jivesoftware/openfire/spi/ConnectionConfiguration.java
@@ -34,10 +34,8 @@ public class ConnectionConfiguration
     private final CertificateStoreConfiguration trustStoreConfiguration;
     private final boolean acceptSelfSignedCertificates;
     private final boolean verifyCertificateValidity;
-    private final Set<String> encryptionProtocolsEnabled;
-    private final Set<String> encryptionProtocolsDisabled;
-    private final Set<String> cipherSuitesEnabled;
-    private final Set<String> cipherSuitesDisabled;
+    private final Set<String> encryptionProtocols;
+    private final Set<String> encryptionCipherSuites;
     private final Connection.CompressionPolicy compressionPolicy;
 
     // derived
@@ -55,7 +53,7 @@ public class ConnectionConfiguration
      * @param tlsPolicy The TLS policy that is applied to connections (cannot be null).
      */
     // TODO input validation
-    public ConnectionConfiguration( ConnectionType type, boolean enabled, int maxThreadPoolSize, int maxBufferSize, Connection.ClientAuth clientAuth, InetAddress bindAddress, int port, Connection.TLSPolicy tlsPolicy, CertificateStoreConfiguration identityStoreConfiguration, CertificateStoreConfiguration trustStoreConfiguration, boolean acceptSelfSignedCertificates, boolean verifyCertificateValidity, Set<String> encryptionProtocolsEnabled, Set<String> encryptionProtocolsDisabled, Set<String> cipherSuitesEnabled, Set<String> cipherSuitesDisabled, Connection.CompressionPolicy compressionPolicy )
+    public ConnectionConfiguration( ConnectionType type, boolean enabled, int maxThreadPoolSize, int maxBufferSize, Connection.ClientAuth clientAuth, InetAddress bindAddress, int port, Connection.TLSPolicy tlsPolicy, CertificateStoreConfiguration identityStoreConfiguration, CertificateStoreConfiguration trustStoreConfiguration, boolean acceptSelfSignedCertificates, boolean verifyCertificateValidity, Set<String> encryptionProtocols, Set<String> encryptionCipherSuites, Connection.CompressionPolicy compressionPolicy )
     {
         if ( maxThreadPoolSize <= 0 ) {
             throw new IllegalArgumentException( "Argument 'maxThreadPoolSize' must be equal to or greater than one." );
@@ -76,21 +74,8 @@ public class ConnectionConfiguration
         this.trustStoreConfiguration = trustStoreConfiguration;
         this.acceptSelfSignedCertificates = acceptSelfSignedCertificates;
         this.verifyCertificateValidity = verifyCertificateValidity;
-
-        // Remove all disabled protocols from the enabled ones.
-        final Set<String> protocolsEnabled = new HashSet<>();
-        protocolsEnabled.addAll( encryptionProtocolsEnabled );
-        protocolsEnabled.removeAll( encryptionProtocolsDisabled );
-        this.encryptionProtocolsEnabled = Collections.unmodifiableSet( protocolsEnabled );
-        this.encryptionProtocolsDisabled = Collections.unmodifiableSet( encryptionProtocolsDisabled );
-
-        // Remove all disabled suites from the enabled ones.
-        final Set<String> suitesEnabled = new HashSet<>();
-        suitesEnabled.addAll( cipherSuitesEnabled );
-        suitesEnabled.removeAll( cipherSuitesDisabled );
-        this.cipherSuitesEnabled = Collections.unmodifiableSet( suitesEnabled );
-        this.cipherSuitesDisabled = Collections.unmodifiableSet( cipherSuitesDisabled );
-
+        this.encryptionProtocols = Collections.unmodifiableSet( encryptionProtocols );
+        this.encryptionCipherSuites = Collections.unmodifiableSet( encryptionCipherSuites );
         this.compressionPolicy = compressionPolicy;
 
         final CertificateStoreManager certificateStoreManager = XMPPServer.getInstance().getCertificateStoreManager();
@@ -175,66 +160,30 @@ public class ConnectionConfiguration
      * When non-empty, the list is intended to specify those protocols (from a larger collection of implementation-
      * supported protocols) that can be used to establish encryption.
      *
-     * Values returned by {@link #getEncryptionProtocolsDisabled()} are not included in the result of this method.
-     *
      * The order over which values are iterated in the result is equal to the order of values in the comma-separated
      * configuration string. This can, but is not guaranteed to, indicate preference.
      *
      * @return An (ordered) set of protocols, never null but possibly empty.
      */
-    public Set<String> getEncryptionProtocolsEnabled()
+    public Set<String> getEncryptionProtocols()
     {
-        return encryptionProtocolsEnabled;
-    }
-
-    /**
-     * A collection of protocols that must not be used for encryption of connections.
-     *
-     * When non-empty, the list is intended to specify those protocols (from a larger collection of implementation-
-     * supported protocols) that must not be used to establish encryption.
-     *
-     * The order over which values are iterated in the result is equal to the order of values in the comma-separated
-     * configuration string.
-     *
-     * @return An (ordered) set of protocols, never null but possibly empty.
-     */
-    public Set<String> getEncryptionProtocolsDisabled()
-    {
-        return encryptionProtocolsDisabled;
+        return encryptionProtocols;
     }
 
     /**
      * A collection of cipher suite names that can be used for encryption of connections.
      *
      * When non-empty, the list is intended to specify those cipher suites (from a larger collection of implementation-
-     * supported cipher suties) that can be used to establish encryption.
-     *
-     * Values returned by {@link #getCipherSuitesDisabled()} are not included in the result of this method.
+     * supported cipher suites) that can be used to establish encryption.
      *
      * The order over which values are iterated in the result is equal to the order of values in the comma-separated
      * configuration string. This can, but is not guaranteed to, indicate preference.
      *
      * @return An (ordered) set of cipher suites, never null but possibly empty.
      */
-    public Set<String> getCipherSuitesEnabled()
+    public Set<String> getEncryptionCipherSuites()
     {
-        return cipherSuitesEnabled;
-    }
-
-    /**
-     * A collection of cipher suites that must not be used for encryption of connections.
-     *
-     * When non-empty, the list is intended to specify those cipher suites (from a larger collection of implementation-
-     * supported cipher suites) that must not be used to establish encryption.
-     *
-     * The order over which values are iterated in the result is equal to the order of values in the comma-separated
-     * configuration string.
-     *
-     * @return An (ordered) set of cipher suites, never null but possibly empty.
-     */
-    public Set<String> getCipherSuitesDisabled()
-    {
-        return cipherSuitesDisabled;
+        return encryptionCipherSuites;
     }
 
     public IdentityStore getIdentityStore()

--- a/src/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/src/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -434,7 +434,7 @@ public class ConnectionListener
             return;
         }
         Log.debug( "Changing client auth configuration from '{}' to '{}'.", oldValue, clientAuth );
-        JiveGlobals.setProperty( tlsPolicyPropertyName, clientAuth.toString() );
+        JiveGlobals.setProperty( clientAuthPolicyPropertyName, clientAuth.toString() );
         restart();
     }
 

--- a/src/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/src/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -259,10 +260,8 @@ public class ConnectionListener
                 trustStoreConfiguration,
                 acceptSelfSignedCertificates(),
                 verifyCertificateValidity(),
-                getEncryptionProtocolsEnabled(),
-                getEncryptionProtocolsDisabled(),
-                getCipherSuitesEnabled(),
-                getCipherSuitesDisabled(),
+                getEncryptionProtocols(),
+                getEncryptionCipherSuites(),
                 getCompressionPolicy()
         );
     }
@@ -655,7 +654,7 @@ public class ConnectionListener
      * If the listener is currently enabled, this configuration change will be applied immediately (which will cause a
      * restart of the underlying connection acceptor).
      *
-     * @return The configuration of the identity store (not null)
+     * @param configuration The configuration of the identity store (not null)
      */
     public void setTrustStoreConfiguration( CertificateStoreConfiguration configuration )
     {
@@ -668,188 +667,6 @@ public class ConnectionListener
         this.trustStoreConfiguration = configuration;
         restart();
     }
-
-//    /**
-//     * The KeyStore type (jks, jceks, pkcs12, etc) for the identity and trust store for connections created by this
-//     * listener.
-//     *
-//     * @return a store type (never null).
-//     * @see <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#KeyStore">Java Cryptography Architecture Standard Algorithm Name Documentation</a>
-//     */
-//    public String getKeyStoreType()
-//    {
-//        final String propertyName = type.getPrefix() + "storeType";
-//        final String defaultValue = "jks";
-//
-//        if ( type.getFallback() == null )
-//        {
-//            return JiveGlobals.getProperty( propertyName, defaultValue ).trim();
-//        }
-//        else
-//        {
-//            return JiveGlobals.getProperty( propertyName, getConnectionListener( type.getFallback() ).getKeyStoreType() ).trim();
-//        }
-//    }
-//
-//    public void setKeyStoreType( String keyStoreType )
-//    {
-//        // Always set the property explicitly even if it appears the equal to the old value (the old value might be a fallback value).
-//        JiveGlobals.setProperty( type.getPrefix() + "storeType", keyStoreType );
-//
-//        final String oldKeyStoreType = getKeyStoreType();
-//        if ( oldKeyStoreType.equals( keyStoreType ) )
-//        {
-//            Log.debug( "Ignoring KeyStore type change request (to '{}'): listener already in this state.", keyStoreType );
-//            return;
-//        }
-//
-//        Log.debug( "Changing KeyStore type from '{}' to '{}'.", oldKeyStoreType, keyStoreType );
-//        restart();
-//    }
-//
-//    /**
-//     * The password of the identity store for connection created by this listener.
-//     *
-//     * @return a password (never null).
-//     */
-//    public String getIdentityStorePassword()
-//    {
-//        final String propertyName = type.getPrefix() + "keypass";
-//        final String defaultValue = "changeit";
-//
-//        if ( type.getFallback() == null )
-//        {
-//            return JiveGlobals.getProperty( propertyName, defaultValue ).trim();
-//        }
-//        else
-//        {
-//            return JiveGlobals.getProperty( propertyName, getConnectionListener( type.getFallback() ).getIdentityStorePassword() ).trim();
-//        }
-//    }
-//
-//    public void setIdentityStorePassword( String password )
-//    {
-//        // Always set the property explicitly even if it appears the equal to the old value (the old value might be a fallback value).
-//        JiveGlobals.setProperty( type.getPrefix() + "keypass", password );
-//
-//        final String oldPassword = getIdentityStorePassword();
-//        if ( oldPassword.equals( password ) )
-//        {
-//            Log.debug( "Ignoring identity store password change request: listener already in this state." ); // Do not put passwords in a logfile.
-//            return;
-//        }
-//
-//        Log.debug( "Changing identity store password." ); // Do not put passwords in a logfile.
-//        restart();
-//    }
-//
-//    /**
-//     * The password of the trust store for connections created by this listener.
-//     *
-//     * @return a password (never null).
-//     */
-//    public String getTrustStorePassword()
-//    {
-//        final String propertyName = type.getPrefix() + "trustpass";
-//        final String defaultValue = "changeit";
-//
-//        if ( type.getFallback() == null )
-//        {
-//            return JiveGlobals.getProperty( propertyName, defaultValue ).trim();
-//        }
-//        else
-//        {
-//            return JiveGlobals.getProperty( propertyName, getConnectionListener( type.getFallback() ).getTrustStorePassword() ).trim();
-//        }
-//    }
-//
-//    public void setTrustStorePassword( String password )
-//    {
-//        // Always set the property explicitly even if it appears the equal to the old value (the old value might be a fallback value).
-//        JiveGlobals.setProperty( type.getPrefix() + "trustpass", password );
-//
-//        final String oldPassword = getTrustStorePassword();
-//        if ( oldPassword.equals( password ) )
-//        {
-//            Log.debug( "Ignoring trust store password change request: listener already in this state." ); // Do not put passwords in a logfile.
-//            return;
-//        }
-//
-//        Log.debug( "Changing trust store password." ); // Do not put passwords in a logfile.
-//        restart();
-//    }
-//
-//    /**
-//     * The location (relative to OPENFIRE_HOME) of the identity store for connections created by this listener.
-//     *
-//     * @return a path (never null).
-//     */
-//    public String getIdentityStoreLocation()
-//    {
-//        final String propertyName = type.getPrefix()  + "keystore";
-//        final String defaultValue = "resources" + File.separator + "security" + File.separator + "keystore";
-//
-//        if ( type.getFallback() == null )
-//        {
-//            return JiveGlobals.getProperty( propertyName, defaultValue ).trim();
-//        }
-//        else
-//        {
-//            return JiveGlobals.getProperty( propertyName, getConnectionListener( type.getFallback() ).getIdentityStoreLocation() ).trim();
-//        }
-//    }
-//
-//    public void setIdentityStoreLocation( String location )
-//    {
-//        // Always set the property explicitly even if it appears the equal to the old value (the old value might be a fallback value).
-//        JiveGlobals.setProperty( type.getPrefix() + "keystore", location );
-//
-//        final String oldLocation = getIdentityStoreLocation();
-//        if ( oldLocation.equals( location ) )
-//        {
-//            Log.debug( "Ignoring identity store location change request (to '{}'): listener already in this state.", location );
-//            return;
-//        }
-//
-//        Log.debug( "Changing identity store location from '{}' to '{}'.", oldLocation, location );
-//        restart();
-//    }
-//
-//    /**
-//     * The location (relative to OPENFIRE_HOME) of the trust store for connections created by this listener.
-//     *
-//     * @return a path (never null).
-//     */
-//    public String getTrustStoreLocation()
-//    {
-//        final String propertyName = type.getPrefix()  + "truststore";
-//        final String defaultValue = "resources" + File.separator + "security" + File.separator + "truststore";
-//
-//        if ( type.getFallback() == null )
-//        {
-//            return JiveGlobals.getProperty( propertyName, defaultValue ).trim();
-//        }
-//        else
-//        {
-//            return JiveGlobals.getProperty( propertyName, getConnectionListener( type.getFallback() ).getTrustStoreLocation() ).trim();
-//        }
-//    }
-//
-//    public void setTrustStoreLocation( String location )
-//    {
-//        // Always set the property explicitly even if it appears the equal to the old value (the old value might be a fallback value).
-//        JiveGlobals.setProperty( type.getPrefix() + "truststore", location );
-//
-//        final String oldLocation = getTrustStoreLocation();
-//        if ( oldLocation.equals( location ) )
-//        {
-//            Log.debug( "Ignoring trust store location change request (to '{}'): listener already in this state.", location );
-//            return;
-//        }
-//
-//        Log.debug( "Changing trust store location from '{}' to '{}'.", oldLocation, location );
-//        restart();
-//    }
 
     /**
      * A boolean that indicates if self-signed peer certificates can be used to establish an encrypted connection.
@@ -945,27 +762,32 @@ public class ConnectionListener
      * When non-empty, the list is intended to specify those protocols (from a larger collection of implementation-
      * supported protocols) that can be used to establish encryption.
      *
-     * Values returned by {@link #getEncryptionProtocolsDisabled()} are not included in the result of this method.
-     *
      * The order over which values are iterated in the result is equal to the order of values in the comma-separated
      * configuration string. This can, but is not guaranteed to, indicate preference.
      *
      * @return An (ordered) set of protocols, never null but possibly empty.
      */
     // TODO add setter!
-    public Set<String> getEncryptionProtocolsEnabled()
+    public Set<String> getEncryptionProtocols()
     {
         final Set<String> result = new LinkedHashSet<>();
-        final String csv = getEncryptionProtocolsEnabledCommaSeparated();
-        result.addAll( Arrays.asList( csv.split( "\\s*,\\s*" ) ) );
-        result.removeAll( getEncryptionProtocolsDisabled() );
+        final String csv = getEncryptionProtocolsCommaSeparated();
+        if ( csv.isEmpty() ) {
+            try {
+                result.addAll( EncryptionArtifactFactory.getDefaultProtocols() );
+            } catch ( Exception ex ) {
+                Log.error( "An error occurred while obtaining the default encryption protocol setting.", ex );
+            }
+        } else {
+            result.addAll( Arrays.asList( csv.split( "\\s*,\\s*" ) ) );
+        }
         return result;
     }
 
-    protected String getEncryptionProtocolsEnabledCommaSeparated()
+    protected String getEncryptionProtocolsCommaSeparated()
     {
-        final String propertyName = type.getPrefix() + "protocols.enabled";
-        final String defaultValue = "TLSv1,TLSv1.1,TLSv1.2";
+        final String propertyName = type.getPrefix() + "protocols";
+        final String defaultValue = "";
 
         if ( type.getFallback() == null )
         {
@@ -973,71 +795,97 @@ public class ConnectionListener
         }
         else
         {
-            return JiveGlobals.getProperty( propertyName, getConnectionListener( type.getFallback() ).getEncryptionProtocolsEnabledCommaSeparated() ).trim();
+            return JiveGlobals.getProperty( propertyName, getConnectionListener( type.getFallback() ).getEncryptionProtocolsCommaSeparated() ).trim();
         }
     }
 
     /**
-     * A collection of protocols that must not be used for encryption of connections.
+     * Defines the collection of protocols (by name) that can be used for encryption of connections.
      *
      * When non-empty, the list is intended to specify those protocols (from a larger collection of implementation-
-     * supported protocols) that must not be used to establish encryption.
+     * supported protocols) that can be used to establish encryption. An empty list will cause an implementation
+     * default to be used.
      *
-     * The order over which values are iterated in the result is equal to the order of values in the comma-separated
-     * configuration string.
+     * The order over which values are presented can, but is not guaranteed to, indicate preference.
      *
-     * @return An (ordered) set of protocols, never null but possibly empty.
+     * @param protocols An (ordered) set of protocol names, can be null.
      */
-    // TODO add setter!
-    public Set<String> getEncryptionProtocolsDisabled()
-    {
-        final Set<String> result = new LinkedHashSet<>();
-        final String csv = getEncryptionProtocolsDisabledCommaSeparated();
-        result.addAll( Arrays.asList( csv.split( "\\s*,\\s*" ) ) );
-        return result;
+    public void setEncryptionProtocols( Set<String> protocols ) {
+        if ( protocols == null ) {
+            setEncryptionProtocols( new String[0] );
+        } else {
+            setEncryptionProtocols( protocols.toArray( new String[ protocols.size() ] ) );
+        }
     }
 
-    protected String getEncryptionProtocolsDisabledCommaSeparated()
+    /**
+     * Defines the collection of protocols (by name) that can be used for encryption of connections.
+     *
+     * When non-empty, the list is intended to specify those protocols (from a larger collection of implementation-
+     * supported protocols) that can be used to establish encryption. An empty list will cause an implementation
+     * default to be used.
+     *
+     * The order over which values are presented can, but is not guaranteed to, indicate preference.
+     *
+     * @param protocols An array of protocol names, can be null.
+     */
+    public void setEncryptionProtocols( String[] protocols )
     {
-        final String propertyName = type.getPrefix() + "protocols.disabled";
-        final String defaultValue = "SSLv1,SSLv2,SSLv2Hello,SSLv3";
+        if ( protocols == null) {
+            protocols = new String[0];
+        }
+        final String oldValue = getEncryptionProtocolsCommaSeparated();
 
-        if ( type.getFallback() == null )
+        // Always set the property explicitly even if it appears the equal to the old value (the old value might be a fallback value).
+        final StringBuilder csv = new StringBuilder();
+        for( String protocol : protocols )
         {
-            return JiveGlobals.getProperty( propertyName, defaultValue ).trim();
+            csv.append( protocol );
+            csv.append( ',' );
         }
-        else
+        final String newValue = csv.length() > 0 ? csv.substring( 0, csv.length() - 1 ) : "";
+        JiveGlobals.setProperty( type.getPrefix() + "protocols", newValue );
+
+        if ( oldValue.equals( newValue ) )
         {
-            return JiveGlobals.getProperty( propertyName, getConnectionListener( type.getFallback() ).getEncryptionProtocolsDisabledCommaSeparated() ).trim();
+            Log.debug( "Ignoring protocol configuration change request (to '{}'): listener already in this state.", newValue );
+            return;
         }
+
+        Log.debug( "Changing protocol configuration from '{}' to '{}'.", oldValue, newValue );
+        restart();
     }
 
     /**
      * A collection of cipher suite names that can be used for encryption of connections.
      *
      * When non-empty, the list is intended to specify those cipher suites (from a larger collection of implementation-
-     * supported cipher suties) that can be used to establish encryption.
-     *
-     * Values returned by {@link #getCipherSuitesDisabled()} are not included in the result of this method.
+     * supported cipher suites) that can be used to establish encryption.
      *
      * The order over which values are iterated in the result is equal to the order of values in the comma-separated
      * configuration string. This can, but is not guaranteed to, indicate preference.
      *
-     * @return An (ordered) set of cipher suites, never null but possibly empty.
+     * @return An (ordered) set of cipher suite names, never null but possibly empty.
      */
-    // TODO add setter!
-    public Set<String> getCipherSuitesEnabled()
+    public Set<String> getEncryptionCipherSuites()
     {
         final Set<String> result = new LinkedHashSet<>();
-        final String csv = getCipherSuitesEnabledCommaSeparated();
-        result.addAll( Arrays.asList( csv.split( "\\s*,\\s*" ) ) );
-        result.removeAll( getCipherSuitesDisabled() );
+        final String csv = getEncryptionCipherSuitesCommaSeparated();
+        if ( csv.isEmpty() ) {
+            try {
+                result.addAll( EncryptionArtifactFactory.getDefaultCipherSuites() );
+            } catch ( Exception ex ) {
+                Log.error( "An error occurred while obtaining the default encryption cipher suite setting.", ex );
+            }
+        } else {
+            result.addAll( Arrays.asList( csv.split( "\\s*,\\s*" ) ) );
+        }
         return result;
     }
 
-    protected String getCipherSuitesEnabledCommaSeparated()
+    protected String getEncryptionCipherSuitesCommaSeparated()
     {
-        final String propertyName = type.getPrefix() + "ciphersuites.enabled";
+        final String propertyName = type.getPrefix() + "ciphersuites";
         final String defaultValue = "";
 
         if ( type.getFallback() == null )
@@ -1046,43 +894,65 @@ public class ConnectionListener
         }
         else
         {
-            return JiveGlobals.getProperty( propertyName, getConnectionListener( type.getFallback() ).getCipherSuitesEnabledCommaSeparated() );
+            return JiveGlobals.getProperty( propertyName, getConnectionListener( type.getFallback() ).getEncryptionCipherSuitesCommaSeparated() );
         }
     }
 
     /**
-     * A collection of cipher suites that must not be used for encryption of connections.
+     * Defines the collection of cipher suite (by name) that can be used for encryption of connections.
      *
      * When non-empty, the list is intended to specify those cipher suites (from a larger collection of implementation-
-     * supported cipher suites) that must not be used to establish encryption.
+     * supported cipher suites) that can be used to establish encryption. An empty list will cause an implementation
+     * default to be used.
      *
-     * The order over which values are iterated in the result is equal to the order of values in the comma-separated
-     * configuration string.
+     * The order over which values are presented can, but is not guaranteed to, indicate preference.
      *
-     * @return An (ordered) set of cipher suites, never null but possibly empty.
+     * @param cipherSuites An (ordered) set of cipher suite names, can be null.
      */
-    // TODO add setter!
-    public Set<String> getCipherSuitesDisabled()
-    {
-        final Set<String> result = new LinkedHashSet<>();
-        final String csv = getCipherSuitesDisabledCommaSeparated();
-        result.addAll( Arrays.asList( csv.split( "\\s*,\\s*" ) ) );
-        return result;
+    public void setEncryptionCipherSuites( Set<String> cipherSuites ) {
+        if ( cipherSuites == null ) {
+            setEncryptionCipherSuites( new String[0] );
+        } else {
+            setEncryptionCipherSuites( cipherSuites.toArray( new String[ cipherSuites.size() ] ) );
+        }
     }
 
-    protected String getCipherSuitesDisabledCommaSeparated()
+    /**
+     * Defines the collection of cipher suite (by name) that can be used for encryption of connections.
+     *
+     * When non-empty, the list is intended to specify those cipher suites (from a larger collection of implementation-
+     * supported cipher suites) that can be used to establish encryption. An empty list will cause an implementation
+     * default to be used.
+     *
+     * The order over which values are presented can, but is not guaranteed to, indicate preference.
+     *
+     * @param cipherSuites An array of cipher suite names, can be null.
+     */
+    public void setEncryptionCipherSuites( String[] cipherSuites )
     {
-        final String propertyName = type.getPrefix() + "ciphersuites.disabled";
-        final String defaultValue = "";
+        if ( cipherSuites == null) {
+            cipherSuites = new String[0];
+        }
+        final String oldValue = getEncryptionCipherSuitesCommaSeparated();
 
-        if ( type.getFallback() == null )
+        // Always set the property explicitly even if it appears the equal to the old value (the old value might be a fallback value).
+        final StringBuilder csv = new StringBuilder();
+        for( String cipherSuite : cipherSuites )
         {
-            return JiveGlobals.getProperty( propertyName, defaultValue ).trim();
+            csv.append( cipherSuite );
+            csv.append( ',' );
         }
-        else
+        final String newValue = csv.length() > 0 ? csv.substring( 0, csv.length() - 1 ) : "";
+        JiveGlobals.setProperty( type.getPrefix() + "ciphersuites", newValue );
+
+        if ( oldValue.equals( newValue ) )
         {
-            return JiveGlobals.getProperty( propertyName, getConnectionListener( type.getFallback() ).getCipherSuitesDisabledCommaSeparated() ).trim();
+            Log.debug( "Ignoring cipher suite configuration change request (to '{}'): listener already in this state.", newValue );
+            return;
         }
+
+        Log.debug( "Changing cipher suite configuration from '{}' to '{}'.", oldValue, newValue );
+        restart();
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactory.java
+++ b/src/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactory.java
@@ -325,4 +325,30 @@ public class EncryptionArtifactFactory
         }
         return filter;
     }
+
+    /**
+     * Returns the names of all encryption protocols that are supported (but not necessarily enabled).
+     *
+     * @return An array of protocol names. Not expected to be empty.
+     */
+    public static String[] getSupportedProtocols() throws NoSuchAlgorithmException, KeyManagementException
+    {
+        // TODO Might want to cache the result. It's unlikely to change at runtime.
+        final SSLContext context = SSLContext.getInstance( "TLSv1" );
+        context.init( null, null, null );
+        return context.createSSLEngine().getSupportedProtocols();
+    }
+
+    /**
+     * Returns the names of all encryption cipher suites that are supported (but not necessarily enabled).
+     *
+     * @return An array of cipher suite names. Not expected to be empty.
+     */
+    public static String[] getSupportedCipherSuites() throws NoSuchAlgorithmException, KeyManagementException
+    {
+        // TODO Might want to cache the result. It's unlikely to change at runtime.
+        final SSLContext context = SSLContext.getInstance( "TLSv1" );
+        context.init( null, null, null );
+        return context.createSSLEngine().getSupportedCipherSuites();
+    }
 }

--- a/src/test/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactoryTest.java
+++ b/src/test/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactoryTest.java
@@ -1,0 +1,44 @@
+package org.jivesoftware.openfire.spi;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests that verify the functionality of {@link EncryptionArtifactFactory}.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class EncryptionArtifactFactoryTest
+{
+    /**
+     * Verifies that the collection of supported encryption protocols is not empty.
+     */
+    @Test
+    public void testHasSupportedProtocols() throws Exception
+    {
+        // Setup fixture.
+        // (not needed)
+
+        // Execute system under test.
+        final String[] result = EncryptionArtifactFactory.getSupportedProtocols();
+
+        // Verify results.
+        Assert.assertTrue( result.length > 0 );
+    }
+
+    /**
+     * Verifies that the collection of supported cipher suites is not empty.
+     */
+    @Test
+    public void testHasSupportedCipherSuites() throws Exception
+    {
+        // Setup fixture.
+        // (not needed)
+
+        // Execute system under test.
+        final String[] result = EncryptionArtifactFactory.getSupportedCipherSuites();
+
+        // Verify results.
+        Assert.assertTrue( result.length > 0 );
+    }
+}

--- a/src/test/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactoryTest.java
+++ b/src/test/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactoryTest.java
@@ -3,6 +3,8 @@ package org.jivesoftware.openfire.spi;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collection;
+
 /**
  * Unit tests that verify the functionality of {@link EncryptionArtifactFactory}.
  *
@@ -20,10 +22,26 @@ public class EncryptionArtifactFactoryTest
         // (not needed)
 
         // Execute system under test.
-        final String[] result = EncryptionArtifactFactory.getSupportedProtocols();
+        final Collection<String> result = EncryptionArtifactFactory.getSupportedProtocols();
 
         // Verify results.
-        Assert.assertTrue( result.length > 0 );
+        Assert.assertFalse( result.isEmpty() );
+    }
+
+    /**
+     * Verifies that the collection of default encryption protocols is not empty.
+     */
+    @Test
+    public void testHasDefaultProtocols() throws Exception
+    {
+        // Setup fixture.
+        // (not needed)
+
+        // Execute system under test.
+        final Collection<String> result = EncryptionArtifactFactory.getDefaultProtocols();
+
+        // Verify results.
+        Assert.assertFalse( result.isEmpty() );
     }
 
     /**
@@ -36,9 +54,25 @@ public class EncryptionArtifactFactoryTest
         // (not needed)
 
         // Execute system under test.
-        final String[] result = EncryptionArtifactFactory.getSupportedCipherSuites();
+        final Collection<String> result = EncryptionArtifactFactory.getSupportedCipherSuites();
 
         // Verify results.
-        Assert.assertTrue( result.length > 0 );
+        Assert.assertFalse( result.isEmpty() );
+    }
+
+    /**
+     * Verifies that the collection of default cipher suites is not empty.
+     */
+    @Test
+    public void testHasDefaultCipherSuites() throws Exception
+    {
+        // Setup fixture.
+        // (not needed)
+
+        // Execute system under test.
+        final Collection<String> result = EncryptionArtifactFactory.getDefaultCipherSuites();
+
+        // Verify results.
+        Assert.assertFalse( result.isEmpty() );
     }
 }

--- a/src/web/connection-settings-advanced.jsp
+++ b/src/web/connection-settings-advanced.jsp
@@ -1,0 +1,426 @@
+<%@ page import="org.jivesoftware.openfire.XMPPServer" %>
+<%@ page import="org.jivesoftware.util.ParamUtils" %>
+<%@ page import="org.jivesoftware.openfire.Connection" %>
+<%@ page import="org.jivesoftware.openfire.spi.*" %>
+<%@ page import="java.util.*" %>
+<%@ page errorPage="error.jsp" %>
+
+<%@ taglib uri="admin" prefix="admin" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager"  />
+<% webManager.init(request, response, session, application, out ); %>
+<%
+    final boolean update = request.getParameter( "update" ) != null;
+
+    final Map<String, String> errors = new HashMap<>();
+    pageContext.setAttribute( "errors", errors );
+
+    ConnectionType connectionType = null;
+    try {
+        connectionType = ConnectionType.valueOf( ParamUtils.getParameter( request, "connectionType" ) );
+        pageContext.setAttribute( "connectionType", connectionType );
+    } catch (RuntimeException ex) {
+        errors.put( "connectionType", ex.getMessage() );
+    }
+
+    final String connectionModeParam = ParamUtils.getParameter( request, "connectionMode" );
+    if ( "plain".equalsIgnoreCase( connectionModeParam ) || "legacy".equalsIgnoreCase( connectionModeParam ) ) {
+        pageContext.setAttribute( "connectionMode", connectionModeParam.toLowerCase() );
+    } else {
+        errors.put( "connectionMode", "Unrecognized connection mode." );
+    }
+
+    final ConnectionManagerImpl manager = (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager();
+    final boolean startInSslMode = "legacy".equalsIgnoreCase( connectionModeParam );
+
+    if ( update && errors.isEmpty() )
+    {
+        final ConnectionConfiguration configuration = manager.getListener( connectionType, startInSslMode ).generateConnectionConfiguration();
+
+        // Read and parse parameters
+        final boolean enabled = ParamUtils.getBooleanParameter( request, "enabled" );
+        final int tcpPort = ParamUtils.getIntParameter( request, "tcpPort", configuration.getPort() );
+        final int readBuffer  = ParamUtils.getIntParameter( request, "readBuffer", -1 );
+        final String tlsPolicyText = ParamUtils.getParameter( request, "tlspolicy", true );
+        final Connection.TLSPolicy tlsPolicy;
+        if ( tlsPolicyText == null || tlsPolicyText.isEmpty() ) {
+            tlsPolicy = configuration.getTlsPolicy();
+        } else {
+            tlsPolicy = Connection.TLSPolicy.valueOf( tlsPolicyText );
+        }
+        final String mutualAuthenticationText = ParamUtils.getParameter( request, "mutualauthentication", true );
+        final Connection.ClientAuth mutualAuthentication;
+        if ( mutualAuthenticationText == null || mutualAuthenticationText.isEmpty() ) {
+            mutualAuthentication = configuration.getClientAuth();
+        } else {
+            mutualAuthentication = Connection.ClientAuth.valueOf( mutualAuthenticationText );
+        }
+
+        final Enumeration<String> parameterNames = request.getParameterNames();
+        final Set<String> protocols = new TreeSet<>();
+        while ( parameterNames.hasMoreElements() )
+        {
+            final String parameterName = parameterNames.nextElement();
+            if ( parameterName.startsWith( "protocol-" ) )
+            {
+                protocols.add( parameterName.substring( "protocols-".length() -1 ) );
+            }
+        }
+
+        final String[] cipherSuites = ParamUtils.getParameters( request, "cipherSuitesEnabled" );
+        final int listenerMaxThreads = ParamUtils.getIntParameter( request, "maxThreads", configuration.getMaxThreadPoolSize() );
+        final boolean acceptSelfSignedCertificates = ParamUtils.getBooleanParameter( request, "accept-self-signed-certificates" );
+        final boolean verifyCertificateValidity = ParamUtils.getBooleanParameter( request, "verify-certificate-validity" );
+
+
+        // Apply new configuration
+        final ConnectionListener listener = manager.getListener( connectionType, startInSslMode );
+
+        listener.enable( enabled );
+        listener.setPort( tcpPort );
+        // TODO: listener.setMaxBufferSize( readBuffer );
+        listener.setTLSPolicy( tlsPolicy );
+        listener.setClientAuth( mutualAuthentication );
+        // TODO: listener.setMaxThreadPoolSize( listenerMaxThreads);
+        listener.setEncryptionProtocols( protocols );
+        listener.setEncryptionCipherSuites( cipherSuites );
+        listener.setAcceptSelfSignedCertificates( acceptSelfSignedCertificates );
+        listener.setVerifyCertificateValidity( verifyCertificateValidity );
+
+        // Log the event
+        webManager.logEvent( "Updated connection settings for " + connectionType + " (mode: " + connectionModeParam + ")", configuration.toString() );
+    }
+
+    if ( errors.isEmpty() ) {
+        // Refresh the configuration (in case new settings were applied)
+        final ConnectionConfiguration configuration = manager.getListener( connectionType, startInSslMode ).generateConnectionConfiguration();
+        if ( configuration == null ) {
+            errors.put( "configuration", null );
+        } else {
+            pageContext.setAttribute( "configuration", configuration );
+        }
+    }
+
+    pageContext.setAttribute( "supportedProtocols", EncryptionArtifactFactory.getSupportedProtocols() );
+    pageContext.setAttribute( "supportedCipherSuites", EncryptionArtifactFactory.getSupportedCipherSuites() );
+
+%>
+<c:set var="connectionTypeTranslation">
+    <c:choose>
+        <c:when test="${connectionType eq 'SOCKET_S2S'}">
+            <fmt:message key="connection-type.socket-s2s"/>
+        </c:when>
+        <c:when test="${connectionType eq 'SOCKET_C2S'}">
+            <fmt:message key="connection-type.socket-c2s"/>
+        </c:when>
+        <c:when test="${connectionType eq 'BOSH_C2S'}">
+            <fmt:message key="connection-type.bosh-c2s"/>
+        </c:when>
+        <c:when test="${connectionType eq 'WEBADMIN'}">
+            <fmt:message key="connection-type.webadmin"/>
+        </c:when>
+        <c:when test="${connectionType eq 'COMPONENT'}">
+            <fmt:message key="connection-type.component"/>
+        </c:when>
+        <c:when test="${connectionType eq 'CONNECTION_MANAGER'}">
+            <fmt:message key="connection-type.connection-manager"/>
+        </c:when>
+        <c:otherwise>
+            <fmt:message key="connection-type.unspecified"/>
+        </c:otherwise>
+    </c:choose>
+</c:set>
+<c:set var="connectionModeTranslation">
+    <c:choose>
+        <c:when test="${connectionMode eq 'plain'}">
+            <fmt:message key="connection-mode.plain"/>
+        </c:when>
+        <c:when test="${connectionMode eq 'legacy'}">
+            <fmt:message key="connection-mode.legacy"/>
+        </c:when>
+        <c:otherwise>
+            <fmt:message key="connection-mode.unspecified"/>
+        </c:otherwise>
+    </c:choose>
+</c:set>
+<html>
+<head>
+    <c:choose>
+        <c:when test="${connectionType eq 'SOCKET_S2S'}">
+            <title><fmt:message key="server2server.settings.title"/></title>
+            <meta name="pageID" content="server2server-settings"/>
+        </c:when>
+        <c:when test="${connectionType eq 'SOCKET_C2S'}">
+            <title><fmt:message key="client.connections.settings.title"/></title>
+            <meta name="pageID" content="client-connections-settings"/>
+        </c:when>
+        <c:when test="${connectionType eq 'COMPONENT'}">
+            <title><fmt:message key="component.settings.title"/></title>
+            <meta name="pageID" content="external-components-settings"/>
+        </c:when>
+        <c:when test="${connectionType eq 'CONNECTION_MANAGER'}">
+            <title><fmt:message key="connection-manager.settings.title"/></title>
+            <meta name="pageID" content="connection-managers-settings"/>
+        </c:when>
+    </c:choose>
+    <%--<meta name="subPageID" content="connection-settings-advanced"/>--%>
+    <script type="text/javascript">
+        // Displays or hides the configuration blocks, based on the status of selected settings.
+        function applyDisplayable()
+        {
+            var tlsConfigs, displayValue, i, len;
+
+            displayValue = ( document.getElementById( "tlspolicy-disabled" ).checked ? "none" : "block" );
+
+            // Select the right configuration block and enable or disable it as defined by the the corresponding checkbox.
+            tlsConfigs = document.getElementsByClassName( "tlsconfig" );
+            for ( i = 0, len = tlsConfigs.length; i < len; i++ )
+            {
+                // Hide or show the info block (as well as it's title, which is the previous sibling element)
+                tlsConfigs[ i ].parentElement.style.display = displayValue;
+                tlsConfigs[ i ].parentElement.previousSibling.style.display = displayValue;
+            }
+        }
+
+        // Marks all options in a select element as 'selected' (useful prior to form submission)
+        function selectAllOptions( selectedId )
+        {
+            var select, i, len;
+
+            select = document.getElementById( selectedId );
+
+            for ( i = 0, len = select.options.length; i < len; i++ )
+            {
+                select.options[ i ].selected = true;
+            }
+        }
+
+        // Moves selected option values from one select element to another.
+        function moveSelectedFromTo( from, to )
+        {
+            var selected, i, len;
+
+            selected = getSelectValues( document.getElementById( from ) );
+
+            for ( i = 0, len = selected.length; i < len; i++ )
+            {
+                document.getElementById( to ).appendChild( selected[ i ] );
+            }
+        }
+
+        // Return an array of the selected options. argument is an HTML select element
+        function getSelectValues( select )
+        {
+            var i, len, result;
+
+            result = [];
+
+            for ( i = 0, len = select.options.length; i < len; i++ )
+            {
+                if ( select.options[ i ].selected )
+                {
+                    result.push( select.options[ i ] );
+                }
+            }
+            return result;
+        }
+
+        // Ensure that the various elements are set properly when the page is loaded.
+        window.onload = function()
+        {
+            applyDisplayable();
+        };
+    </script>
+
+</head>
+<body>
+
+<!-- Display all errors -->
+<c:forEach var="err" items="${errors}">
+    <admin:infobox type="error">
+        <c:choose>
+            <c:when test="${err.key eq 'connectionType'}">The connection type is unrecognized.</c:when>
+            <c:when test="${err.key eq 'connectionMode'}">The connection mode is unrecognized.</c:when>
+            <c:otherwise>
+                <c:if test="${not empty err.value}">
+                    <fmt:message key="admin.error"/>: <c:out value="${err.value}"/>
+                </c:if>
+                (<c:out value="${err.key}"/>)
+            </c:otherwise>
+        </c:choose>
+    </admin:infobox>
+</c:forEach>
+
+<!-- Display all success reports, but only if there were no errors. -->
+<c:if test="${param.success and empty errors}">
+    <admin:infoBox type="success">
+        <c:choose>
+            <c:when test="${connectionType eq 'SOCKET_S2S'}">
+                <fmt:message key="server2server.settings.update" />
+            </c:when>
+            <c:when test="${connectionType eq 'SOCKET_C2S'}">
+                <fmt:message key="client.connections.settings.confirm.updated" />
+            </c:when>
+            <c:when test="${connectionType eq 'COMPONENT'}">
+                <fmt:message key="component.settings.confirm.updated" />
+            </c:when>
+            <c:when test="${connectionType eq 'CONNECTION_MANAGER'}">
+                <fmt:message key="connection-manager.settings.confirm.updated" />
+            </c:when>
+        </c:choose>
+    </admin:infoBox>
+</c:if>
+
+<!-- Introduction at the top of the page -->
+<p>
+    The configuration on this page applies to ${connectionModeTranslation} ${connectionTypeTranslation} connections.
+</p>
+
+<form action="connection-settings-advanced.jsp?connectionType=${connectionType}&connectionMode=${connectionMode}" onsubmit="selectAllOptions('cipherSuitesEnabled')" method="post">
+    <input type="hidden" name="update" value="true" />
+
+    <admin:contentBox title="TCP Settings">
+        
+        <table cellpadding="3" cellspacing="0" border="0">
+            <tr valign="middle">
+                <td width="100%" colspan="2"><input type="checkbox" name="enabled" id="enabled" ${configuration.enabled ? 'checked' : ''}/><label for="enabled">Enabled</label></td>
+            </tr>
+            <tr valign="middle">
+                <td width="1%" nowrap><label for="tcpPort">Port number</label></td>
+                <td width="99%"><input type="text" name="tcpPort" id="tcpPort" value="${configuration.port}"/></td>
+            </tr>
+            <tr valign="middle">
+                <td width="1%" nowrap><label for="readBuffer">Read buffer</label></td>
+                <td width="99%"><input type="text" name="readBuffer" id="readBuffer" value="${configuration.maxBufferSize gt 0 ? configuration.maxBufferSize : ''}" readonly/> (in bytes - empty for unlimited size)</td>
+            </tr>
+        </table>
+
+    </admin:contentBox>
+
+    <c:if test="${connectionMode eq 'plain'}">
+        <admin:contentBox title="STARTTLS policy">
+            <table cellpadding="3" cellspacing="0" border="0">
+                <tr valign="middle">
+                    <td>
+                        <input type="radio" name="tlspolicy" value="disabled" id="tlspolicy-disabled" ${configuration.tlsPolicy.name() eq 'disabled' ? 'checked' : ''} onclick="applyDisplayable()"/>
+                        <label for="tlspolicy-disabled"><b>Disabled</b> - Encryption is not allowed.</label>
+                    </td>
+                </tr>
+                <tr valign="middle">
+                    <td>
+                        <input type="radio" name="tlspolicy" value="optional" id="tlspolicy-optional" ${configuration.tlsPolicy.name() eq 'optional' ? 'checked' : ''} onclick="applyDisplayable()"/>
+                        <label for="tlspolicy-optional"><b>Optional</b> - Encryption may be used, but is not required.</label>
+                    </td>
+                </tr>
+                <tr valign="middle">
+                    <td>
+                        <input type="radio" name="tlspolicy" value="required" id="tlspolicy-required" ${configuration.tlsPolicy.name() eq 'required' ? 'checked' : ''} onclick="applyDisplayable()"/>
+                        <label for="tlspolicy-required"><b>Required</b> - Connections cannot be established unless they are encrypted.</label>
+                    </td>
+                </tr>
+            </table>
+        </admin:contentBox>
+    </c:if>
+
+    <admin:contentBox title="Mutual Authentication">
+        <p>In addition to requiring peers to use encryption (which will force them to verify the security certificates of this Openfire instance) an additional level of security can be enabled. With this option, the server can be configured to verify certificates that are to be provided by the peers. This is commonly referred to as 'mutual authentication'.</p>
+        <table cellpadding="3" cellspacing="0" border="0" class="tlsconfig">
+            <tr valign="middle">
+                <td>
+                    <input type="radio" name="mutualauthentication" value="disabled" id="mutualauthentication-disabled" ${configuration.clientAuth.name() eq 'disabled' ? 'checked' : ''}/>
+                    <label for="mutualauthentication-disabled"><b>Disabled</b> - Peer certificates are not verified.</label>
+                </td>
+            </tr>
+            <tr valign="middle">
+                <td>
+                    <input type="radio" name="mutualauthentication" value="wanted" id="mutualauthentication-wanted" ${configuration.clientAuth.name() eq 'wanted' ? 'checked' : ''}/>
+                    <label for="mutualauthentication-wanted"><b>Wanted</b> - Peer certificates are verified, but only when they are presented by the peer.</label>
+                </td>
+            </tr>
+            <tr valign="middle">
+                <td>
+                    <input type="radio" name="mutualauthentication" value="needed" id="mutualauthentication-needed" ${configuration.clientAuth.name() eq 'needed' ? 'checked' : ''}/>
+                    <label for="mutualauthentication-needed"><b>Needed</b> - A connection cannot be established if the peer does not present a valid certificate.</label>
+                </td>
+            </tr>
+        </table>
+    </admin:contentBox>
+
+    <admin:contentBox title="Certificate chain checking">
+        <p>These options configure some aspects of the verification/validation of the certificates that are presented by peers while setting up encrypted connections.</p>
+        <table cellpadding="3" cellspacing="0" border="0" class="tlsconfig">
+            <tr valign="middle">
+                <td>
+                    <input type="checkbox" name="accept-self-signed-certificates" id="accept-self-signed-certificates" ${configuration.acceptSelfSignedCertificates ? 'checked' : ''}/><label for="accept-self-signed-certificates">Allow peer certificates to be self-signed.</label>
+                </td>
+            </tr>
+            <tr valign="middle">
+                <td>
+                    <input type="checkbox" name="verify-certificate-validity" id="verify-certificate-validity" ${configuration.verifyCertificateValidity ? 'checked' : ''}/><label for="verify-certificate-validity">Verify that the certificate is currently valid (based on the 'notBefore' and 'notAfter' values of the certificate).</label>
+                </td>
+            </tr>
+        </table>
+    </admin:contentBox>
+
+    <admin:contentBox title="Encryption protocols">
+        <p>These are all encryption protocols that this instance of Openfire supports. Those with a checked box are enabled, and can be used to establish an encrypted connection. Deselecting all values will cause a default to be restored.</p>
+        <table cellpadding="3" cellspacing="0" border="0" class="tlsconfig">
+            <c:forEach var="supportedProtocol" items="${supportedProtocols}">
+                <c:set var="idForForm">protocol-<c:out value="${supportedProtocol}"/></c:set>
+                <c:set var="enabled" value="${configuration.encryptionProtocols.contains(supportedProtocol)}"/>
+                <tr valign="middle">
+                    <td>
+                        <input type="checkbox" name="${idForForm}" id="${idForForm}" ${enabled ? 'checked' : ''}/><label for="${idForForm}"><c:out value="${supportedProtocol}"/></label>
+                    </td>
+                </tr>
+            </c:forEach>
+        </table>
+    </admin:contentBox>
+
+    <admin:contentBox title="Encryption cipher suites">
+        <p>These are all encryption cipher suites that this instance of Openfire supports. Those with a checked box are enabled, and can be used to establish an encrypted connection. Deselecting all values will cause a default to be restored.</p>
+        <table cellpadding="3" cellspacing="0" border="0" class="tlsconfig">
+            <tr><th>Enabled</th><th></th><th>Supported</th></tr>
+            <tr>
+                <td>
+                    <select name="cipherSuitesEnabled" id="cipherSuitesEnabled" size="10" multiple>
+                        <c:forEach items="${configuration.encryptionCipherSuites}" var="item">
+                            <c:if test="${supportedCipherSuites.contains(item)}">
+                                <option><c:out value="${item}"/></option>
+                            </c:if>
+                        </c:forEach>
+                    </select>
+                </td>
+                <td>
+                    <input type="button" onclick="moveSelectedFromTo('cipherSuitesEnabled','cipherSuitesSupported')" value="&gt;&gt;" /><br/>
+                    <input type="button" onclick="moveSelectedFromTo('cipherSuitesSupported','cipherSuitesEnabled')" value="&lt;&lt;" />
+                </td>
+                <td>
+                    <select name="cipherSuitesSupported" id="cipherSuitesSupported" size="10" multiple>
+                        <c:forEach items="${supportedCipherSuites}" var="item">
+                            <c:if test="${not configuration.encryptionCipherSuites.contains(item)}">
+                                <option><c:out value="${item}"/></option>
+                            </c:if>
+                        </c:forEach>
+                    </select>
+                </td>
+            </tr>
+        </table>
+    </admin:contentBox>
+
+    <admin:contentBox title="Miscellaneous settings">
+        <table cellpadding="3" cellspacing="0" border="0">
+            <tr valign="middle">
+                <td width="1%" nowrap><label for="maxThreads">Maximum worker threads</label></td>
+                <td width="99%"><input type="text" name="maxThreads" id="maxThreads" value="${configuration.maxThreadPoolSize}" readonly/></td>
+            </tr>
+        </table>
+    </admin:contentBox>
+
+    <input type="submit" name="update" value="<fmt:message key="global.save_settings" />">
+
+</form>
+</body>
+</html>

--- a/src/web/connection-settings-external-components.jsp
+++ b/src/web/connection-settings-external-components.jsp
@@ -34,39 +34,10 @@
         // plaintext
         final boolean plaintextEnabled      = ParamUtils.getBooleanParameter( request, "plaintext-enabled" );
         final int plaintextTcpPort          = ParamUtils.getIntParameter( request, "plaintext-tcpPort", plaintextConfiguration.getPort() );
-        final int plaintextReadBuffer       = ParamUtils.getIntParameter( request, "plaintext-readBuffer", plaintextConfiguration.getMaxBufferSize() );
-        final String plaintextTlsPolicyText = ParamUtils.getParameter( request, "plaintext-tlspolicy", true );
-        final Connection.TLSPolicy plaintextTlsPolicy;
-        if ( plaintextTlsPolicyText == null || plaintextTlsPolicyText.isEmpty() ) {
-            plaintextTlsPolicy = plaintextConfiguration.getTlsPolicy();
-        } else {
-            plaintextTlsPolicy = Connection.TLSPolicy.valueOf( plaintextTlsPolicyText );
-        }
-        final String plaintextMutualAuthenticationText = ParamUtils.getParameter( request, "plaintext-mutualauthentication", true );
-        final Connection.ClientAuth plaintextMutualAuthentication;
-        if ( plaintextMutualAuthenticationText == null || plaintextMutualAuthenticationText.isEmpty() ) {
-            plaintextMutualAuthentication = plaintextConfiguration.getClientAuth();
-        } else {
-            plaintextMutualAuthentication = Connection.ClientAuth.valueOf( plaintextMutualAuthenticationText );
-        }
-        final int plaintextListenerMaxThreads = ParamUtils.getIntParameter( request, "plaintext-maxThreads", plaintextConfiguration.getMaxThreadPoolSize() );
-        final boolean plaintextAcceptSelfSignedCertificates = ParamUtils.getBooleanParameter( request, "plaintext-accept-self-signed-certificates" );
-        final boolean plaintextVerifyCertificateValidity = ParamUtils.getBooleanParameter( request, "plaintext-verify-certificate-validity" );
 
         // legacymode
         final boolean legacymodeEnabled      = ParamUtils.getBooleanParameter( request, "legacymode-enabled" );
         final int legacymodeTcpPort          = ParamUtils.getIntParameter( request, "legacymode-tcpPort", legacymodeConfiguration.getPort() );
-        final int legacymodeReadBuffer       = ParamUtils.getIntParameter( request, "legacymode-readBuffer", legacymodeConfiguration.getMaxBufferSize() );
-        final String legacymodeMutualAuthenticationText = ParamUtils.getParameter( request, "legacymode-mutualauthentication", true );
-        final Connection.ClientAuth legacymodeMutualAuthentication;
-        if ( legacymodeMutualAuthenticationText == null || legacymodeMutualAuthenticationText.isEmpty() ) {
-            legacymodeMutualAuthentication = legacymodeConfiguration.getClientAuth();
-        } else {
-            legacymodeMutualAuthentication = Connection.ClientAuth.valueOf( legacymodeMutualAuthenticationText );
-        }
-        final int legacymodeListenerMaxThreads = ParamUtils.getIntParameter( request, "legacymode-maxThreads", legacymodeConfiguration.getMaxThreadPoolSize() );
-        final boolean legacymodeAcceptSelfSignedCertificates = ParamUtils.getBooleanParameter( request, "legacymode-accept-self-signed-certificates" );
-        final boolean legacymodeVerifyCertificateValidity = ParamUtils.getBooleanParameter( request, "legacymode-verify-certificate-validity" );
 
         // Apply
         final ConnectionListener plaintextListener  = manager.getListener( connectionType, false );
@@ -74,23 +45,11 @@
 
         plaintextListener.enable( plaintextEnabled );
         plaintextListener.setPort( plaintextTcpPort );
-        // TODO: plaintextListener.setMaxBufferSize( plaintextReadBuffer );
-        plaintextListener.setTLSPolicy( plaintextTlsPolicy );
-        plaintextListener.setClientAuth( plaintextMutualAuthentication );
-        // TODO: plaintextListener.setMaxThreadPoolSize( plaintextListenerMaxThreads);
-        plaintextListener.setAcceptSelfSignedCertificates( plaintextAcceptSelfSignedCertificates );
-        plaintextListener.setVerifyCertificateValidity( plaintextVerifyCertificateValidity );
-
         legacymodeListener.enable( legacymodeEnabled );
         legacymodeListener.setPort( legacymodeTcpPort );
-        // TODO: legacymodeListener.setMaxBufferSize( legacymodeReadBuffer );
-        legacymodeListener.setClientAuth( legacymodeMutualAuthentication );
-        // TODO:  legacymodeListener.setMaxThreadPoolSize( legacymodeListenerMaxThreads);
-        legacymodeListener.setAcceptSelfSignedCertificates( legacymodeAcceptSelfSignedCertificates );
-        legacymodeListener.setVerifyCertificateValidity( legacymodeVerifyCertificateValidity );
 
         // Log the event
-        webManager.logEvent( "Updated connection settings for " + connectionType, "Applied configuration to plain-text as well as legacy-mode connection listeners." );
+        webManager.logEvent( "Updated connection settings for " + connectionType, "plain: enabled=" + plaintextEnabled + ", port=" + plaintextTcpPort + "\nlegacy: enabled=" + legacymodeEnabled+ ", port=" + legacymodeTcpPort+ "\n" );
         response.sendRedirect( "connection-settings-external-components.jsp?success=true" );
         return;
     }
@@ -307,105 +266,16 @@
 
         <table cellpadding="3" cellspacing="0" border="0">
             <tr valign="middle">
-                <td>
-                    <input type="checkbox" name="plaintext-enabled" id="plaintext-enabled" onclick="applyDisplayable('plaintext')" ${plaintextConfiguration.enabled ? 'checked' : ''}/><label for="plaintext-enabled">Enabled</label>
-                </td>
+                <td colspan="2"><input type="checkbox" name="plaintext-enabled" id="plaintext-enabled" onclick="applyDisplayable('plaintext')" ${plaintextConfiguration.enabled ? 'checked' : ''}/><label for="plaintext-enabled">Enabled</label></td>
+            </tr>
+            <tr valign="middle">
+                <td width="1%" nowrap><label for="plaintext-tcpPort">Port number</label></td>
+                <td width="99%"><input type="text" name="plaintext-tcpPort" id="plaintext-tcpPort" value="${plaintextConfiguration.port}"/></td>
+            </tr>
+            <tr valign="middle">
+                <td colspan="2"><a href="./connection-settings-advanced.jsp?connectionType=COMPONENT&connectionMode=plain"><fmt:message key="ssl.settings.client.label_custom_info"/>...</a></td>
             </tr>
         </table>
-
-        <div id="plaintext-config">
-
-            <br/>
-
-            <h4>TCP settings</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="plaintext-tcpPort">Port number</label></td>
-                    <td width="99%"><input type="text" name="plaintext-tcpPort" id="plaintext-tcpPort" value="${plaintextConfiguration.port}"/></td>
-                </tr>
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="plaintext-readBuffer">Read buffer</label></td>
-                    <td width="99%"><input type="text" name="plaintext-readBuffer" id="plaintext-readBuffer" value="${plaintextConfiguration.maxBufferSize}" readonly/> (in bytes)</td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>STARTTLS policy</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-tlspolicy" value="disabled" id="plaintext-tlspolicy-disabled" ${plaintextConfiguration.tlsPolicy.name() eq 'disabled' ? 'checked' : ''}/>
-                        <label for="plaintext-tlspolicy-disabled"><b>Disabled</b> - Encryption is not allowed.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-tlspolicy" value="optional" id="plaintext-tlspolicy-optional" ${plaintextConfiguration.tlsPolicy.name() eq 'optional' ? 'checked' : ''}/>
-                        <label for="plaintext-tlspolicy-optional"><b>Optional</b> - Encryption may be used, but is not required.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-tlspolicy" value="required" id="plaintext-tlspolicy-required" ${plaintextConfiguration.tlsPolicy.name() eq 'required' ? 'checked' : ''}/>
-                        <label for="plaintext-tlspolicy-required"><b>Required</b> - Connections cannot be established unless they are encrypted.</label>
-                    </td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Mutual Authentication</h4>
-            <p>In addition to requiring peers to use encryption (which will force them to verify the security certificates of this Openfire instance) an additional level of security can be enabled. With this option, the server can be configured to verify certificates that are to be provided by the peers. This is commonly referred to as 'mutual authentication'.</p>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-mutualauthentication" value="disabled" id="plaintext-mutualauthentication-disabled" ${plaintextConfiguration.clientAuth.name() eq 'disabled' ? 'checked' : ''}/>
-                        <label for="plaintext-mutualauthentication-disabled"><b>Disabled</b> - Peer certificates are not verified.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-mutualauthentication" value="wanted" id="plaintext-mutualauthentication-wanted" ${plaintextConfiguration.clientAuth.name() eq 'wanted' ? 'checked' : ''}/>
-                        <label for="plaintext-mutualauthentication-wanted"><b>Wanted</b> - Peer certificates are verified, but only when they are presented by the peer.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-mutualauthentication" value="needed" id="plaintext-mutualauthentication-needed" ${plaintextConfiguration.clientAuth.name() eq 'needed' ? 'checked' : ''}/>
-                        <label for="plaintext-mutualauthentication-needed"><b>Needed</b> - A connection cannot be established if the peer does not present a valid certificate.</label>
-                    </td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Certificate chain checking</h4>
-            <p>These options configure some aspects of the verification/validation of the certificates that are presented by peers while setting up encrypted connections.</p>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td>
-                        <input type="checkbox" name="plaintext-accept-self-signed-certificates" id="plaintext-accept-self-signed-certificates" ${plaintextConfiguration.acceptSelfSignedCertificates ? 'checked' : ''}/><label for="plaintext-accept-self-signed-certificates">Allow peer certificates to be self-signed.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="checkbox" name="plaintext-verify-certificate-validity" id="plaintext-verify-certificate-validity" ${plaintextConfiguration.verifyCertificateValidity ? 'checked' : ''}/><label for="plaintext-verify-certificate-validity">Verify that the certificate is currently valid (based on the 'notBefore' and 'notAfter' values of the certificate).</label>
-                    </td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Miscellaneous settings</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="plaintext-maxThreads">Maximum worker threads</label></td>
-                    <td width="99%"><input type="text" name="plaintext-maxThreads" id="plaintext-maxThreads" value="${plaintextConfiguration.maxThreadPoolSize}" readonly/></td>
-                </tr>
-            </table>
-
-        </div>
 
     </admin:contentBox>
 
@@ -415,79 +285,16 @@
 
         <table cellpadding="3" cellspacing="0" border="0">
             <tr valign="middle">
-                <td><input type="checkbox" name="legacymode-enabled" id="legacymode-enabled" onclick="applyDisplayable('legacymode')" ${legacymodeConfiguration.enabled ? 'checked' : ''}/><label for="legacymode-enabled">Enabled</label></td>
+                <td colspan="2"><input type="checkbox" name="legacymode-enabled" id="legacymode-enabled" onclick="applyDisplayable('legacymode')" ${legacymodeConfiguration.enabled ? 'checked' : ''}/><label for="legacymode-enabled">Enabled</label></td>
+            </tr>
+            <tr valign="middle">
+                <td width="1%" nowrap><label for="legacymode-tcpPort">Port number</label></td>
+                <td width="99%"><input type="text" name="legacymode-tcpPort" id="legacymode-tcpPort" value="${legacymodeConfiguration.port}"></td>
+            </tr>
+            <tr valign="middle">
+                <td colspan="2"><a href="./connection-settings-advanced.jsp?connectionType=COMPONENT&connectionMode=legacy"><fmt:message key="ssl.settings.client.label_custom_info"/>...</a></td>
             </tr>
         </table>
-
-        <div id="legacymode-config">
-
-            <br/>
-
-            <h4>TCP settings</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="legacymode-tcpPort">Port number</label></td>
-                    <td width="99%"><input type="text" name="legacymode-tcpPort" id="legacymode-tcpPort" value="${legacymodeConfiguration.port}"></td>
-                </tr>
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="legacymode-readBuffer">Read buffer</label></td>
-                    <td width="99%"><input type="text" name="legacymode-readBuffer" id="legacymode-readBuffer" value="${legacymodeConfiguration.maxBufferSize}" readonly/> (in bytes)</td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Mutual Authentication</h4>
-            <p>In addition to requiring peers to use encryption (which will force them to verify the security certificates of this Openfire instance) an additional level of security can be enabled. With this option, the server can be configured to verify certificates that are to be provided by the peers. This is commonly referred to as 'mutual authentication'.</p>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="legacymode-mutualauthentication" value="disabled" id="legacymode-mutualauthentication-disabled" ${legacymodeConfiguration.clientAuth.name() eq 'disabled' ? 'checked' : ''}/>
-                        <label for="legacymode-mutualauthentication-disabled"><b>Disabled</b> - Peer certificates are not verified.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="legacymode-mutualauthentication" value="wanted" id="legacymode-mutualauthentication-wanted" ${legacymodeConfiguration.clientAuth.name() eq 'optional' ? 'checked' : ''}/>
-                        <label for="legacymode-mutualauthentication-wanted"><b>Wanted</b> - Peer certificates are verified, but only when they are presented by the peer.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="legacymode-mutualauthentication" value="needed" id="legacymode-mutualauthentication-needed" ${legacymodeConfiguration.clientAuth.name() eq 'required' ? 'checked' : ''}/>
-                        <label for="legacymode-mutualauthentication-needed"><b>Needed</b> - A connection cannot be established if the peer does not present a valid certificate.</label>
-                    </td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Certificate chain checking</h4>
-            <p>These options configure some aspects of the verification/validation of the certificates that are presented by peers while setting up encrypted connections.</p>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td>
-                        <input type="checkbox" name="legacymode-accept-self-signed-certificates" id="legacymode-accept-self-signed-certificates" ${legacymodeConfiguration.acceptSelfSignedCertificates ? 'checked' : ''}/><label for="legacymode-accept-self-signed-certificates">Allow peer certificates to be self-signed.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="checkbox" name="legacymode-verify-certificate-validity" id="legacymode-verify-certificate-validity" ${legacymodeConfiguration.verifyCertificateValidity ? 'checked' : ''}/><label for="legacymode-verify-certificate-validity">Verify that the certificate is currently valid (based on the 'notBefore' and 'notAfter' values of the certificate).</label>
-                    </td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Miscellaneous settings</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="legacymode-maxThreads">Maximum worker threads</label></td>
-                    <td width="99%"><input type="text" name="legacymode-maxThreads" id="legacymode-maxThreads" value="${legacymodeConfiguration.maxThreadPoolSize}" readonly/></td>
-                </tr>
-            </table>
-
-        </div>
 
     </admin:contentBox>
 

--- a/src/web/connection-settings-socket-c2s.jsp
+++ b/src/web/connection-settings-socket-c2s.jsp
@@ -4,7 +4,6 @@
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionListener" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
-<%@ page import="org.jivesoftware.openfire.Connection" %>
 <%@ page import="org.jivesoftware.util.JiveGlobals" %>
 <%@ page import="org.jivesoftware.openfire.session.ConnectionSettings" %>
 <%@ page import="java.util.HashMap" %>
@@ -31,39 +30,10 @@
         // plaintext
         final boolean plaintextEnabled      = ParamUtils.getBooleanParameter( request, "plaintext-enabled" );
         final int plaintextTcpPort          = ParamUtils.getIntParameter( request, "plaintext-tcpPort", plaintextConfiguration.getPort() );
-        final int plaintextReadBuffer       = ParamUtils.getIntParameter( request, "plaintext-readBuffer", plaintextConfiguration.getMaxBufferSize() );
-        final String plaintextTlsPolicyText = ParamUtils.getParameter( request, "plaintext-tlspolicy", true );
-        final Connection.TLSPolicy plaintextTlsPolicy;
-        if ( plaintextTlsPolicyText == null || plaintextTlsPolicyText.isEmpty() ) {
-            plaintextTlsPolicy = plaintextConfiguration.getTlsPolicy();
-        } else {
-            plaintextTlsPolicy = Connection.TLSPolicy.valueOf( plaintextTlsPolicyText );
-        }
-        final String plaintextMutualAuthenticationText = ParamUtils.getParameter( request, "plaintext-mutualauthentication", true );
-        final Connection.ClientAuth plaintextMutualAuthentication;
-        if ( plaintextMutualAuthenticationText == null || plaintextMutualAuthenticationText.isEmpty() ) {
-            plaintextMutualAuthentication = plaintextConfiguration.getClientAuth();
-        } else {
-            plaintextMutualAuthentication = Connection.ClientAuth.valueOf( plaintextMutualAuthenticationText );
-        }
-        final int plaintextListenerMaxThreads = ParamUtils.getIntParameter( request, "plaintext-maxThreads", plaintextConfiguration.getMaxThreadPoolSize() );
-        final boolean plaintextAcceptSelfSignedCertificates = ParamUtils.getBooleanParameter( request, "plaintext-accept-self-signed-certificates" );
-        final boolean plaintextVerifyCertificateValidity = ParamUtils.getBooleanParameter( request, "plaintext-verify-certificate-validity" );
 
         // legacymode
         final boolean legacymodeEnabled      = ParamUtils.getBooleanParameter( request, "legacymode-enabled" );
         final int legacymodeTcpPort          = ParamUtils.getIntParameter( request, "legacymode-tcpPort", legacymodeConfiguration.getPort() );
-        final int legacymodeReadBuffer       = ParamUtils.getIntParameter( request, "legacymode-readBuffer", legacymodeConfiguration.getMaxBufferSize() );
-        final String legacymodeMutualAuthenticationText = ParamUtils.getParameter( request, "legacymode-mutualauthentication", true );
-        final Connection.ClientAuth legacymodeMutualAuthentication;
-        if ( legacymodeMutualAuthenticationText == null || legacymodeMutualAuthenticationText.isEmpty() ) {
-            legacymodeMutualAuthentication = legacymodeConfiguration.getClientAuth();
-        } else {
-            legacymodeMutualAuthentication = Connection.ClientAuth.valueOf( legacymodeMutualAuthenticationText );
-        }
-        final int legacymodeListenerMaxThreads = ParamUtils.getIntParameter( request, "legacymode-maxThreads", legacymodeConfiguration.getMaxThreadPoolSize() );
-        final boolean legacymodeAcceptSelfSignedCertificates = ParamUtils.getBooleanParameter( request, "legacymode-accept-self-signed-certificates" );
-        final boolean legacymodeVerifyCertificateValidity = ParamUtils.getBooleanParameter( request, "legacymode-verify-certificate-validity" );
 
         // Apply
         final ConnectionListener plaintextListener  = manager.getListener( connectionType, false );
@@ -71,23 +41,12 @@
 
         plaintextListener.enable( plaintextEnabled );
         plaintextListener.setPort( plaintextTcpPort );
-        // TODO: plaintextListener.setMaxBufferSize( plaintextReadBuffer );
-        plaintextListener.setTLSPolicy( plaintextTlsPolicy );
-        plaintextListener.setClientAuth( plaintextMutualAuthentication );
-        // TODO: plaintextListener.setMaxThreadPoolSize( plaintextListenerMaxThreads);
-        plaintextListener.setAcceptSelfSignedCertificates( plaintextAcceptSelfSignedCertificates );
-        plaintextListener.setVerifyCertificateValidity( plaintextVerifyCertificateValidity );
 
         legacymodeListener.enable( legacymodeEnabled );
         legacymodeListener.setPort( legacymodeTcpPort );
-        // TODO: legacymodeListener.setMaxBufferSize( legacymodeReadBuffer );
-        legacymodeListener.setClientAuth( legacymodeMutualAuthentication );
-        // TODO:  legacymodeListener.setMaxThreadPoolSize( legacymodeListenerMaxThreads);
-        legacymodeListener.setAcceptSelfSignedCertificates( legacymodeAcceptSelfSignedCertificates );
-        legacymodeListener.setVerifyCertificateValidity( legacymodeVerifyCertificateValidity );
 
         // Log the event
-        webManager.logEvent( "Updated connection settings for " + connectionType, "Applied configuration to plain-text as well as legacy-mode connection listeners." );
+        webManager.logEvent( "Updated connection settings for " + connectionType, "plain: enabled=" + plaintextEnabled + ", port=" + plaintextTcpPort + "\nlegacy: enabled=" + legacymodeEnabled+ ", port=" + legacymodeTcpPort+ "\n" );
         response.sendRedirect( "connection-settings-socket-c2s.jsp?success=true" );
 
 
@@ -174,105 +133,16 @@
 
         <table cellpadding="3" cellspacing="0" border="0">
             <tr valign="middle">
-                <td>
-                    <input type="checkbox" name="plaintext-enabled" id="plaintext-enabled" onclick="applyDisplayable('plaintext')" ${plaintextConfiguration.enabled ? 'checked' : ''}/><label for="plaintext-enabled">Enabled</label>
-                </td>
+                <td colspan="2"><input type="checkbox" name="plaintext-enabled" id="plaintext-enabled" onclick="applyDisplayable('plaintext')" ${plaintextConfiguration.enabled ? 'checked' : ''}/><label for="plaintext-enabled">Enabled</label></td>
+            </tr>
+            <tr valign="middle">
+                <td width="1%" nowrap><label for="plaintext-tcpPort">Port number</label></td>
+                <td width="99%"><input type="text" name="plaintext-tcpPort" id="plaintext-tcpPort" value="${plaintextConfiguration.port}"/></td>
+            </tr>
+            <tr valign="middle">
+                <td colspan="2"><a href="./connection-settings-advanced.jsp?connectionType=SOCKET_C2S&connectionMode=plain"><fmt:message key="ssl.settings.client.label_custom_info"/>...</a></td>
             </tr>
         </table>
-
-        <div id="plaintext-config">
-
-            <br/>
-
-            <h4>TCP settings</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="plaintext-tcpPort">Port number</label></td>
-                    <td width="99%"><input type="text" name="plaintext-tcpPort" id="plaintext-tcpPort" value="${plaintextConfiguration.port}"/></td>
-                </tr>
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="plaintext-readBuffer">Read buffer</label></td>
-                    <td width="99%"><input type="text" name="plaintext-readBuffer" id="plaintext-readBuffer" value="${plaintextConfiguration.maxBufferSize}" readonly/> (in bytes)</td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>STARTTLS policy</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-tlspolicy" value="disabled" id="plaintext-tlspolicy-disabled" ${plaintextConfiguration.tlsPolicy.name() eq 'disabled' ? 'checked' : ''}/>
-                        <label for="plaintext-tlspolicy-disabled"><b>Disabled</b> - Encryption is not allowed.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-tlspolicy" value="optional" id="plaintext-tlspolicy-optional" ${plaintextConfiguration.tlsPolicy.name() eq 'optional' ? 'checked' : ''}/>
-                        <label for="plaintext-tlspolicy-optional"><b>Optional</b> - Encryption may be used, but is not required.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-tlspolicy" value="required" id="plaintext-tlspolicy-required" ${plaintextConfiguration.tlsPolicy.name() eq 'required' ? 'checked' : ''}/>
-                        <label for="plaintext-tlspolicy-required"><b>Required</b> - Connections cannot be established unless they are encrypted.</label>
-                    </td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Mutual Authentication</h4>
-            <p>In addition to requiring peers to use encryption (which will force them to verify the security certificates of this Openfire instance) an additional level of security can be enabled. With this option, the server can be configured to verify certificates that are to be provided by the peers. This is commonly referred to as 'mutual authentication'.</p>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-mutualauthentication" value="disabled" id="plaintext-mutualauthentication-disabled" ${plaintextConfiguration.clientAuth.name() eq 'disabled' ? 'checked' : ''}/>
-                        <label for="plaintext-mutualauthentication-disabled"><b>Disabled</b> - Peer certificates are not verified.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-mutualauthentication" value="wanted" id="plaintext-mutualauthentication-wanted" ${plaintextConfiguration.clientAuth.name() eq 'wanted' ? 'checked' : ''}/>
-                        <label for="plaintext-mutualauthentication-wanted"><b>Wanted</b> - Peer certificates are verified, but only when they are presented by the peer.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="plaintext-mutualauthentication" value="needed" id="plaintext-mutualauthentication-needed" ${plaintextConfiguration.clientAuth.name() eq 'needed' ? 'checked' : ''}/>
-                        <label for="plaintext-mutualauthentication-needed"><b>Needed</b> - A connection cannot be established if the peer does not present a valid certificate.</label>
-                    </td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Certificate chain checking</h4>
-            <p>These options configure some aspects of the verification/validation of the certificates that are presented by peers while setting up encrypted connections.</p>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td>
-                        <input type="checkbox" name="plaintext-accept-self-signed-certificates" id="plaintext-accept-self-signed-certificates" ${plaintextConfiguration.acceptSelfSignedCertificates ? 'checked' : ''}/><label for="plaintext-accept-self-signed-certificates">Allow peer certificates to be self-signed.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="checkbox" name="plaintext-verify-certificate-validity" id="plaintext-verify-certificate-validity" ${plaintextConfiguration.verifyCertificateValidity ? 'checked' : ''}/><label for="plaintext-verify-certificate-validity">Verify that the certificate is currently valid (based on the 'notBefore' and 'notAfter' values of the certificate).</label>
-                    </td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Miscellaneous settings</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="plaintext-maxThreads">Maximum worker threads</label></td>
-                    <td width="99%"><input type="text" name="plaintext-maxThreads" id="plaintext-maxThreads" value="${plaintextConfiguration.maxThreadPoolSize}" readonly/></td>
-                </tr>
-            </table>
-
-        </div>
 
     </admin:contentBox>
 
@@ -282,79 +152,16 @@
 
         <table cellpadding="3" cellspacing="0" border="0">
             <tr valign="middle">
-                <td><input type="checkbox" name="legacymode-enabled" id="legacymode-enabled" onclick="applyDisplayable('legacymode')" ${legacymodeConfiguration.enabled ? 'checked' : ''}/><label for="legacymode-enabled">Enabled</label></td>
+                <td colspan="2"><input type="checkbox" name="legacymode-enabled" id="legacymode-enabled" onclick="applyDisplayable('legacymode')" ${legacymodeConfiguration.enabled ? 'checked' : ''}/><label for="legacymode-enabled">Enabled</label></td>
+            </tr>
+            <tr valign="middle">
+                <td width="1%" nowrap><label for="legacymode-tcpPort">Port number</label></td>
+                <td width="99%"><input type="text" name="legacymode-tcpPort" id="legacymode-tcpPort" value="${legacymodeConfiguration.port}"></td>
+            </tr>
+            <tr valign="middle">
+                <td colspan="2"><a href="./connection-settings-advanced.jsp?connectionType=SOCKET_C2S&connectionMode=legacy"><fmt:message key="ssl.settings.client.label_custom_info"/>...</a></td>
             </tr>
         </table>
-
-        <div id="legacymode-config">
-
-            <br/>
-
-            <h4>TCP settings</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="legacymode-tcpPort">Port number</label></td>
-                    <td width="99%"><input type="text" name="legacymode-tcpPort" id="legacymode-tcpPort" value="${legacymodeConfiguration.port}"></td>
-                </tr>
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="legacymode-readBuffer">Read buffer</label></td>
-                    <td width="99%"><input type="text" name="legacymode-readBuffer" id="legacymode-readBuffer" value="${legacymodeConfiguration.maxBufferSize}" readonly/> (in bytes)</td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Mutual Authentication</h4>
-            <p>In addition to requiring peers to use encryption (which will force them to verify the security certificates of this Openfire instance) an additional level of security can be enabled. With this option, the server can be configured to verify certificates that are to be provided by the peers. This is commonly referred to as 'mutual authentication'.</p>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="legacymode-mutualauthentication" value="disabled" id="legacymode-mutualauthentication-disabled" ${legacymodeConfiguration.clientAuth.name() eq 'disabled' ? 'checked' : ''}/>
-                        <label for="legacymode-mutualauthentication-disabled"><b>Disabled</b> - Peer certificates are not verified.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="legacymode-mutualauthentication" value="wanted" id="legacymode-mutualauthentication-wanted" ${legacymodeConfiguration.clientAuth.name() eq 'optional' ? 'checked' : ''}/>
-                        <label for="legacymode-mutualauthentication-wanted"><b>Wanted</b> - Peer certificates are verified, but only when they are presented by the peer.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="radio" name="legacymode-mutualauthentication" value="needed" id="legacymode-mutualauthentication-needed" ${legacymodeConfiguration.clientAuth.name() eq 'required' ? 'checked' : ''}/>
-                        <label for="legacymode-mutualauthentication-needed"><b>Needed</b> - A connection cannot be established if the peer does not present a valid certificate.</label>
-                    </td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Certificate chain checking</h4>
-            <p>These options configure some aspects of the verification/validation of the certificates that are presented by peers while setting up encrypted connections.</p>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td>
-                        <input type="checkbox" name="legacymode-accept-self-signed-certificates" id="legacymode-accept-self-signed-certificates" ${legacymodeConfiguration.acceptSelfSignedCertificates ? 'checked' : ''}/><label for="legacymode-accept-self-signed-certificates">Allow peer certificates to be self-signed.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="checkbox" name="legacymode-verify-certificate-validity" id="legacymode-verify-certificate-validity" ${legacymodeConfiguration.verifyCertificateValidity ? 'checked' : ''}/><label for="legacymode-verify-certificate-validity">Verify that the certificate is currently valid (based on the 'notBefore' and 'notAfter' values of the certificate).</label>
-                    </td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Miscellaneous settings</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="legacymode-maxThreads">Maximum worker threads</label></td>
-                    <td width="99%"><input type="text" name="legacymode-maxThreads" id="legacymode-maxThreads" value="${legacymodeConfiguration.maxThreadPoolSize}" readonly/></td>
-                </tr>
-            </table>
-
-        </div>
 
     </admin:contentBox>
 

--- a/src/web/connection-settings-socket-s2s.jsp
+++ b/src/web/connection-settings-socket-s2s.jsp
@@ -4,7 +4,6 @@
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionListener" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
-<%@ page import="org.jivesoftware.openfire.Connection" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="org.jivesoftware.openfire.server.RemoteServerManager" %>
@@ -21,8 +20,7 @@
     final ConnectionType connectionType = ConnectionType.SOCKET_S2S;
     final ConnectionManagerImpl manager = (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager();
 
-//    final ConnectionConfiguration plaintextConfiguration  = manager.getListener( connectionType, false ).generateConnectionConfiguration();
-    final ConnectionConfiguration legacymodeConfiguration = manager.getListener( connectionType, true  ).generateConnectionConfiguration();
+    final ConnectionConfiguration plaintextConfiguration  = manager.getListener( connectionType, false ).generateConnectionConfiguration();
 
     final boolean update = request.getParameter( "update" ) != null;
     final boolean closeSettings = request.getParameter( "closeSettings" ) != null;
@@ -35,71 +33,17 @@
     if ( update && errors.isEmpty() )
     {
         // plaintext
-//        final boolean plaintextEnabled = ParamUtils.getBooleanParameter( request, "plaintext-enabled" );
-//        final int plaintextTcpPort = ParamUtils.getIntParameter( request, "plaintext-tcpPort", plaintextConfiguration.getPort() );
-//        final int plaintextReadBuffer = ParamUtils.getIntParameter( request, "plaintext-readBuffer", plaintextConfiguration.getMaxBufferSize() );
-//        final String plaintextTlsPolicyText = ParamUtils.getParameter( request, "plaintext-tlspolicy", true );
-//        final Connection.TLSPolicy plaintextTlsPolicy;
-//        if ( plaintextTlsPolicyText == null || plaintextTlsPolicyText.isEmpty() )
-//        {
-//            plaintextTlsPolicy = plaintextConfiguration.getTlsPolicy();
-//        }
-//        else
-//        {
-//            plaintextTlsPolicy = Connection.TLSPolicy.valueOf( plaintextTlsPolicyText );
-//        }
-//        final String plaintextMutualAuthenticationText = ParamUtils.getParameter( request, "plaintext-mutualauthentication", true );
-//        final Connection.ClientAuth plaintextMutualAuthentication;
-//        if ( plaintextMutualAuthenticationText == null || plaintextMutualAuthenticationText.isEmpty() )
-//        {
-//            plaintextMutualAuthentication = plaintextConfiguration.getClientAuth();
-//        }
-//        else
-//        {
-//            plaintextMutualAuthentication = Connection.ClientAuth.valueOf( plaintextMutualAuthenticationText );
-//        }
-//        final int plaintextListenerMaxThreads = ParamUtils.getIntParameter( request, "plaintext-maxThreads", plaintextConfiguration.getMaxThreadPoolSize() );
-
-        // legacymode
-        final boolean legacymodeEnabled = ParamUtils.getBooleanParameter( request, "legacymode-enabled" );
-        final int legacymodeTcpPort = ParamUtils.getIntParameter( request, "legacymode-tcpPort", legacymodeConfiguration.getPort() );
-        final int legacymodeReadBuffer = ParamUtils.getIntParameter( request, "legacymode-readBuffer", legacymodeConfiguration.getMaxBufferSize() );
-        final String legacymodeMutualAuthenticationText = ParamUtils.getParameter( request, "legacymode-mutualauthentication", true );
-        final Connection.ClientAuth legacymodeMutualAuthentication;
-        final boolean legacymodeAcceptSelfSignedCertificates = ParamUtils.getBooleanParameter( request, "legacymode-accept-self-signed-certificates" );
-        final boolean legacymodeVerifyCertificateValidity = ParamUtils.getBooleanParameter( request, "legacymode-verify-certificate-validity" );
-
-        if ( legacymodeMutualAuthenticationText == null || legacymodeMutualAuthenticationText.isEmpty() )
-        {
-            legacymodeMutualAuthentication = legacymodeConfiguration.getClientAuth();
-        }
-        else
-        {
-            legacymodeMutualAuthentication = Connection.ClientAuth.valueOf( legacymodeMutualAuthenticationText );
-        }
-        final int legacymodeListenerMaxThreads = ParamUtils.getIntParameter( request, "legacymode-maxThreads", legacymodeConfiguration.getMaxThreadPoolSize() );
+        final boolean plaintextEnabled = ParamUtils.getBooleanParameter( request, "plaintext-enabled" );
+        final int plaintextTcpPort = ParamUtils.getIntParameter( request, "plaintext-tcpPort", plaintextConfiguration.getPort() );
 
         // Apply
-//        final ConnectionListener plaintextListener = manager.getListener( connectionType, false );
-        final ConnectionListener legacymodeListener = manager.getListener( connectionType, true );
+        final ConnectionListener plaintextListener = manager.getListener( connectionType, false );
 
-//        plaintextListener.enable( plaintextEnabled );
-//        plaintextListener.setPort( plaintextTcpPort );
-//        // TODO: plaintextListener.setMaxBufferSize( plaintextReadBuffer );
-//        plaintextListener.setTLSPolicy( plaintextTlsPolicy );
-//        plaintextListener.setClientAuth( plaintextMutualAuthentication );
-//        // TODO: plaintextListener.setMaxThreadPoolSize( plaintextListenerMaxThreads);
-
-        legacymodeListener.enable( legacymodeEnabled );
-        legacymodeListener.setPort( legacymodeTcpPort );
-        // TODO: legacymodeListener.setMaxBufferSize( legacymodeReadBuffer );
-        legacymodeListener.setClientAuth( legacymodeMutualAuthentication );
-        // TODO:  legacymodeListener.setMaxThreadPoolSize( legacymodeListenerMaxThreads);
-        legacymodeListener.setAcceptSelfSignedCertificates( legacymodeAcceptSelfSignedCertificates );
-        legacymodeListener.setVerifyCertificateValidity( legacymodeVerifyCertificateValidity );
+        plaintextListener.enable( plaintextEnabled );
+        plaintextListener.setPort( plaintextTcpPort );
 
         // Log the event
-        webManager.logEvent( "Updated connection settings for " + connectionType, "Applied configuration to legacy-mode connection listener." );
+        webManager.logEvent( "Updated connection settings for " + connectionType, "plain: enabled=" + plaintextEnabled + ", port=" + plaintextTcpPort);
         response.sendRedirect( "connection-settings-socket-s2s.jsp?success=update" );
     }
     else if ( closeSettings && errors.isEmpty() )
@@ -234,8 +178,7 @@
     }
 
     pageContext.setAttribute( "errors",                  errors );
-    //pageContext.setAttribute( "plaintextConfiguration",  plaintextConfiguration );
-    pageContext.setAttribute( "legacymodeConfiguration", legacymodeConfiguration );
+    pageContext.setAttribute( "plaintextConfiguration",  plaintextConfiguration );
     // pageContext.setAttribute( "clientIdle",              JiveGlobals.getIntProperty(     ConnectionSettings.Client.IDLE_TIMEOUT,    6*60*1000 ) );
     // pageContext.setAttribute( "pingIdleClients",         JiveGlobals.getBooleanProperty( ConnectionSettings.Client.KEEP_ALIVE_PING, true) );
 
@@ -320,60 +263,22 @@
 
 <form action="connection-settings-socket-s2s.jsp" method="post">
 
-    <admin:contentBox title="Encrypted (legacy-mode) connections">
+    <admin:contentBox title="Plain-text (with STARTTLS) connections">
 
-        <p>Connections of this type are established using encryption immediately (as opposed to using STARTTLS). This type of connectivity is commonly referred to as the "legacy" method of establishing encrypted communications.</p>
+        <p>Openfire can accept plain-text connections, which, depending on the policy that is configured here, can be upgraded to encrypted connections (using the STARTTLS protocol).</p>
 
         <table cellpadding="3" cellspacing="0" border="0">
             <tr valign="middle">
-                <td><input type="checkbox" name="legacymode-enabled" id="legacymode-enabled" onclick="applyDisplayable('legacymode')" ${legacymodeConfiguration.enabled ? 'checked' : ''}/><label for="legacymode-enabled">Enabled</label></td>
+                <td colspan="2"><input type="checkbox" name="plaintext-enabled" id="plaintext-enabled" onclick="applyDisplayable('plaintext')" ${plaintextConfiguration.enabled ? 'checked' : ''}/><label for="plaintext-enabled">Enabled</label></td>
+            </tr>
+            <tr valign="middle">
+                <td width="1%" nowrap><label for="plaintext-tcpPort">Port number</label></td>
+                <td width="99%"><input type="text" name="plaintext-tcpPort" id="plaintext-tcpPort" value="${plaintextConfiguration.port}"/></td>
+            </tr>
+            <tr valign="middle">
+                <td colspan="2"><a href="./connection-settings-advanced.jsp?connectionType=SOCKET_S2S&connectionMode=plain"><fmt:message key="ssl.settings.client.label_custom_info"/>...</a></td>
             </tr>
         </table>
-
-        <div id="legacymode-config">
-
-            <br/>
-
-            <h4>TCP settings</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="legacymode-tcpPort">Port number</label></td>
-                    <td width="99%"><input type="text" name="legacymode-tcpPort" id="legacymode-tcpPort" value="${legacymodeConfiguration.port}"></td>
-                </tr>
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="legacymode-readBuffer">Read buffer</label></td>
-                    <td width="99%"><input type="text" name="legacymode-readBuffer" id="legacymode-readBuffer" value="${legacymodeConfiguration.maxBufferSize}" readonly/> (in bytes)</td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Certificate chain checking</h4>
-            <p>These options configure some aspects of the verification/validation of the certificates that are presented by peers while setting up encrypted connections.</p>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td>
-                        <input type="checkbox" name="legacymode-accept-self-signed-certificates" id="legacymode-accept-self-signed-certificates" ${legacymodeConfiguration.acceptSelfSignedCertificates ? 'checked' : ''}/><label for="legacymode-accept-self-signed-certificates">Allow peer certificates to be self-signed.</label>
-                    </td>
-                </tr>
-                <tr valign="middle">
-                    <td>
-                        <input type="checkbox" name="legacymode-verify-certificate-validity" id="legacymode-verify-certificate-validity" ${legacymodeConfiguration.verifyCertificateValidity ? 'checked' : ''}/><label for="legacymode-verify-certificate-validity">Verify that the certificate is currently valid (based on the 'notBefore' and 'notAfter' values of the certificate).</label>
-                    </td>
-                </tr>
-            </table>
-
-            <br/>
-
-            <h4>Miscellaneous settings</h4>
-            <table cellpadding="3" cellspacing="0" border="0">
-                <tr valign="middle">
-                    <td width="1%" nowrap><label for="legacymode-maxThreads">Maximum worker threads</label></td>
-                    <td width="99%"><input type="text" name="legacymode-maxThreads" id="legacymode-maxThreads" value="${legacymodeConfiguration.maxThreadPoolSize}" readonly/></td>
-                </tr>
-            </table>
-
-        </div>
 
     </admin:contentBox>
 


### PR DESCRIPTION
This pull request has two major changes:
1. The configuration of protocols and cipher suites now depends on one setting, instead of having both a 'enabled' as well as a 'disabled' list. As a side effect, this improves the default values, which up until this change were either to narrow (nothing) or to wide (every possible option was enabled). Now, the Java-configured default is used when no Openfire-specific setting is available.
2. Most of the TLS settings have been moved to an 'advanced settings' page on the Admin console. There, you can now also configure encryption protocols en cipher suites.