### PR TITLE
OF-144 History type change should be applied without a restart

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
+++ b/src/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
@@ -144,6 +144,12 @@ public class HistoryStrategy {
         if (newType != null){
             type = newType;
         }
+        if (newType == Type.none ) {
+            history.clear();
+        }
+        if (newType == Type.number) {
+            limitHistoryTo(maxNumber);
+        }
         if (contextPrefix != null){
             MUCPersistenceManager.setProperty(contextSubdomain, contextPrefix + ".type", type.toString());
         }
@@ -196,21 +202,25 @@ public class HistoryStrategy {
             history.add(packet);
         }
         else if (strategyType == Type.number) {
-            if (history.size() >= strategyMaxNumber) {
-                // We have to remove messages so the new message won't exceed
-                // the max history size
-                // This is complicated somewhat because we must skip over the
-                // last room subject
-                // message because we want to preserve the room subject if
-                // possible.
-                Iterator<Message> historyIter = history.iterator();
-                while (historyIter.hasNext() && history.size() > strategyMaxNumber) {
-                    if (historyIter.next() != roomSubject) {
-                        historyIter.remove();
-                    }
+            limitHistoryTo(strategyMaxNumber);
+            history.add(packet);
+        }
+    }
+
+    private void limitHistoryTo(int max) {
+        if (history.size() >= max) {
+            // We have to remove messages so the new message won't exceed
+            // the max history size
+            // This is complicated somewhat because we must skip over the
+            // last room subject
+            // message because we want to preserve the room subject if
+            // possible.
+            Iterator<Message> historyIter = history.iterator();
+            while (historyIter.hasNext() && history.size() >= max) {
+                if (historyIter.next() != roomSubject) {
+                    historyIter.remove();
                 }
             }
-            history.add(packet);
         }
     }
 

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -373,7 +373,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         this.canChangeNickname = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.canChangeNickname", true);
         this.registrationEnabled = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.registrationEnabled", true);
         // TODO Allow to set the history strategy from the configuration form?
-        roomHistory = new MUCRoomHistory(this, new HistoryStrategy(mucService.getHistoryStrategy()));
+        roomHistory = new MUCRoomHistory(this, mucService.getHistoryStrategy());
         this.iqOwnerHandler = new IQOwnerHandler(this, packetRouter);
         this.iqAdminHandler = new IQAdminHandler(this, packetRouter);
         // No one can join the room except the room's owner


### PR DESCRIPTION
Basically the issue was, that each room had it's own HistoryStrategy copied on room creation (startup), while the UI only modified the MUC service's history (i.e. they worked on different objects).

It also fixed a minor oversight (> should be >=), which sent 5 messages from history to the client, although 4 were configured.
