### PR TITLE
OF-1042: Don't NPE when a session is already closed when </stream>

### DIFF
--- a/src/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -150,7 +150,9 @@ public abstract class StanzaHandler {
 
         // Verify if end of stream was requested
         if (stanza.equals("</stream:stream>")) {
-            session.close();
+            if (session != null) {
+                session.close();
+            }
             return;
         }
         // Ignore <?xml version="1.0"?> stanzas sent by clients


### PR DESCRIPTION
I did not reproduce the NPE, but having a session already closed when </stream> is received sounds plausible to me. Some kind of race between handling the last data and following socket disconnect perhaps?