### PR TITLE
Include nickname in actor element when kick a MUC occupant.

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -530,15 +530,16 @@ public interface MUCRoom extends Externalizable, Result {
 
     /**
      * Kicks a user from the room. If the user was in the room, the returned updated presence will
-     * be sent to the remaining occupants. 
-     * 
-     * @param fullJID The full JID of the kicked user  (cannot be <tt>null</tt>).
-     * @param actorJID The JID of the actor that initiated the kick (cannot be <tt>null</tt>).
-     * @param reason An optional reason why the user was kicked (can be <tt>null</tt>).
+     * be sent to the remaining occupants.
+     *
+     * @param fullJID       The full JID of the kicked user  (cannot be <tt>null</tt>).
+     * @param actorJID      The JID of the actor that initiated the kick (cannot be <tt>null</tt>).
+     * @param actorNickname The actor nickname.
+     * @param reason        An optional reason why the user was kicked (can be <tt>null</tt>).
      * @return the updated presence of the kicked user or null if the user was not in the room.
      * @throws NotAllowedException Thrown if trying to ban an owner or an administrator.
      */
-    public Presence kickOccupant(JID fullJID, JID actorJID, String reason)
+    public Presence kickOccupant(JID fullJID, JID actorJID, String actorNickname, String reason)
             throws NotAllowedException;
 
     public IQOwnerHandler getIQOwnerHandler();

--- a/src/java/org/jivesoftware/openfire/muc/spi/IQAdminHandler.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/IQAdminHandler.java
@@ -347,7 +347,7 @@ public class IQAdminHandler {
                                 if (MUCRole.Role.moderator != senderRole.getRole()) {
                                     throw new ForbiddenException();
                                 }
-                                presences.add(room.kickOccupant(jid, senderRole.getUserAddress(),
+                                presences.add(room.kickOccupant(jid, senderRole.getUserAddress(), senderRole.getNickname(),
                                         item.elementTextTrim("reason")));
                             }
                         } else {

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1848,7 +1848,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
                             x.element("item").addElement("reason").setText(reason);
                         }
                         x.addElement("status").addAttribute("code", isOutcast ? "301" : "321");
-                        kickPresence(presence, senderRole.getUserAddress());
+                        kickPresence(presence, senderRole.getUserAddress(), senderRole.getNickname());
                     }
                 }
     			updatedPresences.addAll(thisOccupant);
@@ -2256,7 +2256,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
     }
 
     @Override
-    public Presence kickOccupant(JID jid, JID actorJID, String reason)
+    public Presence kickOccupant(JID jid, JID actorJID, String actorNickname, String reason)
             throws NotAllowedException {
         // Update the presence with the new role and inform all occupants
         Presence updatedPresence = changeOccupantRole(jid, MUCRole.Role.none);
@@ -2272,7 +2272,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             }
 
             // Effectively kick the occupant from the room
-            kickPresence(updatedPresence, actorJID);
+            kickPresence(updatedPresence, actorJID, actorNickname);
 
             //Inform the other occupants that user has been kicked
             broadcastPresence(updatedPresence, false);
@@ -2287,18 +2287,22 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
      *
      * @param kickPresence the presence of the occupant to kick from the room.
      * @param actorJID The JID of the actor that initiated the kick or <tt>null</tt> if the info
+     * @param nick The actor nickname.
      * was not provided.
      */
-    private void kickPresence(Presence kickPresence, JID actorJID) {
+    private void kickPresence(Presence kickPresence, JID actorJID, String nick) {
         // Get the role(s) to kick
         List<MUCRole> occupants = new ArrayList<>(occupantsByNickname.get(kickPresence.getFrom().getResource().toLowerCase()));
         for (MUCRole kickedRole : occupants) {
-            kickPresence = kickPresence.createCopy();
             // Add the actor's JID that kicked this user from the room
             if (actorJID != null && actorJID.toString().length() > 0) {
                 Element frag = kickPresence.getChildElement(
                         "x", "http://jabber.org/protocol/muc#user");
-                frag.element("item").addElement("actor").addAttribute("jid", actorJID.toBareJID());
+                Element actor = frag.element("item").addElement("actor");
+                actor.addAttribute("jid", actorJID.toBareJID());
+                if (nick != null) {
+                    actor.addAttribute("nick", nick);
+                }
             }
             // Send the unavailable presence to the banned user
             kickedRole.send(kickPresence);
@@ -2377,7 +2381,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             for (MUCRole occupant : occupantsByFullJID.values()) {
                 if (occupant.getAffiliation().compareTo(MUCRole.Affiliation.member) > 0) {
                     try {
-                        presences.add(kickOccupant(occupant.getRoleAddress(), null,
+                        presences.add(kickOccupant(occupant.getRoleAddress(), null, null,
                                 LocaleUtils.getLocalizedString("muc.roomIsNowMembersOnly")));
                     }
                     catch (NotAllowedException e) {

--- a/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -528,7 +528,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                         room = role.getChatRoom();
                         try {
                             kickedPresence =
-                                    room.kickOccupant(user.getAddress(), null, null);
+                                    room.kickOccupant(user.getAddress(), null, null, null);
                             // Send the updated presence to the room occupants
                             room.send(kickedPresence);
                         }

--- a/src/web/muc-room-occupants.jsp
+++ b/src/web/muc-room-occupants.jsp
@@ -53,7 +53,7 @@
         MUCRole role = room.getOccupant(nickName);
         if (role != null) {
             try {
-                room.kickOccupant(role.getUserAddress(), XMPPServer.getInstance().createJID(webManager.getUser().getUsername(), null), "");
+                room.kickOccupant(role.getUserAddress(), XMPPServer.getInstance().createJID(webManager.getUser().getUsername(), null), null, "");
                 // Log the event
                 webManager.logEvent("kicked MUC occupant "+nickName+" from "+roomName, null);
                 // Done, so redirect


### PR DESCRIPTION
Also include the actor in every presence, not just the presence sent to the kicked occupant, so that other occupants know, who kicked whom.
This is achieved by not creating a copy of the presence.