### PR TITLE
OF-1245: Prevent error while parsing self-generated certificate

### DIFF
--- a/src/java/org/jivesoftware/util/CertificateManager.java
+++ b/src/java/org/jivesoftware/util/CertificateManager.java
@@ -60,12 +60,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.DERSequence;
-import org.bouncycastle.asn1.DERTaggedObject;
-import org.bouncycastle.asn1.DERUTF8String;
+import org.bouncycastle.asn1.*;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
@@ -1017,7 +1012,7 @@ public class CertificateManager {
         // add subjectAlternativeName extension
         boolean critical = subjectDN.getRDNs().length == 0;
         ASN1Sequence othernameSequence = new DERSequence(new ASN1Encodable[]{
-                new ASN1ObjectIdentifier("1.3.6.1.5.5.7.8.5"), new DERTaggedObject(true, 0, new DERUTF8String(domain))});
+                new ASN1ObjectIdentifier("1.3.6.1.5.5.7.8.5"), new DERUTF8String( domain )});
         GeneralName othernameGN = new GeneralName(GeneralName.otherName, othernameSequence);
         GeneralNames subjectAltNames = new GeneralNames(new GeneralName[]{othernameGN});
         certBuilder.addExtension(Extension.subjectAlternativeName, critical, subjectAltNames);


### PR DESCRIPTION
Openfire, during setup, generates a certificate, that it cannot parse later.

This commit changes the generation routine, changing the subjectAltName value
from a tagged object to non-tagged string.