### PR TITLE
OF-1180: BOSH endpoints redirect all the requests with the trailing slash

### DIFF
--- a/src/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -542,6 +542,7 @@ public final class HttpBindManager {
         initializers.add(new ContainerInitializer(new JasperInitializer(), null));
         context.setAttribute("org.eclipse.jetty.containerInitializers", initializers);
         context.setAttribute(InstanceManager.class.getName(), new SimpleInstanceManager());
+        context.setAllowNullPathInfo(true);
         context.addServlet(new ServletHolder(new HttpBindServlet()),"/*");
         if (isHttpCompressionEnabled()) {
 	        Filter gzipFilter = new AsyncGzipFilter() {
@@ -573,6 +574,7 @@ public final class HttpBindManager {
         initializers.add(new ContainerInitializer(new JasperInitializer(), null));
         context.setAttribute("org.eclipse.jetty.containerInitializers", initializers);
         context.setAttribute(InstanceManager.class.getName(), new SimpleInstanceManager());
+        context.setAllowNullPathInfo(true);
         context.addServlet(new ServletHolder(new FlashCrossDomainServlet()),"");
     }
 


### PR DESCRIPTION
Documentation: http://download.eclipse.org/jetty/9.3.11.v20160721/apidocs/org/eclipse/jetty/server/handler/ContextHandler.html#setAllowNullPathInfo-boolean-