### PR TITLE
OF-1175 Require jre-headless >= 1:1.7.0 for noarch RPM

### DIFF
--- a/build/rpm/openfire.spec
+++ b/build/rpm/openfire.spec
@@ -7,6 +7,11 @@ Source0: %{OPENFIRE_SOURCE}
 %ifnarch noarch
 Source1: %{JRE_BUNDLE}
 %endif
+%ifarch noarch
+# Note that epoch is set here to 1, this appears to be consistent with non-Redhat
+# jres as well due to an ancient problem with java-1.5.0-ibm jpackage RPM
+Requires: java-headless >= 1:1.7.0
+%endif
 Group: Applications/Communications
 Vendor: Igniterealtime Community
 Packager: Igniterealtime Community


### PR DESCRIPTION
Adds explicit requirement for jre-headless to be installed for the noarch RPM.

Note: the epoch is set to 1 for this requirement as well, which seems to be the convention based on https://fedorahosted.org/released/javapackages/doc/#_jvm