### PR TITLE
Should not store chat state messages, which contain a thread element.

### DIFF
--- a/src/java/org/jivesoftware/openfire/OfflineMessageStore.java
+++ b/src/java/org/jivesoftware/openfire/OfflineMessageStore.java
@@ -22,6 +22,7 @@ package org.jivesoftware.openfire;
 
 import org.dom4j.DocumentException;
 import org.dom4j.Element;
+import org.dom4j.Namespace;
 import org.dom4j.QName;
 import org.dom4j.io.SAXReader;
 import org.jivesoftware.database.DbConnectionManager;
@@ -492,7 +493,9 @@ public class OfflineMessageStore extends BasicModule implements UserEventListene
 
                     if (item instanceof Element) {
                         Element el = (Element) item;
-
+                        if (Namespace.NO_NAMESPACE.equals(el.getNamespace())) {
+                            continue;
+                        }
                         if (!el.getNamespaceURI().equals("http://jabber.org/protocol/chatstates")
                                 && !(el.getQName().equals(QName.get("rtt", "urn:xmpp:rtt:0")))
                                 ) {
@@ -501,7 +504,7 @@ public class OfflineMessageStore extends BasicModule implements UserEventListene
                     }
                 }
 
-                return false;
+                return message.getBody() != null && !message.getBody().isEmpty();
 
             case groupchat:
             case headline:

--- a/src/test/java/org/jivesoftware/openfire/OfflineMessageStoreTest.java
+++ b/src/test/java/org/jivesoftware/openfire/OfflineMessageStoreTest.java
@@ -76,6 +76,16 @@ public class OfflineMessageStoreTest {
     }
 
     @Test
+    public void shouldNotStoreEmptyChatMessagesWithOnlyChatStatesAndThread() {
+        Message message = new Message();
+        message.setType(Message.Type.chat);
+        message.setThread("1234");
+        PacketExtension chatState = new PacketExtension("composing", "http://jabber.org/protocol/chatstates");
+        message.addExtension(chatState);
+        assertFalse(OfflineMessageStore.shouldStoreMessage(message));
+    }
+
+    @Test
     public void shouldStoreEmptyChatMessagesWithOtherExtensions() {
         Message message = new Message();
         message.setType(Message.Type.chat);


### PR DESCRIPTION
The problem was, that the logic stored empty chat messages, which contained a thread and chat state. The loop first checked the namespace of the thread, which was empty and therefore thought it should store it.