### PR TITLE
OF-1172 Add support for a wildcard DNS override

### DIFF
--- a/src/java/org/jivesoftware/openfire/net/DNSUtil.java
+++ b/src/java/org/jivesoftware/openfire/net/DNSUtil.java
@@ -88,6 +88,9 @@ public class DNSUtil {
         List<HostAddress> results = new LinkedList<>();
         if (dnsOverride != null) {
             HostAddress hostAddress = dnsOverride.get(domain);
+            if (hostAddress == null) {
+                hostAddress = dnsOverride.get("*");
+            }
             if (hostAddress != null) {
                 results.add(hostAddress);
                 return results;


### PR DESCRIPTION
Individual domains can be redirected to a specific handling host by use
of the DNS override property, dnsutil.dnsOverride

This patch allows a wildcard "*" entry to override all domains without
a specific override, for example:

dnsutil.dnsOverride = {*,127.0.0.1:5269}

... redirects all outgoing S2S traffic to port 5269 on localhost.