### PR TITLE
OF-1254 and OF-1255: Fix various database scripts.

### DIFF
--- a/src/database/openfire_mysql.sql
+++ b/src/database/openfire_mysql.sql
@@ -250,7 +250,7 @@ CREATE TABLE ofMucConversationLog (
   body                TEXT          NULL,
   stanza                TEXT          NULL,
   INDEX ofMucConversationLog_time_idx (logTime),
-  INDEX ofMucConversationLog_msg_id (messageID);
+  INDEX ofMucConversationLog_msg_id (messageID)
 );
 
 # PubSub Tables

--- a/src/database/upgrade/25/openfire_hsqldb.sql
+++ b/src/database/upgrade/25/openfire_hsqldb.sql
@@ -1,3 +1,3 @@
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
-UPDATE ofVersion SET version = 24 WHERE name = 'openfire';
+UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/src/database/upgrade/25/openfire_mysql.sql
+++ b/src/database/upgrade/25/openfire_mysql.sql
@@ -1,3 +1,3 @@
 ALTER TABLE ofMucConversationLog ADD INDEX ofMucConvLog_msg_id (messageID);
 
-UPDATE ofVersion SET version = 24 WHERE name = 'openfire';
+UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/src/database/upgrade/25/openfire_oracle.sql
+++ b/src/database/upgrade/25/openfire_oracle.sql
@@ -1,3 +1,3 @@
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
-UPDATE ofVersion SET version = 24 WHERE name = 'openfire';
+UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/src/database/upgrade/25/openfire_postgresql.sql
+++ b/src/database/upgrade/25/openfire_postgresql.sql
@@ -1,3 +1,3 @@
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
-UPDATE ofVersion SET version = 24 WHERE name = 'openfire';
+UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/src/database/upgrade/25/openfire_sqlserver.sql
+++ b/src/database/upgrade/25/openfire_sqlserver.sql
@@ -1,3 +1,3 @@
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
-UPDATE ofVersion SET version = 24 WHERE name = 'openfire';
+UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/src/database/upgrade/25/openfire_sybase.sql
+++ b/src/database/upgrade/25/openfire_sybase.sql
@@ -1,3 +1,3 @@
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
-UPDATE ofVersion SET version = 24 WHERE name = 'openfire';
+UPDATE ofVersion SET version = 25 WHERE name = 'openfire';


### PR DESCRIPTION
Most database update scripts version 25 identify themselfs incorrectly as 24. This causes the update script to be executed each time that Openfire starts.