### PR TITLE
OF-546: Plugins should not inherit from parent.

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -1,11 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <artifactId>parent</artifactId>
-        <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.2.0-SNAPSHOT</version>
-    </parent>
+    <groupId>org.igniterealtime.openfire</groupId>
+    <version>4.2.0-SNAPSHOT</version>
     <artifactId>plugins</artifactId>
     <packaging>pom</packaging>
     <name>Openfire Plugins</name>
@@ -52,7 +49,25 @@
         <module>xmldebugger</module>
     </modules>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Versions -->
+        <openfire.version>4.2.0-SNAPSHOT</openfire.version>
+        <jetty.version>9.2.14.v20151106</jetty.version>
+        <slf4j.version>1.7.7</slf4j.version>
+    </properties>
+
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -62,7 +77,7 @@
                         <dependency>
                             <groupId>org.igniterealtime.openfire.plugins</groupId>
                             <artifactId>openfire-plugin-assembly-descriptor</artifactId>
-                            <version>${project.version}</version>
+                            <version>${openfire.version}</version>
                         </dependency>
                     </dependencies>
                     <executions>
@@ -122,9 +137,9 @@
                     </executions>
                     <dependencies>
                         <dependency>
-                            <groupId>${project.parent.groupId}</groupId>
+                            <groupId>org.igniterealtime.openfire</groupId>
                             <artifactId>xmppserver</artifactId>
-                            <version>${project.version}</version>
+                            <version>${openfire.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -134,9 +149,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>${project.parent.groupId}</groupId>
+            <groupId>org.igniterealtime.openfire</groupId>
             <artifactId>xmppserver</artifactId>
-            <version>${project.version}</version>
+            <version>${openfire.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -54,7 +54,6 @@
         <!-- Versions -->
         <openfire.version>4.2.0-SNAPSHOT</openfire.version>
         <jetty.version>9.2.14.v20151106</jetty.version>
-        <slf4j.version>1.7.7</slf4j.version>
     </properties>
 
     <build>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -53,7 +53,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Versions -->
         <openfire.version>4.2.0-SNAPSHOT</openfire.version>
-        <jetty.version>9.2.14.v20151106</jetty.version>
     </properties>
 
     <build>
@@ -116,7 +115,7 @@
                 <plugin>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-jspc-maven-plugin</artifactId>
-                    <version>${jetty.version}</version>
+                    <version>9.2.14.v20151106</version>
                     <configuration>
                         <webAppSourceDirectory>${project.build.sourceDirectory}/../web</webAppSourceDirectory>
                         <webXml>${project.build.sourceDirectory}/../web/WEB-INF/web.xml</webXml>


### PR DESCRIPTION
The build plans for the plugins should not inherit from the parent project, as this
ties their existence in with our parent project. Third party developers cannot do
this (without modifying the parent project structure). We should facilitate third
party developers, and use the same tools as we provide them.

This commit removes the parent/child dependencies between the top-level parent POM
and the plugins POM. There still as a parent/child dependency between the plugins
POM and each individual plugin.

Although I'm not sure this change is a complete solution, it is aimed to more closely
represent a development setup in which a third party developer might find itself. To
create a plugin of their own, they can now:

 - Use our 'plugins' module directly (define it as a parent)
 - Replace our 'plugins' module by a proprietary one (when developing multiple
   proprietary plugins).
 - Take most POM definition from our 'plugins' module and merge that with a new
   stand-alone plugin project.