### PR TITLE
OF-1232 Bump fastpath minServerVersion to 4.1

### DIFF
--- a/src/plugins/fastpath/changelog.html
+++ b/src/plugins/fastpath/changelog.html
@@ -44,6 +44,11 @@
 Fastpath Plugin Changelog
 </h1>
 
+<p><b>4.4.2</b> -- December 2, 2016</p>
+<ul>
+    <li>[<a href='https://issues.igniterealtime.org/browse/OF-1232'>OF-1232</a>] - Fastpath now has JiveSharedSecretSaslServer requirement found in 4.1 Openfire.</li>
+</ul>
+
 <p><b>4.4.1</b> -- November 18, 2016</p>
 <ul>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-266'>OF-266</a>] - Fastpath Form UI page in Admin Console doesnt show images.</li>

--- a/src/plugins/fastpath/plugin.xml
+++ b/src/plugins/fastpath/plugin.xml
@@ -5,9 +5,9 @@
     <name>Fastpath Service</name>
     <description>Support for managed queued chat requests, such as a support team might use.</description>
     <author>Jive Software</author>
-    <version>4.4.1</version>
-    <date>11/18/2016</date>
-    <minServerVersion>4.0.0</minServerVersion>
+    <version>4.4.2</version>
+    <date>12/2/2016</date>
+    <minServerVersion>4.1.0</minServerVersion>
     <databaseKey>fastpath</databaseKey>
     <databaseVersion>0</databaseVersion>
 	


### PR DESCRIPTION
Refactoring work done in 4.1 release of Openfire lead to an introduction of a requirement on `JiveSharedSecretSaslServer`