### PR TITLE
make sure jars in openfire lib are added to the classpath in predictable order

### DIFF
--- a/src/java/org/jivesoftware/openfire/starter/JiveClassLoader.java
+++ b/src/java/org/jivesoftware/openfire/starter/JiveClassLoader.java
@@ -21,6 +21,7 @@ import java.io.FilenameFilter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Arrays;
 
 /**
  * A simple classloader to extend the classpath to
@@ -66,6 +67,9 @@ class JiveClassLoader extends URLClassLoader {
             return;
         }
 
+        // sort jars otherwise order differs between installations (e.g. it's not alphabetical)
+        // order may matter if trying to patch an install by adding patch jar to lib folder
+        Arrays.sort(jars);
         for (int i = 0; i < jars.length; i++) {
             if (jars[i].isFile()) {
                 addURL(jars[i].toURI().toURL());


### PR DESCRIPTION
We had some patches in a jar in the lib folder and the jar was named something like aaa_patches.jar so that it would override classes in openfire.jar. This worked sometimes but it wasn't consistent across installations despite using the same versions of Java and the same OS. Files.listFiles() doesn't make any promises about the order it will return files in. (This patch sorts the list of jars so that the order is consistent across installations on the same platform (unix or windows, or everywhere if you don't have jars with mixed case filenames). 