### PR TITLE
OF-1290 fix EXTERNAL auth stackoverflow error - 4.1.x

### DIFF
--- a/src/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -47,6 +47,8 @@ import org.jivesoftware.openfire.net.SASLAuthentication;
 import org.jivesoftware.openfire.net.VirtualConnection;
 import org.jivesoftware.openfire.session.LocalClientSession;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
+import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
+import org.jivesoftware.openfire.spi.ConnectionType;
 import org.jivesoftware.util.JiveConstants;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.TaskEngine;
@@ -134,7 +136,7 @@ public class HttpSession extends LocalClientSession {
 
     public HttpSession(PacketDeliverer backupDeliverer, String serverName, InetAddress address,
                        StreamID streamID, long rid, HttpConnection connection, Locale language) {
-        super(serverName, new HttpVirtualConnection(address), streamID, language);
+        super(serverName, new HttpVirtualConnection(address, ConnectionType.SOCKET_C2S), streamID, language);
         this.isClosed = false;
         this.lastActivity = System.currentTimeMillis();
         this.lastRequestID = rid;
@@ -1101,9 +1103,16 @@ public class HttpSession extends LocalClientSession {
 
         private InetAddress address;
         private ConnectionConfiguration configuration;
+        private ConnectionType connectionType;
 
         public HttpVirtualConnection(InetAddress address) {
             this.address = address;
+            this.connectionType = ConnectionType.SOCKET_C2S;
+        }
+
+        public HttpVirtualConnection(InetAddress address, ConnectionType connectionType) {
+            this.address = address;
+            this.connectionType = connectionType;
         }
 
         @Override
@@ -1143,7 +1152,11 @@ public class HttpSession extends LocalClientSession {
 
         @Override
         public ConnectionConfiguration getConfiguration() {
-            return session.getConnection().getConfiguration();
+            if (configuration == null) {
+            	final ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
+                configuration = connectionManager.getListener( connectionType, true ).generateConnectionConfiguration();
+            }
+            return configuration;
         }
 
         @Override

--- a/src/java/org/jivesoftware/openfire/sasl/ExternalClientSaslServer.java
+++ b/src/java/org/jivesoftware/openfire/sasl/ExternalClientSaslServer.java
@@ -11,6 +11,7 @@ import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -57,14 +58,15 @@ public class ExternalClientSaslServer implements SaslServer
         complete = true;
 
         final Connection connection = session.getConnection();
-        if ( connection.getPeerCertificates().length < 1 )
+        Certificate[] peerCertificates = connection.getPeerCertificates();
+        if ( peerCertificates == null || peerCertificates.length < 1 )
         {
             throw new SaslException( "No peer certificates." );
         }
 
         final KeyStore keyStore = connection.getConfiguration().getIdentityStore().getStore();
         final KeyStore trustStore = connection.getConfiguration().getTrustStore().getStore();
-        final X509Certificate trusted = CertificateManager.getEndEntityCertificate( connection.getPeerCertificates(), keyStore, trustStore );
+        final X509Certificate trusted = CertificateManager.getEndEntityCertificate( peerCertificates, keyStore, trustStore );
         if ( trusted == null )
         {
             throw new SaslException( "Certificate chain of peer is not trusted." );


### PR DESCRIPTION
This patches the 4.1 branch so that EXTERNAL sasl auth works. Existing code was causing StackOverFlow error. 

It looks like my editor also removed trailing white space and removed unused imports, let me know if that is a problem. 