### PR TITLE
OF-1089: Send IQ result only after messages

### DIFF
--- a/src/plugins/monitoring/changelog.html
+++ b/src/plugins/monitoring/changelog.html
@@ -44,6 +44,11 @@
 Monitoring Plugin Changelog
 </h1>
 
+<p><b>1.5.2</b> -- Feb 15, 2016</p>
+<ul>
+    <li>[<a href='https://igniterealtime.org/issues/browse/OF-1089'>OF-1089</a>] - Send IQ result only after messages.</li>
+</ul>
+
 <p><b>1.5.1</b> -- Feb 15, 2016</p>
 <ul>
     <li>[<a href='https://igniterealtime.org/issues/browse/OF-1087'>OF-1087</a>] - Fixed namespace handling (BOSH).</li>

--- a/src/plugins/monitoring/plugin.xml
+++ b/src/plugins/monitoring/plugin.xml
@@ -5,7 +5,7 @@
     <name>Monitoring Service</name>
     <description>Monitors conversations and statistics of the server.</description>
     <author>Jive Software</author>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <date>2/15/2016</date>
     <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler.java
@@ -76,8 +76,6 @@ public class IQQueryHandler extends AbstractIQHandler implements
 			}
 		}
 
-		sendAcknowledgementResult(packet, session);
-
 		final QueryRequest queryRequest = new QueryRequest(packet.getChildElement(), archiveJid);
 		Collection<ArchivedMessage> archivedMessages = retrieveMessages(queryRequest);
 
@@ -86,6 +84,8 @@ public class IQQueryHandler extends AbstractIQHandler implements
 		}
 
 		sendFinalMessage(session, queryRequest);
+
+		sendAcknowledgementResult(packet, session);
 
 		return null;
 	}


### PR DESCRIPTION
IQ result should be the last stanza. This way, clients know that the
last archived message has arrived.