### PR TITLE
OF-1116: Apply workaround for Java 7/8 compatibility issue

### DIFF
--- a/src/java/org/jivesoftware/openfire/group/ConcurrentGroupMap.java
+++ b/src/java/org/jivesoftware/openfire/group/ConcurrentGroupMap.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.xmpp.packet.JID;
 
@@ -119,7 +120,7 @@ public class ConcurrentGroupMap<K, V> extends ConcurrentHashMap<K, V>  implement
 				if (result == null) {
 					result = new HashSet<>();
 					// add all the groups into the group set
-					Iterator<K> iterator = keySet().iterator();
+					Iterator<K> iterator = ((ConcurrentMap) this).keySet().iterator(); // Cast prevents Java compatibility issue as described in OF-1116. Remove the cast when Java 7 support is dropped from Openfire.
 					while (iterator.hasNext()) {
 						K key = iterator.next();
 						Group group = Group.resolveFrom(key);

--- a/src/java/org/jivesoftware/openfire/roster/Roster.java
+++ b/src/java/org/jivesoftware/openfire/roster/Roster.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.jivesoftware.database.JiveID;
 import org.jivesoftware.openfire.PresenceManager;
@@ -78,12 +79,12 @@ public class Roster implements Cacheable, Externalizable {
     /**
      * Roster item cache - table: key jabberid string; value roster item.
      */
-    protected ConcurrentHashMap<String, RosterItem> rosterItems = new ConcurrentHashMap<>();
+    protected ConcurrentMap<String, RosterItem> rosterItems = new ConcurrentHashMap<>();
     /**
      * Contacts with subscription FROM that only exist due to shared groups
      * key: jabberid string; value: groups why the implicit roster item exists (aka invisibleSharedGroups).
      */
-    protected ConcurrentHashMap<String, Set<String>> implicitFrom = new ConcurrentHashMap<>();
+    protected ConcurrentMap<String, Set<String>> implicitFrom = new ConcurrentHashMap<>();
 
     private RosterItemProvider rosterItemProvider;
     private String username;

--- a/src/java/org/jivesoftware/util/ConcurrentHashSet.java
+++ b/src/java/org/jivesoftware/util/ConcurrentHashSet.java
@@ -22,6 +22,7 @@ package org.jivesoftware.util;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * This class implements the <tt>Set</tt> interface, backed by a ConcurrentHashMap instance.
@@ -34,7 +35,7 @@ public class ConcurrentHashSet<E> extends AbstractSet<E> implements Set<E>, Clon
         java.io.Serializable
 {
 
-    private transient ConcurrentHashMap<E,Object> map;
+    private transient ConcurrentMap<E,Object> map;
 
     // Dummy value to associate with an Object in the backing Map
     private static final Object PRESENT = new Object();


### PR DESCRIPTION
The JDK 7 signature of ConcurrentHashMap#keySet() returns a Set, while JDK 8 signature
returns a KeySetView, which is a new class in JDK 8. As a result, using Java 7 to run
an Openfire instance that is compiled with Java 8 (using the -source/-target 1.7
compilation flags) causes a java.lang.NoSuchMethodError.

To work around this problem, this commit applies a workaround as presented by
Martin Buchholz in https://bugs.openjdk.java.net/browse/JDK-8151366

This commit should be reverted after Openfire stops to support Java 7.