### PR TITLE
Don't add multiple delayed delivery extension to resent messages.

### DIFF
--- a/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -178,9 +178,11 @@ public class StreamManager {
 					for (StreamManager.UnackedPacket unacked : unacknowledgedStanzas) {
 						if (unacked.packet instanceof Message) {
 							Message m = (Message) unacked.packet;
-							Element delayInformation = m.addChildElement("delay", "urn:xmpp:delay");
-							delayInformation.addAttribute("stamp", XMPPDateTimeFormat.format(unacked.timestamp));
-							delayInformation.addAttribute("from", serverAddress.toBareJID());
+							if (m.getExtension("delay", "urn:xmpp:delay") == null) {
+								Element delayInformation = m.addChildElement("delay", "urn:xmpp:delay");
+								delayInformation.addAttribute("stamp", XMPPDateTimeFormat.format(unacked.timestamp));
+								delayInformation.addAttribute("from", serverAddress.toBareJID());
+							}
 						}
 						router.route(unacked.packet);
 					}


### PR DESCRIPTION
The issue is that messages, which get resent from offline storage already have an older timestamp.

There should not be another delayed delivery extension, which "overwrites" the old one.

Messages looked like that:
&lt;message>&lt;body>...&lt;/body>&lt;delay xmlns="urn:xmpp:delay" stamp="2016-01-06T13:48:45.312Z">&lt;/delay>&lt;delay xmlns="urn:xmpp:delay" stamp="2016-01-06T13:49:56.674Z">&lt;/delay>&lt;/message>

Instead the original timestamp should be preserved.