### PR TITLE
Fix twice sending of messages on route.really-all-resources=true

### DIFF
--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -560,6 +560,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                 session.process(packet);
             }
         }
+        
+        if (JiveGlobals.getBooleanProperty("route.really-all-resources", false))
+        	return true;
 
         // Get the highest priority sessions for normal processing.
         List<ClientSession> highestPrioritySessions = getHighestPrioritySessions(nonNegativePrioritySessions);


### PR DESCRIPTION
If route.really-all-resources enabled it's not requere process message again via priority algorithm.
We already processed in 560 line. 
If we not stop (return) than session.process() call twice (first in line 560 and next in next other)