### PR TITLE
Include correct affiliation and role after revoking MUC membership.

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRole.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRole.java
@@ -163,6 +163,12 @@ public class LocalMUCRole implements MUCRole {
         this.presence = newPresence;
         this.presence.setFrom(getRoleAddress());
         if (extendedInformation != null) {
+            // Remove any previous extendedInformation, then re-add it.
+            Element mucUser = presence.getElement().element(QName.get("x", "http://jabber.org/protocol/muc#user"));
+            if (mucUser != null) {
+                // Remove any previous extendedInformation, then re-add it.
+                presence.getElement().remove(mucUser);
+            }
             Element exi = extendedInformation.createCopy();
             presence.getElement().add(exi);
         }

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1377,6 +1377,8 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             if (role.isLocal()) {
                 role.setAffiliation(newAffiliation);
                 role.setRole(newRole);
+                // Set the new presence, so that the updated affiliation and role is reflected in the presence stanza.
+                role.setPresence(role.getPresence());
                 // Notify the other cluster nodes to update the occupant
                 CacheFactory.doClusterTask(new UpdateOccupant(this, role));
                 // Prepare a new presence to be sent to all the room occupants


### PR DESCRIPTION
Previous stanza had status code 321 (membership revoked), but still had the owner and role set to the old role:
affiliation="owner" role="moderator"

Now it is the correct role after revoking membership:
affiliation="none" role="none"

(sorry for the presenceUpdated method. I don't know why git thinks there are changes. I tried 3 times without formatting anything there and it's always the same).