### PR TITLE
OF-119: LDAP users with '@' sign can be made admin.

### DIFF
--- a/src/web/setup/setup-admin-settings.jsp
+++ b/src/web/setup/setup-admin-settings.jsp
@@ -123,8 +123,9 @@
     }
 
     if (addAdmin && !doTest) {
-        final String admin = request.getParameter("administrator");
+        String admin = request.getParameter("administrator");
         if (admin != null) {
+            admin = JID.escapeNode( admin );
             if (ldap) {
                 // Try to verify that the username exists in LDAP
                 Map<String, String> settings = (Map<String, String>) session.getAttribute("ldapSettings");
@@ -456,7 +457,7 @@ if (errors.size() > 0) { %>
 %>
     <tr valign="top">
         <td>
-            <%= authJID.getNode()%>
+            <%= JID.unescapeNode( authJID.getNode() )%>
         </td>
         <td width="1%" align="center">
             <a href="setup-admin-settings.jsp?ldap=true&test=true&username=<%= URLEncoder.encode(authJID.getNode(), "UTF-8") %>"

--- a/src/web/setup/setup-admin-settings_test.jsp
+++ b/src/web/setup/setup-admin-settings_test.jsp
@@ -2,12 +2,13 @@
 <%@ page import="org.jivesoftware.util.ParamUtils, org.jivesoftware.openfire.ldap.LdapManager, org.jivesoftware.openfire.user.UserNotFoundException, org.xmpp.packet.JID" %>
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="java.net.URLDecoder" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%
-    String username = ParamUtils.getParameter(request, "username");
+    String username = URLDecoder.decode( ParamUtils.getParameter( request, "username"), "UTF-8" );
     String password = ParamUtils.getParameter(request, "password");
     boolean ldap = "true".equals(request.getParameter("ldap"));
 


### PR DESCRIPTION
This fixes some encoding issues, preventing LDAP users that have an '@' character in their username from becoming admin.