### PR TITLE
OF-821: Count occupants by nickname

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -512,7 +512,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
 
     @Override
     public int getOccupantsCount() {
-        return occupantsByFullJID.size();
+        return occupantsByNickname.size();
     }
 
     @Override


### PR DESCRIPTION
Returns the count of nicknames rather than the number of connections
(full JIDs), which will now also match the list of occupants.