### PR TITLE
OF-1233 More cases

### DIFF
--- a/src/java/org/jivesoftware/openfire/net/SocketReader.java
+++ b/src/java/org/jivesoftware/openfire/net/SocketReader.java
@@ -400,7 +400,7 @@ public abstract class SocketReader implements Runnable {
             sb.append("'?>");
             // Append stream header
             sb.append("<stream:stream ");
-            sb.append("from=\"").append(serverName).append("\" ");
+            sb.append("from=\"").append(host).append("\" ");
             sb.append("id=\"").append( STREAM_ID_FACTORY.createStreamID() ).append( "\" " );
             sb.append("xmlns=\"").append(xpp.getNamespace(null)).append("\" ");
             sb.append("xmlns:stream=\"").append(xpp.getNamespace("stream")).append("\" ");
@@ -429,7 +429,7 @@ public abstract class SocketReader implements Runnable {
             sb.append("'?>");
             // Append stream header
             sb.append("<stream:stream ");
-            sb.append("from=\"").append(serverName).append("\" ");
+            sb.append("from=\"").append(host).append("\" ");
             sb.append("id=\"").append( STREAM_ID_FACTORY.createStreamID() ).append( "\" " );
             sb.append("xmlns=\"").append(xpp.getNamespace(null)).append("\" ");
             sb.append("xmlns:stream=\"").append(xpp.getNamespace("stream")).append("\" ");

--- a/src/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -33,7 +33,6 @@ import org.jivesoftware.openfire.spi.BasicStreamIDFactory;
 import org.jivesoftware.openfire.streammanagement.StreamManager;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.LocaleUtils;
-import org.jivesoftware.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
@@ -434,7 +433,7 @@ public abstract class StanzaHandler {
     private void tlsNegotiated() {
         // Offer stream features including SASL Mechanisms
         StringBuilder sb = new StringBuilder(620);
-        sb.append(geStreamHeader());
+        sb.append(getStreamHeader());
         sb.append("<stream:features>");
         // Include available SASL Mechanisms
         sb.append(SASLAuthentication.getSASLMechanisms(session));
@@ -455,7 +454,7 @@ public abstract class StanzaHandler {
      */
     private void saslSuccessful() {
         StringBuilder sb = new StringBuilder(420);
-        sb.append(geStreamHeader());
+        sb.append(getStreamHeader());
         sb.append("<stream:features>");
 
         // Include specific features such as resource binding and session establishment
@@ -531,7 +530,7 @@ public abstract class StanzaHandler {
      */
     private void compressionSuccessful() {
         StringBuilder sb = new StringBuilder(340);
-        sb.append(geStreamHeader());
+        sb.append(getStreamHeader());
         sb.append("<stream:features>");
         // Include SASL mechanisms only if client has not been authenticated
         if (session.getStatus() != Session.STATUS_AUTHENTICATED) {
@@ -558,7 +557,7 @@ public abstract class StanzaHandler {
 				StreamManager.NAMESPACE_V3.equals(stanza.getNamespace().getStringValue());
 	}
 
-    private String geStreamHeader() {
+    private String getStreamHeader() {
         StringBuilder sb = new StringBuilder(200);
         sb.append("<?xml version='1.0' encoding='");
         sb.append(CHARSET);

--- a/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -267,7 +267,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
             openingStream.append(" xmlns:db=\"jabber:server:dialback\"");
             openingStream.append(" xmlns:stream=\"http://etherx.jabber.org/streams\"");
             openingStream.append(" xmlns=\"jabber:server\"");
-            openingStream.append(" from=\"").append(XMPPServer.getInstance().getServerInfo().getXMPPDomain()).append("\""); // OF-673
+            openingStream.append(" from=\"").append(localDomain).append("\""); // OF-673
             openingStream.append(" to=\"").append(remoteDomain).append("\"");
             openingStream.append(" version=\"1.0\">");
             connection.deliverRawText(openingStream.toString());


### PR DESCRIPTION
In one case, the outgoing stream header includes the wrong domain, which causes an error in SASL EXTERNAL on some servers.