### PR TITLE
OF-1010: Cannot re-init default SSLContext

### DIFF
--- a/src/java/org/jivesoftware/util/SimpleSSLSocketFactory.java
+++ b/src/java/org/jivesoftware/util/SimpleSSLSocketFactory.java
@@ -56,7 +56,7 @@ public class SimpleSSLSocketFactory extends SSLSocketFactory implements Comparat
     public SimpleSSLSocketFactory() {
 
         try {
-            final SSLContext sslContext = SSLContext.getDefault();
+            final SSLContext sslContext = SSLContext.getInstance("TLSv1");
             sslContext.init(null, // KeyManager not required
                             new TrustManager[] { new DummyTrustManager() },
                             new java.security.SecureRandom());


### PR DESCRIPTION
A default SSLContext object cannot be re-initialized. This causes LDAPS to fail.