### PR TITLE
OF-210 - Support for Roster Versioning

### DIFF
--- a/src/java/org/jivesoftware/openfire/handler/IQRosterHandler.java
+++ b/src/java/org/jivesoftware/openfire/handler/IQRosterHandler.java
@@ -198,7 +198,7 @@ public class IQRosterHandler extends IQHandler implements ServerFeaturesProvider
                         returnPacket.getChildElement().addAttribute("ver", cachedRoster.getLatestRosterVersion());
                     } else {
                         // ... or return an empty IQ-result
-                        returnPacket = new org.xmpp.packet.Roster();
+                        returnPacket = new org.xmpp.packet.IQ();
                     }
                 } else {
                     returnPacket = cachedRoster.getReset();

--- a/src/java/org/jivesoftware/openfire/handler/IQRosterHandler.java
+++ b/src/java/org/jivesoftware/openfire/handler/IQRosterHandler.java
@@ -188,10 +188,10 @@ public class IQRosterHandler extends IQHandler implements ServerFeaturesProvider
             if (IQ.Type.get == type) {
 
                 if (RosterManager.isRosterVersioningEnabled()) {
-                    String rosterVersion = packet.getChildElement().attributeValue("ver");
-
+                    String clientVersion = packet.getChildElement().attributeValue("ver");
+                    String latestVersion = cachedRoster.getLatestRosterVersion();
                     // Whether or not the roster has been modified since the version ID enumerated by the client, ...
-                    if (cachedRoster.hasRosterVersionBeenModified(rosterVersion)) {
+                    if (!latestVersion.equals(clientVersion)) {
                         // ... the server MUST either return the complete roster
                         // (including a 'ver' attribute that signals the latest version)
                         returnPacket = cachedRoster.getReset();

--- a/src/java/org/jivesoftware/openfire/roster/RosterManager.java
+++ b/src/java/org/jivesoftware/openfire/roster/RosterManager.java
@@ -77,6 +77,15 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
         return JiveGlobals.getBooleanProperty("xmpp.client.roster.active", true);
     }
 
+    /**
+     * Returns true if the roster versioning is enabled.
+     *
+     * @return true if the roster versioning is enabled.
+     */
+    public static boolean isRosterVersioningEnabled() {
+        return JiveGlobals.getBooleanProperty("xmpp.client.roster.versioning.active", false);
+    }
+
     public RosterManager() {
         super("Roster Manager");
         rosterCache = CacheFactory.createCache("Roster");

--- a/src/java/org/jivesoftware/openfire/roster/RosterManager.java
+++ b/src/java/org/jivesoftware/openfire/roster/RosterManager.java
@@ -363,11 +363,13 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
                 // Get the roster to update.
                 Roster roster = null;
                 if (server.isLocal(updatedUser)) {
-                    roster = rosterCache.get(updatedUser.getNode());
-                }
-                if (roster != null) {
-                    // Update the roster with the new group display name
-                    roster.shareGroupRenamed(users);
+                    try {
+                        roster = getRoster(updatedUser.getNode());
+
+                        // Update the roster with the new group display name
+                        roster.shareGroupRenamed(users);
+                    } catch (UserNotFoundException e) {
+                    }
                 }
             }
         }
@@ -551,19 +553,17 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
                 // Get the roster to update
                 Roster roster = null;
                 if (server.isLocal(userToUpdate)) {
-                    // Check that the user exists, if not then continue with the next user
+                    // Get the roster. If the user does not exist then continue with the next user
                     try {
-                        UserManager.getInstance().getUser(userToUpdate.getNode());
+                        roster = getRoster(userToUpdate.getNode());
                     }
                     catch (UserNotFoundException e) {
                         continue;
                     }
-                    roster = rosterCache.get(userToUpdate.getNode());
                 }
-                // Only update rosters in memory
-                if (roster != null) {
-                    roster.addSharedUser(group, newUserJID);
-                }
+                // Update roster
+                roster.addSharedUser(group, newUserJID);
+
                 if (!server.isLocal(userToUpdate)) {
                     // Susbcribe to the presence of the remote user. This is only necessary for
                     // remote users and may only work with remote users that **automatically**
@@ -590,19 +590,17 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
                 // Get the roster to update
                 Roster roster = null;
                 if (server.isLocal(userToUpdate)) {
-                    // Check that the user exists, if not then continue with the next user
+                    // Get the roster. If the user does not exist then continue with the next user
                     try {
-                        UserManager.getInstance().getUser(userToUpdate.getNode());
+                        roster = getRoster(userToUpdate.getNode());
                     }
                     catch (UserNotFoundException e) {
                         continue;
                     }
-                    roster = rosterCache.get(userToUpdate.getNode());
                 }
-                // Only update rosters in memory
-                if (roster != null) {
-                    roster.deleteSharedUser(group, userJID);
-                }
+                // Update roster
+                roster.deleteSharedUser(group, userJID);
+
                 if (!server.isLocal(userToUpdate)) {
                     // Unsusbcribe from the presence of the remote user. This is only necessary for
                     // remote users and may only work with remote users that **automatically**
@@ -652,7 +650,10 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
         // Get the roster of the added user.
         Roster addedUserRoster = null;
         if (server.isLocal(addedUser)) {
-            addedUserRoster = rosterCache.get(addedUser.getNode());
+            try {
+                addedUserRoster = getRoster(addedUser.getNode());
+            } catch (UserNotFoundException e) {
+            }
         }
 
         // Iterate on all the affected users and update their rosters
@@ -661,23 +662,24 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
                 // Get the roster to update
                 Roster roster = null;
                 if (server.isLocal(userToUpdate)) {
-                    // Check that the user exists, if not then continue with the next user
+                    // Get the roster. If the user does not exist then continue with the next user
                     try {
-                        UserManager.getInstance().getUser(userToUpdate.getNode());
+                        roster = getRoster(userToUpdate.getNode());
                     }
                     catch (UserNotFoundException e) {
                         continue;
                     }
-                    roster = rosterCache.get(userToUpdate.getNode());
                 }
-                // Only update rosters in memory
-                if (roster != null) {
-                    roster.addSharedUser(group, addedUser);
-                }
+                // Update roster
+                roster.addSharedUser(group, addedUser);
+
                 // Check if the roster is still not in memory
                 if (addedUserRoster == null && server.isLocal(addedUser)) {
-                    addedUserRoster =
-                            rosterCache.get(addedUser.getNode());
+                    try {
+                        addedUserRoster =
+                                getRoster(addedUser.getNode());
+                    } catch (UserNotFoundException e) {
+                    }
                 }
                 // Update the roster of the newly added group user.
                 if (addedUserRoster != null) {
@@ -721,7 +723,10 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
         // Get the roster of the deleted user.
         Roster deletedUserRoster = null;
         if (server.isLocal(deletedUser)) {
-            deletedUserRoster = rosterCache.get(deletedUser.getNode());
+            try {
+                deletedUserRoster = getRoster(deletedUser.getNode());
+            } catch (UserNotFoundException e) {
+            }
         }
 
         // Iterate on all the affected users and update their rosters
@@ -729,24 +734,17 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
             // Get the roster to update
             Roster roster = null;
             if (server.isLocal(userToUpdate)) {
-                // Check that the user exists, if not then continue with the next user
+                // Get the roster. If the user does not exist then continue with the next user
                 try {
-                    UserManager.getInstance().getUser(userToUpdate.getNode());
+                    roster = getRoster(userToUpdate.getNode());
                 }
                 catch (UserNotFoundException e) {
                     continue;
-                }
-                roster = rosterCache.get(userToUpdate.getNode());
+                } 
             }
-            // Only update rosters in memory
-            if (roster != null) {
-                roster.deleteSharedUser(group, deletedUser);
-            }
-            // Check if the roster is still not in memory
-            if (deletedUserRoster == null && server.isLocal(deletedUser)) {
-                deletedUserRoster =
-                        rosterCache.get(deletedUser.getNode());
-            }
+            // Update roster
+            roster.deleteSharedUser(group, deletedUser);
+
             // Update the roster of the newly deleted group user.
             if (deletedUserRoster != null) {
                 deletedUserRoster.deleteSharedUser(userToUpdate, group);

--- a/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -33,6 +33,7 @@ import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.net.SASLAuthentication;
 import org.jivesoftware.openfire.privacy.PrivacyList;
 import org.jivesoftware.openfire.privacy.PrivacyListManager;
+import org.jivesoftware.openfire.roster.RosterManager;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
 import org.jivesoftware.openfire.streammanagement.StreamManager;
 import org.jivesoftware.openfire.user.PresenceEventDispatcher;
@@ -879,6 +880,12 @@ public class LocalClientSession extends LocalSession implements ClientSession {
                 !conn.isCompressed()) {
             sb.append(
                     "<compression xmlns=\"http://jabber.org/features/compress\"><method>zlib</method></compression>");
+        }
+
+        // If a server supports roster versioning, 
+        // then it MUST advertise the following stream feature during stream negotiation.
+        if (RosterManager.isRosterVersioningEnabled()) {
+            sb.append("<ver xmlns=\"urn:xmpp:features:rosterver\"/>");
         }
 
         if (getAuthToken() == null) {


### PR DESCRIPTION
I implemented the Roster versioning ( http://xmpp.org/rfcs/rfc6121.html#roster-versioning ) so that if the roster version is not updated, it returns an empty IQ-result.

I tried to follow the spec in all aspects, and added comments copied from the spec.

The spec says:
"_In general, unless returning the complete roster would (1) use less bandwidth than sending individual roster pushes to the client (e.g., if the roster contains only a few items) or (2) the server cannot associate the version ID with any previous version it has on file, the server SHOULD send an empty IQ-result and then send the modifications (if any) via roster pushes._"

In this implementation, we have the case that "_the server cannot associate the version ID with any previous version it has on file_". So there is no way to send the modifications via roster pushes.
