### PR TITLE
Outcasts should not be allowed to register with room.

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/IQMUCRegisterHandler.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/IQMUCRegisterHandler.java
@@ -29,6 +29,7 @@ import org.dom4j.Element;
 import org.dom4j.QName;
 import org.jivesoftware.openfire.muc.ConflictException;
 import org.jivesoftware.openfire.muc.ForbiddenException;
+import org.jivesoftware.openfire.muc.MUCRole;
 import org.jivesoftware.openfire.muc.MUCRoom;
 import org.jivesoftware.openfire.muc.MultiUserChatService;
 import org.jivesoftware.util.ElementUtil;
@@ -126,8 +127,11 @@ class IQMUCRegisterHandler {
             reply.setError(PacketError.Condition.item_not_found);
             return reply;
         }
-        else if (!room.isRegistrationEnabled()) {
-            // The room does not accept users to register
+        else if (!room.isRegistrationEnabled() ||
+                 (packet.getFrom() != null && 
+                  MUCRole.Affiliation.outcast == room.getAffiliation(packet.getFrom().asBareJID()))) {
+            // The room does not accept users to register or
+            // the user is an outcast and is not allowed to register
             reply = IQ.createResultIQ(packet);
             reply.setChildElement(packet.getChildElement().createCopy());
             reply.setError(PacketError.Condition.not_allowed);


### PR DESCRIPTION
With the current implementation, any user can send the register IQ to register with
a room as a 'member'. This also allows outcasts, that were banned from a room, to be
able to register again as a member, and eventually re-join the room. The solution is
to prevent outcasts from registering with the room.