### PR TITLE
OF-1094: Allow reset of UserProvider

### DIFF
--- a/src/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/src/java/org/jivesoftware/openfire/user/UserManager.java
@@ -107,7 +107,9 @@ public class UserManager implements IQResultListener {
 
             @Override
             public void propertyDeleted(String property, Map params) {
-                //Ignore
+                if ("provider.user.className".equals(property)) {
+                    initProvider();
+                }
             }
 
             @Override

--- a/src/test/java/org/jivesoftware/openfire/keystore/KeystoreTestUtils.java
+++ b/src/test/java/org/jivesoftware/openfire/keystore/KeystoreTestUtils.java
@@ -83,7 +83,7 @@ public class KeystoreTestUtils
     {
         int length = 4;
         final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance( "RSA" );
-        keyPairGenerator.initialize( 1024 );
+        keyPairGenerator.initialize( 512 );
 
         // Root certificate (representing the CA) is self-signed.
         KeyPair subjectKeyPair = keyPairGenerator.generateKeyPair();
@@ -112,7 +112,7 @@ public class KeystoreTestUtils
     {
         int length = 4;
         final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance( "RSA" );
-        keyPairGenerator.initialize( 1024 );
+        keyPairGenerator.initialize( 512 );
 
         // Root certificate (representing the CA) is self-signed.
         KeyPair subjectKeyPair = keyPairGenerator.generateKeyPair();
@@ -142,7 +142,7 @@ public class KeystoreTestUtils
     {
         int length = 4;
         final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance( "RSA" );
-        keyPairGenerator.initialize( 1024 );
+        keyPairGenerator.initialize( 512 );
 
         // Root certificate (representing the CA) is self-signed.
         KeyPair subjectKeyPair = keyPairGenerator.generateKeyPair();
@@ -313,7 +313,7 @@ public class KeystoreTestUtils
     private static X509Certificate generateTestCertificate( final boolean isValid, final boolean isSelfSigned, int indexAwayFromEndEntity ) throws Exception
     {
         final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance( "RSA" );
-        keyPairGenerator.initialize( 1024 );
+        keyPairGenerator.initialize( 512 );
 
         final KeyPair subjectKeyPair;
         final KeyPair issuerKeyPair;


### PR DESCRIPTION
When the property provider.user.className is set, a new UserProvider will be initialized.
Openfire should revert back to the default provider when that property is deleted.