### PR TITLE
solve the memory leak problems which is caused by add LocalMUCRoom ob…

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -45,6 +45,7 @@ import org.jivesoftware.openfire.disco.DiscoItem;
 import org.jivesoftware.openfire.disco.DiscoItemsProvider;
 import org.jivesoftware.openfire.disco.DiscoServerItem;
 import org.jivesoftware.openfire.disco.ServerItemsProvider;
+import org.jivesoftware.openfire.event.GroupEventDispatcher;
 import org.jivesoftware.openfire.group.ConcurrentGroupList;
 import org.jivesoftware.openfire.group.GroupAwareList;
 import org.jivesoftware.openfire.group.GroupJID;
@@ -676,6 +677,9 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
 
     private void removeChatRoom(String roomName, boolean notify) {
         MUCRoom room = rooms.remove(roomName);
+		Log.info("removing chat room:" + roomName + "|" + room.getClass().getName());
+		if (room instanceof LocalMUCRoom)
+			GroupEventDispatcher.removeListener((LocalMUCRoom) room);
         if (room != null) {
             totalChatTime += room.getChatLength();
             if (notify) {


### PR DESCRIPTION
LocalMUCRoom implements interface GroupEventListener and was add to listeners of GroupEventListener when constructed. But it is never removed from the listeners. According to the result of experiment, I do find that after a long time run ,openfire will consume a lot of memory.After analysed 
by MAT Tools, I find out that most of memory is consumed by the LocalMUCRoom object.Even user leave the room , it still cannot be reclaimed by GC.This will lead the result that each packet of workgroup will be broadcasted to all rooms in listeners. So, it should be removed from listeners when LocalMUCRoom is removed.
experiments has been done after I modified the code.Memory leak disappeared and GC can remove LocalMUCRoom objects which are destroyed.