### PR TITLE
OF-462 PEP should process IQ-gets that have no 'to' attribute.

### DIFF
--- a/src/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/src/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -78,7 +78,6 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
 
     private List<Element> anonymousUserIdentities = new ArrayList<>();
     private List<Element> registeredUserIdentities = new ArrayList<>();
-    private List<String> userFeatures = new ArrayList<>();
 
     public IQDiscoInfoHandler() {
         super("XMPP Disco Info Handler");
@@ -93,7 +92,6 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
         userIdentity.addAttribute("category", "account");
         userIdentity.addAttribute("type", "registered");
         registeredUserIdentities.add(userIdentity);
-        userFeatures.add(NAMESPACE_DISCO_INFO);
     }
 
     @Override
@@ -428,7 +426,7 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                     // Redirect the request to the disco info provider of the specified node
                     return serverNodeProviders.get(node).getIdentities(name, node, senderJID);
                 }
-                if (name == null) {
+                if (name != null && name.equals(XMPPServer.getInstance().getServerInfo().getXMPPDomain())) {
                     // Answer identity of the server
                     synchronized (identities) {
                         if (identities.isEmpty()) {
@@ -467,14 +465,8 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                     // Redirect the request to the disco info provider of the specified node
                     return serverNodeProviders.get(node).getFeatures(name, node, senderJID);
                 }
-                if (name == null) {
-                    // Answer features of the server
-                    return new HashSet<>(serverFeatures.keySet()).iterator();
-                }
-                else {
-                    // Answer features of the user
-                    return userFeatures.iterator();
-                }
+                // Answer features of the server
+                return new HashSet<>(serverFeatures.keySet()).iterator();
             }
 
             @Override

--- a/src/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
+++ b/src/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
@@ -116,7 +116,7 @@ public class IQDiscoItemsHandler extends IQHandler implements ServerFeaturesProv
         // DiscoItemsProvider responsibility to provide the items associated with the JID's name  
         // together with any possible requested node.
         DiscoItemsProvider itemsProvider = getProvider(packet.getTo() == null ?
-                XMPPServer.getInstance().getServerInfo().getXMPPDomain() : packet.getTo().getDomain());
+                packet.getFrom().getNode() : packet.getTo().getNode() != null ? packet.getTo().getNode() : packet.getTo().getDomain());
         if (itemsProvider != null) {
             // Get the JID's name
             String name = packet.getTo() == null ? null : packet.getTo().getNode();


### PR DESCRIPTION
I've removed the "userFeatures", because I think a user cannot have features.

As per XEP-0163:

The server MUST return an identity of "pubsub/pep" on behalf of the account (as well as a list of the namespaces and other features it [the server?)] supports)
Anyway, the old logic only returned one feature (disco#info) for the user,
which was wrong, too (the pubsub features were missing at least)

disco#items addressed to the account (bare jid) or without 'to' attribute are treated the same now, too.

Also partially addresses OF-872.