### PR TITLE
Improve certificate signatures with SHA-2 functions

### DIFF
--- a/src/java/org/jivesoftware/openfire/keystore/IdentityStore.java
+++ b/src/java/org/jivesoftware/openfire/keystore/IdentityStore.java
@@ -389,12 +389,12 @@ public class IdentityStore extends CertificateStore
         {
             case "RSA":
                 keySize = JiveGlobals.getIntProperty( "cert.rsa.keysize", 2048 );
-                signAlgorithm = "SHA1WITHRSAENCRYPTION";
+                signAlgorithm = "SHA256WITHRSAENCRYPTION";
                 break;
 
             case "DSA":
                 keySize = JiveGlobals.getIntProperty( "cert.dsa.keysize", 1024 );
-                signAlgorithm = "SHA1withDSA";
+                signAlgorithm = "SHA256withDSA";
                 break;
 
             default:


### PR DESCRIPTION
OF-1049 fix provided by aberenguel in https://github.com/igniterealtime/Openfire/pull/514

This PR contains the SHA-1 to SHA-2 commit from the original PR. As it's a major change, we shouldn't add that in a patch release (4.0.1), but we do want this on master (4.1.0).