### PR TITLE
Allow components to subscribe to nodes

### DIFF
--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -543,7 +543,7 @@ public class PubSubEngine {
             return;
         }
         // Check if the subscriber is an anonymous user
-        if (!UserManager.getInstance().isRegisteredUser(subscriberJID)) {
+        if (!UserManager.getInstance().isRegisteredUser(subscriberJID) && !isComponent(subscriberJID)) {
             // Anonymous users cannot subscribe to the node. Return forbidden error
             sendErrorPacket(iq, PacketError.Condition.forbidden, null);
             return;

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -543,7 +543,7 @@ public class PubSubEngine {
             return;
         }
         // Check if the subscriber is an anonymous user
-        if (!UserManager.getInstance().isRegisteredUser(subscriberJID) && !isComponent(subscriberJID)) {
+        if (!isComponent(subscriberJID) && !UserManager.getInstance().isRegisteredUser(subscriberJID)) {
             // Anonymous users cannot subscribe to the node. Return forbidden error
             sendErrorPacket(iq, PacketError.Condition.forbidden, null);
             return;


### PR DESCRIPTION
This PR allows a component to subscribe to XMPP pubsub nodes. Given a component is part of the Openfire deployment, it must already be trusted so there are no security issues.