### PR TITLE
OF-1207 Fix join room send private packet issue

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1072,11 +1072,11 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
                 throw new ForbiddenException();
             default:
             case visitor:
-                if (canSendPrivateMessage.equals( "participants" )) throw new ForbiddenException();
+                if (canSendPrivateMessage().equals( "participants" )) throw new ForbiddenException();
             case participant:
-                if (canSendPrivateMessage.equals( "moderators" )) throw new ForbiddenException();
+                if (canSendPrivateMessage().equals( "moderators" )) throw new ForbiddenException();
             case moderator:
-                if (canSendPrivateMessage.equals( "none" )) throw new ForbiddenException();
+                if (canSendPrivateMessage().equals( "none" )) throw new ForbiddenException();
         }
         String resource = packet.getTo().getResource();
         List<MUCRole> occupants = occupantsByNickname.get(resource.toLowerCase());


### PR DESCRIPTION
```
when canSendPrivateMessage is null will throw NullPointException

if use canSendPrivateMessage() method when canSendPrivateMessage
is null will return "anyone"
```
