### PR TITLE
Support UPN OID extraction directly in SANCertificateIdentityMapping

### DIFF
--- a/src/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
+++ b/src/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
@@ -42,7 +42,15 @@ public class SANCertificateIdentityMapping implements CertificateIdentityMapping
      * @see <a href="https://tools.ietf.org/html/rfc4985">RFC 4985</a>
      */
     public static final String OTHERNAME_SRV_OID = "1.3.6.1.5.5.7.8.7";
+    
+    /**
+     * User Principal Name (UPN) Object Identifier.
+     *
+     * @see <a href="http://www.oid-info.com/get/1.3.6.1.4.1.311.20.2.3">User Principal Name (UPN)</a>
+     */
+    public static final String OTHERNAME_UPN_OID = "1.3.6.1.4.1.311.20.2.3";
 
+    
     /**
      * Returns the JID representation of an XMPP entity contained as a SubjectAltName extension
      * in the certificate. If none was found then return an empty list.
@@ -71,7 +79,7 @@ public class SANCertificateIdentityMapping implements CertificateIdentityMapping
                 switch ( type )
                 {
                     case 0:
-                        // OtherName: search for "id-on-xmppAddr" or 'sRVName'
+                        // OtherName: search for "id-on-xmppAddr" or 'sRVName' or 'userPrincipalName'
                         result = parseOtherName( (byte[]) value );
                         break;
                     case 2:
@@ -158,6 +166,9 @@ public class SANCertificateIdentityMapping implements CertificateIdentityMapping
 
                 case OTHERNAME_XMPP_OID:
                     return parseOtherNameXmppAddr( value );
+                    
+                case OTHERNAME_UPN_OID:
+                    return parseOtherNameUpn( value );
 
                 default:
                     String otherName = parseOtherName(typeId, value);
@@ -195,7 +206,7 @@ public class SANCertificateIdentityMapping implements CertificateIdentityMapping
      * @param srvName The ASN.1 representation of the srvName value (cannot be null).
      * @return an XMPP address value, or null when the record does not relate to XMPP.
      */
-    public static String parseOtherNameDnsSrv( ASN1Primitive srvName )
+    protected String parseOtherNameDnsSrv( ASN1Primitive srvName )
     {
         // RFC 4985 says that this should be a IA5 String. Lets be tolerant and allow all text-based values.
         final String value = ( (ASN1String) srvName ).getString();
@@ -222,9 +233,33 @@ public class SANCertificateIdentityMapping implements CertificateIdentityMapping
      * @param xmppAddr The ASN.1 representation of the xmppAddr value (cannot be null).
      * @return The parsed xmppAddr value.
      */
-    public static String parseOtherNameXmppAddr( ASN1Primitive xmppAddr )
+    protected String parseOtherNameXmppAddr( ASN1Primitive xmppAddr )
     {
         // RFC 6120 says that this should be a UTF8String. Lets be tolerant and allow all text-based values.
         return ( (ASN1String) xmppAddr ).getString();
     }
+    
+    /**
+     * Parse a UPN value 
+     *
+     * @param otherName The ASN.1 representation of the UPN (cannot be null).
+     * @return The parsed UPN value.
+     */
+    protected String parseOtherNameUpn( ASN1Primitive value )
+    {
+        String otherName = null;
+        if (value instanceof ASN1TaggedObject) {
+            ASN1TaggedObject taggedObject = (ASN1TaggedObject) value;
+            ASN1Primitive objectPrimitive = taggedObject.getObject();
+            if (objectPrimitive instanceof ASN1String) {
+                otherName = ((ASN1String)objectPrimitive).getString();
+            }
+        }
+        if (otherName == null) {
+            Log.warn("UPN type unexpected, UPN extraction failed: " + value.getClass().getName() + ":" + value.toString());
+        } else {
+            Log.debug("UPN from certificate has value of: " + otherName );
+        }
+        return otherName;
+    }    
 }

--- a/src/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
+++ b/src/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
@@ -125,7 +125,7 @@ public class SANCertificateIdentityMapping implements CertificateIdentityMapping
      * @param item A byte array representation of a subjectAltName 'otherName' entry (cannot be null).
      * @return an xmpp address, or null when the otherName entry does not relate to XMPP (or fails to parse).
      */
-    public static String parseOtherName( byte[] item )
+    public String parseOtherName( byte[] item )
     {
         if ( item == null || item.length == 0 )
         {
@@ -160,6 +160,10 @@ public class SANCertificateIdentityMapping implements CertificateIdentityMapping
                     return parseOtherNameXmppAddr( value );
 
                 default:
+                    String otherName = parseOtherName(typeId, value);
+                    if (otherName != null) {
+                        return otherName;
+                    }
                     Log.debug( "Ignoring subjectAltName 'otherName' type-id '{}' that's neither id-on-xmppAddr nor id-on-dnsSRV.", typeId.getId() );
                     return null;
             }
@@ -171,6 +175,17 @@ public class SANCertificateIdentityMapping implements CertificateIdentityMapping
         }
     }
 
+    /**
+     * Allow sub-class to support additional OID values, possibly taking typeId into account
+     *
+     * @param typeId The ASN.1 object identifier (cannot be null).
+     * @param value The ASN.1 representation of the value (cannot be null).
+     * @return The parsed otherName String value.
+     */
+    protected String parseOtherName(ASN1ObjectIdentifier typeId, ASN1Primitive value) {
+        return null;
+    }
+    
     /**
      * Parses a SRVName value as specified by RFC 4985.
      *


### PR DESCRIPTION
This change allows a sub-class to support additional OID values in the certificate by overriding a single method.

I am extracting the "otherName" from a client cert (smartcard) and the OID is 
[1.3.6.1.4.1.311.20.2.3](http://www.oid-info.com/get/1.3.6.1.4.1.311.20.2.3) which this class doesn't handle. 

With the change in this pull request my subclass is able to extract the string value of otherName with the following code:

```java
	protected String parseOtherName(ASN1ObjectIdentifier typeId, ASN1Primitive value) {
		String otherName = null;
		if (value instanceof ASN1TaggedObject) {
			ASN1TaggedObject taggedObject = (ASN1TaggedObject) value;
			ASN1Primitive primitive = taggedObject.getObject();
			if (primitive instanceof DERUTF8String) {
				otherName = ((DERUTF8String)primitive).getString();
			} else {
		    	logger.info("Object in tagged object is of type: " + primitive.getClass().getName() );
				otherName = primitive.toString();
			}
	    } else {
	    	logger.info("Other name in certificate is of type: " + value.getClass().getName() );
	    	otherName = value.toString();
	    }
    	logger.info("otherName from certificate has value of: " + otherName );
    	return otherName;
    }
```
If you would prefer I could add support for that OID directly to the case statement in this class, but in that case this change still might be helpful if someone needed handle a different OID in the future or if they needed to override one of the parse* methods for the OIDs that are handled (I would need to change two existing parse* methods in the class to not be static, they don't really need to be static).