### PR TITLE
Forced set of JAVA_HOME

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -104,7 +104,7 @@
     <property name="copy.dbscripts" value="true"/>
     <property name="overwrite" value="true"/>
 
-    <property name="installer.install4j.home" value="/home/j2ee-bamboo/install4j.5.1.11"/>
+    <property name="installer.install4j.home" value="/home/bamboo/install4j.6.0.4"/>
     <property name="installer.src" value="${basedir}/build/installer"/>
     <property name="installer.dest.dir" value="${release.dest.dir}"/>
     <property name="installer.install4j.srcfile" value="${installer.src}/openfire.install4j"/>

--- a/build/debian/rules
+++ b/build/debian/rules
@@ -13,7 +13,7 @@ ETCDIR := $(DEST)/etc/openfire
 LOGDIR := $(DEST)/var/log/openfire
 VARDIR := $(DEST)/var/lib/openfire
 
-JAVA_HOME ?= /usr/lib/jvm/java-8-openjdk-amd64
+JAVA_HOME := /usr/lib/jvm/java-8-openjdk-amd64
 DEB_ANT_BUILDFILE := build/build.xml
 DEB_ANT_CLEAN_TARGET := clean
 


### PR DESCRIPTION
The ?= was not setting JAVA_HOME, despite it not being set in the shell before starting the ant command. The build was then failing with a "You must specify a valid JAVA_HOME or JAVACMD!"
The := forces it to that path. Which is slightly brittle, but if someone else wants to figure it out they're welcome.