### PR TITLE
OF-1104 Ensure SCRAM uses AuthProvider API

### DIFF
--- a/src/java/org/jivesoftware/openfire/auth/AuthFactory.java
+++ b/src/java/org/jivesoftware/openfire/auth/AuthFactory.java
@@ -293,4 +293,17 @@ public class AuthFactory {
         // TODO Auto-generated method stub
         return authProvider.isScramSupported();
     }
+
+    public static String getSalt(String username) throws UnsupportedOperationException, UserNotFoundException {
+        return authProvider.getSalt(username);
+    }
+    public static int getIterations(String username) throws UnsupportedOperationException, UserNotFoundException {
+        return authProvider.getIterations(username);
+    }
+    public static String getServerKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        return authProvider.getServerKey(username);
+    }
+    public static String getStoredKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        return authProvider.getStoredKey(username);
+    }
 }

--- a/src/java/org/jivesoftware/openfire/auth/AuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/AuthProvider.java
@@ -90,4 +90,8 @@ public interface AuthProvider {
     public boolean supportsPasswordRetrieval();
 
     boolean isScramSupported();
+    String getSalt(String username) throws UnsupportedOperationException, UserNotFoundException;
+    int getIterations(String username) throws UnsupportedOperationException, UserNotFoundException;
+    String getServerKey(String username) throws UnsupportedOperationException, UserNotFoundException;
+    String getStoredKey(String username) throws UnsupportedOperationException, UserNotFoundException;
 }

--- a/src/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -55,7 +55,7 @@ public class DefaultAuthProvider implements AuthProvider {
 	    private static final String LOAD_PASSWORD =
 	            "SELECT plainPassword,encryptedPassword FROM ofUser WHERE username=?";
 	    private static final String TEST_PASSWORD =
-	            "SELECT plainPassword,encryptedPassword,iterations,salt,storedKey FROM ofUser WHERE username=?";
+	            "SELECT plainPassword,encryptedPassword,iterations,salt,storedKey,serverKey FROM ofUser WHERE username=?";
     private static final String UPDATE_PASSWORD =
             "UPDATE ofUser SET plainPassword=?, encryptedPassword=?, storedKey=?, serverKey=?, salt=?, iterations=? WHERE username=?";
     
@@ -66,6 +66,88 @@ public class DefaultAuthProvider implements AuthProvider {
      */
     public DefaultAuthProvider() {
 
+    }
+
+    private class UserInfo {
+        String plainText;
+        String encrypted;
+        int iterations;
+        String salt;
+        String storedKey;
+        String serverKey;
+    }
+
+    private UserInfo getUserInfo(String username) throws UnsupportedOperationException, UserNotFoundException {
+        if (!isScramSupported()) {
+            // Reject the operation since the provider  does not support SCRAM
+            throw new UnsupportedOperationException();
+        }
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            con = DbConnectionManager.getConnection();
+            pstmt = con.prepareStatement(TEST_PASSWORD);
+            pstmt.setString(1, username);
+            rs = pstmt.executeQuery();
+            if (!rs.next()) {
+                throw new UserNotFoundException(username);
+            }
+            UserInfo userInfo = new UserInfo();
+            userInfo.plainText = rs.getString(1);
+            userInfo.encrypted = rs.getString(2);
+            userInfo.iterations = rs.getInt(3);
+            userInfo.salt = rs.getString(4);
+            userInfo.storedKey = rs.getString(5);
+            if (userInfo.encrypted != null) {
+                try {
+                    userInfo.plainText = AuthFactory.decryptPassword(userInfo.encrypted);
+                }
+                catch (UnsupportedOperationException uoe) {
+                    // Ignore and return plain password instead.
+                }
+            }
+            if (userInfo.plainText != null) {
+                boolean scramOnly = JiveGlobals.getBooleanProperty("user.scramHashedPasswordOnly");
+                if (scramOnly) {
+                    // If we have a password here, but we're meant to be scramOnly, we should reset it.
+                    setPassword(username, userInfo.plainText);
+                }
+                if (userInfo.salt == null) {
+                    // RECURSE
+                    return getUserInfo(username);
+                }
+            }
+            // Good to go.
+            return userInfo;
+        }
+        catch (SQLException sqle) {
+            Log.error("User SQL failure:", sqle);
+            throw new UserNotFoundException(sqle);
+        }
+        finally {
+            DbConnectionManager.closeConnection(rs, pstmt, con);
+        }
+    }
+
+    @Override
+    public String getSalt(String username) throws UserNotFoundException {
+        return getUserInfo(username).salt;
+    }
+
+    @Override
+    public int getIterations(String username) throws UserNotFoundException {
+        return getUserInfo(username).iterations;
+    }
+
+    @Override
+    public String getStoredKey(String username) throws UserNotFoundException {
+        return getUserInfo(username).storedKey;
+    }
+
+    @Override
+    public String getServerKey(String username) throws UserNotFoundException {
+        return getUserInfo(username).serverKey;
     }
 
     @Override

--- a/src/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -99,6 +99,7 @@ public class DefaultAuthProvider implements AuthProvider {
             userInfo.iterations = rs.getInt(3);
             userInfo.salt = rs.getString(4);
             userInfo.storedKey = rs.getString(5);
+            userInfo.serverKey = rs.getString(6);
             if (userInfo.encrypted != null) {
                 try {
                     userInfo.plainText = AuthFactory.decryptPassword(userInfo.encrypted);

--- a/src/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
@@ -232,4 +232,24 @@ public class HybridAuthProvider implements AuthProvider {
         // TODO Auto-generated method stub
         return false;
     }
+
+    @Override
+    public String getSalt(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getIterations(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServerKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getStoredKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
@@ -448,7 +448,27 @@ public class JDBCAuthProvider implements AuthProvider, PropertyEventListener {
         // TODO Auto-generated method stub
         return false;
     }
-    
+
+    @Override
+    public String getSalt(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getIterations(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServerKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getStoredKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Support a subset of JDBCAuthProvider properties when updated via REST,
      * web GUI, or other sources. Provider strings (and related settings) must

--- a/src/java/org/jivesoftware/openfire/auth/MappedAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/MappedAuthProvider.java
@@ -139,4 +139,48 @@ public class MappedAuthProvider implements AuthProvider
 
         return false;
     }
+
+    @Override
+    public String getSalt(String username) throws UserNotFoundException
+    {
+        final AuthProvider provider = mapper.getAuthProvider( username );
+        if ( provider == null )
+        {
+            throw new UserNotFoundException();
+        }
+        return provider.getSalt( username );
+    }
+
+    @Override
+    public int getIterations(String username) throws UserNotFoundException
+    {
+        final AuthProvider provider = mapper.getAuthProvider( username );
+        if ( provider == null )
+        {
+            throw new UserNotFoundException();
+        }
+        return provider.getIterations( username );
+    }
+
+    @Override
+    public String getServerKey(String username) throws UserNotFoundException
+    {
+        final AuthProvider provider = mapper.getAuthProvider( username );
+        if ( provider == null )
+        {
+            throw new UserNotFoundException();
+        }
+        return provider.getServerKey( username );
+    }
+
+    @Override
+    public String getStoredKey(String username) throws UserNotFoundException
+    {
+        final AuthProvider provider = mapper.getAuthProvider( username );
+        if ( provider == null )
+        {
+            throw new UserNotFoundException();
+        }
+        return provider.getStoredKey( username );
+    }
 }

--- a/src/java/org/jivesoftware/openfire/auth/NativeAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/NativeAuthProvider.java
@@ -204,4 +204,24 @@ public class NativeAuthProvider implements AuthProvider {
         // TODO Auto-generated method stub
         return false;
     }
+
+    @Override
+    public String getSalt(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getIterations(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServerKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getStoredKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/java/org/jivesoftware/openfire/auth/POP3AuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/POP3AuthProvider.java
@@ -240,4 +240,24 @@ public class POP3AuthProvider implements AuthProvider {
     public boolean isScramSupported() {
         return false;
     }
+
+    @Override
+    public String getSalt(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getIterations(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServerKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getStoredKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
@@ -107,4 +107,24 @@ public class CrowdAuthProvider implements AuthProvider {
         return false;
     }
 
+
+	@Override
+	public String getSalt(String username) throws UnsupportedOperationException, UserNotFoundException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int getIterations(String username) throws UnsupportedOperationException, UserNotFoundException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getServerKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getStoredKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/src/java/org/jivesoftware/openfire/ldap/LdapAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapAuthProvider.java
@@ -157,4 +157,24 @@ public class LdapAuthProvider implements AuthProvider {
     public boolean isScramSupported() {
         return false;
     }
+
+    @Override
+    public String getSalt(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getIterations(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServerKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getStoredKey(String username) throws UnsupportedOperationException, UserNotFoundException {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/src/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -38,7 +38,6 @@ import org.jivesoftware.openfire.auth.AuthFactory;
 import org.jivesoftware.openfire.auth.ConnectionException;
 import org.jivesoftware.openfire.auth.InternalUnauthenticatedException;
 import org.jivesoftware.openfire.auth.ScramUtils;
-import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -319,13 +318,13 @@ public class ScramSha1SaslServer implements SaslServer {
      */
     private byte[] getSalt(final String username) {
         try {
-            String saltshaker = UserManager.getUserProvider().loadUser(username).getSalt();
+            String saltshaker = AuthFactory.getSalt(username);
             byte[] salt;
             if (saltshaker == null) {
                 Log.debug("No salt found, so resetting password.");
                 String password = AuthFactory.getPassword(username);
                 AuthFactory.setPassword(username, password);
-                salt = DatatypeConverter.parseBase64Binary(UserManager.getUserProvider().loadUser(username).getSalt());
+                salt = DatatypeConverter.parseBase64Binary(AuthFactory.getSalt(username));
             } else {
                 salt = DatatypeConverter.parseBase64Binary(saltshaker);
             }
@@ -342,14 +341,14 @@ public class ScramSha1SaslServer implements SaslServer {
      * Retrieve the iteration count from the database for a given username.
      */
     private int getIterations(final String username) throws UserNotFoundException {
-    	return UserManager.getUserProvider().loadUser(username).getIterations();
+    	return AuthFactory.getIterations(username);
     }
     
     /**
      * Retrieve the server key from the database for a given username.
      */
     private byte[] getServerKey(final String username) throws UserNotFoundException {
-        final String serverKey = UserManager.getUserProvider().loadUser( username ).getServerKey();
+        final String serverKey = AuthFactory.getServerKey(username);
         if (serverKey == null) {
             return null;
         } else {
@@ -361,7 +360,7 @@ public class ScramSha1SaslServer implements SaslServer {
      * Retrieve the stored key from the database for a given username.
      */
     private byte[] getStoredKey(final String username) throws UserNotFoundException {
-        final String storedKey = UserManager.getUserProvider().loadUser( username ).getStoredKey();
+        final String storedKey = AuthFactory.getStoredKey(username);
         if (storedKey == null) {
             return null;
         } else {


### PR DESCRIPTION
This PR makes the existing SCRAM support use the AuthProvider interface throughout.

It should be noted that there is an internal API which pulls a "UserInfo" structure from the database
in a single call, and the individual API calls simply fetch this and extract the required portion.

It feels as though this UserInfo access ought to be a public API, perhaps?