### PR TITLE
Adjust monitoring plugin for use with oracle database

### DIFF
--- a/src/plugins/monitoring/src/database/monitoring_oracle.sql
+++ b/src/plugins/monitoring/src/database/monitoring_oracle.sql
@@ -28,15 +28,15 @@ CREATE INDEX ofConParticipant_conv_idx ON ofConParticipant (conversationID, bare
 CREATE INDEX ofConParticipant_jid_idx ON ofConParticipant (bareJID);
 
 CREATE TABLE ofMessageArchive (
-   messageID		 INTEGER		  NULL,
+   messageID         INTEGER              NULL,
    conversationID    INTEGER          NOT NULL,
    fromJID           VARCHAR2(1024)   NOT NULL,
-   fromJIDResource   VARCHAR2(255)    NULL,
+   fromJIDResource   VARCHAR2(255)        NULL,
    toJID             VARCHAR2(1024)   NOT NULL,
-   toJIDResource   VARCHAR2(255)      NULL,
+   toJIDResource     VARCHAR2(255)        NULL,
    sentDate          INTEGER          NOT NULL,
-   stanza			 LONG			  NULL,
-   body              LONG
+   stanza            CLOB                 NULL,
+   body              CLOB
 );
 CREATE INDEX ofMessageArchive_con_idx ON ofMessageArchive (conversationID);
 

--- a/src/plugins/monitoring/src/i18n/monitoring_i18n.properties
+++ b/src/plugins/monitoring/src/i18n/monitoring_i18n.properties
@@ -95,6 +95,7 @@ archive.settings.rebuild = Rebuild Index
 archive.settings.any = Any
 archive.settings.one_to_one=Archive one-to-one chats
 archive.settings.group_chats=Archive group chats
+archive.settings.group_chats.stanzas=Archive stanzas for group chats
 archive.settings.certain_rooms=Only archive conversations of the following room names (separated by comma)
 
 archive.search.title = Search Archive

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -32,27 +33,48 @@ import com.reucon.openfire.plugin.archive.xep0059.XmppResultSet;
 public class JdbcPersistenceManager implements PersistenceManager {
 	public static final int DEFAULT_MAX = 1000;
 
-	public static final String SELECT_MESSAGES_BY_CONVERSATION = "SELECT DISTINCT " + "ofConversation.conversationID, " + "ofConversation.room, "
-			+ "ofConversation.isExternal, " + "ofConversation.startDate, " + "ofConversation.lastActivity, " + "ofConversation.messageCount, "
-			+ "ofConParticipant.joinedDate, " + "ofConParticipant.leftDate, " + "ofConParticipant.bareJID, " + "ofConParticipant.jidResource, "
-			+ "ofConParticipant.nickname, " + "ofMessageArchive.fromJID, " + "ofMessageArchive.toJID, " + "ofMessageArchive.sentDate, "
-			+ "ofMessageArchive.body " + "FROM ofConversation "
-			+ "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
-			+ "INNER JOIN ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID "
-			+ "WHERE ofConversation.conversationID = ? AND ofConParticipant.bareJID = ? ORDER BY ofMessageArchive.sentDate";
+   public static final String SELECT_MESSAGES_BY_CONVERSATION = "SELECT DISTINCT "
+                                                                + "ofConversation.conversationID, "
+                                                                + "ofConversation.room, "
+                                                                + "ofConversation.isExternal, "
+                                                                + "ofConversation.startDate, "
+                                                                + "ofConversation.lastActivity, "
+                                                                + "ofConversation.messageCount, "
+                                                                + "ofConParticipant.joinedDate, "
+                                                                + "ofConParticipant.leftDate, "
+                                                                + "ofConParticipant.bareJID, "
+                                                                + "ofConParticipant.jidResource, "
+                                                                + "ofConParticipant.nickname, "
+                                                                + "ofMessageArchive.fromJID, "
+                                                                + "ofMessageArchive.toJID, "
+                                                                + "ofMessageArchive.sentDate, "
+                                                                + "ofMessageArchive.body "
+                                                                + "FROM ofConversation "
+                                                                + "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
+                                                                + "INNER JOIN ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID "
+                                                                + "WHERE ofConversation.conversationID = ? AND ofConParticipant.bareJID = ? ORDER BY ofMessageArchive.sentDate";
 
 	// public static final String SELECT_MESSAGES_BY_CONVERSATION =
 	// "SELECT messageId,time,direction,type,subject,body "
 	// + "FROM archiveMessages WHERE conversationId = ? ORDER BY time";
 
- 	public static final String SELECT_CONVERSATIONS = "SELECT "
-            + "ofConversation.conversationID, " + " ofConversation.room, " + "ofConversation.isExternal, "+ "ofConversation.lastActivity, "
-            + "ofConversation.messageCount, " + "ofConversation.startDate, " + "ofConParticipant.bareJID, " + "ofConParticipant.jidResource,"
-            + "ofConParticipant.nickname, " + "ofConParticipant.bareJID AS fromJID, " + "ofMessageArchive.toJID, "
-            + "min(ofConParticipant.joinedDate) AS startDate, " + "max(ofConParticipant.leftDate) as leftDate "
-			+ "FROM ofConversation "
-			+ "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
-            + "INNER JOIN (SELECT conversationID, toJID FROM ofMessageArchive union all SELECT conversationID, fromJID as toJID FROM ofMessageArchive) ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID ";
+   public static final String SELECT_CONVERSATIONS = "SELECT "
+                                                     + "ofConversation.conversationID, "
+                                                     + "ofConversation.room, "
+                                                     + "ofConversation.isExternal, "
+                                                     + "ofConversation.lastActivity, "
+                                                     + "ofConversation.messageCount, "
+                                                     + "ofConversation.startDate, "
+                                                     + "ofConParticipant.bareJID, "
+                                                     + "ofConParticipant.jidResource,"
+                                                     + "ofConParticipant.nickname, "
+                                                     + "ofConParticipant.bareJID AS fromJID, "
+                                                     + "ofMessageArchive.toJID, "
+                                                     + "min(ofConParticipant.joinedDate) AS startDate, "
+                                                     + "max(ofConParticipant.leftDate) as leftDate "
+                                                     + "FROM ofConversation "
+                                                     + "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
+                                                     + "INNER JOIN (SELECT conversationID, toJID FROM ofMessageArchive union all SELECT conversationID, fromJID as toJID FROM ofMessageArchive) ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID ";
 
     	public static final String SELECT_CONVERSATIONS_GROUP_BY = " GROUP BY ofConversation.conversationID, ofConversation.room, ofConversation.isExternal, ofConversation.lastActivity, ofConversation.messageCount, ofConversation.startDate, ofConParticipant.bareJID, ofConParticipant.jidResource, ofConParticipant.nickname, ofConParticipant.bareJID, ofMessageArchive.toJID";
 
@@ -72,11 +94,11 @@ public class JdbcPersistenceManager implements PersistenceManager {
 	// "SELECT c.conversationId,c.startTime,c.endTime,c.ownerJid,c.ownerResource,c.withJid,c.withResource,"
 	// + " c.subject,c.thread " + "FROM archiveConversations AS c";
 
-	public static final String COUNT_CONVERSATIONS = "SELECT COUNT(DISTINCT ofConversation.conversationID) FROM ofConversation "
-			+ "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
-			+ "INNER JOIN (SELECT conversationID, toJID FROM ofMessageArchive "
-			+ "union all "
-			+ "SELECT conversationID, fromJID as toJID FROM ofMessageArchive) ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID";
+   public static final String COUNT_CONVERSATIONS = "SELECT COUNT(DISTINCT ofConversation.conversationID) FROM ofConversation "
+                                                    + "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
+                                                    + "INNER JOIN (SELECT conversationID, toJID FROM ofMessageArchive "
+                                                    + "union all "
+                                                    + "SELECT conversationID, fromJID as toJID FROM ofMessageArchive) ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID";
 
 	// public static final String COUNT_CONVERSATIONS =
 	// "SELECT count(*) FROM archiveConversations AS c";
@@ -103,37 +125,107 @@ public class JdbcPersistenceManager implements PersistenceManager {
 
 	public static final String MESSAGE_FROM_JID = "ofMessageArchive.fromJID";
 
-	public static final String SELECT_ACTIVE_CONVERSATIONS = "SELECT DISTINCT " + "ofConversation.conversationID, " + "ofConversation.room, "
-			+ "ofConversation.isExternal, " + "ofConversation.startDate, " + "ofConversation.lastActivity, " + "ofConversation.messageCount, "
-			+ "ofConParticipant.joinedDate, " + "ofConParticipant.leftDate, " + "ofConParticipant.bareJID, " + "ofConParticipant.jidResource, "
-			+ "ofConParticipant.nickname, " + "ofMessageArchive.fromJID, " + "ofMessageArchive.toJID, " + "ofMessageArchive.sentDate, "
-			+ "ofMessageArchive.body " + "FROM ofConversation "
-			+ "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
-			+ "INNER JOIN ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID "
-			+ "WHERE ofConversation.lastActivity > ?";
+   public static final String SELECT_ACTIVE_CONVERSATIONS = "SELECT DISTINCT "
+                                                            + "ofConversation.conversationID, "
+                                                            + "ofConversation.room, "
+                                                            + "ofConversation.isExternal, "
+                                                            + "ofConversation.startDate, "
+                                                            + "ofConversation.lastActivity, "
+                                                            + "ofConversation.messageCount, "
+                                                            + "ofConParticipant.joinedDate, "
+                                                            + "ofConParticipant.leftDate, "
+                                                            + "ofConParticipant.bareJID, "
+                                                            + "ofConParticipant.jidResource, "
+                                                            + "ofConParticipant.nickname, "
+                                                            + "ofMessageArchive.fromJID, "
+                                                            + "ofMessageArchive.toJID, "
+                                                            + "ofMessageArchive.sentDate, "
+                                                            + "ofMessageArchive.body "
+                                                            + "FROM ofConversation "
+                                                            + "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
+                                                            + "INNER JOIN ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID "
+                                                            + "WHERE ofConversation.lastActivity > ?";
+   public static final String SELECT_ACTIVE_CONVERSATIONS_ORACLE = "select SUBSET.conversationID,"
+                                                                   + "SUBSET.room,"
+                                                                   + "SUBSET.isExternal,"
+                                                                   + "SUBSET.startDate,"
+                                                                   + "SUBSET.lastActivity,"
+                                                                   + "SUBSET.messageCount,"
+                                                                   + "SUBSET.joinedDate,"
+                                                                   + "SUBSET.leftDate,"
+                                                                   + "SUBSET.bareJID,"
+                                                                   + "SUBSET.jidResource,"
+                                                                   + "SUBSET.nickname,"
+                                                                   + "SUBSET.fromJID,"
+                                                                   + "SUBSET.toJID,"
+                                                                   + "SUBSET.sentDate,"
+                                                                   + "MAR.body from ("
+                                                                   + "SELECT DISTINCT ofConversation.conversationID as conversationID,"
+                                                                   + "ofConversation.room as room,"
+                                                                   + "ofConversation.isExternal as isExternal,"
+                                                                   + "ofConversation.startDate as startDate,"
+                                                                   + "ofConversation.lastActivity as lastActivity,"
+                                                                   + "ofConversation.messageCount as messageCount,"
+                                                                   + "ofConParticipant.joinedDate as joinedDate,"
+                                                                   + "ofConParticipant.leftDate as leftDate,"
+                                                                   + "ofConParticipant.bareJID as bareJID,"
+                                                                   + "ofConParticipant.jidResource as jidResource,"
+                                                                   + "ofConParticipant.nickname as nickname,"
+                                                                   + "ofMessageArchive.fromJID as fromJID,"
+                                                                   + "ofMessageArchive.toJID as toJID,"
+                                                                   + "ofMessageArchive.sentDate as sentDate,"
+                                                                   + "ofMessageArchive.MESSAGEID as msgId "
+                                                                   + "FROM ofConversation "
+                                                                   + "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
+                                                                   + "INNER JOIN ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID "
+                                                                   + "where ofConversation.lastActivity > ? ) SUBSET "
+                                                                   + "INNER JOIN ofMessageArchive MAR ON MAR.conversationID = SUBSET.conversationID "
+                                                                   + "where MAR.MESSAGEID = SUBSET.msgId "
+                                                                   + "and MAR.sentDate = SUBSET.sentDate "
+                                                                   + "and MAR.fromJID = SUBSET.fromJID "
+                                                                   + "and MAR.toJID = SUBSET.toJID";
 
 	// public static final String SELECT_ACTIVE_CONVERSATIONS =
 	// "SELECT c.conversationId,c.startTime,c.endTime,c.ownerJid,c.ownerResource,withJid,c.withResource,"
 	// + " c.subject,c.thread "
 	// + "FROM archiveConversations AS c WHERE c.endTime > ?";
 
-	public static final String SELECT_PARTICIPANTS_BY_CONVERSATION = "SELECT DISTINCT " + "ofConversation.conversationID, "
-			+ "ofConversation.startDate, " + "ofConversation.lastActivity, " + "ofConParticipant.bareJID " + "FROM ofConversation "
-			+ "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
-			+ "INNER JOIN ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID "
-			+ "WHERE ofConversation.conversationID = ? ORDER BY ofConversation.startDate";
+   public static final String SELECT_PARTICIPANTS_BY_CONVERSATION = "SELECT DISTINCT "
+                                                                    + "ofConversation.conversationID, "
+                                                                    + "ofConversation.startDate, "
+                                                                    + "ofConversation.lastActivity, "
+                                                                    + "ofConParticipant.bareJID "
+                                                                    + "FROM ofConversation "
+                                                                    + "INNER JOIN ofConParticipant ON ofConversation.conversationID = ofConParticipant.conversationID "
+                                                                    + "INNER JOIN ofMessageArchive ON ofConParticipant.conversationID = ofMessageArchive.conversationID "
+                                                                    + "WHERE ofConversation.conversationID = ? ORDER BY ofConversation.startDate";
 
 	// public static final String SELECT_PARTICIPANTS_BY_CONVERSATION =
 	// "SELECT participantId,startTime,endTime,jid FROM archiveParticipants WHERE conversationId =? ORDER BY startTime";
-	 public static final String SELECT_MESSAGES = "SELECT DISTINCT " + "ofMessageArchive.fromJID, "
-			+ "ofMessageArchive.toJID, " + "ofMessageArchive.sentDate, " + "ofMessageArchive.stanza, "
-			+ "ofMessageArchive.messageID, " + "ofConParticipant.bareJID "
-			+ "FROM ofMessageArchive "
-			+ "INNER JOIN ofConParticipant ON ofMessageArchive.conversationID = ofConParticipant.conversationID ";
+   public static final String SELECT_MESSAGES = "SELECT DISTINCT "
+                                                + "ofMessageArchive.fromJID, "
+                                                + "ofMessageArchive.toJID, "
+                                                + "ofMessageArchive.sentDate, "
+                                                + "ofMessageArchive.stanza, "
+                                                + "ofMessageArchive.messageID, "
+                                                + "ofConParticipant.bareJID "
+                                                + "FROM ofMessageArchive "
+                                                + "INNER JOIN ofConParticipant ON ofMessageArchive.conversationID = ofConParticipant.conversationID ";
+   public static final String SELECT_MESSAGE_ORACLE = "SELECT "
+                                                      + "ofMessageArchive.fromJID, "
+                                                      + "ofMessageArchive.toJID, "
+                                                      + "ofMessageArchive.sentDate, "
+                                                      + "ofMessageArchive.stanza, "
+                                                      + "ofMessageArchive.messageID "
+                                                      + "FROM ofMessageArchive";
+   public static final String SELECT_CONVERSATIONS_BY_OWNER = "SELECT DISTINCT ofConParticipant.conversationID FROM ofConParticipant WHERE "
+                                                              + CONVERSATION_OWNER_JID
+                                                              + " = ?";
 
-	 public static final String COUNT_MESSAGES = "SELECT COUNT(DISTINCT ofMessageArchive.messageID) "
-			+ "FROM ofMessageArchive "
-			+ "INNER JOIN ofConParticipant ON ofMessageArchive.conversationID = ofConParticipant.conversationID ";
+
+   public static final String COUNT_MESSAGES = "SELECT COUNT(DISTINCT ofMessageArchive.messageID) "
+                                               + "FROM ofMessageArchive "
+                                               + "INNER JOIN ofConParticipant ON ofMessageArchive.conversationID = ofConParticipant.conversationID ";
 
 	public boolean createMessage(ArchivedMessage message) {
 		/* read only */
@@ -369,6 +461,7 @@ public class JdbcPersistenceManager implements PersistenceManager {
 	@Override
 	public Collection<ArchivedMessage> findMessages(Date startDate,
 			Date endDate, String ownerJid, String withJid, XmppResultSet xmppResultSet) {
+	   final boolean isOracleDB = isOracleDB();
 
 		final StringBuilder querySB;
 		final StringBuilder whereSB;
@@ -376,7 +469,7 @@ public class JdbcPersistenceManager implements PersistenceManager {
 
 		final TreeMap<Long, ArchivedMessage> archivedMessages = new TreeMap<Long, ArchivedMessage>();
 
-		querySB = new StringBuilder(SELECT_MESSAGES);
+		querySB = new StringBuilder( isOracleDB ? SELECT_MESSAGE_ORACLE : SELECT_MESSAGES  );
 		whereSB = new StringBuilder();
 		limitSB = new StringBuilder();
 
@@ -391,7 +484,12 @@ public class JdbcPersistenceManager implements PersistenceManager {
 			appendWhere(whereSB, MESSAGE_SENT_DATE, " <= ?");
 		}
 		if (ownerJid != null) {
-			appendWhere(whereSB, CONVERSATION_OWNER_JID, " = ?");
+		   if( isOracleDB ) {
+		      appendWhere( whereSB, "ofMessageArchive.conversationID in ( ", SELECT_CONVERSATIONS_BY_OWNER, " )" );
+		   }
+		   else {
+		      appendWhere(whereSB, CONVERSATION_OWNER_JID, " = ?");
+		   }
 		}
 		if(withJid != null) {
 			appendWhere(whereSB, "( ", MESSAGE_TO_JID, " = ? OR ", MESSAGE_FROM_JID, " = ? )");
@@ -442,6 +540,36 @@ public class JdbcPersistenceManager implements PersistenceManager {
 				limitSB.append(" BETWEEN ").append(firstIndex+1);
 				limitSB.append(" AND ").append(firstIndex+max);
 			}
+			else if( isOracleDB ) {
+			   try {
+               final Statement statement = DbConnectionManager.getConnection().createStatement();
+               final ResultSet resultSet = statement.executeQuery( "select VERSION from PRODUCT_COMPONENT_VERSION P where P.PRODUCT like 'Oracle Database%'" );
+               resultSet.next();
+               final String versionString = resultSet.getString( "VERSION" );
+               final String[] versionParts = versionString.split( "\\." );
+               final int majorVersion = Integer.parseInt( versionParts[ 0 ] );
+               final int minorVersion = Integer.parseInt( versionParts[ 1 ] );
+
+               if( ( majorVersion == 12 && minorVersion >= 1 ) || majorVersion > 12 ) {
+                  limitSB.append(" LIMIT ").append(max);
+                  limitSB.append(" OFFSET ").append(firstIndex);
+               }
+               else {
+                  querySB.insert( 0, "SELECT * FROM ( " );
+                  limitSB.append( " ) WHERE rownum BETWEEN " )
+                         .append( firstIndex + 1 )
+                         .append( " AND " )
+                         .append( firstIndex + max );
+               }
+            } catch( SQLException e ) {
+               Log.warn( "Unable to determine oracle database version using fallback", e );
+               querySB.insert( 0, "SELECT * FROM ( " );
+               limitSB.append( " ) WHERE rownum BETWEEN " )
+                      .append( firstIndex + 1 )
+                      .append( " AND " )
+                      .append( firstIndex + max );
+            }
+			}
 			else {
 				limitSB.append(" LIMIT ").append(max);
 				limitSB.append(" OFFSET ").append(firstIndex);
@@ -486,6 +614,15 @@ public class JdbcPersistenceManager implements PersistenceManager {
 
 		return archivedMessages.values();
 	}
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+   private boolean isOracleDB()
+   {
+      return DbConnectionManager.getDatabaseType() == DbConnectionManager.DatabaseType.oracle;
+   }
+
+   //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	private Integer countMessages(Date startDate, Date endDate,
 			String ownerJid, String withJid, String whereClause) {
@@ -586,7 +723,7 @@ public class JdbcPersistenceManager implements PersistenceManager {
 		ResultSet rs = null;
 		try {
 			con = DbConnectionManager.getConnection();
-			pstmt = con.prepareStatement(SELECT_ACTIVE_CONVERSATIONS);
+			pstmt = con.prepareStatement( isOracleDB() ? SELECT_ACTIVE_CONVERSATIONS_ORACLE : SELECT_ACTIVE_CONVERSATIONS );
 
 			pstmt.setLong(1, now - conversationTimeout * 60L * 1000L);
 			rs = pstmt.executeQuery();

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler.java
@@ -67,7 +67,6 @@ public class IQQueryHandler extends AbstractIQHandler implements
 
 		// Default to user's own archive
 		JID archiveJid = packet.getFrom();
-
 		if(packet.getElement().attribute("to") != null) {
 			archiveJid = new JID(packet.getElement().attribute("to").getStringValue());
 			// Only allow queries to users own archives
@@ -233,7 +232,6 @@ public class IQQueryHandler extends AbstractIQHandler implements
 			// If we can't parse stanza then we have no message to send to client, abort
 			return;
 		}
-
 		session.process(messagePacket);
 	}
 

--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/ConversationEvent.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/ConversationEvent.java
@@ -40,6 +40,7 @@ public class ConversationEvent implements Externalizable {
     private Type type;
     private Date date;
     private String body;
+    private String stanza;
 
     private JID sender;
     private JID receiver;
@@ -77,7 +78,7 @@ public class ConversationEvent implements Externalizable {
             conversationManager.joinedGroupConversation(roomJID, user, nickname, new Date(date.getTime() + 1));
         }
         else if (Type.roomMessageReceived == type) {
-            conversationManager.processRoomMessage(roomJID, user, nickname, body, date);
+            conversationManager.processRoomMessage( roomJID, user, nickname, body, stanza, date );
         }
     }
 
@@ -184,14 +185,19 @@ public class ConversationEvent implements Externalizable {
         return event;
     }
 
-    public static ConversationEvent roomMessageReceived(JID roomJID, JID user, String nickname, String body,
-                                                        Date date) {
+    public static ConversationEvent roomMessageReceived( JID roomJID,
+                                                         JID user,
+                                                         String nickname,
+                                                         String body,
+                                                         String stanza,
+                                                         Date date) {
         ConversationEvent event = new ConversationEvent();
         event.type = Type.roomMessageReceived;
         event.roomJID = roomJID;
         event.user = user;
         event.nickname = nickname;
         event.body = body;
+        event.stanza = stanza;
         event.date = date;
         return event;
     }

--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/ConversationManager.java
@@ -67,8 +67,6 @@ import org.xmpp.packet.IQ;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 
-import com.lowagie.text.RomanList;
-
 /**
  * Manages all conversations in the system. Optionally, conversations (messages plus meta-data) can be archived to the database. Archiving of
  * conversation data is enabled by default, but can be disabled by setting "conversation.metadataArchiving" to <tt>false</tt>. Archiving of messages
@@ -157,7 +155,8 @@ public class ConversationManager implements Startable, ComponentEventListener{
 		this.conversationEventsQueue = new ConversationEventsQueue(this, taskEngine);
 	}
 
-	public void start() {
+	@Override
+   public void start() {
 		metadataArchivingEnabled = JiveGlobals.getBooleanProperty("conversation.metadataArchiving", true);
 		messageArchivingEnabled = JiveGlobals.getBooleanProperty("conversation.messageArchiving", false);
 		if (messageArchivingEnabled && !metadataArchivingEnabled) {
@@ -268,27 +267,33 @@ public class ConversationManager implements Startable, ComponentEventListener{
 		// Register a statistic.
 		Statistic conversationStat = new Statistic() {
 
-			public String getName() {
+			@Override
+         public String getName() {
 				return LocaleUtils.getLocalizedString("stat.conversation.name", MonitoringConstants.NAME);
 			}
 
-			public Type getStatType() {
+			@Override
+         public Type getStatType() {
 				return Type.count;
 			}
 
-			public String getDescription() {
+			@Override
+         public String getDescription() {
 				return LocaleUtils.getLocalizedString("stat.conversation.desc", MonitoringConstants.NAME);
 			}
 
-			public String getUnits() {
+			@Override
+         public String getUnits() {
 				return LocaleUtils.getLocalizedString("stat.conversation.units", MonitoringConstants.NAME);
 			}
 
-			public double sample() {
+			@Override
+         public double sample() {
 				return getConversationCount();
 			}
 
-			public boolean isPartialSample() {
+			@Override
+         public boolean isPartialSample() {
 				return false;
 			}
 		};
@@ -296,7 +301,8 @@ public class ConversationManager implements Startable, ComponentEventListener{
 		InternalComponentManager.getInstance().addListener(this);
 	}
 
-	public void stop() {
+	@Override
+   public void stop() {
 		archiveTask.cancel();
 		archiveTask = null;
 		cleanupTask.cancel();
@@ -577,7 +583,8 @@ public class ConversationManager implements Startable, ComponentEventListener{
 			List<Conversation> conversationList = new ArrayList<Conversation>(conversations.values());
 			// Sort the conversations by creation date.
 			Collections.sort(conversationList, new Comparator<Conversation>() {
-				public int compare(Conversation c1, Conversation c2) {
+				@Override
+            public int compare(Conversation c1, Conversation c2) {
 					return c1.getStartDate().compareTo(c2.getStartDate());
 				}
 			});
@@ -958,7 +965,8 @@ public class ConversationManager implements Startable, ComponentEventListener{
 		return roomJID.toString();
 	}
 
-	public void componentInfoReceived(IQ iq) {
+	@Override
+   public void componentInfoReceived(IQ iq) {
 		// Check if the component is a gateway
 		boolean gatewayFound = false;
 		Element childElement = iq.getChildElement();
@@ -974,11 +982,13 @@ public class ConversationManager implements Startable, ComponentEventListener{
 		}
 	}
 
-	public void componentRegistered(JID componentJID) {
+	@Override
+   public void componentRegistered(JID componentJID) {
 		// Do nothing
 	}
 
-	public void componentUnregistered(JID componentJID) {
+	@Override
+   public void componentUnregistered(JID componentJID) {
 		// Remove stored information about this component
 		gateways.remove(componentJID.getDomain());
 	}
@@ -997,7 +1007,8 @@ public class ConversationManager implements Startable, ComponentEventListener{
 	 */
 	private class ArchivingTask implements Runnable {
 
-		public void run() {
+		@Override
+      public void run() {
 			synchronized (this) {
 				if (archivingRunning) {
 					return;
@@ -1102,7 +1113,8 @@ public class ConversationManager implements Startable, ComponentEventListener{
 	 */
 	private class ConversationPropertyListener implements PropertyEventListener {
 
-		public void propertySet(String property, Map<String, Object> params) {
+		@Override
+      public void propertySet(String property, Map<String, Object> params) {
 			if (property.equals("conversation.metadataArchiving")) {
 				String value = (String) params.get("value");
 				metadataArchivingEnabled = Boolean.valueOf(value);
@@ -1171,7 +1183,8 @@ public class ConversationManager implements Startable, ComponentEventListener{
 			}
 		}
 
-		public void propertyDeleted(String property, Map<String, Object> params) {
+		@Override
+      public void propertyDeleted(String property, Map<String, Object> params) {
 			if (property.equals("conversation.metadataArchiving")) {
 				metadataArchivingEnabled = true;
 			} else if (property.equals("conversation.messageArchiving")) {
@@ -1196,11 +1209,13 @@ public class ConversationManager implements Startable, ComponentEventListener{
 			}
 		}
 
-		public void xmlPropertySet(String property, Map<String, Object> params) {
+		@Override
+      public void xmlPropertySet(String property, Map<String, Object> params) {
 			// Ignore.
 		}
 
-		public void xmlPropertyDeleted(String property, Map<String, Object> params) {
+		@Override
+      public void xmlPropertyDeleted(String property, Map<String, Object> params) {
 			// Ignore.
 		}
 	}

--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/archive/GroupConversationInterceptor.java
@@ -112,7 +112,7 @@ public class GroupConversationInterceptor implements MUCEventListener, Startable
     public void messageReceived(JID roomJID, JID user, String nickname, Message message) {
         // Process this event in the senior cluster member or local JVM when not in a cluster
         if (ClusterManager.isSeniorClusterMember()) {
-            conversationManager.processRoomMessage(roomJID, user, nickname, message.getBody(), new Date());
+            conversationManager.processRoomMessage(roomJID, user, nickname, message.getBody(), message.toXML(), new Date());
         }
         else {
             boolean withBody = conversationManager.isRoomArchivingEnabled() && (
@@ -120,8 +120,8 @@ public class GroupConversationInterceptor implements MUCEventListener, Startable
                             conversationManager.getRoomsArchived().contains(roomJID.getNode()));
 
             ConversationEventsQueue eventsQueue = conversationManager.getConversationEventsQueue();
-            eventsQueue.addGroupChatEvent(conversationManager.getRoomConversationKey(roomJID),
-                    ConversationEvent.roomMessageReceived(roomJID, user, nickname, withBody ? message.getBody() : null, new Date()));
+            eventsQueue.addGroupChatEvent( conversationManager.getRoomConversationKey(roomJID),
+                    ConversationEvent.roomMessageReceived( roomJID, user, nickname, withBody ? message.getBody() : null, message.toXML(), new Date()));
         }
     }
 

--- a/src/plugins/monitoring/src/web/archiving-settings.jsp
+++ b/src/plugins/monitoring/src/web/archiving-settings.jsp
@@ -161,12 +161,13 @@
     boolean update = request.getParameter("update") != null;
     boolean messageArchiving = conversationManager.isMessageArchivingEnabled();
     boolean roomArchiving = conversationManager.isRoomArchivingEnabled();
+    boolean roomArchivingStanzas = conversationManager.isRoomArchivingStanzasEnabled();
     int idleTime = ParamUtils.getIntParameter(request, "idleTime", conversationManager.getIdleTime());
     int maxTime = ParamUtils.getIntParameter(request, "maxTime", conversationManager.getMaxTime());
-    
+
     int maxAge = ParamUtils.getIntParameter(request, "maxAge", conversationManager.getMaxAge());
     int maxRetrievable = ParamUtils.getIntParameter(request, "maxRetrievable", conversationManager.getMaxRetrievable());
-    
+
     boolean rebuildIndex = request.getParameter("rebuild") != null;
 
     if (request.getParameter("cancel") != null) {
@@ -186,6 +187,7 @@
         boolean metadataArchiving = request.getParameter("metadataArchiving") != null;
         messageArchiving = request.getParameter("messageArchiving") != null;
         roomArchiving = request.getParameter("roomArchiving") != null;
+        roomArchivingStanzas = request.getParameter("roomArchivingStanzas") != null;
         String roomsArchived = request.getParameter("roomsArchived");
 
         // Validate params
@@ -214,10 +216,11 @@
             conversationManager.setMetadataArchivingEnabled(metadataArchiving);
             conversationManager.setMessageArchivingEnabled(messageArchiving);
             conversationManager.setRoomArchivingEnabled(roomArchiving);
+            conversationManager.setRoomArchivingStanzasEnabled(roomArchivingStanzas);
             conversationManager.setRoomsArchived(StringUtils.stringToCollection(roomsArchived));
             conversationManager.setIdleTime(idleTime);
             conversationManager.setMaxTime(maxTime);
-            
+
             conversationManager.setMaxAge(maxAge);
             conversationManager.setMaxRetrievable(maxRetrievable);
 
@@ -282,6 +285,10 @@
                         <td><input type="checkbox" name="roomArchiving" <%= conversationManager.isRoomArchivingEnabled() ? "checked" : ""%> /></td>
                     </tr>
                     <tr>
+                        <td><fmt:message key="archive.settings.group_chats.stanzas"/></td>
+                        <td><input type="checkbox" name="roomArchivingStanzas" <%= conversationManager.isRoomArchivingStanzasEnabled() ? "checked" : ""%> /></td>
+                    </tr>
+                    <tr>
                         <td><fmt:message key="archive.settings.certain_rooms"/></td>
                         <td><textarea name="roomsArchived" cols="30" rows="2" wrap="virtual"><%= StringUtils.collectionToString(conversationManager.getRoomsArchived()) %></textarea></td>
                     </tr>
@@ -300,7 +307,7 @@
                 <td><input type="text" name="maxTime" size="10" maxlength="10" value="<%= conversationManager.getMaxTime()%>" /></td>
                 <td></td>
             </tr>
-            
+
             <tr>
                 <td><label class="jive-label"><fmt:message key="archive.settings.max.age"/>:</label><br>
                 <fmt:message key="archive.settings.max.age.description"/><br><br>
@@ -308,14 +315,14 @@
                 <td><input type="text" name="maxAge" size="10" maxlength="10" value="<%= conversationManager.getMaxAge()%>" /></td>
                 <td></td>
             </tr>
-            
+
             <tr>
                 <td><label class="jive-label"><fmt:message key="archive.settings.max.retrievable"/>:</label><br>
                 <fmt:message key="archive.settings.max.retrievable.description"/><br><br></td>
                 <td><input type="text" name="maxRetrievable" size="10" maxlength="10" value="<%= conversationManager.getMaxRetrievable()%>" /></td>
                 <td></td>
             </tr>
-            
+
         </tbody>
     </table>
 


### PR DESCRIPTION
since oracle does not permit two long columns in a single table and also
stated "long" column type as deprecated, long columns are changed to
clob

as distinct modifier is not allowed on clob columns by oracle, adjust
severall (not all) statements accordingly

add a switch for oracle 11g as it does not support keywords "LIMIT"
and "OFFSET"

add an option to the monitoring/archiving settings to store complete
stanzas for muc's