### PR TITLE
WebSocket plugin: Fix wrong namespace adding to empty elements

### DIFF
--- a/src/plugins/websocket/src/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
+++ b/src/plugins/websocket/src/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
@@ -75,11 +75,17 @@ public class WebSocketConnection extends VirtualConnection
 	@Override
     public void deliver(Packet packet) throws UnauthorizedException
     {
-    	if (Namespace.NO_NAMESPACE.equals(packet.getElement().getNamespace())) {
-    		packet.getElement().add(Namespace.get(CLIENT_NAMESPACE));
-    	}
+        final String xml;
+        if (Namespace.NO_NAMESPACE.equals(packet.getElement().getNamespace())) {
+            // use string-based operation here to avoid cascading xmlns wonkery
+            StringBuilder packetXml = new StringBuilder(packet.toXML());
+            packetXml.insert(packetXml.indexOf(" "), " xmlns=\"jabber:client\"");
+            xml = packetXml.toString();
+        } else {
+            xml = packet.toXML();
+        }
     	if (validate()) {
-    		deliverRawText(packet.toXML());
+    		deliverRawText(xml);
     	} else {
     		// use fallback delivery mechanism (offline)
     		getPacketDeliverer().deliver(packet);


### PR DESCRIPTION
The old logic produced XML like:
&lt;presence xmlns="jabber:client" from="..." to="...">&lt;show xmlns="">xa&lt;/show>&lt;status xmlns=""/>&lt;/presence>

This is basically the same fix as in 6965c13.

Relates to OF-938.