### PR TITLE
Admin Console: prevent NPE on missing user creation date.

### DIFF
--- a/src/web/user-summary.jsp
+++ b/src/web/user-summary.jsp
@@ -261,7 +261,7 @@
             %>
         </td>
         <td width="12%">
-            <%= JiveGlobals.formatDate(user.getCreationDate()) %>
+            <%= user.getCreationDate() != null ? JiveGlobals.formatDate(user.getCreationDate()) : "&nbsp;" %>
         </td>
         <td width="23%">
             <% long logoutTime = presenceManager.getLastActivity(user);


### PR DESCRIPTION
Some user providers might not provide a creation date for each user. There's no reason that the Admin Console should not be able to cope with that.