### PR TITLE
OF-1146 Update presence after setting a MUC role.

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRole.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRole.java
@@ -162,16 +162,7 @@ public class LocalMUCRole implements MUCRole {
         }
         this.presence = newPresence;
         this.presence.setFrom(getRoleAddress());
-        if (extendedInformation != null) {
-            // Remove any previous extendedInformation, then re-add it.
-            Element mucUser = presence.getElement().element(QName.get("x", "http://jabber.org/protocol/muc#user"));
-            if (mucUser != null) {
-                // Remove any previous extendedInformation, then re-add it.
-                presence.getElement().remove(mucUser);
-            }
-            Element exi = extendedInformation.createCopy();
-            presence.getElement().add(exi);
-        }
+        updatePresence();
     }
 
     @Override
@@ -297,8 +288,21 @@ public class LocalMUCRole implements MUCRole {
         ElementUtil.setProperty(extendedInformation, "x.item:jid", user.getAddress().toString());
         ElementUtil.setProperty(extendedInformation, "x.item:affiliation", affiliation.toString());
         ElementUtil.setProperty(extendedInformation, "x.item:role", role.toString());
+        updatePresence();
     }
 
+    private void updatePresence() {
+        if (extendedInformation != null && presence != null) {
+            // Remove any previous extendedInformation, then re-add it.
+            Element mucUser = presence.getElement().element(QName.get("x", "http://jabber.org/protocol/muc#user"));
+            if (mucUser != null) {
+                // Remove any previous extendedInformation, then re-add it.
+                presence.getElement().remove(mucUser);
+            }
+            Element exi = extendedInformation.createCopy();
+            presence.getElement().add(exi);
+        }
+    }
 
 	@Override
 	public int hashCode() {

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1393,8 +1393,6 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             if (role.isLocal()) {
                 role.setAffiliation(newAffiliation);
                 role.setRole(newRole);
-                // Set the new presence, so that the updated affiliation and role is reflected in the presence stanza.
-                role.setPresence(role.getPresence());
                 // Notify the other cluster nodes to update the occupant
                 CacheFactory.doClusterTask(new UpdateOccupant(this, role));
                 // Prepare a new presence to be sent to all the room occupants


### PR DESCRIPTION
This is related to f2386cc, where affiliation updates were not broadcast correctly to MUC occupants.

The error here is, when an owner/admin assigns the moderator role, the new role is not reflected in the presence broadcast.
So neither the actor, nor all other particpants get notifications about the new moderator.