### PR TITLE
OF-190 show java process owner on admin console

### DIFF
--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -1048,6 +1048,7 @@ index.jvm=Java Version:
 index.app=Appserver:
 index.os=OS / Hardware:
 index.local=Locale / Timezone:
+index.process_owner=OS Process Owner:
 index.memory=Java Memory
 index.update.alert=Update information
 index.update.info=Server version {0} is now available. Click {1}here{2} to download or read the \

--- a/src/web/index.jsp
+++ b/src/web/index.jsp
@@ -304,6 +304,10 @@
                 </td>
             </tr>
             <tr>
+                <td class="c1"><fmt:message key="index.process_owner" /></td>
+                <td class="c2"><%= System.getProperty("user.name") %></td>
+            </tr>
+            <tr>
                 <td class="c1"><fmt:message key="index.memory" /></td>
                 <td>
                 <%    // The java runtime


### PR DESCRIPTION
Introduces i18n string of index.process_owner "OS Process Owner:".
On Windows, I believe the value field will be 'SYSTEM'