### PR TITLE
OF-1033: Users should be notified of MUC service shutdown

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -60,10 +60,7 @@ import org.jivesoftware.openfire.muc.cluster.GetNumberConnectedUsers;
 import org.jivesoftware.openfire.muc.cluster.OccupantAddedEvent;
 import org.jivesoftware.openfire.muc.cluster.RoomAvailableEvent;
 import org.jivesoftware.openfire.muc.cluster.RoomRemovedEvent;
-import org.jivesoftware.util.JiveProperties;
-import org.jivesoftware.util.LocaleUtils;
-import org.jivesoftware.util.TaskEngine;
-import org.jivesoftware.util.XMPPDateTimeFormat;
+import org.jivesoftware.util.*;
 import org.jivesoftware.util.cache.CacheFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -488,7 +485,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         service.shutdown();
         try
         {
-            service.awaitTermination( 500, TimeUnit.MILLISECONDS );
+            service.awaitTermination( JiveGlobals.getIntProperty( "xmpp.muc.await-termination-millis", 500 ), TimeUnit.MILLISECONDS );
             Log.debug( "Successfully notified all {} local users about the imminent destruction of chat service '{}'", users.size(), chatServiceName );
         }
         catch ( InterruptedException e )


### PR DESCRIPTION
This commit notifies all users that are in a MUC on the local server node of
a shut down of the service. The notification conforms to XEP-0045.

In order to prevent a prolonged shut down, this commit:
- ensures that a shutdown routine is executed just once (instead of for each
  type of interface being shut down: module,component and listener)
- the presence stanza that is sent is constructed using in-memory objects
  only (no database lookups)
- all notification occurs in a thread pool, which will concurrently process
  them, but will terminate forcibly after a certain amount of time.