### PR TITLE
OF-1275

### DIFF
--- a/src/java/org/jivesoftware/util/SimpleSSLSocketFactory.java
+++ b/src/java/org/jivesoftware/util/SimpleSSLSocketFactory.java
@@ -52,7 +52,7 @@ public class SimpleSSLSocketFactory extends SSLSocketFactory implements Comparat
     public SimpleSSLSocketFactory() {
 
         try {
-            final SSLContext sslContext = SSLContext.getInstance("TLSv1");
+            final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
             sslContext.init(null, // KeyManager not required
                             new TrustManager[] { new DummyTrustManager() },
                             new java.security.SecureRandom());


### PR DESCRIPTION
This should allow Openfire to connect to LDAPs using TLS 1.0, TLS 1.1, or TLS 1.2, instead of capping the protocol to TLS 1.0

