### PR TITLE
Making Travis happy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,11 @@ sudo: false
 language: java
 jdk:
   - oraclejdk8
-script: ant -Dhalt.on.plugin.error=true -f build/build.xml openfire test plugins
+env:
+  - ENVTARGET=compile
+  - ENVTARGET=test
+  - ENVTARGET=openfire
+  - ENVTARGET=plugins
+
+script: ant -Dhalt.on.plugin.error=true -f build/build.xml clean $ENVTARGET 
+

--- a/build/build.xml
+++ b/build/build.xml
@@ -215,6 +215,7 @@
 
     <patternset id="test.sources">
         <include name="**/*Test.java"/>
+        <exclude name="**/CheckChainTrustedTest.java" if="skipResourceIntensiveTests"/>
     </patternset>
 
     <patternset id="web.sources">

--- a/src/test/java/org/jivesoftware/openfire/keystore/CheckChainTrustedTest.java
+++ b/src/test/java/org/jivesoftware/openfire/keystore/CheckChainTrustedTest.java
@@ -16,7 +16,6 @@ import java.util.List;
  *
  * @author Guus der Kinderen, guus.der.kinderen@gmail.com
  */
-@Ignore // These tests make the continuous integration on GitHub (Travis) fail.
 @RunWith( Parameterized.class )
 public class CheckChainTrustedTest
 {


### PR DESCRIPTION
The Github-based CI server (Travis), tends to run out of resources quickly.
This commit adds a new optional flag that allows the build to skip tests that
are known to be resource intensive.
Example usage: ant -DskipResourceIntensiveTests=true clean test