### PR TITLE
OF-1122: Restoring GSSAPI SASL support

### DIFF
--- a/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -500,6 +500,17 @@ public class SASLAuthentication {
                     it.remove();
                 }
             }
+            else if (mech.equals("GSSAPI")) {
+                final String gssapiConfig = JiveGlobals.getProperty("sasl.gssapi.config");
+                if (gssapiConfig != null) {
+                    System.setProperty("java.security.krb5.debug", JiveGlobals.getProperty("sasl.gssapi.debug", "false"));
+                    System.setProperty("java.security.auth.login.config", gssapiConfig);
+                    System.setProperty("javax.security.auth.useSubjectCredsOnly", JiveGlobals.getProperty("sasl.gssapi.useSubjectCredsOnly", "false"));
+                }
+                else {
+                    it.remove();
+                }
+            }
         }
         return answer;
     }


### PR DESCRIPTION
The changes for OF-1092 accidentally removed a snippet of code that translates
a non-optional part of the GSSAPI SASL configuration. This commit restores that,
with a difference: the configuration is now checked continuously, intead of just
on server startup. This allows for configuration changes that need not be followed
by an Openfire restart.