### PR TITLE
Add newly added jmxweb libs to the eclipse project classpath.

### DIFF
--- a/build/eclipse/classpath
+++ b/build/eclipse/classpath
@@ -175,5 +175,8 @@
 	<classpathentry kind="lib" path="src/plugins/rayo/lib/cmu_us_kal.jar"/>
 	<classpathentry kind="lib" path="src/plugins/rayo/lib/en_us.jar"/>
 	<classpathentry kind="lib" path="build/lib/merge/jetty-annotations.jar"/>
+	<classpathentry kind="lib" path="src/plugins/jmxweb/lib/quartz-2.2.2.jar"/>
+	<classpathentry kind="lib" path="src/plugins/jmxweb/lib/genson-1.4.jar"/>
+	<classpathentry kind="lib" path="src/plugins/jmxweb/lib/itextpdf-5.4.1.jar"/>
 	<classpathentry kind="output" path="work/classes"/>
 </classpath>


### PR DESCRIPTION
As above extra libs needed to make the eclipse project error free after initial check out.
