### PR TITLE
OF-1141 Fix default configuration of PEP/PubSub

### DIFF
--- a/src/java/org/jivesoftware/openfire/pep/PEPService.java
+++ b/src/java/org/jivesoftware/openfire/pep/PEPService.java
@@ -155,7 +155,7 @@ public class PEPService implements PubSubService, Cacheable {
             leafDefaultConfiguration.setNotifyDelete(true);
             leafDefaultConfiguration.setNotifyRetract(true);
             leafDefaultConfiguration.setPersistPublishedItems(false);
-            leafDefaultConfiguration.setMaxPublishedItems(-1);
+            leafDefaultConfiguration.setMaxPublishedItems(1);
             leafDefaultConfiguration.setPresenceBasedDelivery(false);
             leafDefaultConfiguration.setSendItemSubscribe(true);
             leafDefaultConfiguration.setSubscriptionEnabled(true);

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -427,7 +427,7 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
             leafDefaultConfiguration.setNotifyDelete(true);
             leafDefaultConfiguration.setNotifyRetract(true);
             leafDefaultConfiguration.setPersistPublishedItems(false);
-            leafDefaultConfiguration.setMaxPublishedItems(-1);
+            leafDefaultConfiguration.setMaxPublishedItems(1);
             leafDefaultConfiguration.setPresenceBasedDelivery(false);
             leafDefaultConfiguration.setSendItemSubscribe(true);
             leafDefaultConfiguration.setSubscriptionEnabled(true);


### PR DESCRIPTION
Both PEP and Pubsub configure leaf nodes to store -1 items by default; however
this value is not corrected by the usual post-configuration checks to 1, and
this in turn means that when gathering the items to return, the single
item is removed.

This PR corrects the issue by setting the maxPublishedItems in the default
configuration to 1 instead in both cases.