### PR TITLE
OF-1051: Prevent ConcurrentModificationException

### DIFF
--- a/src/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/src/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -198,7 +198,7 @@ public class PluginManager {
      * @return a Collection of all installed plugins.
      */
     public Collection<Plugin> getPlugins() {
-        return Collections.unmodifiableCollection(plugins.values());
+        return Collections.unmodifiableCollection(Arrays.asList( plugins.values().toArray( new Plugin[ plugins.size() ]) ));
     }
 
     /**


### PR DESCRIPTION
The unmodifiable collection in the original code is not immutable: when
the original collection is modified, this is reflected (which can cause
problems in iterators created from the unmodifiable collection). This
commit creates a new collection to prevent this from happening.