### PR TITLE
OF-1126: Abstract implemenation should not change signature

### DIFF
--- a/src/java/org/jivesoftware/openfire/group/AbstractGroupProvider.java
+++ b/src/java/org/jivesoftware/openfire/group/AbstractGroupProvider.java
@@ -90,7 +90,7 @@ public abstract class AbstractGroupProvider implements GroupProvider {
 	 * @throws UnsupportedOperationException
 	 */
     @Override
-    public Group createGroup(String name) {
+    public Group createGroup(String name) throws GroupAlreadyExistsException {
         throw new UnsupportedOperationException("Cannot create groups via read-only provider");
     }
 


### PR DESCRIPTION
The abstract implementation of GroupProvider should not hide the thrown
clause as defined by the createGroup() signature.