### PR TITLE
OF-1212 adjust ddl statements for oracle

### DIFF
--- a/src/plugins/monitoring/src/database/monitoring_oracle.sql
+++ b/src/plugins/monitoring/src/database/monitoring_oracle.sql
@@ -35,8 +35,8 @@ CREATE TABLE ofMessageArchive (
    toJID             VARCHAR2(1024)   NOT NULL,
    toJIDResource   VARCHAR2(255)      NULL,
    sentDate          INTEGER          NOT NULL,
-   stanza			 LONG			  NULL,
-   body              LONG
+   stanza			 CLOB			  NULL,
+   body              CLOB
 );
 CREATE INDEX ofMessageArchive_con_idx ON ofMessageArchive (conversationID);
 


### PR DESCRIPTION
since two long columns are not permitted in one table by oracle and the
datatype long is deprecated, the respective columns are changed to clob