### PR TITLE
OF-1235 Fixes user_created event not being fired on user creation due to auth.

### DIFF
--- a/src/java/org/jivesoftware/openfire/auth/AuthorizationManager.java
+++ b/src/java/org/jivesoftware/openfire/auth/AuthorizationManager.java
@@ -165,7 +165,7 @@ public class AuthorizationManager {
                             return false;
                         }
                         try {
-                            UserManager.getUserProvider().createUser(username, StringUtils.randomString(8), null, null);
+                            UserManager.getInstance().createUser(username, StringUtils.randomString(8), null, null);
                             if (Log.isDebugEnabled()) {
                                 Log.info("AuthorizationManager: User "+username+" created.");
                             }


### PR DESCRIPTION
When a user is created due to successful authentication, now calls the full process of user creation, including firing events for plugins.