### PR TITLE
OF-1132: Ensure that retreived messages have a namespace.

### DIFF
--- a/src/plugins/monitoring/changelog.html
+++ b/src/plugins/monitoring/changelog.html
@@ -43,6 +43,11 @@
 <h1>
 Monitoring Plugin Changelog
 </h1>
+<p><b>1.5.4</b> -- April 27, 2016</p>
+<ul>
+    <li>[<a href='https://igniterealtime.org/issues/browse/OF-1132'>OF-1132</a>] - Ensure that namespace is defined on forwarded messages.</li>
+</ul>
+
 <p><b>1.5.3</b> -- March 22, 2016</p>
 <ul>
     <li>[<a href='https://igniterealtime.org/issues/browse/OF-1117'>OF-1117</a>] - Improve performance of monitoring plugin by adding database indexes.</li>

--- a/src/plugins/monitoring/plugin.xml
+++ b/src/plugins/monitoring/plugin.xml
@@ -5,8 +5,8 @@
     <name>Monitoring Service</name>
     <description>Monitors conversations and statistics of the server.</description>
     <author>Jive Software</author>
-    <version>1.5.3</version>
-    <date>2/15/2016</date>
+    <version>1.5.4</version>
+    <date>4/27/2016</date>
     <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>4</databaseVersion>

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler.java
@@ -9,10 +9,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.TimeZone;
 
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.DocumentHelper;
-import org.dom4j.Element;
+import org.dom4j.*;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.disco.ServerFeaturesProvider;
 import org.jivesoftware.openfire.handler.IQHandler;
@@ -227,6 +224,12 @@ public class IQQueryHandler extends AbstractIQHandler implements
 		Document stanza;
 		try {
 			stanza = DocumentHelper.parseText(archivedMessage.getStanza());
+			if ( stanza.getRootElement().getNamespaceURI() == null || stanza.getRootElement().getNamespaceURI().isEmpty() )
+			{
+				// OF-1132: If no 'xmlns' is set for the stanza then as per XML namespacing rules it would inherit the
+				// 'urn:xmpp:forward:0' namespace, which is wrong (see XEP-0297).
+				stanza.getRootElement().setQName( QName.get( stanza.getRootElement().getName(), "jabber:client") );
+			}
 			forwarded.add(stanza.getRootElement());
 		} catch (DocumentException e) {
 			Log.error("Failed to parse message stanza.", e);


### PR DESCRIPTION
If no 'xmlns' is set for the stanza then as per XML namespacing rules it would
inherit the default namespace, which is wrong (see XEP-0297).