### PR TITLE
OF-1156 Do not store null LockOutFlag in Cache

### DIFF
--- a/src/java/org/jivesoftware/openfire/lockout/LockOutManager.java
+++ b/src/java/org/jivesoftware/openfire/lockout/LockOutManager.java
@@ -249,7 +249,7 @@ public class LockOutManager {
 				// If group wan't found in cache, load it up and put it there.
 				if (flag == null) {
 					flag = provider.getDisabledStatus(username);
-					lockOutCache.put(username, flag);
+					if (flag != null) lockOutCache.put(username, flag);
 				}
 			}
 		}


### PR DESCRIPTION
The LockOutManager stores a null LockOutFlag (the default) in the cache,
which shouldn't work (and doesn't in a cluster).