### PR TITLE
Update plugin min Openfire version requirement to 4.0.0

### DIFF
--- a/src/plugins/clientControl/plugin.xml
+++ b/src/plugins/clientControl/plugin.xml
@@ -10,7 +10,7 @@
     <author>Jive Software</author>
     <version>1.3.1</version>
     <date>11/05/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>clientcontrol</databaseKey>
     <databaseVersion>0</databaseVersion>
 

--- a/src/plugins/clustering/plugin.xml
+++ b/src/plugins/clustering/plugin.xml
@@ -7,5 +7,5 @@
     <author>Jive Software</author>
     <version>1.4.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 </plugin>

--- a/src/plugins/contentFilter/plugin.xml
+++ b/src/plugins/contentFilter/plugin.xml
@@ -10,7 +10,7 @@
     <author>Conor Hayes</author>
     <version>1.8.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     
     <!-- UI extension -->
     <adminconsole>		

--- a/src/plugins/dbaccess/plugin.xml
+++ b/src/plugins/dbaccess/plugin.xml
@@ -7,7 +7,7 @@
     <author>Daniel Henninger</author>
     <version>1.2.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 
     <adminconsole>
         <tab id="tab-server">

--- a/src/plugins/emailListener/plugin.xml
+++ b/src/plugins/emailListener/plugin.xml
@@ -11,7 +11,7 @@
     <url>http://www.igniterealtime.org</url>
     <version>1.2.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 
     <adminconsole>
         <tab id="tab-server">

--- a/src/plugins/fastpath/plugin.xml
+++ b/src/plugins/fastpath/plugin.xml
@@ -7,7 +7,7 @@
     <author>Jive Software</author>
     <version>4.4.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>fastpath</databaseKey>
     <databaseVersion>0</databaseVersion>
 	

--- a/src/plugins/gojara/plugin.xml
+++ b/src/plugins/gojara/plugin.xml
@@ -13,7 +13,7 @@
 	<date>10/12/2015</date>
 	<databaseKey>gojara</databaseKey>
 	<databaseVersion>1</databaseVersion>
-	<minServerVersion>3.11.0 alpha</minServerVersion>
+	<minServerVersion>4.0.0</minServerVersion>
 
 	<!-- Admin console entries -->
 

--- a/src/plugins/hazelcast/plugin.xml
+++ b/src/plugins/hazelcast/plugin.xml
@@ -7,5 +7,5 @@
     <author>Tom Evans</author>
     <version>2.2.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 </plugin>

--- a/src/plugins/jingleNodes/plugin.xml
+++ b/src/plugins/jingleNodes/plugin.xml
@@ -7,7 +7,7 @@
     <author>Jingle Nodes (Rodrigo Martins)</author>
     <version>0.2.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 
     <adminconsole>
         <tab id="tab-server">

--- a/src/plugins/justmarried/plugin.xml
+++ b/src/plugins/justmarried/plugin.xml
@@ -7,7 +7,7 @@
    <author>Holger Bergunde</author>
     <version>1.2.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
    
    <adminconsole>
         <tab id="tab-users">

--- a/src/plugins/kraken/plugin.xml
+++ b/src/plugins/kraken/plugin.xml
@@ -10,7 +10,7 @@
     <author>Daniel Henninger</author>
     <version>1.3.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>gateway</databaseKey>
     <databaseVersion>12</databaseVersion>
     <licenseType>gpl</licenseType>

--- a/src/plugins/monitoring/plugin.xml
+++ b/src/plugins/monitoring/plugin.xml
@@ -7,7 +7,7 @@
     <author>Jive Software</author>
     <version>1.5.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>3</databaseVersion>
 

--- a/src/plugins/motd/plugin.xml
+++ b/src/plugins/motd/plugin.xml
@@ -7,7 +7,7 @@
    <author>Ryan Graham</author>
    <version>1.2.0</version>
    <date>10/12/2015</date>
-   <minServerVersion>3.11.0 alpha</minServerVersion>
+   <minServerVersion>4.0.0</minServerVersion>
 
    <adminconsole>
       <tab id="tab-users">

--- a/src/plugins/nodejs/plugin.xml
+++ b/src/plugins/nodejs/plugin.xml
@@ -7,7 +7,7 @@
     <licenseType>Apache 2.0</licenseType>
     <version>0.1.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 
    <adminconsole>
         <tab id="tab-server">

--- a/src/plugins/packetFilter/plugin.xml
+++ b/src/plugins/packetFilter/plugin.xml
@@ -9,7 +9,7 @@
     <author>Nate Putnam</author>
     <version>3.3.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>packetfilter</databaseKey>
     <databaseVersion>2</databaseVersion>
 

--- a/src/plugins/presence/plugin.xml
+++ b/src/plugins/presence/plugin.xml
@@ -7,7 +7,7 @@
     <author>Jive Software</author>
     <version>1.7.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 	
     <adminconsole>		
         <tab id="tab-server">

--- a/src/plugins/rayo/plugin.xml
+++ b/src/plugins/rayo/plugin.xml
@@ -7,7 +7,7 @@
     <author>Ignite Realtime Community</author>
     <version>0.1.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 
     <adminconsole>
         <tab id="tab-rayo" name="Rayo" url="rayo.jsp" description="${admin.item.rayo.description}">

--- a/src/plugins/registration/plugin.xml
+++ b/src/plugins/registration/plugin.xml
@@ -7,7 +7,7 @@
     <author>Ryan Graham</author>
     <version>1.7.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 	
 	<adminconsole>
 		<tab id="tab-users">

--- a/src/plugins/restAPI/plugin.xml
+++ b/src/plugins/restAPI/plugin.xml
@@ -7,7 +7,7 @@
     <author>Roman Soldatow</author>
     <version>1.2.1</version>
     <date>11/24/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">

--- a/src/plugins/search/plugin.xml
+++ b/src/plugins/search/plugin.xml
@@ -7,7 +7,7 @@
     <author>Ryan Graham</author>
     <version>1.7.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     
     <adminconsole>
         <tab id="tab-server">

--- a/src/plugins/sip/plugin.xml
+++ b/src/plugins/sip/plugin.xml
@@ -9,7 +9,7 @@
     <date>10/12/2015</date>
     <databaseKey>sip</databaseKey>
     <databaseVersion>2</databaseVersion>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     
     <adminconsole>
         <tab id="tab-server">

--- a/src/plugins/stunserver/plugin.xml
+++ b/src/plugins/stunserver/plugin.xml
@@ -7,7 +7,7 @@
     <author>Ignite Realtime</author>
     <version>1.2.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     
     <adminconsole>
         <tab id="sidebar-media-services">

--- a/src/plugins/subscription/plugin.xml
+++ b/src/plugins/subscription/plugin.xml
@@ -8,7 +8,7 @@
    <version>1.4.0</version>
    <date>10/12/2015</date>
    <url>http://www.igniterealtime.org</url>
-   <minServerVersion>3.11.0 alpha</minServerVersion>
+   <minServerVersion>4.0.0</minServerVersion>
 
    <adminconsole>
       <tab id="tab-server">

--- a/src/plugins/userCreation/plugin.xml
+++ b/src/plugins/userCreation/plugin.xml
@@ -11,7 +11,7 @@
     <version>1.3.0</version>
     <date>10/12/2015</date>
     <url>http://www.igniterealtime.org</url>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 
     <adminconsole>
         <tab id="tab-users">

--- a/src/plugins/userImportExport/plugin.xml
+++ b/src/plugins/userImportExport/plugin.xml
@@ -8,7 +8,7 @@
    <author>Ryan Graham</author>
    <version>2.5.0</version>
    <date>10/12/2015</date>
-   <minServerVersion>3.11.0 alpha</minServerVersion>
+   <minServerVersion>4.0.0</minServerVersion>
 
    <adminconsole>
       <tab id="tab-users">

--- a/src/plugins/userservice/plugin.xml
+++ b/src/plugins/userservice/plugin.xml
@@ -7,7 +7,7 @@
     <author>Roman Soldatow, Justin Hunt</author>
     <version>2.1.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
     
     <adminconsole>		
         <tab id="tab-server">

--- a/src/plugins/xmldebugger/plugin.xml
+++ b/src/plugins/xmldebugger/plugin.xml
@@ -10,7 +10,7 @@
     <author>Jive Software</author>
     <version>1.5.0</version>
     <date>10/12/2015</date>
-    <minServerVersion>3.11.0 alpha</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 
    <adminconsole>
       <tab id="tab-server">


### PR DESCRIPTION
Previously, we had a quasi-hack of `3.11.0-alpha` as the min requirement
on these, but this release never happened.  This update moves all these
plugins to 4.0.0, which hopefully provokes less confusion.