### PR TITLE
Disallow addMember request with empty nicknames in rooms with reserved nicknames.

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1610,6 +1610,10 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             if (owners.contains(bareJID) && owners.size() == 1) {
                 throw new ConflictException();
             }
+            // Check if the room has reserved nicknames, but the provided nickname is empty
+            if (isLoginRestrictedToNickname() && (nickname != null || nickname.trim().length() == 0)) {
+                throw new ConflictException();
+            }
             // Check if user is already an member
             if (members.containsKey(bareJID)) {
                 // Do nothing

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1611,7 +1611,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
                 throw new ConflictException();
             }
             // Check if the room has reserved nicknames, but the provided nickname is empty
-            if (isLoginRestrictedToNickname() && (nickname != null || nickname.trim().length() == 0)) {
+            if (isLoginRestrictedToNickname() && (nickname == null || nickname.trim().length() == 0)) {
                 throw new ConflictException();
             }
             // Check if user is already an member


### PR DESCRIPTION
If there is an addMember request, say from a room admin, with an empty nickname,
then an empty string is assigned as the nickname. For rooms with reserved nicknames,
this will create problems for the following scenario - A room admin grants membership
to a user JID, but with an empty nickname. The user then requests to join the room
with a non-empty nickname, but the room does not allow that since the reserved nickname
does not match with the provided one.
