### PR TITLE
OF-1061 Always send room subject after history

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/HistoryRequest.java
+++ b/src/java/org/jivesoftware/openfire/muc/HistoryRequest.java
@@ -143,13 +143,8 @@ public class HistoryRequest {
             }
         }
         else {
-            Message changedSubject = roomHistory.getChangedSubject();
-            boolean addChangedSubject = (changedSubject != null) ? true : false;
             if (getMaxChars() == 0) {
                 // The user requested to receive no history
-                if (addChangedSubject) {
-                    joinRole.send(changedSubject);
-                }
                 return;
             }
             int accumulatedChars = 0;
@@ -201,18 +196,7 @@ public class HistoryRequest {
 
                 }
 
-                // Don't add the latest subject change if it's already in the history.
-                if (addChangedSubject) {
-                    if (changedSubject != null && changedSubject.equals(message)) {
-                        addChangedSubject = false;
-                    }
-                }
-
                 historyToSend.addFirst(message);
-            }
-            // Check if we should add the latest subject change.
-            if (addChangedSubject) {
-                historyToSend.addFirst(changedSubject);
             }
             // Send the smallest amount of traffic to the user
             for (Object aHistoryToSend : historyToSend) {

--- a/src/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
+++ b/src/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
@@ -185,14 +185,11 @@ public class HistoryStrategy {
         boolean subjectChange = isSubjectChangeRequest(packet);
         if (subjectChange) {
             roomSubject = packet;
+            return;
         }
 
         // store message according to active strategy
-        if (strategyType == Type.none && subjectChange) {
-            history.clear();
-            history.add(packet);
-        }
-        else if (strategyType == Type.all || subjectChange) {
+        if (strategyType == Type.all) {
             history.add(packet);
         }
         else if (strategyType == Type.number) {

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -722,6 +722,10 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         else {
             historyRequest.sendHistory(joinRole, roomHistory);
         }
+        Message roomSubject = roomHistory.getChangedSubject();
+        if (roomSubject != null) {
+            joinRole.send(roomSubject);
+        }
         if (!clientOnlyJoin) {
             // Update the date when the last occupant left the room
             setEmptyDate(null);


### PR DESCRIPTION
This change means that room subject changes are no longer held within the
history transcript, but instead are always sent in a distinct action afterward.

Although this means that repeated changes will not be replayed in history, this
seems to be normal behaviour on other servers, and simplified the history replay
code considerably.