### PR TITLE
OF-546: Distribute custom tags in a library.

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -141,6 +141,11 @@
                             <artifactId>xmppserver</artifactId>
                             <version>${openfire.version}</version>
                         </dependency>
+                        <dependency>
+                            <groupId>org.igniterealtime.openfire</groupId>
+                            <artifactId>webadmintld</artifactId>
+                            <version>${openfire.version}</version>
+                        </dependency>
                     </dependencies>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <module>starter</module>
         <module>plugins</module>
         <module>webadmin</module>
+        <module>webadmintld</module>
     </modules>
 
     <organization>

--- a/src/java/org/jivesoftware/admin/JSTLFunctions.java
+++ b/src/java/org/jivesoftware/admin/JSTLFunctions.java
@@ -1,14 +1,5 @@
 package org.jivesoftware.admin;
 
-import org.bouncycastle.asn1.*;
-import org.jivesoftware.util.Log;
-
-import java.io.IOException;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 /**
  * Utility functions that are exposed through a taglib.
  *

--- a/webadmintld/pom.xml
+++ b/webadmintld/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>parent</artifactId>
+        <groupId>org.igniterealtime.openfire</groupId>
+        <version>4.2.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>webadmintld</artifactId>
+    <name>Administration Interface Taglibs</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>org/jivesoftware/admin/*Tag.java</include>
+                        <include>org/jivesoftware/admin/JSTL*.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+
+        <sourceDirectory>../src/java</sourceDirectory>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.igniterealtime.openfire</groupId>
+            <artifactId>xmppserver</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/webadmintld/src/assembly/taglib.xml
+++ b/webadmintld/src/assembly/taglib.xml
@@ -1,0 +1,29 @@
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>taglib</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <outputDirectory>META-INF/tags/admin</outputDirectory>
+            <directory>${project.basedir}/../src/web/WEB-INF/tags/admin</directory>
+            <includes>
+                <include>*.tag</include>
+                <include>*.tagx</include>
+            </includes>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>META-INF/</outputDirectory>
+            <directory>${project.basedir}/src/main/webapp/META-INF/</directory>
+            <includes>
+                <include>*.tld</include>
+            </includes>
+        </fileSet>
+
+    </fileSets>
+</assembly>

--- a/webadmintld/src/main/resources/META-INF/admin.tld
+++ b/webadmintld/src/main/resources/META-INF/admin.tld
@@ -9,8 +9,8 @@
     <description>Tab Library for Openfire Admin Console</description>
     <short-name>admin</short-name>
     <uri>admin</uri>
-	<tag>
-		<name>tabs</name>
+    <tag>
+        <name>tabs</name>
         <tag-class>org.jivesoftware.admin.TabsTag</tag-class>
         <body-content>JSP</body-content>
         <attribute>
@@ -65,7 +65,7 @@
         </attribute>
     </tag>
     <tag>
-		<name>sidebar</name>
+        <name>sidebar</name>
         <tag-class>org.jivesoftware.admin.SidebarTag</tag-class>
         <body-content>JSP</body-content>
         <attribute>
@@ -93,9 +93,9 @@
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
-	</tag>
-	<tag>
-		<name>subsidebar</name>
+    </tag>
+    <tag>
+        <name>subsidebar</name>
         <tag-class>org.jivesoftware.admin.SubSidebarTag</tag-class>
         <body-content>JSP</body-content>
         <attribute>
@@ -118,7 +118,7 @@
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
-	</tag>
+    </tag>
     <tag>
         <name>ASN1DER</name>
         <tag-class>org.jivesoftware.admin.ASN1DERTag</tag-class>
@@ -131,15 +131,15 @@
     </tag>
     <tag-file>
         <name>contentBox</name>
-        <path>/WEB-INF/tags/admin/contentBox.tagx</path>
+        <path>/META-INF/tags/admin/contentBox.tagx</path>
     </tag-file>
     <tag-file>
         <name>infobox</name>
-        <path>/WEB-INF/tags/admin/infoBox.tagx</path>
+        <path>/META-INF/tags/admin/infoBox.tagx</path>
     </tag-file>
     <tag-file>
         <name>infoBox</name>
-        <path>/WEB-INF/tags/admin/infoBox.tagx</path>
+        <path>/META-INF/tags/admin/infoBox.tagx</path>
     </tag-file>
     <function>
         <name>replaceAll</name>

--- a/webadmintld/src/main/resources/META-INF/tags/admin/contentBox.tagx
+++ b/webadmintld/src/main/resources/META-INF/tags/admin/contentBox.tagx
@@ -1,0 +1,14 @@
+<jsp:root xmlns:c="http://java.sun.com/jsp/jstl/core"
+          xmlns:jsp="http://java.sun.com/JSP/Page"
+          version="2.0">
+
+    <jsp:directive.attribute name="title" required="true" />
+
+    <div class="jive-contentBoxHeader">
+        <c:out value="${title}" />
+    </div>
+    <div class="jive-contentBox">
+        <jsp:doBody />
+    </div>
+
+</jsp:root>

--- a/webadmintld/src/main/resources/META-INF/tags/admin/infoBox.tagx
+++ b/webadmintld/src/main/resources/META-INF/tags/admin/infoBox.tagx
@@ -1,0 +1,21 @@
+<jsp:root xmlns:jsp="http://java.sun.com/JSP/Page"
+          version="2.0">
+
+    <jsp:directive.attribute name="type" required="true" />
+
+    <div class="jive-${type}">
+        <table cellpadding="0" cellspacing="0" border="0">
+            <tbody>
+                <tr>
+                    <td class="jive-icon"><img src="images/${type}-16x16.gif" width="16" height="16" border="0" alt=""/></td>
+                    <td class="jive-icon-label">
+                        <jsp:doBody />
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <br />
+
+</jsp:root>
+


### PR DESCRIPTION
For plugins to be able to use the tags used in the admin console, the tags should be distributed in a library. By making this library a Maven module, plugins can define the library as a dependency.

Note that the admin.tld file is duplicated, but *slightly* modified in the Maven module: the path of the tags is different (META-INF vs WEB-INF).