### PR TITLE
OF-1201: Complete context if an exception is thrown when setting read listener

### DIFF
--- a/src/java/org/jivesoftware/openfire/http/HttpBindServlet.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpBindServlet.java
@@ -149,7 +149,12 @@ public class HttpBindServlet extends HttpServlet {
         final AsyncContext context = request.startAsync();
 
         // Asynchronously reads the POSTed input, then triggers #processContent.
-        request.getInputStream().setReadListener(new ReadListenerImpl(context));
+        try {
+            request.getInputStream().setReadListener(new ReadListenerImpl(context));
+        } catch (IllegalStateException e) {
+            Log.warn("Error when setting read listener", e);
+            context.complete();
+        }
     }
 
     protected void processContent(AsyncContext context, String content)


### PR DESCRIPTION
We've yet to find the root cause of the state=EOF errors we've been seeing (which may be caused by an issue in our infrastructure or possibly client implementation), but this server-side change stopped file desciptors from being leaked when the error is thrown.

For more details see discussion in https://community.igniterealtime.org/thread/58399 
