### PR TITLE
OF-1168 fix Oracle DDL to use varchar2 and fix alter statements

### DIFF
--- a/src/database/upgrade/22/openfire_oracle.sql
+++ b/src/database/upgrade/22/openfire_oracle.sql
@@ -1,8 +1,8 @@
 // add columns for SASL SCRAM-SHA-1
-ALTER TABLE ofUser ADD COLUMN storedKey VARCHAR(32);
-ALTER TABLE ofUser ADD COLUMN serverKey VARCHAR(32);
-ALTER TABLE ofUser ADD COLUMN salt VARCHAR(32);
-ALTER TABLE ofUser ADD COLUMN iterations INTEGER;
+ALTER TABLE ofUser ADD storedKey VARCHAR2(32);
+ALTER TABLE ofUser ADD serverKey VARCHAR2(32);
+ALTER TABLE ofUser ADD salt VARCHAR2(32);
+ALTER TABLE ofUser ADD iterations INTEGER;
 
 UPDATE ofVersion SET version = 22 WHERE name = 'openfire';
 

--- a/src/database/upgrade/23/openfire_oracle.sql
+++ b/src/database/upgrade/23/openfire_oracle.sql
@@ -1,3 +1,3 @@
-ALTER TABLE ofMucRoom ADD COLUMN allowpm INTEGER NULL;
+ALTER TABLE ofMucRoom ADD allowpm INTEGER NULL;
 UPDATE ofVersion SET version = 23 WHERE name = 'openfire';
 COMMIT;


### PR DESCRIPTION
alter statements (at least in oracle 11g or earlier) do not allow the
COLUMN keyword after ADD in an ALTER statement

It looks like the update SQL for Oracle was copied from Postgresql? Or maybe it works on Oracle 12c? Anyway this fixes the DDL for Oracle 11g and I assume it would still work on Oracle 12c. 