### PR TITLE
Fix non-working XEP-0136 for monitoring plugin

### DIFF
--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep/AbstractXepSupport.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep/AbstractXepSupport.java
@@ -25,12 +25,12 @@ public abstract class AbstractXepSupport {
 	protected final String namespace;
 	protected Collection<IQHandler> iqHandlers;
 
-	public AbstractXepSupport(XMPPServer server, String namespace, String iqDispatcherName) {
+	public AbstractXepSupport(XMPPServer server, String namespace,String iqDispatcherNamespace, String iqDispatcherName) {
 
 		this.server = server;
 		this.element2Handlers = Collections
 				.synchronizedMap(new HashMap<String, IQHandler>());
-		this.iqDispatcher = new AbstractIQHandler(iqDispatcherName, null, namespace) {
+		this.iqDispatcher = new AbstractIQHandler(iqDispatcherName, null, iqDispatcherNamespace) {
 			public IQ handleIQ(IQ packet) throws UnauthorizedException {
 				if (!MonitoringPlugin.getInstance().isEnabled()) {
 					return error(packet,

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0136/Xep0136Support.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0136/Xep0136Support.java
@@ -14,7 +14,7 @@ import com.reucon.openfire.plugin.archive.xep.AbstractXepSupport;
 public class Xep0136Support extends AbstractXepSupport {
 
 	private static final String NAMESPACE_AUTO = "urn:xmpp:archive:auto";
-	private static final String IQ_NAMESPACE = "urn:xmpp:archive:auto";
+	private static final String IQ_NAMESPACE = "urn:xmpp:archive";
 
 	public Xep0136Support(XMPPServer server) {
 		super(server, NAMESPACE_AUTO,IQ_NAMESPACE, "XEP-0136 IQ Dispatcher");

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0136/Xep0136Support.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0136/Xep0136Support.java
@@ -13,10 +13,11 @@ import com.reucon.openfire.plugin.archive.xep.AbstractXepSupport;
  */
 public class Xep0136Support extends AbstractXepSupport {
 
-	private static final String NAMESPACE = "urn:xmpp:archive:auto";
+	private static final String NAMESPACE_AUTO = "urn:xmpp:archive:auto";
+	private static final String IQ_NAMESPACE = "urn:xmpp:archive:auto";
 
 	public Xep0136Support(XMPPServer server) {
-		super(server, NAMESPACE, "XEP-0136 IQ Dispatcher");
+		super(server, NAMESPACE_AUTO,IQ_NAMESPACE, "XEP-0136 IQ Dispatcher");
 
 		iqHandlers = new ArrayList<IQHandler>();
 

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/Xep0313Support.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/Xep0313Support.java
@@ -16,7 +16,7 @@ public class Xep0313Support extends AbstractXepSupport {
 	private static final String NAMESPACE = "urn:xmpp:mam:0";
 
 	public Xep0313Support(XMPPServer server) {
-		super(server, NAMESPACE, "XEP-0313 IQ Dispatcher");
+		super(server, NAMESPACE,NAMESPACE, "XEP-0313 IQ Dispatcher");
 
 		this.iqHandlers = new ArrayList<IQHandler>();
 		iqHandlers.add(new IQQueryHandler());


### PR DESCRIPTION
Description [here](https://community.igniterealtime.org/thread/56546).
The problem was due to a wrong namespace for the IQHandler This does NOT fix the [OF-1078 issue](https://community.igniterealtime.org/external-link.jspa?url=https%3A%2F%2Figniterealtime.org%2Fissues%2Fbrowse%2FOF-1078)