### PR TITLE
OF-1063: Prevent TimerThread from exiting

### DIFF
--- a/src/java/org/jivesoftware/util/TaskEngine.java
+++ b/src/java/org/jivesoftware/util/TaskEngine.java
@@ -23,7 +23,15 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ThreadFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Performs tasks using worker threads. It also allows tasks to be scheduled to be
@@ -37,6 +45,7 @@ import java.util.concurrent.*;
  */
 public class TaskEngine {
 
+	private static final Logger Log = LoggerFactory.getLogger(TaskEngine.class);
     private static TaskEngine instance = new TaskEngine();
 
     /**
@@ -69,12 +78,16 @@ public class TaskEngine {
      * @return a Future representing pending completion of the task,
      *      and whose <tt>get()</tt> method will return <tt>null</tt>
      *      upon completion.
-     * @throws java.util.concurrent.RejectedExecutionException if task cannot be scheduled
-     *      for execution.
-     * @throws NullPointerException if task null.
      */
     public Future<?> submit(Runnable task) {
-        return executor.submit(task);
+    	try {
+    		return executor.submit(task);
+    	} catch (Throwable t) {
+    		Log.warn("Failed to schedule task; will retry using caller's thread: {0}", t.getMessage());
+    		FutureTask<?> result = new FutureTask<>(task, null);
+    		result.run();
+    		return result;
+    	}
     }
 
     /**
@@ -290,7 +303,12 @@ public class TaskEngine {
 
         @Override
 		public void run() {
-            executor.submit(task);
+        	try {
+        		submit(task);
+        	} catch (Throwable t) {
+        		// need to catch here to prevent Timer from canceling TimerThread
+        		Log.error("Failed to execute TimerTask", t);
+        	}
         }
     }
 }


### PR DESCRIPTION
Do not allow TimerThread to exit when the server becomes heavily loaded,
preferring instead to use the caller's thread to execute a scheduled
task when needed. This may result in a temporary slowdown, but is better
than a hard failure which requires a restart of the server.