### PR TITLE
Set affiliation to 'none' after removing registration from room.

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1831,7 +1831,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             }
             else {
                 newRole = isModerated() ? MUCRole.Role.visitor : MUCRole.Role.participant;
-            	newAffiliation = MUCRole.Affiliation.member;
+            	newAffiliation = MUCRole.Affiliation.none;
             }
             Log.info("New affiliation: " + newAffiliation);
             try {


### PR DESCRIPTION
Removing registration from room calls #addNone, which removes the requester
JID from all affiliation lists. But #applyAffiliationChange sets the affiliation
back to 'member' after it does not find the JID in any affiliation lists. It
should set the affiliation to 'none' before sending the updated presences.