### PR TITLE
OF-1093: Allow for empty/unknown user creation dates.

### DIFF
--- a/src/plugins/search/src/web/advance-user-search.jsp
+++ b/src/plugins/search/src/web/advance-user-search.jsp
@@ -167,7 +167,7 @@
            <%= user.getName() %> &nbsp;
        </td>
        <td width="15%">
-           <%= JiveGlobals.formatDate(user.getCreationDate()) %> &nbsp;
+           <%= user.getCreationDate() != null ? JiveGlobals.formatDate(user.getCreationDate()) : "&nbsp;" %>
        </td>
         <td width="25%">
             <% long logoutTime = presenceManager.getLastActivity(user);

--- a/src/web/user-properties.jsp
+++ b/src/web/user-properties.jsp
@@ -270,7 +270,7 @@
             <fmt:message key="user.properties.registered" />:
         </td>
         <td>
-            <%= JiveGlobals.formatDate(user.getCreationDate()) %>
+            <%= user.getCreationDate() != null ? JiveGlobals.formatDate(user.getCreationDate()) : "&nbsp;" %>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
Some user providers might not be able to provide a creation date. There's no reason
that the admin page should fail over that.
Note that this commit completes commit 2746a7f409b075bbeb74fba37bda6765a0fe2b6d,
which had an correct but incomplete fix for the same problem.