### PR TITLE
OF-1118: Don't try to use unsupported encryption settings.

### DIFF
--- a/src/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/src/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -767,7 +767,6 @@ public class ConnectionListener
      *
      * @return An (ordered) set of protocols, never null but possibly empty.
      */
-    // TODO add setter!
     public Set<String> getEncryptionProtocols()
     {
         final Set<String> result = new LinkedHashSet<>();
@@ -781,6 +780,14 @@ public class ConnectionListener
         } else {
             result.addAll( Arrays.asList( csv.split( "\\s*,\\s*" ) ) );
         }
+
+        // OF-1118: Do not return protocols that are not supported by the implementation.
+        try {
+            result.retainAll( EncryptionArtifactFactory.getSupportedProtocols() );
+        } catch ( Exception ex ) {
+            Log.error( "An error occurred while obtaining the supported encryption protocols.", ex );
+        }
+
         return result;
     }
 
@@ -880,6 +887,14 @@ public class ConnectionListener
         } else {
             result.addAll( Arrays.asList( csv.split( "\\s*,\\s*" ) ) );
         }
+
+        // OF-1118: Do not return cipher suites that are not supported by the implementation.
+        try {
+            result.retainAll( EncryptionArtifactFactory.getSupportedCipherSuites() );
+        } catch ( Exception ex ) {
+            Log.warn( "An error occurred while obtaining the supported encryption cipher suites.", ex );
+        }
+
         return result;
     }
 


### PR DESCRIPTION
Stored preferences of encryption protocols and/or cipher suites might include
non-supported items. To prevent issues, the list of preferences should be checked
against the currently supported items.