### PR TITLE
Fix memory leak when getChatRoom() calls return null or throw exception

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -645,6 +645,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                         else {
                             // Room does not exist and delegate does not recognize it and does
                             // not allow room creation
+                            GroupEventDispatcher.removeListener(room);
                             throw new NotAllowedException();
 
                         }
@@ -658,6 +659,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                             if (!allowedToCreate.includes(bareJID)) {
                                 // The user is not in the list of allowed JIDs to create a room so raise
                                 // an exception
+                                GroupEventDispatcher.removeListener(room);
                                 throw new NotAllowedException();
                             }
                         }
@@ -705,6 +707,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                     }
                     catch (IllegalArgumentException e) {
                         // The room does not exist so do nothing
+                        GroupEventDispatcher.removeListener(room);
                         room = null;
                     }
                 }


### PR DESCRIPTION
Every instantiation of LocalMUCRoom registers itself in the
GroupEventDispatcher. However, when the instantiation is done in the
getChatRoom methods and so after it fails, the room is not returned and
it stays registered in the GroupEventDispatcher. This fix unregister the
room from GroupEventDispatcher in these cases.
