### PR TITLE
MUC Invitation rejection delegate call

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/MUCEventDelegate.java
+++ b/src/java/org/jivesoftware/openfire/muc/MUCEventDelegate.java
@@ -34,8 +34,13 @@ public abstract class MUCEventDelegate {
     public enum InvitationResult {
         HANDLED_BY_DELEGATE,
         HANDLED_BY_OPENFIRE,
-        REJECTED;
-    }
+        REJECTED
+    };
+    
+    public enum InvitationRejectionResult {
+        HANDLED_BY_DELEGATE,
+        HANDLED_BY_OPENFIRE,
+    };
 
     /**
      * This event will be triggered when an entity joins an existing room.
@@ -60,6 +65,19 @@ public abstract class MUCEventDelegate {
      * @return true if the user is allowed to join the room.
      */
     public abstract InvitationResult sendingInvitation(MUCRoom room, JID inviteeJID, JID inviterJID, String inviteMessage);
+
+    /**
+     * This event will be triggered when an entity reject invite from someone to a room.
+     *
+     * Returns a String indicating whether the invitation should be abandoned, handled by the delegate, or handled by openfire.
+     *
+     * @param room the MUC room.
+     * @param to the JID of the user the rejecting of invitation will be sent to.
+     * @param from the JID of the user that is sending the rejecting of invitation
+     * @param reason the (optional) message that is sent explaining the rejection invitation
+     * @return true if the user is allowed to join the room.
+     */
+    public abstract InvitationRejectionResult sendingInvitationRejection(MUCRoom room, JID to, JID from, String reason);
 
     /**
      * Returns a map containing room configuration variables and values.

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -2115,6 +2115,17 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
 
     @Override
     public void sendInvitationRejection(JID to, String reason, JID sender) {
+	if (((MultiUserChatServiceImpl)mucService).getMUCDelegate() != null) {
+        	switch(((MultiUserChatServiceImpl)mucService).getMUCDelegate().sendingInvitationRejection(this, to, sender, reason)) {
+                	case HANDLED_BY_DELEGATE:
+                    	//if the delegate is taking care of it, there's nothing for us to do
+                    		return;
+                	case HANDLED_BY_OPENFIRE:
+                    	//continue as normal if we're asked to handle it
+                    		break;
+            	}
+        }
+
         Message message = new Message();
         message.setFrom(role.getRoleAddress());
         message.setTo(to);


### PR DESCRIPTION
Extend MUCEventDelegate by sendingInvitationRejection method similarly as sendingInvitation methods for thrid-party developers that impliment MUCEventDelegate for thrid-party MUC providers
