### PR TITLE
OF-929 prevent ghosts by removing ioSession check

### DIFF
--- a/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
+++ b/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
@@ -295,10 +295,6 @@ public class NIOConnection implements Connection {
             IoBuffer buffer = IoBuffer.allocate(4096);
             buffer.setAutoExpand(true);
             try {
-            	// OF-464: if the connection has been dropped, fail over to backupDeliverer (offline)
-            	if (!ioSession.isConnected()) {
-            		throw new IOException("Connection reset/closed by peer");
-            	}
                 buffer.putString(packet.getElement().asXML(), encoder.get());
                 if (flashClient) {
                     buffer.put((byte) '\0');
@@ -344,10 +340,6 @@ public class NIOConnection implements Connection {
                 buffer.flip();
                 ioSessionLock.lock();
                 try {
-                    // OF-464: handle dropped connections (no backupDeliverer in this case?)
-                    if (!ioSession.isConnected()) {
-                        throw new IOException("Connection reset/closed by peer");
-                    }
                     ioSession.write(buffer);
                 }
                 finally {


### PR DESCRIPTION
Since the release of Openfire 3.9.3, users have reported problems with
"ghost" sessions left on the server. After reviewing the changes that
went into the 3.9.3 release, it seemed the fix for OF-464 may have had
some side effect causing this.

Since Igniterealtime's Openfire was reproducing OF-829, I did a test
whereby the functional changes of Igniterealtime/Openfire@ad08cae
were reverted.  After 36 hours, there were no ghosts!  Thinking about
this further, I think that only the change made to deliverRawText may
be to blame here.  Typically, this is used as a last gasp attempt
at delivering data to a connection that is closing/about to close.

The hope is that this change does not necessitate reopening OF-464.