### PR TITLE
Add NT hashing for JDBC connections

### DIFF
--- a/src/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
@@ -20,6 +20,8 @@
 package org.jivesoftware.openfire.auth;
 
 import java.security.SecureRandom;
+import java.security.MessageDigest;
+import java.security.Security;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -33,6 +35,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.encoders.Hex;
 
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.openfire.XMPPServer;
@@ -99,6 +103,7 @@ import org.slf4j.LoggerFactory;
  *      <li>{@link PasswordType#sha256 sha256}
  *      <li>{@link PasswordType#sha512 sha512}
  *      <li>{@link PasswordType#bcrypt bcrypt}
+ *      <li>{@link PasswordType#nt nt}
  *  </ul>
  *
  * @author David Snopek
@@ -156,6 +161,9 @@ public class JDBCAuthProvider implements AuthProvider, PropertyEventListener {
         setPasswordTypes(JiveGlobals.getProperty("jdbcAuthProvider.passwordType", "plain"));
         bcryptCost = JiveGlobals.getIntProperty("jdbcAuthProvider.bcrypt.cost", -1);
         PropertyEventDispatcher.addListener(this);
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            java.security.Security.addProvider(new BouncyCastleProvider());
+        }
     }
     
     private void setPasswordTypes(String passwordTypeProperty){
@@ -252,6 +260,18 @@ public class JDBCAuthProvider implements AuthProvider, PropertyEventListener {
                 new SecureRandom().nextBytes(salt);
                 int cost = (bcryptCost < 4 || bcryptCost > 31) ? DEFAULT_BCRYPT_COST : bcryptCost;
                 return OpenBSDBCrypt.generate(password.toCharArray(), salt, cost);
+            case nt:
+                byte[] digestBytes;
+                byte[] utf16leBytes = null;
+                try {
+                  MessageDigest md = MessageDigest.getInstance("MD4");
+                  utf16leBytes = password.getBytes("UTF-16LE");
+                  digestBytes = md.digest(utf16leBytes);
+                  return new String(new String(Hex.encode(digestBytes)));
+                }
+                catch (Exception e) {
+                  return null;
+                }
             case plain:
             default:
                 return password;
@@ -416,7 +436,12 @@ public class JDBCAuthProvider implements AuthProvider, PropertyEventListener {
         /**
           * The password is stored as a bcrypt hash.
           */
-        bcrypt;
+        bcrypt,
+
+        /**
+          * The password is stored as an nt hash.
+          */
+        nt;
    }
 
     /**


### PR DESCRIPTION
This allows using nt password hashes in JDBC connections. This is useful if you have users that are imported from or stored with compatibility to active directory in mind. E.g. this is done in the Alfresco database.