### PR TITLE
OF-1177 allow java7-runtime-headless to satisfy .deb requirement

### DIFF
--- a/build/debian/control
+++ b/build/debian/control
@@ -9,7 +9,7 @@ Homepage: http://www.igniterealtime.org
 Package: openfire
 Section: net
 Priority: optional
-Pre-Depends: default-jre-headless (>= 1.7)
+Pre-Depends: default-jre-headless (>= 1.7) | java7-runtime-headless | java7-runtime | java8-runtime-headless | java8-runtime | java9-runtime-headless | java9-runtime
 Architecture: all
 Description: A high performance XMPP (Jabber) server.
  Openfire is an instant messaging server that implements the XMPP


### PR DESCRIPTION
See discussion on PR #624 , it is not clear to me what the equivalent of this is for build-deps, but this will at least help those who installed Oracle JRE and not OpenJDK