### PR TITLE
OF-1305: Make escaping of multibyte characters in LDAP search optional.

### DIFF
--- a/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -253,6 +253,7 @@ public class LdapManager {
         JiveGlobals.migrateProperty("ldap.pagedResultsSize");
         JiveGlobals.migrateProperty("ldap.clientSideSorting");
         JiveGlobals.migrateProperty("ldap.ldapDebugEnabled");
+        JiveGlobals.migrateProperty("ldap.encodeMultibyteCharacters");
 
         String host = properties.get("ldap.host");
         if (host != null) {
@@ -2268,11 +2269,19 @@ public class LdapManager {
                         // regular 1-byte UTF-8 char
             			result.append(String.valueOf(c));
                     }
-                    else if (c >= 0x080) { 
+                    else if (c >= 0x080) {
                         // higher-order 2, 3 and 4-byte UTF-8 chars
-                        byte[] utf8bytes = String.valueOf(c).getBytes(StandardCharsets.UTF_8);
-                        for (byte b : utf8bytes) {
-                            result.append(String.format("\\%02x", b));
+                        if ( JiveGlobals.getBooleanProperty( "ldap.encodeMultibyteCharacters", false ) )
+                        {
+                            byte[] utf8bytes = String.valueOf( c ).getBytes( StandardCharsets.UTF_8 );
+                            for ( byte b : utf8bytes )
+                            {
+                                result.append( String.format( "\\%02x", b ) );
+                            }
+                        }
+                        else
+                        {
+                            result.append(String.valueOf(c));
                         }
                     }
                 }


### PR DESCRIPTION
A new property (ldap.encodeMultibyteCharacters) is introduced that controls if multibyte characters in LDAP search queries are escaped.

Escaping of these characters started with the fix for OF-830, which appears to have caused OF-1305. Although I can't say that escaping of characters is wrong (per RFC 4515), it does cause real-world problems.

This fix defaults to not encoding again (reverting back to the behavior pre OF-830, without affecting other changes made in OF-830).