### PR TITLE
OF-1139: User-to-provider mapping

### DIFF
--- a/src/java/org/jivesoftware/openfire/auth/AuthProviderMapper.java
+++ b/src/java/org/jivesoftware/openfire/auth/AuthProviderMapper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 IgniteRealtime.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.auth;
+
+import java.util.Set;
+import java.util.SortedSet;
+
+/**
+ * Implementations are used to determine what AuthProvider is to be used for a particular username.
+ *
+ * Implementation must have a no-argument constructor.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see MappedAuthProvider
+ */
+public interface AuthProviderMapper
+{
+    /**
+     * Finds a suitable AuthProvider for the user. Returns null when no AuthProvider can be found for the particular
+     * user.
+     *
+     * @param username A user identifier (cannot be null or empty).
+     * @return An AuthProvider for the user (possibly null).
+     */
+    AuthProvider getAuthProvider( String username );
+
+    /**
+     * Returns all providers that are used by this instance.
+     *
+     * The returned collection should have a consistent, predictable iteration order.
+     *
+     * @return all providers (never null).
+     */
+    Set<AuthProvider> getAuthProviders();
+}

--- a/src/java/org/jivesoftware/openfire/auth/AuthorizationBasedAuthProviderMapper.java
+++ b/src/java/org/jivesoftware/openfire/auth/AuthorizationBasedAuthProviderMapper.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016 IgniteRealtime.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.auth;
+
+import org.jivesoftware.openfire.admin.AdminManager;
+import org.jivesoftware.util.ClassUtils;
+import org.jivesoftware.util.JiveGlobals;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * A {@link AuthProviderMapper} that can be used to draw administrative users from another source than the regular, non-
+ * administrative users.
+ *
+ * This implementation uses {@link AdminManager} to determine if a particular user is an administrative user. When a
+ * user is not recognized, it is deemed a regular, non-administrative user.
+ *
+ * To configure this provider, the both system properties from the example below <em>must</em> be defined. Their value
+ * must reference the classname of an {@link AuthProvider}.
+ *
+ * <ul>
+ * <li><tt>authorizationBasedAuthMapper.adminProvider.className = org.jivesoftware.openfire.auth.DefaultAuthProvider</tt></li>
+ * <li><tt>authorizationBasedAuthMapper.userProvider.className = org.jivesoftware.openfire.auth.NativeAuthProvider</tt></li>
+ * </ul>
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class AuthorizationBasedAuthProviderMapper implements AuthProviderMapper
+{
+    /**
+     * Name of the property of which the value is expected to be the classname of the AuthProvider which will serve the
+     * administrative users.
+     */
+    public static final String PROPERTY_ADMINPROVIDER_CLASSNAME = "authorizationBasedAuthMapper.adminProvider.className";
+
+    /**
+     * Name of the property of which the value is expected to be the classname of the AuthProvider which will serve the
+     * regular, non-administrative users.
+     */
+    public static final String PROPERTY_USERPROVIDER_CLASSNAME = "authorizationBasedAuthMapper.userProvider.className";
+
+    /**
+     * Serves the administrative users.
+     */
+    protected final AuthProvider adminProvider;
+
+    /**
+     * Serves the regular, non-administrative users.
+     */
+    protected final AuthProvider userProvider;
+
+    public AuthorizationBasedAuthProviderMapper()
+    {
+        // Migrate properties.
+        JiveGlobals.migrateProperty( PROPERTY_ADMINPROVIDER_CLASSNAME );
+        JiveGlobals.migrateProperty( PROPERTY_USERPROVIDER_CLASSNAME );
+
+        // Instantiate providers.
+        adminProvider = instantiateProvider( PROPERTY_ADMINPROVIDER_CLASSNAME );
+        userProvider = instantiateProvider( PROPERTY_USERPROVIDER_CLASSNAME );
+    }
+
+    protected static AuthProvider instantiateProvider( String propertyName )
+    {
+        final String className = JiveGlobals.getProperty( propertyName );
+        if ( className == null )
+        {
+            throw new IllegalStateException( "A class name must be specified via openfire.xml or the system properties." );
+        }
+
+        try
+        {
+            final Class c = ClassUtils.forName( className );
+            return (AuthProvider) c.newInstance();
+        }
+        catch ( Exception e )
+        {
+            throw new IllegalStateException( "Unable to create new instance of AuthProvider: " + className, e );
+        }
+    }
+
+    @Override
+    public AuthProvider getAuthProvider( String username )
+    {
+        // TODO add optional caching, to prevent retrieving the administrative users upon every invocation.
+        final boolean isAdmin = AdminManager.getAdminProvider().getAdmins().contains( username );
+
+        if ( isAdmin )
+        {
+            return adminProvider;
+        } else
+        {
+            return userProvider;
+        }
+    }
+
+    @Override
+    public SortedSet<AuthProvider> getAuthProviders()
+    {
+        final SortedSet<AuthProvider> result = new TreeSet<>();
+        result.add( adminProvider );
+        result.add( userProvider );
+
+        return result;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
@@ -39,6 +39,10 @@ import org.slf4j.LoggerFactory;
  *      <li>If the tertiary provider is defined, attempt authentication.
  * </ol>
  *
+ * This class related to, but is distinct from {@link MappedAuthProvider}. The Hybrid variant of the provider iterates
+ * over providers, operating on the first applicable instance. The Mapped variant, however, maps each user to exactly
+ * one provider.
+ *
  * To enable this provider, set the <tt>provider.auth.className</tt> system property to
  * <tt>org.jivesoftware.openfire.auth.HybridAuthProvider</tt>.
  *
@@ -77,7 +81,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HybridAuthProvider implements AuthProvider {
 
-	private static final Logger Log = LoggerFactory.getLogger(HybridAuthProvider.class);
+    private static final Logger Log = LoggerFactory.getLogger(HybridAuthProvider.class);
 
     private AuthProvider primaryProvider;
     private AuthProvider secondaryProvider;

--- a/src/java/org/jivesoftware/openfire/auth/MappedAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/MappedAuthProvider.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2016 IgniteRealtime.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.auth;
+
+import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.jivesoftware.util.ClassUtils;
+import org.jivesoftware.util.JiveGlobals;
+
+/**
+ * A {@link AuthProvider} that delegates to a user-specific AuthProvider.
+ *
+ * This class related to, but is distinct from {@link HybridAuthProvider}. The Hybrid variant of the provider iterates
+ * over providers, operating on the first applicable instance. This Mapped variant, however, maps each user to exactly
+ * one provider.
+ *
+ * To use this provider, use the following system property definition:
+ *
+ * <ul>
+ * <li><tt>provider.auth.className = org.jivesoftware.openfire.user.MappedAuthProvider</tt></li>
+ * </ul>
+ *
+ * To be usable, a {@link AuthProviderMapper} must be configured using the <tt>mappedAuthProvider.mapper.className</tt>
+ * system property. It is of importance to note that most AuthProviderMapper implementations will require additional
+ * configuration.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class MappedAuthProvider implements AuthProvider
+{
+    /**
+     * Name of the property of which the value is expected to be the classname of the AuthProviderMapper instance to be
+     * used by instances of this class.
+     */
+    public static final String PROPERTY_MAPPER_CLASSNAME = "mappedAuthProvider.mapper.className";
+
+    /**
+     * Used to determine what provider is to be used to operate on a particular user.
+     */
+    protected final AuthProviderMapper mapper;
+
+    public MappedAuthProvider()
+    {
+        // Migrate properties.
+        JiveGlobals.migrateProperty( PROPERTY_MAPPER_CLASSNAME );
+
+        // Instantiate mapper.
+        final String mapperClass = JiveGlobals.getProperty( PROPERTY_MAPPER_CLASSNAME );
+        if ( mapperClass == null )
+        {
+            throw new IllegalStateException( "A mapper must be specified via openfire.xml or the system properties." );
+        }
+
+        try
+        {
+            final Class c = ClassUtils.forName( mapperClass );
+            mapper = (AuthProviderMapper) c.newInstance();
+        }
+        catch ( Exception e )
+        {
+            throw new IllegalStateException( "Unable to create new instance of AuthProviderMapper class: " + mapperClass, e );
+        }
+    }
+
+    @Override
+    public void authenticate( String username, String password ) throws UnauthorizedException, ConnectionException, InternalUnauthenticatedException
+    {
+        final AuthProvider provider = mapper.getAuthProvider( username );
+        if ( provider == null )
+        {
+            throw new UnauthorizedException();
+        }
+        provider.authenticate( username, password );
+    }
+
+    @Override
+    public String getPassword( String username ) throws UserNotFoundException, UnsupportedOperationException
+    {
+        final AuthProvider provider = mapper.getAuthProvider( username );
+        if ( provider == null )
+        {
+            throw new UserNotFoundException();
+        }
+        return provider.getPassword( username );
+    }
+
+    @Override
+    public void setPassword( String username, String password ) throws UserNotFoundException, UnsupportedOperationException
+    {
+        final AuthProvider provider = mapper.getAuthProvider( username );
+        if ( provider == null )
+        {
+            throw new UserNotFoundException();
+        }
+        provider.setPassword( username, password );
+    }
+
+    @Override
+    public boolean supportsPasswordRetrieval()
+    {
+        // TODO Make calls concurrent for improved throughput.
+        for ( final AuthProvider provider : mapper.getAuthProviders() )
+        {
+            // If at least one provider supports password retrieval, so does this proxy.
+            if ( provider.supportsPasswordRetrieval() )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean isScramSupported()
+    {
+        // TODO Make calls concurrent for improved throughput.
+        for ( final AuthProvider provider : mapper.getAuthProviders() )
+        {
+            // If at least one provider supports SCRAM, so does this proxy.
+            if ( provider.isScramSupported() )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/user/AuthorizationBasedUserProviderMapper.java
+++ b/src/java/org/jivesoftware/openfire/user/AuthorizationBasedUserProviderMapper.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 IgniteRealtime.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.user;
+
+import org.jivesoftware.openfire.admin.AdminManager;
+import org.jivesoftware.util.JiveGlobals;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * A {@link UserProviderMapper} that can be used to draw administrative users from another source than the regular, non-
+ * administrative users.
+ *
+ * This implementation uses {@link AdminManager} to determine if a particular user is an administrative user. When a
+ * user is not recognized, it is deemed a regular, non-administrative user.
+ *
+ * To configure this provider, the both system properties from the example below <em>must</em> be defined. Their value
+ * must reference the classname of an {@link UserProvider}.
+ *
+ * <ul>
+ * <li><tt>authorizationBasedUserMapper.adminProvider.className = org.jivesoftware.openfire.auth.DefaultUserProvider</tt></li>
+ * <li><tt>authorizationBasedUserMapper.userProvider.className = org.jivesoftware.openfire.auth.NativeUserProvider</tt></li>
+ * </ul>
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class AuthorizationBasedUserProviderMapper implements UserProviderMapper
+{
+    /**
+     * Name of the property of which the value is expected to be the classname of the UserProvider which will serve the
+     * administrative users.
+     */
+    public static final String PROPERTY_ADMINPROVIDER_CLASSNAME = "authorizationBasedUserMapper.adminProvider.className";
+
+    /**
+     * Name of the property of which the value is expected to be the classname of the UserProvider which will serve the
+     * regular, non-administrative users.
+     */
+    public static final String PROPERTY_USERPROVIDER_CLASSNAME = "authorizationBasedUserMapper.userProvider.className";
+
+    /**
+     * Serves the administrative users.
+     */
+    protected final UserProvider adminProvider;
+
+    /**
+     * Serves the regular, non-administrative users.
+     */
+    protected final UserProvider userProvider;
+
+    public AuthorizationBasedUserProviderMapper()
+    {
+        // Migrate properties.
+        JiveGlobals.migrateProperty( PROPERTY_ADMINPROVIDER_CLASSNAME );
+        JiveGlobals.migrateProperty( PROPERTY_USERPROVIDER_CLASSNAME );
+
+        // Instantiate providers.
+        adminProvider = UserMultiProvider.instantiate( PROPERTY_ADMINPROVIDER_CLASSNAME );
+        if ( adminProvider == null )
+        {
+            throw new IllegalStateException( "A class name for the admin provider must be specified via openfire.xml or the system properties using property: " + PROPERTY_ADMINPROVIDER_CLASSNAME );
+        }
+        userProvider = UserMultiProvider.instantiate( PROPERTY_USERPROVIDER_CLASSNAME );
+        if ( userProvider == null )
+        {
+            throw new IllegalStateException( "A class name for the user provider must be specified via openfire.xml or the system properties using property: " + PROPERTY_USERPROVIDER_CLASSNAME );
+        }
+    }
+
+    @Override
+    public UserProvider getUserProvider( String username )
+    {
+        // TODO add optional caching, to prevent retrieving the administrative users upon every invocation.
+        final boolean isAdmin = AdminManager.getAdminProvider().getAdmins().contains( username );
+
+        if ( isAdmin )
+        {
+            return adminProvider;
+        } else
+        {
+            return userProvider;
+        }
+    }
+
+    @Override
+    public SortedSet<UserProvider> getUserProviders()
+    {
+        final SortedSet<UserProvider> result = new TreeSet<>();
+        result.add( adminProvider );
+        result.add( userProvider );
+
+        return result;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/user/MappedUserProvider.java
+++ b/src/java/org/jivesoftware/openfire/user/MappedUserProvider.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2016 IgniteRealtime.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.user;
+
+import org.jivesoftware.util.ClassUtils;
+import org.jivesoftware.util.JiveGlobals;
+
+import java.util.Collection;
+import java.util.Date;
+
+/**
+ * A {@link UserProvider} that delegates to a user-specific UserProvider.
+ *
+ * This class related to, but is distinct from {@link HybridUserProvider}. The Hybrid variant of the provider iterates
+ * over providers, operating on the first applicable instance. This Mapped variant, however, maps each user to exactly
+ * one provider.
+ *
+ * To use this provider, use the following system property definition:
+ *
+ * <ul>
+ * <li><tt>provider.user.className = org.jivesoftware.openfire.user.MappedUserProvider</tt></li>
+ * </ul>
+ *
+ * To be usable, a {@link UserProviderMapper} must be configured using the <tt>mappedUserProvider.mapper.className</tt>
+ * system property. It is of importance to note that most UserProviderMapper implementations will require additional
+ * configuration.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see org.jivesoftware.openfire.auth.MappedAuthProvider
+ */
+public class MappedUserProvider extends UserMultiProvider
+{
+    /**
+     * Name of the property of which the value is expected to be the classname of the UserProviderMapper instance to be
+     * used by instances of this class.
+     */
+    public static final String PROPERTY_MAPPER_CLASSNAME = "mappedUserProvider.mapper.className";
+
+    /**
+     * Used to determine what provider is to be used to operate on a particular user.
+     */
+    protected final UserProviderMapper mapper;
+
+    public MappedUserProvider()
+    {
+
+        // Migrate properties.
+        JiveGlobals.migrateProperty( PROPERTY_MAPPER_CLASSNAME );
+
+        // Instantiate mapper.
+        final String mapperClass = JiveGlobals.getProperty( PROPERTY_MAPPER_CLASSNAME );
+        if ( mapperClass == null )
+        {
+            throw new IllegalStateException( "A mapper must be specified via openfire.xml or the system properties." );
+        }
+
+        try
+        {
+            final Class c = ClassUtils.forName( mapperClass );
+            mapper = (UserProviderMapper) c.newInstance();
+        }
+        catch ( Exception e )
+        {
+            throw new IllegalStateException( "Unable to create new instance of UserProviderMapper class: " + mapperClass, e );
+        }
+    }
+
+    @Override
+    public Collection<UserProvider> getUserProviders()
+    {
+        return mapper.getUserProviders();
+    }
+
+    @Override
+    public UserProvider getUserProvider( String username )
+    {
+        return mapper.getUserProvider( username );
+    }
+
+    @Override
+    public User loadUser( String username ) throws UserNotFoundException
+    {
+        final UserProvider userProvider;
+        try{
+            userProvider = getUserProvider( username );
+        } catch (RuntimeException e){
+            throw new UserNotFoundException("Unable to identify user provider for username "+username, e);
+        }
+        return userProvider.loadUser( username );
+    }
+
+    @Override
+    public User createUser( String username, String password, String name, String email ) throws UserAlreadyExistsException
+    {
+        return getUserProvider( username ).createUser( username, password, name, email );
+    }
+
+    @Override
+    public void deleteUser( String username )
+    {
+        getUserProvider( username ).deleteUser( username );
+    }
+
+    @Override
+    public void setName( String username, String name ) throws UserNotFoundException
+    {
+        getUserProvider( username ).setName( username, name );
+    }
+
+    @Override
+    public void setEmail( String username, String email ) throws UserNotFoundException
+    {
+        getUserProvider( username ).setEmail( username, email );
+    }
+
+    @Override
+    public void setCreationDate( String username, Date creationDate ) throws UserNotFoundException
+    {
+        getUserProvider( username ).setCreationDate( username, creationDate );
+    }
+
+    @Override
+    public void setModificationDate( String username, Date modificationDate ) throws UserNotFoundException
+    {
+        getUserProvider( username ).setModificationDate( username, modificationDate );
+    }
+}

--- a/src/java/org/jivesoftware/openfire/user/UserMultiProvider.java
+++ b/src/java/org/jivesoftware/openfire/user/UserMultiProvider.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2016 IgniteRealtime.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.user;
+
+import org.jivesoftware.util.ClassUtils;
+import org.jivesoftware.util.JiveGlobals;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * A {@link UserProvider} that delegates to one or more 'backing' UserProvider.
+ *
+ * @author GUus der Kinderen, guus@goodbytes.nl
+ */
+public abstract class UserMultiProvider implements UserProvider
+{
+    private final static Logger Log = LoggerFactory.getLogger( UserMultiProvider.class );
+
+    /**
+     * Instantiates a UserProvider based on a property value (that is expected to be a class name). When the property
+     * is not set, this method returns null. When the property is set, but an exception occurs while instantiating
+     * the class, this method logs the error and returns null.
+     *
+     * UserProvider classes are required to have a public, no-argument constructor.
+     *
+     * @param propertyName A property name (cannot ben ull).
+     * @return A user provider (can be null).
+     */
+    public static UserProvider instantiate( String propertyName )
+    {
+        final String className = JiveGlobals.getProperty( propertyName );
+        if ( className == null )
+        {
+            Log.debug( "Property '{}' is undefined. Skipping.", propertyName );
+            return null;
+        }
+        Log.debug( "About to to instantiate an UserProvider '{}' based on the value of property '{}'.", className, propertyName );
+        try
+        {
+            final Class c = ClassUtils.forName( className );
+            final UserProvider provider = (UserProvider) c.newInstance();
+            Log.debug( "Instantiated UserProvider '{}'", className );
+            return provider;
+        }
+        catch ( Exception e )
+        {
+            Log.error( "Unable to load UserProvider '{}'. Users in this provider will be disabled.", className, e );
+            return null;
+        }
+    }
+
+    /**
+     * Returns all UserProvider instances that serve as 'backing' providers.
+     *
+     * @return A collection of providers (never null).
+     */
+    abstract Collection<UserProvider> getUserProviders();
+
+    /**
+     * Returns the 'backing' provider that serves the provided user. Note that the user need not exist.
+     *
+     * Finds a suitable UserProvider for the user.
+     *
+     * Note that the provided username need not reflect a pre-existing user (the instance might be used to determine in
+     * which provider a new user is to be created).
+     *
+     * Implementations are expected to be able to find a UserProvider for any username. If an implementation fails to do
+     * so, such a failure is assumed to be the result of a problem in implementation or configuration.
+     *
+     * @param username A user identifier (cannot be null or empty).
+     * @return A UserProvider for the user (never null).
+     */
+    abstract UserProvider getUserProvider( String username );
+
+    @Override
+    public int getUserCount()
+    {
+        int total = 0;
+        // TODO Make calls concurrent for improved throughput.
+        for ( final UserProvider provider : getUserProviders() )
+        {
+            total += provider.getUserCount();
+        }
+
+        return total;
+    }
+
+    @Override
+    public Collection<User> getUsers()
+    {
+        final Collection<User> result = new ArrayList<>();
+        for ( final UserProvider provider : getUserProviders() )
+        {
+            // TODO Make calls concurrent for improved throughput.
+            result.addAll( provider.getUsers() );
+        }
+
+        return result;
+    }
+
+    @Override
+    public Collection<String> getUsernames()
+    {
+        final Collection<String> result = new ArrayList<>();
+        for ( final UserProvider provider : getUserProviders() )
+        {
+            // TODO Make calls concurrent for improved throughput.
+            result.addAll( provider.getUsernames() );
+        }
+
+        return result;
+    }
+
+    @Override
+    public Collection<User> getUsers( int startIndex, int numResults )
+    {
+        final List<User> userList = new ArrayList<>();
+        int totalUserCount = 0;
+
+        for ( final UserProvider provider : getUserProviders() )
+        {
+            final int providerStartIndex = Math.max( ( startIndex - totalUserCount ), 0 );
+            totalUserCount += provider.getUserCount();
+            if ( startIndex >= totalUserCount )
+            {
+                continue;
+            }
+            final int providerResultMax = numResults - userList.size();
+            userList.addAll( provider.getUsers( providerStartIndex, providerResultMax ) );
+            if ( userList.size() >= numResults )
+            {
+                break;
+            }
+        }
+        return userList;
+    }
+
+    /**
+     * Searches for users based on a set of fields and a query string. The fields must  be taken from the values
+     * returned by {@link #getSearchFields()}. The query can  include wildcards. For example, a search on the field
+     * "Name" with a query of "Ma*"  might return user's with the name "Matt", "Martha" and "Madeline".
+     *
+     * This method throws an UnsupportedOperationException when none of the backing providers support search.
+     *
+     * When fields are provided that are not supported by a particular provider, those fields are ignored by that
+     * provider (but can still be used by other providers).
+     *
+     * @param fields the fields to search on.
+     * @param query  the query string.
+     * @return a Collection of users that match the search.
+     * @throws UnsupportedOperationException When none of the providers support search.
+     */
+    @Override
+    public Collection<User> findUsers( Set<String> fields, String query ) throws UnsupportedOperationException
+    {
+        final List<User> userList = new ArrayList<>();
+        int supportSearch = getUserProviders().size();
+
+        // TODO Make calls concurrent for improved throughput.
+        for ( final UserProvider provider : getUserProviders() )
+        {
+            try
+            {
+                // Use only those fields that are supported by the provider.
+                final Set<String> supportedFields = new HashSet<>( fields );
+                supportedFields.retainAll( provider.getSearchFields() );
+
+                userList.addAll( provider.findUsers( supportedFields, query ) );
+            }
+            catch ( UnsupportedOperationException uoe )
+            {
+                Log.warn( "UserProvider.findUsers is not supported by this UserProvider: {}. Its users are not returned as part of search queries.", provider.getClass().getName() );
+                supportSearch--;
+            }
+        }
+
+        if ( supportSearch == 0 )
+        {
+            throw new UnsupportedOperationException( "None of the backing providers support this operation." );
+        }
+        return userList;
+    }
+
+    /**
+     * Searches for users based on a set of fields and a query string. The fields must  be taken from the values
+     * returned by {@link #getSearchFields()}. The query can  include wildcards. For example, a search on the field
+     * "Name" with a query of "Ma*"  might return user's with the name "Matt", "Martha" and "Madeline".
+     *
+     * This method throws an UnsupportedOperationException when none of the backing providers support search.
+     *
+     * When fields are provided that are not supported by a particular provider, those fields are ignored by that
+     * provider (but can still be used by other providers).
+     *
+     * The startIndex and numResults parameters are used to page through search results. For example, if the startIndex
+     * is 0 and numResults is 10, the first  10 search results will be returned. Note that numResults is a request for
+     * the number of results to return and that the actual number of results returned may be fewer.
+     *
+     * @param fields     the fields to search on.
+     * @param query      the query string.
+     * @param startIndex the starting index in the search result to return.
+     * @param numResults the number of users to return in the search result.
+     * @return a Collection of users that match the search.
+     * @throws UnsupportedOperationException When none of the providers support search.
+     */
+    @Override
+    public Collection<User> findUsers( Set<String> fields, String query, int startIndex, int numResults ) throws UnsupportedOperationException
+    {
+        final List<User> userList = new ArrayList<>();
+        int supportSearch = getUserProviders().size();
+        int totalMatchedUserCount = 0;
+
+        for ( final UserProvider provider : getUserProviders() )
+        {
+            try
+            {
+                // Use only those fields that are supported by the provider.
+                final Set<String> supportedFields = new HashSet<>( fields );
+                supportedFields.retainAll( provider.getSearchFields() );
+
+                // Query the provider for sub-results.
+                final Collection<User> providerResults = provider.findUsers( fields, query );
+
+                // Keep track of how many hits we have had so far.
+                totalMatchedUserCount += providerResults.size();
+
+                // Check if this sub-result contains the start of the page of data that is searched for.
+                if ( startIndex >= totalMatchedUserCount )
+                {
+                    continue;
+                }
+
+                // From the sub-results, take those that are of interest.
+                final int providerStartIndex = Math.max( 0, startIndex - totalMatchedUserCount );
+                final int providerResultMax = numResults - userList.size();
+                final List<User> providerList = providerResults instanceof List<?> ?
+                        (List<User>) providerResults : new ArrayList<>( providerResults );
+                userList.addAll( providerList.subList( providerStartIndex, providerResultMax ) );
+
+                // Check if we have enough results.
+                if ( userList.size() >= numResults )
+                {
+                    break;
+                }
+            }
+            catch ( UnsupportedOperationException uoe )
+            {
+                Log.warn( "UserProvider.findUsers is not supported by this UserProvider: " + provider.getClass().getName() );
+                supportSearch--;
+            }
+        }
+
+        if ( supportSearch == 0 )
+        {
+            throw new UnsupportedOperationException( "None of the backing providers support this operation." );
+        }
+        return userList;
+    }
+
+    /**
+     * Returns the combination of search fields supported by the backing providers. Note that the returned fields might
+     * not be supported by every backing provider.
+     *
+     * @throws UnsupportedOperationException If no search fields are returned, or when at least one of the providers throws UnsupportedOperationException when its #getSearchField() is invoked.
+     */
+    @Override
+    public Set<String> getSearchFields() throws UnsupportedOperationException
+    {
+        int supportSearch = getUserProviders().size();
+        final Set<String> result = new HashSet<>();
+
+        // TODO Make calls concurrent for improved throughput.
+        for ( final UserProvider provider : getUserProviders() )
+        {
+            try
+            {
+                result.addAll( provider.getSearchFields() );
+            }
+            catch ( UnsupportedOperationException uoe )
+            {
+                Log.warn( "getSearchFields is not supported by this UserProvider: " + provider.getClass().getName() );
+                supportSearch--;
+            }
+        }
+
+        if ( supportSearch == 0 )
+        {
+            throw new UnsupportedOperationException( "None of the backing providers support this operation." );
+        }
+        return result;
+    }
+
+    /**
+     * Returns whether <em>all</em> backing providers are read-only. When read-only, users can not be created, deleted,
+     * or modified. If at least one provider is not read-only, this method returns false.
+     *
+     * @return true when all backing providers are read-only, otherwise false.
+     */
+    @Override
+    public boolean isReadOnly()
+    {
+        // TODO Make calls concurrent for improved throughput.
+        for ( final UserProvider provider : getUserProviders() )
+        {
+            // If at least one provider is not readonly, neither is this proxy.
+            if ( !provider.isReadOnly() )
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns whether <em>all</em> backing providers require a name to be set on User objects. If at least one proivder
+     * does not, this method returns false.
+     *
+     * @return true when all backing providers require a name to be set on User objects, otherwise false.
+     */
+    @Override
+    public boolean isNameRequired()
+    {
+        // TODO Make calls concurrent for improved throughput.
+        for ( final UserProvider provider : getUserProviders() )
+        {
+            // If at least one provider does not require a name, neither is this proxy.
+            if ( !provider.isNameRequired() )
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns whether <em>all</em> backing providers require an email address to be set on User objects. If at least
+     * one proivder does not, this method returns false.
+     *
+     * @return true when all backing providers require an email address to be set on User objects, otherwise false.
+     */
+    @Override
+    public boolean isEmailRequired()
+    {
+        // TODO Make calls concurrent for improved throughput.
+        for ( final UserProvider provider : getUserProviders() )
+        {
+            // If at least one provider does not require an email, neither is this proxy.
+            if ( !provider.isEmailRequired() )
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/user/UserProviderMapper.java
+++ b/src/java/org/jivesoftware/openfire/user/UserProviderMapper.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 IgniteRealtime.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.user;
+
+import java.util.Set;
+import java.util.SortedSet;
+
+/**
+ * Implementations are used to determine what UserProvider is to be used for a particular username.
+ *
+ * Note that the provided username need not reflect a pre-existing user (the instance might be used to determine in
+ * which provider a new user is to be created).
+ *
+ * Implementation must have a no-argument constructor.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see MappedUserProvider
+ */
+public interface UserProviderMapper
+{
+    /**
+     * Finds a suitable UserProvider for the user.
+     *
+     * Note that the provided username need not reflect a pre-existing user (the instance might be used to determine in
+     * which provider a new user is to be created).
+     *
+     * Implementations are expected to be able to find a UserProvider for any username. If an implementation fails to do
+     * so, such a failure is assumed to be the result of a problem in implementation or configuration.
+     *
+     * @param username A user identifier (cannot be null or empty).
+     * @return A UserProvider for the user (never null).
+     */
+    UserProvider getUserProvider( String username );
+
+    /**
+     * Returns all providers that are used by this instance.
+     *
+     * The returned collection should have a consistent, predictable iteration order.
+     *
+     * @return all providers (never null).
+     */
+    Set<UserProvider> getUserProviders();
+}


### PR DESCRIPTION
This commit introduces a new AuthProvider and UserProvider that, similar to the
HybridAuthProvider and -UserProvider can be configured to use more than one backend
store. Where the Hybrids iterate over all of their providers in an attempt to
fulfill a request, these new 'Mapped' variants will first determine what provider
is to be used for a particular user, and will then operate on only that provider.
This is useful where particular users are required to be restricted to specific
backends.