### PR TITLE
Prevent occasional failure of CheckChainTrustedTest

### DIFF
--- a/src/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManager.java
+++ b/src/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManager.java
@@ -267,6 +267,10 @@ public class OpenfireX509TrustManager implements X509TrustManager
             // This exception generally isn't very helpful. This block attempts to print more debug information.
             try
             {
+                Log.debug( "** Accepted Issuers (trust anchors, \"root CA's\"):" );
+                for ( X509Certificate acceptedIssuer : acceptedIssuers) {
+                    Log.debug( "   - " + acceptedIssuer.getSubjectDN() + "/" + acceptedIssuer.getIssuerDN() );
+                }
                 Log.debug( "** Chain to be validated:" );
                 Log.debug( "   length: " + chain.length );
                 for (int i=0; i<chain.length; i++) {

--- a/src/test/java/org/jivesoftware/openfire/keystore/KeystoreTestUtils.java
+++ b/src/test/java/org/jivesoftware/openfire/keystore/KeystoreTestUtils.java
@@ -41,7 +41,7 @@ public class KeystoreTestUtils
     private static final Provider PROVIDER = new BouncyCastleProvider();
     private static final Object BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
     private static final Object END_CERT = "-----END CERTIFICATE-----";
-    
+
     static
     {
         // Add the BC provider to the list of security providers
@@ -164,9 +164,9 @@ public class KeystoreTestUtils
 
     private static X509Certificate generateTestCertificate( final boolean isValid, final KeyPair issuerKeyPair, final KeyPair subjectKeyPair, int indexAwayFromEndEntity) throws Exception
     {
-        // Issuer and Subject
-        final X500Name subject = new X500Name( "CN=MyName" + subjectKeyPair.getPublic().hashCode() );
-        final X500Name issuer  = new X500Name( "CN=MyName" + issuerKeyPair.getPublic().hashCode() );
+        // Issuer and Subject.
+        final X500Name subject = new X500Name( "CN=" + Base64.encodeBytes( subjectKeyPair.getPublic().getEncoded(), Base64.URL_SAFE ) );
+        final X500Name issuer  = new X500Name( "CN=" + Base64.encodeBytes( issuerKeyPair.getPublic().getEncoded(), Base64.URL_SAFE ) );
 
         // Validity
         final Date notBefore;


### PR DESCRIPTION
There's one unit test that occasionally fails. This occurs as a result of an unintended
collision. As part of the test, many certificates are generated and stored in keystores.
The alias used for the entry was based on the hashcode of the public ke of the certificate.
The value range of those hashcodes is fairly small (it has only a couple of digits), which
leads to occasional collisions, causing the test to fail.

This commit replaces the hashcode-based alias with the Base64-encoded public key information.
This ensures that aliases for distinct keys are also distinct, while ensuring that the
aliases for equal keys are equal.