### PR TITLE
RestAPI plugin synchronizing invalid room state when creating a room in a clustered Openfire

### DIFF
--- a/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -245,11 +245,6 @@ public class MUCRoomController {
 		room.setMaxUsers(mucRoomEntity.getMaxUsers());
 		room.setMembersOnly(mucRoomEntity.isMembersOnly());
 		room.setModerated(mucRoomEntity.isModerated());
-		
-		// Fire RoomUpdateEvent if cluster is started
-		if (ClusterManager.isClusteringStarted()) {
-		  CacheFactory.doClusterTask(new RoomUpdatedEvent((LocalMUCRoom) room));
-		}
 
 		// Set broadcast presence roles
 		if (mucRoomEntity.getBroadcastPresenceRoles() != null) {
@@ -276,6 +271,11 @@ public class MUCRoomController {
 		
 		// Unlock the room, because the default configuration lock the room.  		
 		room.unlock(room.getRole());
+		
+		// Fire RoomUpdateEvent if cluster is started
+		if (ClusterManager.isClusteringStarted()) {
+		  CacheFactory.doClusterTask(new RoomUpdatedEvent((LocalMUCRoom) room));
+		}
 
 		// Save the room to the DB if the room should be persistant
 		if (room.isPersistent()) {


### PR DESCRIPTION
We have a 2 node Openfire cluster (Openfire 4.1.1) and we create persistent chat rooms using the Rest API plugin (version: 1.2.5). When a chat room is created on node1 using the RestAPI it is propagated to node2 before completely processing it. This is causing a variety of issues. Here is a couple of examples:

1. If modification date is not set on the request we run into a HazelcastSerializationException when serializing the room (as org.jivesoftware.openfire.muc.spi.LocalMUCRoom.writeExternal assumes a non null modified date). 
2. The room is in a locked state when it is serialized and sent to the other node. So after a room is created on node1 if a client tries to join the room on node2 it will get an item-not-found error from Openfire. If node2 is restarted at this point then all is good as node2 will have read the room configuration from the database. 

Fixed these issues by moving code that fires the RoomUpdatedEvent to after the room has been fully configured.