### PR TITLE
javadoc fixes and remove legacy SVN RCS tags

### DIFF
--- a/src/java/org/jivesoftware/admin/PluginFilter.java
+++ b/src/java/org/jivesoftware/admin/PluginFilter.java
@@ -1,8 +1,4 @@
 /**
- * $RCSfile$
- * $Revision: 1709 $
- * $Date: 2005-07-26 11:55:27 -0700 (Tue, 26 Jul 2005) $
- *
  * Copyright (C) 2005-2008 Jive Software. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -244,7 +240,7 @@ public class PluginFilter implements Filter {
      * over the filter chain, a simple filter can only control whether further
      * filters in the chain are run.
      *
-     * @Deprecated Use {@link Filter} instead.
+     * @deprecated Use {@link Filter} instead.
      */
     @Deprecated
     public interface SimpleFilter {

--- a/src/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
+++ b/src/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
@@ -47,9 +47,6 @@ public class CrowdAuthProvider implements AuthProvider {
      * Returns if the username and password are valid; otherwise this
      * method throws an UnauthorizedException.<p>
      *
-     * If {@link #isPlainSupported()} returns false, this method should
-     * throw an UnsupportedOperationException.
-     *
      * @param username the username or full JID.
      * @param password the password
      * @throws UnauthorizedException if the username and password do

--- a/src/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -1,8 +1,4 @@
 /**
- * $RCSfile$
- * $Revision: 2979 $
- * $Date: 2005-10-18 19:46:58 -0300 (Tue, 18 Oct 2005) $
- *
  * Copyright (C) 2004-2008 Jive Software. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -633,8 +629,6 @@ public interface MUCRoom extends Externalizable, Result {
     /**
      * Sets the minimal role of persons that are allowed to send private messages in the room. The provided value is
      * any one of: "anyone", "moderators", "participants", "none". If another value is set, "anyone" is used instead.
-     *
-     * @role The minimal role of persons that are allowed to send private messages in the room (never null).
      */
     public void setCanSendPrivateMessage(String role);
 

--- a/src/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -629,6 +629,8 @@ public interface MUCRoom extends Externalizable, Result {
     /**
      * Sets the minimal role of persons that are allowed to send private messages in the room. The provided value is
      * any one of: "anyone", "moderators", "participants", "none". If another value is set, "anyone" is used instead.
+     *
+     * @param role The minimal role of persons that are allowed to send private messages in the room (never null).
      */
     public void setCanSendPrivateMessage(String role);
 

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
@@ -10,8 +10,7 @@ import org.jivesoftware.openfire.muc.MUCRoom;
 
 /**
  * this class supports the simple LocalMUCRoom management including remove,add and query.
- * @author wuchang
- * @email 583424568@qq.com
+ * @author <a href="mailto:583424568@qq.com">wuchang</a>
  * 2016-1-14
  */
 public class LocalMUCRoomManager {

--- a/src/java/org/jivesoftware/util/CertificateManager.java
+++ b/src/java/org/jivesoftware/util/CertificateManager.java
@@ -1,8 +1,4 @@
 /**
- * $RCSfile$
- * $Revision: $
- * $Date: $
- *
  * Copyright (C) 2005-2008 Jive Software. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -417,8 +413,6 @@ public class CertificateManager {
     /**
      * Returns true if the specified certificate is a self-signed certificate.
      *
-     * @param keyStore key store that holds the certificate to verify.
-     * @param alias alias of the certificate in the key store.
      * @return true if the specified certificate is a self-signed certificate.
      * @throws KeyStoreException if an error happens while usign the keystore
      */
@@ -436,8 +430,6 @@ public class CertificateManager {
      * certificates need to get their issuer information entered to be able to generate a Certificate
      * Signing Request (CSR).
      *
-     * @param keyStore key store that holds the certificate to verify.
-     * @param alias alias of the certificate in the key store.
      * @return true if the specified certificate is ready to be signed by a Certificate Authority.
      * @throws KeyStoreException if an error happens while usign the keystore
      */
@@ -456,7 +448,7 @@ public class CertificateManager {
      * requests are required by Certificate Authorities as part of their signing process. The signing request
      * contains information about the certificate issuer, subject DN, subject alternative names and public key.
      * Private keys are not included. After the Certificate Authority verified and signed the certificate a new
-     * certificate is going to be returned. Use {@link #installReply(java.security.KeyStore, java.security.KeyStore, String, String, java.io.InputStream)}
+     * certificate is going to be returned. Use {@link #installReply(java.security.KeyStore, java.security.KeyStore, char[], String, java.io.InputStream)}
      * to import the CA reply.
      *
      * @param cert the certificate to create a signing request.

--- a/src/java/org/jivesoftware/util/log/util/CommonsLogFactory.java
+++ b/src/java/org/jivesoftware/util/log/util/CommonsLogFactory.java
@@ -1,8 +1,4 @@
 /**
- * $RCSfile$
- * $Revision: $
- * $Date: $
- *
  * Copyright (C) 2005-2008 Jive Software. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * A LogFactory implementation to override the default commons-logging behavior. All log
  * statements are written to the Openfire logs. Info level logging is sent to debug.
  *
- * @Deprecated Openfire uses SLF4J's 'jcl-over-slf4j' instead. See http://www.slf4j.org/legacy.html
+ * @deprecated Openfire uses SLF4J's 'jcl-over-slf4j' instead. See http://www.slf4j.org/legacy.html
  */
 @Deprecated
 public class CommonsLogFactory extends LogFactory {


### PR DESCRIPTION
addresses warnings thrown by `ant javadocs`