### PR TITLE
OF-1171 Update message routing to RFC 6120

### DIFF
--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -548,11 +548,13 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
         if (packet.getType() == Message.Type.error) {
             // Errors should be dropped at this point.
+            Log.debug("Error stanza to bare JID discarded: {}", packet.toXML());
             return true; // Not offline.
         }
 
         if (packet.getType() == Message.Type.groupchat) {
             // Surreal message type; cannot occur.
+            Log.debug("Groupchat stanza to bare JID discarded: {}", packet.toXML());
             return false; // Maybe offline has an idea?
         }
 
@@ -581,8 +583,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             return true;
         }
 
-        if (JiveGlobals.getBooleanProperty("route.really-all-resources", false))
-        	return true;
+        if (JiveGlobals.getBooleanProperty("route.really-all-resources", false)) {
+            return true;
+        }
 
         // Get the highest priority sessions for normal processing.
         List<ClientSession> highestPrioritySessions = getHighestPrioritySessions(nonNegativePrioritySessions);

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -546,6 +546,16 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         // Get the sessions with non-negative priority for message carbons processing.
         List<ClientSession> nonNegativePrioritySessions = getNonNegativeSessions(sessions, 0);
 
+        if (packet.getType() == Message.Type.error) {
+            // Errors should be dropped at this point.
+            return true; // Not offline.
+        }
+
+        if (packet.getType() == Message.Type.groupchat) {
+            // Surreal message type; cannot occur.
+            return false; // Maybe offline has an idea?
+        }
+
         if (nonNegativePrioritySessions.isEmpty()) {
             // No session is available so store offline
             Log.debug("Unable to route packet. No session is available so store offline. {} ", packet.toXML());
@@ -554,8 +564,11 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
         // Check for message carbons enabled sessions and send the message to them.
         for (ClientSession session : nonNegativePrioritySessions) {
+            if (packet.getType() == Message.Type.headline) {
+                // Headline messages are broadcast.
+                session.process(packet);
             // Deliver to each session, if is message carbons enabled.
-            if (shouldCarbonCopyToResource(session, packet, isPrivate)) {
+            } else if (shouldCarbonCopyToResource(session, packet, isPrivate)) {
                 session.process(packet);
             // Deliver to each session if property route.really-all-resources is true
             // (in case client does not support carbons)
@@ -563,7 +576,11 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                 session.process(packet);
             }
         }
-        
+
+        if (packet.getType() == Message.Type.headline) {
+            return true;
+        }
+
         if (JiveGlobals.getBooleanProperty("route.really-all-resources", false))
         	return true;
 


### PR DESCRIPTION
Various non-conformances in message routing caused some odd behaviour where
combinations of outgoing PEP events failing to be delivered could cause
errors to be delivered to all available clients.

This fixes message routing for three cases:
- Headline messages sent to the bare JID are now broadcast.
- Headline emssages sent to an offline session are discarded.
- Groupchat messages sent to a bare JID are handed to offline processing,
  however these should not occur.
- Errors sent to the bare JID are discarded.
