### PR TITLE
Adding indexes to PostgreSQL for message search query improvement

### DIFF
--- a/src/plugins/monitoring/changelog.html
+++ b/src/plugins/monitoring/changelog.html
@@ -43,6 +43,10 @@
 <h1>
 Monitoring Plugin Changelog
 </h1>
+<p><b>1.5.3</b> -- March 22, 2016</p>
+<ul>
+    <li>[<a href='https://igniterealtime.org/issues/browse/OF-1117'>OF-1117</a>] - Improve performance of monitoring plugin by adding database indexes.</li>
+</ul>
 
 <p><b>1.5.2</b> -- Feb 15, 2016</p>
 <ul>

--- a/src/plugins/monitoring/plugin.xml
+++ b/src/plugins/monitoring/plugin.xml
@@ -5,11 +5,11 @@
     <name>Monitoring Service</name>
     <description>Monitors conversations and statistics of the server.</description>
     <author>Jive Software</author>
-    <version>1.5.2</version>
+    <version>1.5.3</version>
     <date>2/15/2016</date>
     <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>
-    <databaseVersion>3</databaseVersion>
+    <databaseVersion>4</databaseVersion>
 
     <adminconsole>
         <tab id="tab-server">

--- a/src/plugins/monitoring/src/database/monitoring_db2.sql
+++ b/src/plugins/monitoring/src/database/monitoring_db2.sql
@@ -1,7 +1,7 @@
 -- $Revision$
 -- $Date$
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 3);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER      NOT NULL,
@@ -39,6 +39,8 @@ CREATE TABLE ofMessageArchive (
    body              LONG VARCHAR
 );
 CREATE INDEX ofMessageArchive_con_idx ON ofMessageArchive (conversationID);
+CREATE INDEX ofMessageArchive_fromjid_idx ON ofMessageArchive (fromJID);
+CREATE INDEX ofMessageArchive_tojid_idx ON ofMessageArchive (toJID);
 
 CREATE TABLE ofRRDs (
    id            VARCHAR(100)        NOT NULL,

--- a/src/plugins/monitoring/src/database/monitoring_hsqldb.sql
+++ b/src/plugins/monitoring/src/database/monitoring_hsqldb.sql
@@ -1,7 +1,7 @@
 // $Revision$
 // $Date$
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 3);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT        NOT NULL,
@@ -39,6 +39,8 @@ CREATE TABLE ofMessageArchive (
    body              LONGVARCHAR
 );
 CREATE INDEX ofMessageArchive_con_idx ON ofMessageArchive (conversationID);
+CREATE INDEX ofMessageArchive_fromjid_idx ON ofMessageArchive (fromJID);
+CREATE INDEX ofMessageArchive_tojid_idx ON ofMessageArchive (toJID);
 
 CREATE TABLE ofRRDs (
    id            VARCHAR(100)        NOT NULL,

--- a/src/plugins/monitoring/src/database/monitoring_mysql.sql
+++ b/src/plugins/monitoring/src/database/monitoring_mysql.sql
@@ -1,7 +1,7 @@
 # $Revision$
 # $Date$
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 3);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT        NOT NULL,
@@ -37,7 +37,9 @@ CREATE TABLE ofMessageArchive (
    sentDate          BIGINT           NOT NULL,
    stanza			 TEXT			  NULL,
    body              TEXT,
-   INDEX ofMessageArchive_con_idx (conversationID)
+   INDEX ofMessageArchive_con_idx (conversationID),
+   INDEX ofMessageArchive_fromjid_idx (fromJID),
+   INDEX ofMessageArchive_tojid_idx (toJID)
 );
 
 CREATE TABLE ofRRDs (

--- a/src/plugins/monitoring/src/database/monitoring_oracle.sql
+++ b/src/plugins/monitoring/src/database/monitoring_oracle.sql
@@ -1,7 +1,7 @@
 -- $Revision$
 -- $Date$
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 3);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER        NOT NULL,
@@ -39,6 +39,8 @@ CREATE TABLE ofMessageArchive (
    body              LONG
 );
 CREATE INDEX ofMessageArchive_con_idx ON ofMessageArchive (conversationID);
+CREATE INDEX ofMessageArchive_fromjid_idx ON ofMessageArchive (fromJID);
+CREATE INDEX ofMessageArchive_tojid_idx ON ofMessageArchive (toJID);
 
 CREATE TABLE ofRRDs (
    id            VARCHAR2(100)        NOT NULL,

--- a/src/plugins/monitoring/src/database/monitoring_postgresql.sql
+++ b/src/plugins/monitoring/src/database/monitoring_postgresql.sql
@@ -1,7 +1,7 @@
 -- $Revision$
 -- $Date$
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 3);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
 
 CREATE TABLE ofConversation (
   conversationID        INTEGER       NOT NULL,
@@ -39,6 +39,8 @@ CREATE TABLE ofMessageArchive (
    body              TEXT
 );
 CREATE INDEX ofMessageArchive_con_idx ON ofMessageArchive (conversationID);
+CREATE INDEX ofMessageArchive_fromjid_idx ON ofMessageArchive (fromJID);
+CREATE INDEX ofMessageArchive_tojid_idx ON ofMessageArchive (toJID);
 
 CREATE TABLE ofRRDs (
    id            VARCHAR(100)         NOT NULL,

--- a/src/plugins/monitoring/src/database/monitoring_sqlserver.sql
+++ b/src/plugins/monitoring/src/database/monitoring_sqlserver.sql
@@ -1,7 +1,7 @@
 /* $Revision$   */
 /* $Date$       */
 
-INSERT INTO ofVersion (name, version) VALUES ('monitoring', 3);
+INSERT INTO ofVersion (name, version) VALUES ('monitoring', 4);
 
 CREATE TABLE ofConversation (
   conversationID        BIGINT         NOT NULL,
@@ -39,6 +39,8 @@ CREATE TABLE ofMessageArchive (
    body              NVARCHAR(MAX)
 );
 CREATE INDEX ofMessageArchive_con_idx ON ofMessageArchive (conversationID);
+CREATE INDEX ofMessageArchive_fromjid_idx ON ofMessageArchive (fromJID);
+CREATE INDEX ofMessageArchive_tojid_idx ON ofMessageArchive (toJID);
 
 CREATE TABLE ofRRDs (
    id            NVARCHAR(100)        NOT NULL,

--- a/src/plugins/monitoring/src/database/upgrade/4/monitoring_db2.sql
+++ b/src/plugins/monitoring/src/database/upgrade/4/monitoring_db2.sql
@@ -1,0 +1,6 @@
+-- $Revision$
+-- $Date$
+CREATE INDEX ofMessageArchive_fromjid_idx ON ofMessageArchive (fromJID);
+CREATE INDEX ofMessageArchive_tojid_idx ON ofMessageArchive (toJID);
+-- Update database version
+UPDATE ofVersion SET version = 4 WHERE name = 'monitoring';

--- a/src/plugins/monitoring/src/database/upgrade/4/monitoring_hsqldb.sql
+++ b/src/plugins/monitoring/src/database/upgrade/4/monitoring_hsqldb.sql
@@ -1,0 +1,6 @@
+-- $Revision$
+-- $Date$
+CREATE INDEX ofMessageArchive_fromjid_idx ON ofMessageArchive (fromJID);
+CREATE INDEX ofMessageArchive_tojid_idx ON ofMessageArchive (toJID);
+-- Update database version
+UPDATE ofVersion SET version = 4 WHERE name = 'monitoring';

--- a/src/plugins/monitoring/src/database/upgrade/4/monitoring_mysql.sql
+++ b/src/plugins/monitoring/src/database/upgrade/4/monitoring_mysql.sql
@@ -1,0 +1,6 @@
+-- $Revision$
+-- $Date$
+ALTER TABLE ofMessageArchive ADD INDEX ofMessageArchive_fromjid_idx (fromJID);
+ALTER TABLE ofMessageArchive ADD INDEX ofMessageArchive_tojid_idx (toJID);
+-- Update database version
+UPDATE ofVersion SET version = 4 WHERE name = 'monitoring';

--- a/src/plugins/monitoring/src/database/upgrade/4/monitoring_oracle.sql
+++ b/src/plugins/monitoring/src/database/upgrade/4/monitoring_oracle.sql
@@ -1,0 +1,8 @@
+-- $Revision$
+-- $Date$
+CREATE INDEX ofMessageArchive_fromjid_idx ON ofMessageArchive (fromJID);
+CREATE INDEX ofMessageArchive_tojid_idx ON ofMessageArchive (toJID);
+-- Update database version
+UPDATE ofVersion SET version = 4 WHERE name = 'monitoring';
+
+COMMIT;

--- a/src/plugins/monitoring/src/database/upgrade/4/monitoring_postgresql.sql
+++ b/src/plugins/monitoring/src/database/upgrade/4/monitoring_postgresql.sql
@@ -1,0 +1,6 @@
+-- $Revision$
+-- $Date$
+CREATE INDEX ofMessageArchive_fromjid_idx ON ofMessageArchive (fromJID);
+CREATE INDEX ofMessageArchive_tojid_idx ON ofMessageArchive (toJID);
+-- Update database version
+UPDATE ofVersion SET version = 4 WHERE name = 'monitoring';

--- a/src/plugins/monitoring/src/database/upgrade/4/monitoring_sqlserver.sql
+++ b/src/plugins/monitoring/src/database/upgrade/4/monitoring_sqlserver.sql
@@ -1,0 +1,6 @@
+-- $Revision$
+-- $Date$
+CREATE INDEX ofMessageArchive_fromjid_idx ON ofMessageArchive (fromJID);
+CREATE INDEX ofMessageArchive_tojid_idx ON ofMessageArchive (toJID);
+-- Update database version
+UPDATE ofVersion SET version = 4 WHERE name = 'monitoring';


### PR DESCRIPTION
This is my first commit for this project so i do not know much about the rules when it comes to database changes.

The objective of this pull request is to improve the queries done on a PostgreSQL setup for the message archives.

I have checked that there are several WHERE clauses to the fields fromJID, toJID of the ofMessageArchive table.

The indexes i have added should improve performance on PostgreSQL setup and WILL avoid sequential scan over those fields. Sequential scan are bad when you have lots of messages, rooms and users, which is our company case.

The diff shows changes to the entire file but that is because the file was filled with "^M" chars at the end of every line.

The only changes are: 
CREATE INDEX ofMessageArchive_fromjid_idx ON ofMessageArchive (fromJID);
 CREATE INDEX ofMessageArchive_tojid_idx ON ofMessageArchive (toJID);