### PR TITLE
OF-1226 Enable use of wildcard when searching users in LDAP

### DIFF
--- a/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -2234,6 +2234,21 @@ public class LdapManager {
      *         search filter string.
      */
     public static String sanitizeSearchFilter(final String value) {
+      return sanitizeSearchFilter(value, false);
+      
+    }
+      
+    /**
+     * Escapes any special chars (RFC 4515) from a string representing
+     * a search filter assertion value, with the exception of the '*' wildcard sign
+     *
+     * @param value The input string.
+     *
+     * @return A assertion value string ready for insertion into a 
+     *         search filter string.
+     */
+    public static String sanitizeSearchFilter(final String value, boolean acceptWildcard ) {
+
 
             StringBuilder result = new StringBuilder();
 
@@ -2246,7 +2261,7 @@ public class LdapManager {
 	            	case '&':		result.append("\\26");	break;
 	            	case '(':		result.append("\\28");	break;
 	            	case ')':		result.append("\\29");	break;
-	            	case '*':		result.append("\\2a");	break;
+	            	case '*':		result.append(acceptWildcard ? "*" : "\\2a");	break;
 	            	case ':':		result.append("\\3a");	break;
 	            	case '\\':		result.append("\\5c");	break;
 	            	case '|':		result.append("\\7c");	break;

--- a/src/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
@@ -301,6 +301,15 @@ public class LdapUserProvider implements UserProvider {
         if (fields.isEmpty() || query == null || "".equals(query)) {
             return Collections.emptyList();
         }
+        
+        query = LdapManager.sanitizeSearchFilter(query, true);
+        
+        // Make the query be a wildcard search by default. So, if the user searches for
+        // "John", make the search be "John*" instead.
+        if (!query.endsWith("*")) {
+            query = query + "*";
+        }
+
         if (!searchFields.keySet().containsAll(fields)) {
             throw new IllegalArgumentException("Search fields " + fields + " are not valid.");
         }
@@ -315,10 +324,8 @@ public class LdapUserProvider implements UserProvider {
         }
         for (String field:fields) {
             String attribute = searchFields.get(field);
-            // Make the query be a wildcard search by default. So, if the user searches for
-            // "John", make the sanitized search be "John*" instead.
             filter.append('(').append(attribute).append('=')
-            	.append(LdapManager.sanitizeSearchFilter(query)).append("*)");
+            	.append( query ).append(")");
         }
         if (fields.size() > 1) {
             filter.append(')');

--- a/src/test/java/org/jivesoftware/util/LDAPTest.java
+++ b/src/test/java/org/jivesoftware/util/LDAPTest.java
@@ -73,6 +73,21 @@ public class LDAPTest {
         after = "Wildcard \\2a";
         converted = LdapManager.sanitizeSearchFilter(before);
         assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
+
+        before = "Wildcard *";
+        after = "Wildcard *";
+        converted = LdapManager.sanitizeSearchFilter(before, true);
+        assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
+        
+        before = "Wild*card *";
+        after = "Wild\\2acard \\2a";
+        converted = LdapManager.sanitizeSearchFilter(before, false);
+        assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
+        
+        before = "Wild*card *";
+        after = "Wild*card *";
+        converted = LdapManager.sanitizeSearchFilter(before, true);
+        assertTrue("Conversion result "+before+" to "+converted, converted.equals(after));
         
         before = "~ Group|Section & Teams!";
         after = "\\7e Group\\7cSection \\26 Teams\\21";


### PR DESCRIPTION
As mentioned in https://community.igniterealtime.org/message/261521 the use of wildcards in the user search was broken when using LDAP.