### PR TITLE
OF-1214 Update MAM (XEP-0313) to support :0 and :1 versions

### DIFF
--- a/src/java/org/jivesoftware/openfire/forward/Forwarded.java
+++ b/src/java/org/jivesoftware/openfire/forward/Forwarded.java
@@ -2,21 +2,42 @@ package org.jivesoftware.openfire.forward;
 
 import org.dom4j.Element;
 import org.dom4j.QName;
+import org.jivesoftware.util.XMPPDateTimeFormat;
+import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 import org.xmpp.packet.PacketExtension;
+
+import java.util.Date;
 
 /**
  * @author Christian Schudt
  */
 public class Forwarded extends PacketExtension {
+    public Forwarded(Element copy, Date delay, JID delayFrom) {
+        super("forwarded", "urn:xmpp:forward:0");
+        populate(copy, delay, delayFrom);
+    }
+    public Forwarded(Message message, Date delay, JID delayFrom) {
+        super("forwarded", "urn:xmpp:forward:0");
+
+        Message copy = message.createCopy();
+        populate(copy.getElement(), delay, delayFrom);
+    }
+    public Forwarded(Element copy) {
+        super("forwarded", "urn:xmpp:forward:0");
+        populate(copy, null, null);
+    }
     public Forwarded(Message message) {
         super("forwarded", "urn:xmpp:forward:0");
 
         Message copy = message.createCopy();
+        populate(copy.getElement(), null, null);
+    }
+    private void populate(Element copy, Date delay, JID delayFrom) {
 
-        copy.getElement().setQName(QName.get("message", "jabber:client"));
+        copy.setQName(QName.get("message", "jabber:client"));
 
-        for (Object element : copy.getElement().elements()) {
+        for (Object element : copy.elements()) {
             if (element instanceof Element) {
                 Element el = (Element) element;
                 // Only set the "jabber:client" namespace if the namespace is empty (otherwise the resulting xml would look like <body xmlns=""/>)
@@ -25,6 +46,15 @@ public class Forwarded extends PacketExtension {
                 }
             }
         }
-        element.add(copy.getElement());
+        if (delay != null) {
+            Element delayInfo = element.addElement("delay", "urn:xmpp:delay");
+            delayInfo.addAttribute("stamp", XMPPDateTimeFormat.format(delay));
+            if (delayFrom != null) {
+                // Set the Full JID as the "from" attribute
+                delayInfo.addAttribute("from", delayFrom.toString());
+            }
+            element.add(delayInfo);
+        }
+        element.add(copy);
     }
 }

--- a/src/java/org/jivesoftware/openfire/forward/Forwarded.java
+++ b/src/java/org/jivesoftware/openfire/forward/Forwarded.java
@@ -53,7 +53,6 @@ public class Forwarded extends PacketExtension {
                 // Set the Full JID as the "from" attribute
                 delayInfo.addAttribute("from", delayFrom.toString());
             }
-            element.add(delayInfo);
         }
         element.add(copy);
     }

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/impl/JdbcPersistenceManager.java
@@ -129,11 +129,13 @@ public class JdbcPersistenceManager implements PersistenceManager {
 			+ "ofMessageArchive.toJID, " + "ofMessageArchive.sentDate, " + "ofMessageArchive.stanza, "
 			+ "ofMessageArchive.messageID, " + "ofConParticipant.bareJID "
 			+ "FROM ofMessageArchive "
-			+ "INNER JOIN ofConParticipant ON ofMessageArchive.conversationID = ofConParticipant.conversationID ";
+			+ "INNER JOIN ofConParticipant ON ofMessageArchive.conversationID = ofConParticipant.conversationID "
+			+ "WHERE ofMessageArchive.stanza != NULL OR ofMessageArchive.body != NULL";
 
 	 public static final String COUNT_MESSAGES = "SELECT COUNT(DISTINCT ofMessageArchive.messageID) "
 			+ "FROM ofMessageArchive "
-			+ "INNER JOIN ofConParticipant ON ofMessageArchive.conversationID = ofConParticipant.conversationID ";
+			+ "INNER JOIN ofConParticipant ON ofMessageArchive.conversationID = ofConParticipant.conversationID "
+			+ "WHERE ofMessageArchive.stanza != NULL OR ofMessageArchive.body != NULL";
 
 	public boolean createMessage(ArchivedMessage message) {
 		/* read only */

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler0.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler0.java
@@ -3,6 +3,7 @@ package com.reucon.openfire.plugin.archive.xep0313;
 import org.dom4j.*;
 import org.jivesoftware.openfire.handler.IQHandler;
 import org.jivesoftware.openfire.session.LocalClientSession;
+import org.jivesoftware.openfire.session.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.IQ;
@@ -21,12 +22,12 @@ class IQQueryHandler0 extends IQQueryHandler {
 	}
 
 	@Override
-	protected void sendMidQuery(IQ packet, LocalClientSession session) {
+	protected void sendMidQuery(IQ packet, Session session) {
 		sendAcknowledgementResult(packet, session);
 	}
 
 	@Override
-	protected void sendEndQuery(IQ packet, LocalClientSession session, QueryRequest queryRequest) {
+	protected void sendEndQuery(IQ packet, Session session, QueryRequest queryRequest) {
 		sendFinalMessage(session, queryRequest);
 	}
 
@@ -35,7 +36,7 @@ class IQQueryHandler0 extends IQQueryHandler {
 	 * @param packet Received query packet
 	 * @param session Client session to respond to
 	 */
-	private void sendAcknowledgementResult(IQ packet, LocalClientSession session) {
+	private void sendAcknowledgementResult(IQ packet, Session session) {
 		IQ result = IQ.createResultIQ(packet);
 		session.process(result);
 	}
@@ -45,7 +46,7 @@ class IQQueryHandler0 extends IQQueryHandler {
 	 * @param session Client session to respond to
 	 * @param queryRequest Received query request
 	 */
-	private void sendFinalMessage(LocalClientSession session,
+	private void sendFinalMessage(Session session,
 			final QueryRequest queryRequest) {
 
 		Message finalMessage = new Message();

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler0.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler0.java
@@ -1,0 +1,59 @@
+package com.reucon.openfire.plugin.archive.xep0313;
+
+import org.dom4j.*;
+import org.jivesoftware.openfire.handler.IQHandler;
+import org.jivesoftware.openfire.session.LocalClientSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.IQ;
+import org.xmpp.packet.Message;
+
+/**
+ * XEP-0313 IQ Query Handler
+ */
+class IQQueryHandler0 extends IQQueryHandler {
+
+	private static final Logger Log = LoggerFactory.getLogger(IQHandler.class);
+	private static final String MODULE_NAME = "Message Archive Management Query Handler v0";
+
+	IQQueryHandler0() {
+		super(MODULE_NAME, "urn:xmpp:mam:0");
+	}
+
+	@Override
+	protected void sendMidQuery(IQ packet, LocalClientSession session) {
+		sendAcknowledgementResult(packet, session);
+	}
+
+	@Override
+	protected void sendEndQuery(IQ packet, LocalClientSession session, QueryRequest queryRequest) {
+		sendFinalMessage(session, queryRequest);
+	}
+
+	/**
+	 * Send result packet to client acknowledging query.
+	 * @param packet Received query packet
+	 * @param session Client session to respond to
+	 */
+	private void sendAcknowledgementResult(IQ packet, LocalClientSession session) {
+		IQ result = IQ.createResultIQ(packet);
+		session.process(result);
+	}
+
+	/**
+	 * Send final message back to client following query.
+	 * @param session Client session to respond to
+	 * @param queryRequest Received query request
+	 */
+	private void sendFinalMessage(LocalClientSession session,
+			final QueryRequest queryRequest) {
+
+		Message finalMessage = new Message();
+		finalMessage.setTo(session.getAddress());
+		Element fin = finalMessage.addChildElement("fin", NAMESPACE);
+		completeFinElement(queryRequest, fin);
+
+		session.process(finalMessage);
+	}
+
+}

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler1.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler1.java
@@ -2,6 +2,7 @@ package com.reucon.openfire.plugin.archive.xep0313;
 
 import org.dom4j.*;
 import org.jivesoftware.openfire.session.LocalClientSession;
+import org.jivesoftware.openfire.session.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.IQ;
@@ -19,7 +20,7 @@ class IQQueryHandler1 extends IQQueryHandler {
 	}
 
 	@Override
-	protected void sendEndQuery(IQ packet, LocalClientSession session, QueryRequest queryRequest) {
+	protected void sendEndQuery(IQ packet, Session session, QueryRequest queryRequest) {
 		sendAcknowledgementResult(packet, session, queryRequest);
 	}
 
@@ -28,7 +29,7 @@ class IQQueryHandler1 extends IQQueryHandler {
 	 * @param packet Received query packet
 	 * @param session Client session to respond to
 	 */
-	private void sendAcknowledgementResult(IQ packet, LocalClientSession session, QueryRequest queryRequest) {
+	private void sendAcknowledgementResult(IQ packet, Session session, QueryRequest queryRequest) {
 		IQ result = IQ.createResultIQ(packet);
 		Element fin = result.setChildElement("fin", NAMESPACE);
 		completeFinElement(queryRequest, fin);

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler1.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler1.java
@@ -1,0 +1,37 @@
+package com.reucon.openfire.plugin.archive.xep0313;
+
+import org.dom4j.*;
+import org.jivesoftware.openfire.session.LocalClientSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.IQ;
+
+/**
+ * XEP-0313 IQ Query Handler
+ */
+class IQQueryHandler1 extends IQQueryHandler {
+
+	private static final Logger Log = LoggerFactory.getLogger(IQQueryHandler1.class);
+	private static final String MODULE_NAME = "Message Archive Management Query Handler v1";
+
+	IQQueryHandler1() {
+		super(MODULE_NAME, "urn:xmpp:mam:1");
+	}
+
+	@Override
+	protected void sendEndQuery(IQ packet, LocalClientSession session, QueryRequest queryRequest) {
+		sendAcknowledgementResult(packet, session, queryRequest);
+	}
+
+	/**
+	 * Send result packet to client acknowledging query.
+	 * @param packet Received query packet
+	 * @param session Client session to respond to
+	 */
+	private void sendAcknowledgementResult(IQ packet, LocalClientSession session, QueryRequest queryRequest) {
+		IQ result = IQ.createResultIQ(packet);
+		Element fin = result.setChildElement("fin", NAMESPACE);
+		completeFinElement(queryRequest, fin);
+		session.process(result);
+	}
+}

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/Result.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/Result.java
@@ -1,0 +1,16 @@
+package com.reucon.openfire.plugin.archive.xep0313;
+
+import org.jivesoftware.openfire.forward.Forwarded;
+import org.xmpp.packet.PacketExtension;
+
+import java.util.Date;
+
+/**
+ * Created by dwd on 26/07/16.
+ */
+public final class Result extends PacketExtension {
+    public Result(Forwarded forwarded, String xmlns, String queryId, String id) {
+        super("result", xmlns);
+        element.add(forwarded.getElement());
+    }
+}

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/Xep0313Support1.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/Xep0313Support1.java
@@ -1,25 +1,24 @@
 package com.reucon.openfire.plugin.archive.xep0313;
 
-import java.util.ArrayList;
-
+import com.reucon.openfire.plugin.archive.xep.AbstractXepSupport;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.handler.IQHandler;
 
-import com.reucon.openfire.plugin.archive.xep.AbstractXepSupport;
+import java.util.ArrayList;
 
 /**
  * Encapsulates support for <a
  * href="http://www.xmpp.org/extensions/xep-0313.html">XEP-0313</a>.
  */
-public class Xep0313Support extends AbstractXepSupport {
+public class Xep0313Support1 extends AbstractXepSupport {
 
-	private static final String NAMESPACE = "urn:xmpp:mam:0";
+	private static final String NAMESPACE = "urn:xmpp:mam:1";
 
-	public Xep0313Support(XMPPServer server) {
+	public Xep0313Support1(XMPPServer server) {
 		super(server, NAMESPACE,NAMESPACE, "XEP-0313 IQ Dispatcher");
 
 		this.iqHandlers = new ArrayList<>();
-		iqHandlers.add(new IQQueryHandler0());
+		iqHandlers.add(new IQQueryHandler1());
 	}
 
 }

--- a/src/plugins/monitoring/src/java/org/jivesoftware/openfire/plugin/MonitoringPlugin.java
+++ b/src/plugins/monitoring/src/java/org/jivesoftware/openfire/plugin/MonitoringPlugin.java
@@ -22,6 +22,7 @@ package org.jivesoftware.openfire.plugin;
 import java.io.File;
 import java.io.FileFilter;
 
+import com.reucon.openfire.plugin.archive.xep0313.Xep0313Support1;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.archive.ArchiveIndexer;
 import org.jivesoftware.openfire.archive.ArchiveInterceptor;
@@ -73,6 +74,7 @@ public class MonitoringPlugin implements Plugin {
 	private IndexManager indexManager;
 	private Xep0136Support xep0136Support;
 	private Xep0313Support xep0313Support;
+	private Xep0313Support1 xep0313Support1;
 
 	public MonitoringPlugin() {
 		instance = this;
@@ -161,6 +163,9 @@ public class MonitoringPlugin implements Plugin {
 
 		xep0313Support = new Xep0313Support(XMPPServer.getInstance());
 		xep0313Support.start();
+
+		xep0313Support1 = new Xep0313Support1(XMPPServer.getInstance());
+		xep0313Support1.start();
 
 		// Check if we Enterprise is installed and stop loading this plugin if
 		// found


### PR DESCRIPTION
This PR adds support for multiple versions of MAM in common deployment, the :0 and :1 versions.

While these two variants use much the same protocol, the message delivery and "fin" markers are
delivered in two different ways, and they therefore operate in a different namespace.