### PR TITLE
Fix twice sending of messages (invite/decline) on route.really-all-resources=true and 	sendingInvitationRejection event to MUCEventDelegate

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/MUCEventDelegate.java
+++ b/src/java/org/jivesoftware/openfire/muc/MUCEventDelegate.java
@@ -36,6 +36,12 @@ public abstract class MUCEventDelegate {
         HANDLED_BY_OPENFIRE,
         REJECTED;
     }
+    
+    public enum InvitationRejectionResult {
+        HANDLED_BY_DELEGATE,
+        HANDLED_BY_OPENFIRE,
+    }
+
 
     /**
      * This event will be triggered when an entity joins an existing room.
@@ -60,7 +66,20 @@ public abstract class MUCEventDelegate {
      * @return true if the user is allowed to join the room.
      */
     public abstract InvitationResult sendingInvitation(MUCRoom room, JID inviteeJID, JID inviterJID, String inviteMessage);
-
+    
+    /**
+     * This event will be triggered when an entity reject invite from someone to a room.
+     *
+     * Returns a String indicating whether the invitation should be abandoned, handled by the delegate, or handled by openfire.
+     *
+     * @param room the MUC room.
+     * @param to the JID of the user the rejecting of invitation will be sent to.
+     * @param from the JID of the user that is sending the rejecting of invitation
+     * @param reason the (optional) message that is sent explaining the rejection invitation
+     * @return true if the user is allowed to join the room.
+     */
+    public abstract InvitationRejectionResult sendingInvitationRejection(MUCRoom room, JID to, JID from, String reason);
+    
     /**
      * Returns a map containing room configuration variables and values.
      *

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -2115,6 +2115,17 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
 
     @Override
     public void sendInvitationRejection(JID to, String reason, JID sender) {
+    	if (((MultiUserChatServiceImpl)mucService).getMUCDelegate() != null) {
+            switch(((MultiUserChatServiceImpl)mucService).getMUCDelegate().sendingInvitationRejection(this, to, sender, reason)) {
+                case HANDLED_BY_DELEGATE:
+                    //if the delegate is taking care of it, there's nothing for us to do
+                    return;
+                case HANDLED_BY_OPENFIRE:
+                    //continue as normal if we're asked to handle it
+                    break;
+            }
+        }
+        
         Message message = new Message();
         message.setFrom(role.getRoleAddress());
         message.setTo(to);

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -560,6 +560,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                 session.process(packet);
             }
         }
+        
+        if (JiveGlobals.getBooleanProperty("route.really-all-resources", false))
+        	return true;
 
         // Get the highest priority sessions for normal processing.
         List<ClientSession> highestPrioritySessions = getHighestPrioritySessions(nonNegativePrioritySessions);


### PR DESCRIPTION
If route.really-all-resources enabled it's not requere process message again via priority algorithm.
We already processed in 560 line. 
If we not stop (return) than session.process() call twice (first in line 560 and next in next other)