### PR TITLE
OF-1173: X.509/TLS related fixes

### DIFF
--- a/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -608,7 +608,7 @@ public class SASLAuthentication {
     private static void initMechanisms()
     {
 
-        final String configuration = JiveGlobals.getProperty("sasl.mechs", "ANONYMOUS,PLAIN,DIGEST-MD5,CRAM-MD5,SCRAM-SHA-1,JIVE-SHAREDSECRET,GSSAPI" );
+        final String configuration = JiveGlobals.getProperty("sasl.mechs", "ANONYMOUS,PLAIN,DIGEST-MD5,CRAM-MD5,SCRAM-SHA-1,JIVE-SHAREDSECRET,GSSAPI,EXTERNAL" );
         final StringTokenizer st = new StringTokenizer(configuration, " ,\t\n\r\f");
         mechanisms = new HashSet<>();
         while ( st.hasMoreTokens() )

--- a/src/web/import-truststore-certificate.jsp
+++ b/src/web/import-truststore-certificate.jsp
@@ -140,6 +140,7 @@
 
     <!-- BEGIN 'Import Certificate' -->
     <form action="import-truststore-certificate.jsp?connectionType=${connectionType}" method="post">
+        <input type="hidden" name="csrf" value="${csrf}">
         <fmt:message key="ssl.import.certificate.truststore.boxtitle" var="title"/>
         <admin:contentBox title="${title}">
             <table cellpadding="3" cellspacing="0" border="0">

--- a/src/web/security-truststore.jsp
+++ b/src/web/security-truststore.jsp
@@ -79,7 +79,7 @@
 
                     // Log the event
                     webManager.logEvent( "deleted SSL cert from " + connectionType + " with alias " + alias, null );
-                    response.sendRedirect( "security-keystore.jsp?connectionType=" + connectionType+ "&deletesuccess=true" );
+                    response.sendRedirect( "security-truststore.jsp?connectionType=" + connectionType+ "&deletesuccess=true" );
                     return;
                 }
                 catch ( Exception e )
@@ -221,7 +221,7 @@
                                         <c:out value="${certificate.publicKey.algorithm}"/>
                                     </td>
                                     <td width="1" align="center">
-                                        <a href="security-truststore.jsp?connectionType=${connectionType}&alias=${alias}&delete=true&csrf=csrf"
+                                        <a href="security-truststore.jsp?connectionType=${connectionType}&alias=${alias}&delete=true&csrf=${csrf}"
                                            title="<fmt:message key="global.click_delete"/>"
                                            onclick="return confirm('<fmt:message key="ssl.certificates.confirm_delete"/>');"
                                                 ><img src="images/delete-16x16.gif" width="16" height="16" border="0" alt=""></a>


### PR DESCRIPTION
* OF-1173 EXTERNAL was not offered by default.
* OF-777 CSRF protection was broken for truststore management.
* OF-777 Truststore deletion redirected to the wrong success page.