### PR TITLE
Eclipse project: Add extra plugins

### DIFF
--- a/build/eclipse/classpath
+++ b/build/eclipse/classpath
@@ -1,29 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src/java"/>
+	<classpathentry kind="src" output="work/plugins-dev/bookmarks/target/classes" path="src/plugins/bookmarks/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/broadcast/target/classes" path="src/plugins/broadcast/src/java"/>
+	<classpathentry kind="src" output="work/plugins-dev/callbackOnOffline/target/classes" path="src/plugins/callbackOnOffline/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/clientControl/target/classes" path="src/plugins/clientControl/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/contentFilter/target/classes" path="src/plugins/contentFilter/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/dbaccess/target/classes" path="src/plugins/dbaccess/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/emailListener/target/classes" path="src/plugins/emailListener/src/java"/>
+	<classpathentry kind="src" output="work/plugins-dev/emailOnAway/target/classes" path="src/plugins/emailOnAway/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/fastpath/target/classes" path="src/plugins/fastpath/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/gojara/target/classes" path="src/plugins/gojara/src/java"/>
+	<classpathentry kind="src" output="work/plugins-dev/hazelcast/target/classes" path="src/plugins/hazelcast/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/jingleNodes/target/classes" path="src/plugins/jingleNodes/src/java"/>
+	<classpathentry kind="src" output="work/plugins-dev/jmxweb/target/classes" path="src/plugins/jmxweb/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/justmarried/target/classes" path="src/plugins/justmarried/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/kraken/target/classes" path="src/plugins/kraken/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/loadStats/target/classes" path="src/plugins/loadStats/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/monitoring/target/classes" path="src/plugins/monitoring/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/motd/target/classes" path="src/plugins/motd/src/java"/>
+	<classpathentry kind="src" output="work/plugins-dev/mucservice/target/classes" path="src/plugins/mucservice/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/nodejs/target/classes" path="src/plugins/nodejs/src/java"/>
+	<classpathentry kind="src" output="work/plugins-dev/nonSaslAuthentication/target/classes" path="src/plugins/nonSaslAuthentication/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/packetFilter/target/classes" path="src/plugins/packetFilter/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/presence/target/classes" path="src/plugins/presence/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/registration/target/classes" path="src/plugins/registration/src/java"/>
+	<classpathentry kind="src" output="work/plugins-dev/restAPI/target/classes" path="src/plugins/restAPI/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/search/target/classes" path="src/plugins/search/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/stunserver/target/classes" path="src/plugins/stunserver/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/subscription/target/classes" path="src/plugins/subscription/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/userCreation/target/classes" path="src/plugins/userCreation/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/userImportExport/target/classes" path="src/plugins/userImportExport/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/userservice/target/classes" path="src/plugins/userservice/src/java"/>
+	<classpathentry kind="src" output="work/plugins-dev/websocket/target/classes" path="src/plugins/websocket/src/java"/>
 	<classpathentry kind="src" output="work/plugins-dev/xmldebugger/target/classes" path="src/plugins/xmldebugger/src/java"/>
 	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry kind="src" path="src/test/throttletest/src"/>
@@ -102,7 +111,6 @@
 	<classpathentry kind="lib" path="src/plugins/kraken/lib/smackx.jar"/>
 	<classpathentry kind="lib" path="src/plugins/kraken/lib/stcomm.jar"/>
 	<classpathentry kind="lib" path="src/plugins/kraken/lib/xmlrpc.jar"/>
-	<classpathentry kind="lib" path="src/plugins/jingleNodes/lib/jnsapi.jar"/>
 	<classpathentry kind="lib" path="src/plugins/monitoring/lib/itext.jar"/>
 	<classpathentry kind="lib" path="src/plugins/monitoring/lib/jcommon.jar"/>
 	<classpathentry kind="lib" path="src/plugins/monitoring/lib/jfreechart.jar"/>
@@ -147,5 +155,24 @@
 	<classpathentry kind="lib" path="build/lib/merge/org.eclipse.jetty.apache-jsp.jar"/>
 	<classpathentry kind="lib" path="build/lib/merge/org.eclipse.jetty.orbit.org.eclipse.jdt.core.jar"/>
 	<classpathentry kind="lib" path="build/lib/merge/jcl-over-slf4j.jar"/>
+	<classpathentry kind="lib" path="build/lib/merge/websocket-api.jar"/>
+	<classpathentry kind="lib" path="build/lib/merge/websocket-client.jar"/>
+	<classpathentry kind="lib" path="build/lib/merge/websocket-common.jar"/>
+	<classpathentry kind="lib" path="build/lib/merge/websocket-server.jar"/>
+	<classpathentry kind="lib" path="build/lib/merge/websocket-servlet.jar"/>
+	<classpathentry kind="lib" path="src/plugins/restAPI/lib/asm-3.1.jar"/>
+	<classpathentry kind="lib" path="src/plugins/restAPI/lib/jersey-bundle-1.18.jar"/>
+	<classpathentry kind="lib" path="src/plugins/rayo/lib/rayo-core-2.0-SNAPSHOT.jar"/>
+	<classpathentry kind="lib" path="src/plugins/rayo/lib/netty-3.5.1.Final.jar"/>
+	<classpathentry kind="lib" path="src/plugins/rayo/lib/freetts.jar"/>
+	<classpathentry kind="lib" path="src/plugins/websocket/lib/commons-pool2-2.3.jar"/>
+	<classpathentry kind="lib" path="src/plugins/hazelcast/lib/hazelcast-3.5.1.jar"/>
+	<classpathentry kind="lib" path="src/plugins/rayo/lib/codecLib_dtmf.jar"/>
+	<classpathentry kind="lib" path="src/plugins/rayo/lib/jspeex.jar"/>
+	<classpathentry kind="lib" path="src/plugins/rayo/lib/guava-11.0.1.jar"/>
+	<classpathentry kind="lib" path="src/plugins/rayo/lib/stun.jar"/>
+	<classpathentry kind="lib" path="src/plugins/rayo/lib/validation-api-1.1.0.Final.jar"/>
+	<classpathentry kind="lib" path="src/plugins/rayo/lib/cmu_us_kal.jar"/>
+	<classpathentry kind="lib" path="src/plugins/rayo/lib/en_us.jar"/>
 	<classpathentry kind="output" path="work/classes"/>
 </classpath>


### PR DESCRIPTION
Add their source directories and libraries where possible. 

Unable to add:

- clustering - seems dependant on coherence library not in repo
- rayo - duplicate classes cause clashes with jingleNodes and nodejs plugins so I've skipped adding it for now

e.g.

org.xmpp.jnodes.RelayChannel - in both jingleNodes and rayo
org.jitsi.util.OSUtils - in both nodejs and rayo

For the duplicate classes - I understand that plugins are isolated class-loader wise - but the clashes means you can't use a single eclipse project with them in. If these classes can't be moved to a common library the traditional approach with eclipse would be to have individual projects per plugin. Perhaps I should take this discussion to your forums - or you've indicated your reluctance to have such things in the repo, so maybe this is "Good Enough" _tm_.
