### PR TITLE
xml:lang in stream header should conform to a language tag.

### DIFF
--- a/src/java/org/jivesoftware/openfire/net/SocketReadingMode.java
+++ b/src/java/org/jivesoftware/openfire/net/SocketReadingMode.java
@@ -278,7 +278,7 @@ abstract class SocketReadingMode {
         sb.append("\" id=\"");
         sb.append(socketReader.session.getStreamID().toString());
         sb.append("\" xml:lang=\"");
-        sb.append(socketReader.session.getLanguage());
+        sb.append(socketReader.session.getLanguage().toLanguageTag());
         sb.append("\" version=\"");
         sb.append(Session.MAJOR_VERSION).append('.').append(Session.MINOR_VERSION);
         sb.append("\">");

--- a/src/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -580,7 +580,7 @@ public abstract class StanzaHandler {
         sb.append("\" id=\"");
         sb.append(session.getStreamID());
         sb.append("\" xml:lang=\"");
-        sb.append(session.getLanguage());
+        sb.append(session.getLanguage().toLanguageTag());
         sb.append("\" version=\"");
         sb.append(Session.MAJOR_VERSION).append('.').append(Session.MINOR_VERSION);
         sb.append("\">");

--- a/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -347,7 +347,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
         sb.append("\" id=\"");
         sb.append(session.getStreamID().toString());
         sb.append("\" xml:lang=\"");
-        sb.append(language);
+        sb.append(language.toLanguageTag());
         // Don't include version info if the version is 0.0.
         if (majorVersion != 0) {
             sb.append("\" version=\"");


### PR DESCRIPTION
toString() was called on the Locale here, resulting e.g. in "de_DE".
Instead it should be "de-DE".