### PR TITLE
WIP: Core labelling

### DIFF
--- a/src/database/openfire_db2.sql
+++ b/src/database/openfire_db2.sql
@@ -340,6 +340,7 @@ CREATE TABLE ofPubsubItem (
   jid                 VARCHAR(1024) NOT NULL,
   creationDate        CHAR(15)      NOT NULL,
   payload             CLOB,
+  label               CLOB,
   CONSTRAINT ofPubsubItem_pk PRIMARY KEY (serviceID, nodeID, id)
 );
 
@@ -392,7 +393,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 25);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 26);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_hsqldb.sql
+++ b/src/database/openfire_hsqldb.sql
@@ -327,6 +327,7 @@ CREATE TABLE ofPubsubItem (
   jid                 VARCHAR(1024) NOT NULL,
   creationDate        CHAR(15)      NOT NULL,
   payload             VARCHAR(4000) NULL,
+  label               VARCHAR(4000) NULL,
   CONSTRAINT ofPubsubItem_pk PRIMARY KEY (serviceID, nodeID, id)
 );
 
@@ -378,7 +379,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 25);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 26);
 
 // Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_mysql.sql
+++ b/src/database/openfire_mysql.sql
@@ -316,6 +316,7 @@ CREATE TABLE ofPubsubItem (
   jid                 VARCHAR(255)  NOT NULL,
   creationDate        CHAR(15)      NOT NULL,
   payload             MEDIUMTEXT    NULL,
+  label               MEDIUMTEXT    NULL,
   PRIMARY KEY (serviceID, nodeID, id)
 );
 
@@ -367,7 +368,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 25);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 26);
 
 # Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_oracle.sql
+++ b/src/database/openfire_oracle.sql
@@ -325,6 +325,7 @@ CREATE TABLE ofPubsubItem (
   jid                 VARCHAR2(1024) NOT NULL,
   creationDate        CHAR(15)       NOT NULL,
   payload             VARCHAR(4000)  NULL,
+  label               VARCHAR(4000)  NULL,
   CONSTRAINT ofPubsubItem_pk PRIMARY KEY (serviceID, nodeID, id)
 );
 
@@ -376,7 +377,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 25);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 26);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_postgresql.sql
+++ b/src/database/openfire_postgresql.sql
@@ -333,6 +333,7 @@ CREATE TABLE ofPubsubItem (
   jid                 VARCHAR(1024) NOT NULL,
   creationDate        CHAR(15)      NOT NULL,
   payload             TEXT          NULL,
+  label               TEXT          NULL,
   CONSTRAINT ofPubsubItem_pk PRIMARY KEY (serviceID, nodeID, id)
 );
 
@@ -384,7 +385,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 25);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 26);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_sqlserver.sql
+++ b/src/database/openfire_sqlserver.sql
@@ -330,6 +330,7 @@ CREATE TABLE ofPubsubItem (
   jid                 NVARCHAR(1024) NOT NULL,
   creationDate        CHAR(15)       NOT NULL,
   payload             NTEXT          NULL,
+  label             NTEXT          NULL,
   CONSTRAINT ofPubsubItem_pk PRIMARY KEY (serviceID, nodeID, id)
 );
 
@@ -381,7 +382,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 25);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 26);
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_sybase.sql
+++ b/src/database/openfire_sybase.sql
@@ -331,6 +331,7 @@ CREATE TABLE ofPubsubItem (
   jid                 NVARCHAR(1024) NOT NULL,
   creationDate        CHAR(15)       NOT NULL,
   payload             TEXT           NULL,
+  label               TEXT           NULL,
   CONSTRAINT ofPubsubItem_pk PRIMARY KEY (serviceID, nodeID, id)
 );
 
@@ -382,7 +383,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 25);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 26);
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/upgrade/26/openfire_db2.sql
+++ b/src/database/upgrade/26/openfire_db2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ofPubsubItem ADD COLUMN label clob;
+UPDATE ofVersion SET version = 26 WHERE name = 'openfire';

--- a/src/database/upgrade/26/openfire_hsqldb.sql
+++ b/src/database/upgrade/26/openfire_hsqldb.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ofPubsubItem ADD COLUMN label VARCHAR(4000) NULL;
+UPDATE ofVersion SET version = 26 WHERE name = 'openfire';

--- a/src/database/upgrade/26/openfire_mysql.sql
+++ b/src/database/upgrade/26/openfire_mysql.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ofPubsubItem ADD COLUMN label MEDIUMTEXT NULL;
+UPDATE ofVersion SET version = 26 WHERE name = 'openfire';

--- a/src/database/upgrade/26/openfire_oracle.sql
+++ b/src/database/upgrade/26/openfire_oracle.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ofPubsubItem ADD COLUMN label VARCHAR(4000);
+UPDATE ofVersion SET version = 26 WHERE name = 'openfire';

--- a/src/database/upgrade/26/openfire_postgresql.sql
+++ b/src/database/upgrade/26/openfire_postgresql.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ofPubsubItem ADD COLUMN label TEXT;
+UPDATE ofVersion SET version = 26 WHERE name = 'openfire';

--- a/src/database/upgrade/26/openfire_sqlserver.sql
+++ b/src/database/upgrade/26/openfire_sqlserver.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ofPubsubItem ADD COLUMN label NTEXT;
+UPDATE ofVersion SET version = 26 WHERE name = 'openfire';

--- a/src/database/upgrade/26/openfire_sybase.sql
+++ b/src/database/upgrade/26/openfire_sybase.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ofPubsubItem ADD COLUMN label TEXT;
+UPDATE ofVersion SET version = 26 WHERE name = 'openfire';

--- a/src/java/org/jivesoftware/database/SchemaManager.java
+++ b/src/java/org/jivesoftware/database/SchemaManager.java
@@ -65,7 +65,7 @@ public class SchemaManager {
     /**
      * Current Openfire database schema version.
      */
-    private static final int DATABASE_VERSION = 25;
+    private static final int DATABASE_VERSION = 26;
 
     /**
      * Checks the Openfire database schema to ensure that it's installed and up to date.

--- a/src/java/org/jivesoftware/openfire/labelling/AbstractACDF.java
+++ b/src/java/org/jivesoftware/openfire/labelling/AbstractACDF.java
@@ -1,0 +1,63 @@
+package org.jivesoftware.openfire.labelling;
+
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.user.User;
+import org.jivesoftware.openfire.user.UserManager;
+import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.jivesoftware.util.JiveGlobals;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.JID;
+
+/**
+ * Created by dwd on 20/03/17.
+ */
+abstract public class AbstractACDF implements AccessControlDecisionFunction {
+    private static final Logger Log = LoggerFactory.getLogger(MessageInterceptor.class);
+    private String defaultUserClearance;
+    private String defaultPeerClearance;
+    private String serverClearance;
+
+    private final String PROP_PEER_PREFIX = "clearance.domain."; // + domain
+    private final String PROP_CLEARANCE_USER_DEFAULT = "clearance.user.default";
+    private final String PROP_CLEARANCE_PEER_DEFAULT = "clearance.peer.default";
+    private final String PROP_CLEARANCE_SERVER = "clearance.server";
+
+    protected AbstractACDF() {
+        this.defaultUserClearance = JiveGlobals.getProperty(PROP_CLEARANCE_USER_DEFAULT);
+        this.defaultPeerClearance = JiveGlobals.getProperty(PROP_CLEARANCE_PEER_DEFAULT);
+        this.serverClearance = JiveGlobals.getProperty(PROP_CLEARANCE_SERVER);
+    }
+
+    /**
+     * Get a clearance string for a number of possible target objects.
+     * @return
+     */
+    public String getClearance(JID entity) {
+        if (XMPPServer.getInstance().isLocal(entity)) {
+            User user;
+            try {
+                user = UserManager.getInstance().getUser(entity.getNode());
+            } catch(UserNotFoundException e) {
+                return defaultUserClearance;
+            }
+            String clr = user.getClearance();
+            if (clr == null) {
+                Log.debug("Using default user clearance");
+                return defaultUserClearance;
+            }
+            return clr;
+        } else {
+            // Non-user Domain
+            String clr = JiveGlobals.getProperty(PROP_PEER_PREFIX + entity.getDomain());
+            if (clr == null) {
+                if (XMPPServer.getInstance().matchesComponent(new JID(entity.getDomain()))) {
+                    clr = serverClearance;
+                } else {
+                    clr = defaultPeerClearance;
+                }
+            }
+            return clr;
+        }
+    }
+}

--- a/src/java/org/jivesoftware/openfire/labelling/AccessControlDecisionFunction.java
+++ b/src/java/org/jivesoftware/openfire/labelling/AccessControlDecisionFunction.java
@@ -1,0 +1,14 @@
+package org.jivesoftware.openfire.labelling;
+
+import org.xmpp.packet.JID;
+
+import java.util.Set;
+
+/**
+ * Created by dwd on 15/03/17.
+ */
+public interface AccessControlDecisionFunction {
+    public SecurityLabel check(String clearances, SecurityLabel label, JID rewrite) throws SecurityLabelException;
+    public SecurityLabel valid(SecurityLabel label, boolean rewrite) throws SecurityLabelException;
+    public String getClearance(JID entity);
+}

--- a/src/java/org/jivesoftware/openfire/labelling/Clearance.java
+++ b/src/java/org/jivesoftware/openfire/labelling/Clearance.java
@@ -1,0 +1,14 @@
+package org.jivesoftware.openfire.labelling;
+
+import org.dom4j.Element;
+
+/**
+ * Created by dwd on 16/03/17.
+ */
+public class Clearance {
+    Element element;
+
+    Clearance(Element element) {
+        this.element = element;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/labelling/MessageInterceptor.java
+++ b/src/java/org/jivesoftware/openfire/labelling/MessageInterceptor.java
@@ -1,0 +1,74 @@
+package org.jivesoftware.openfire.labelling;
+
+import org.dom4j.Element;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.interceptor.PacketInterceptor;
+import org.jivesoftware.openfire.interceptor.PacketRejectedException;
+import org.jivesoftware.openfire.session.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.Message;
+import org.xmpp.packet.Packet;
+import org.xmpp.packet.PacketError;
+import org.xmpp.packet.PacketExtension;
+
+import java.util.Set;
+
+/**
+ * Created by dwd on 16/03/17.
+ */
+public class MessageInterceptor implements PacketInterceptor {
+    private static final Logger Log = LoggerFactory.getLogger(MessageInterceptor.class);
+
+    @Override
+    public void interceptPacket(Packet packet, Session session, boolean incoming, boolean processed) throws PacketRejectedException {
+        Log.debug("Packet intercept pre: " + packet.toString());
+        if (processed) {
+            return; // Ignore these.
+        }
+        if (!(packet instanceof Message)) {
+            return;
+        }
+        AccessControlDecisionFunction acdf = XMPPServer.getInstance().getAccessControlDecisionFunction();
+        if (acdf == null) {
+            return;
+        }
+        Log.debug("Packet intercept: " + packet.toString());
+        Message msg = (Message)packet;
+        try {
+            boolean rewritten = false;
+            boolean need_rewrite = false;
+            SecurityLabel secLabel = (SecurityLabel)packet.getExtension("securitylabel", "urn:xmpp:sec-label:0");
+            if (secLabel == null) {
+                Log.debug("Label is default");
+                need_rewrite = true;
+            }
+            if (msg.getType() != Message.Type.error) {
+                Log.debug("Sender");
+                acdf.check(acdf.getClearance(packet.getFrom()), secLabel, null);
+            } else {
+                Log.debug("Skipped originator and server checks for bounced message");
+            }
+            Log.debug("Recipient");
+            SecurityLabel newlabel = acdf.check(acdf.getClearance(packet.getTo()), secLabel, packet.getTo());
+            packet.deleteExtension("securitylabel", "urn:xmpp:sec-label:0");
+            if (newlabel != null) {
+                packet.addExtension(newlabel);
+            }
+        } catch (Exception e) {
+            Log.info("ACDF rejection: ", e);
+            if (incoming) {
+                if (msg.getType() != Message.Type.error) {
+                    Message error = new Message(); // Don't copy; it might introduce an invalid label.
+                    error.setTo(msg.getFrom());
+                    error.setFrom(msg.getTo());
+                    error.setID(msg.getID());
+                    error.setError(PacketError.Condition.forbidden);
+                    error.setType(Message.Type.error);
+                    XMPPServer.getInstance().getMessageRouter().route(error);
+                }
+            }
+            throw new PacketRejectedException(e);
+        }
+    }
+}

--- a/src/java/org/jivesoftware/openfire/labelling/SecurityLabel.java
+++ b/src/java/org/jivesoftware/openfire/labelling/SecurityLabel.java
@@ -10,12 +10,17 @@ import org.xmpp.packet.PacketExtension;
  * themselves.
  */
 public class SecurityLabel extends PacketExtension {
+    public static final String NAMESPACE = "urn:xmpp:sec-label:0";
+    public static final String NAME = "securitylabel";
     public SecurityLabel(Element el) {
         super(el);
+        if (!el.getNamespaceURI().equals(NAMESPACE)) {
+            throw new RuntimeException("Incorrect namespace " + el.getNamespaceURI());
+        }
     }
 
     public SecurityLabel(final String displayMarking, final String fgcolour, final String bgcolour, Element label) {
-        super("securitylabel", "urn:xmpp:sec-label:0");
+        super(NAME, NAMESPACE);
         assert label != null : "Security Label element must not be null";
         if (fgcolour != null || bgcolour != null) {
             assert displayMarking != null : "Colours set without a marking";
@@ -43,7 +48,7 @@ public class SecurityLabel extends PacketExtension {
     }
 
     static {
-        registeredExtensions.put(QName.get("securitylabel", "urn:xmpp:sec-label:0"), SecurityLabel.class);
+        registeredExtensions.put(QName.get(NAME, NAMESPACE), SecurityLabel.class);
     }
 
 }

--- a/src/java/org/jivesoftware/openfire/labelling/SecurityLabel.java
+++ b/src/java/org/jivesoftware/openfire/labelling/SecurityLabel.java
@@ -1,6 +1,7 @@
 package org.jivesoftware.openfire.labelling;
 
 import org.dom4j.Element;
+import org.dom4j.QName;
 import org.xmpp.packet.PacketExtension;
 
 /**
@@ -8,7 +9,11 @@ import org.xmpp.packet.PacketExtension;
  * Note that this does not (intentionally) know anything about the label elements
  * themselves.
  */
-public class SecurityLabel extends PacketExtension{
+public class SecurityLabel extends PacketExtension {
+    public SecurityLabel(Element el) {
+        super(el);
+    }
+
     public SecurityLabel(final String displayMarking, final String fgcolour, final String bgcolour, Element label) {
         super("securitylabel", "urn:xmpp:sec-label:0");
         assert label != null : "Security Label element must not be null";
@@ -36,4 +41,9 @@ public class SecurityLabel extends PacketExtension{
     public Element getLabel() {
         return (Element)this.element.element("label").elements().get(0);
     }
+
+    static {
+        registeredExtensions.put(QName.get("securitylabel", "urn:xmpp:sec-label:0"), SecurityLabel.class);
+    }
+
 }

--- a/src/java/org/jivesoftware/openfire/labelling/SecurityLabel.java
+++ b/src/java/org/jivesoftware/openfire/labelling/SecurityLabel.java
@@ -1,0 +1,39 @@
+package org.jivesoftware.openfire.labelling;
+
+import org.dom4j.Element;
+import org.xmpp.packet.PacketExtension;
+
+/**
+ * XEP-0258 label.
+ * Note that this does not (intentionally) know anything about the label elements
+ * themselves.
+ */
+public class SecurityLabel extends PacketExtension{
+    public SecurityLabel(final String displayMarking, final String fgcolour, final String bgcolour, Element label) {
+        super("securitylabel", "urn:xmpp:sec-label:0");
+        assert label != null : "Security Label element must not be null";
+        if (fgcolour != null || bgcolour != null) {
+            assert displayMarking != null : "Colours set without a marking";
+        }
+        populate(displayMarking, fgcolour, bgcolour, label);
+    }
+
+    public void populate(final String displayMarking, final String fgcolour, final String bgcolour, Element labelelement) {
+        if (displayMarking != null) {
+            Element dm = this.element.addElement("displaymarking");
+            dm.setText(displayMarking);
+            if (fgcolour != null) {
+                dm.addAttribute("fgcolor", fgcolour);
+            }
+            if (bgcolour != null) {
+                dm.addAttribute("bgcolor", bgcolour);
+            }
+        }
+        Element label = this.element.addElement("label");
+        label.add(labelelement);
+    }
+
+    public Element getLabel() {
+        return (Element)this.element.element("label").elements().get(0);
+    }
+}

--- a/src/java/org/jivesoftware/openfire/labelling/SecurityLabelException.java
+++ b/src/java/org/jivesoftware/openfire/labelling/SecurityLabelException.java
@@ -1,0 +1,10 @@
+package org.jivesoftware.openfire.labelling;
+
+/**
+ * Created by dwd on 21/03/17.
+ */
+public class SecurityLabelException extends RuntimeException {
+    public SecurityLabelException(String s) {
+        super(s);
+    }
+}

--- a/src/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
@@ -23,6 +23,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.dom4j.Element;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.labelling.AccessControlDecisionFunction;
+import org.jivesoftware.openfire.labelling.SecurityLabel;
+import org.jivesoftware.openfire.labelling.SecurityLabelException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 
@@ -34,6 +40,7 @@ import org.xmpp.packet.Message;
  * @author Matt Tucker
  */
 public class NodeAffiliate {
+    private static final Logger Log = LoggerFactory.getLogger(NodeAffiliate.class);
 
     private JID jid;
     private Node node;
@@ -86,7 +93,7 @@ public class NodeAffiliate {
      */
     void sendPublishedNotifications(Message notification, Element event, LeafNode leafNode,
             List<PublishedItem> publishedItems) {
-
+        boolean anythingToSend = false;
         if (!publishedItems.isEmpty()) {
             Map<List<NodeSubscription>, List<PublishedItem>> itemsBySubs =
                     getItemsBySubscriptions(leafNode, publishedItems);
@@ -97,6 +104,7 @@ public class NodeAffiliate {
                 Element items = event.addElement("items");
                 items.addAttribute("node", getNode().getNodeID());
                 for (PublishedItem publishedItem : itemsBySubs.get(nodeSubscriptions)) {
+                    AccessControlDecisionFunction acdf = XMPPServer.getInstance().getAccessControlDecisionFunction();
                     // FIXME: This was added for compatibility with PEP supporting clients.
                     //        Alternate solution needed when XEP-0163 version > 1.0 is released.
                     //
@@ -113,14 +121,27 @@ public class NodeAffiliate {
                     if (leafNode.isPayloadDelivered()) {
                         item.add(publishedItem.getPayload().createCopy());
                     }
+                    // Add security label, after checking.
+                    if (acdf != null) {
+                        try {
+                            SecurityLabel securityLabel = acdf.check(acdf.getClearance(this.jid), publishedItem.getSecurityLabel(), this.jid);
+                            item.add(securityLabel.getElement().createCopy());
+                        } catch (SecurityLabelException e) {
+                            Log.debug("Dropped item publish due to SecurityLabel: ", e);
+                            continue;
+                        }
+                    }
+                    anythingToSend = true;
                     // Add leaf leafNode information if affiliated leafNode and node
                     // where the item was published are different
                     if (leafNode != getNode()) {
                         item.addAttribute("node", leafNode.getNodeID());
                     }
                 }
-                // Send the event notification
-                sendEventNotification(notification, nodeSubscriptions);
+                if (anythingToSend) {
+                    // Send the event notification
+                    sendEventNotification(notification, nodeSubscriptions);
+                }
                 // Remove the added items information
                 event.remove(items);
             }
@@ -159,11 +180,12 @@ public class NodeAffiliate {
      */
     void sendDeletionNotifications(Message notification, Element event, LeafNode leafNode,
             List<PublishedItem> publishedItems) {
-
+        AccessControlDecisionFunction acdf = XMPPServer.getInstance().getAccessControlDecisionFunction();
         if (!publishedItems.isEmpty()) {
             Map<List<NodeSubscription>, List<PublishedItem>> itemsBySubs =
                     getItemsBySubscriptions(leafNode, publishedItems);
 
+            boolean anythingToSend = false;
             // Send one notification for published items that affect the same subscriptions
             for (List<NodeSubscription> nodeSubscriptions : itemsBySubs.keySet()) {
                 // Add items information
@@ -175,9 +197,21 @@ public class NodeAffiliate {
                     if (leafNode.isItemRequired()) {
                         item.addAttribute("id", publishedItem.getID());
                     }
+                    // Add security label, after checking.
+                    if (acdf != null) {
+                        try {
+                            SecurityLabel securityLabel = acdf.check(acdf.getClearance(this.jid), publishedItem.getSecurityLabel(), this.jid);
+                        } catch (SecurityLabelException e) {
+                            Log.debug("Dropped item publish due to SecurityLabel: ", e);
+                            continue;
+                        }
+                    }
+                    anythingToSend = true;
                 }
-                // Send the event notification
-                sendEventNotification(notification, nodeSubscriptions);
+                if (anythingToSend) {
+                    // Send the event notification
+                    sendEventNotification(notification, nodeSubscriptions);
+                }
                 // Remove the added items information
                 event.remove(items);
             }

--- a/src/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
@@ -125,7 +125,10 @@ public class NodeAffiliate {
                     if (acdf != null) {
                         try {
                             SecurityLabel securityLabel = acdf.check(acdf.getClearance(this.jid), publishedItem.getSecurityLabel(), this.jid);
-                            item.add(securityLabel.getElement().createCopy());
+                            notification.deleteExtension(SecurityLabel.NAME, SecurityLabel.NAMESPACE);
+                            if (securityLabel != null) {
+                                notification.addExtension(securityLabel);
+                            }
                         } catch (SecurityLabelException e) {
                             Log.debug("Dropped item publish due to SecurityLabel: ", e);
                             continue;

--- a/src/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
@@ -24,6 +24,10 @@ import java.util.Date;
 import java.util.List;
 
 import org.dom4j.Element;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.labelling.AccessControlDecisionFunction;
+import org.jivesoftware.openfire.labelling.SecurityLabel;
+import org.jivesoftware.openfire.labelling.SecurityLabelException;
 import org.jivesoftware.util.LocaleUtils;
 import org.jivesoftware.util.XMPPDateTimeFormat;
 import org.slf4j.Logger;
@@ -613,6 +617,16 @@ public class NodeSubscription {
         if (!canSendEvents()) {
             return false;
         }
+        AccessControlDecisionFunction acdf = XMPPServer.getInstance().getAccessControlDecisionFunction();
+        if (acdf != null) {
+            try {
+                acdf.check(acdf.getClearance(this.jid), publishedItem.getSecurityLabel(), null);
+            } catch (SecurityLabelException e) {
+                Log.debug("Dropped item publish due to SecurityLabel: ", e);
+                return false;
+            }
+        }
+
         // Check that any defined keyword was matched (applies only if an item was published)
         if (publishedItem != null && !isKeywordMatched(publishedItem)) {
             return false;

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -401,10 +401,14 @@ public class PubSubEngine {
             }
             // Check that the payload (if any) contains only one child element
             if (entries.size() > 1) {
-                Element pubsubError = DocumentHelper.createElement(QName.get(
-                        "invalid-payload", "http://jabber.org/protocol/pubsub#errors"));
-                sendErrorPacket(iq, PacketError.Condition.bad_request, pubsubError);
-                return;
+                Element label = (Element)entries.get(1);
+                // It's OK if this is only a security label.
+                if (entries.size() > 2 || !label.getNamespace().getName().equals("urn:xmpp:seclabel:0")) {
+                    Element pubsubError = DocumentHelper.createElement(QName.get(
+                            "invalid-payload", "http://jabber.org/protocol/pubsub#errors"));
+                    sendErrorPacket(iq, PacketError.Condition.bad_request, pubsubError);
+                    return;
+                }
             }
             items.add(item);
         }

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceManager.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceManager.java
@@ -169,17 +169,17 @@ public class PubSubPersistenceManager {
     private static final String DELETE_SUBSCRIPTIONS =
             "DELETE FROM ofPubsubSubscription WHERE serviceID=? AND nodeID=?";
     private static final String LOAD_ITEMS =
-            "SELECT id,jid,creationDate,payload FROM ofPubsubItem " +
+            "SELECT id,jid,creationDate,payload,label FROM ofPubsubItem " +
             "WHERE serviceID=? AND nodeID=? ORDER BY creationDate DESC";
     private static final String LOAD_ITEM =
-            "SELECT jid,creationDate,payload FROM ofPubsubItem " +
+            "SELECT jid,creationDate,payload,label FROM ofPubsubItem " +
             "WHERE serviceID=? AND nodeID=? AND id=?";
     private static final String LOAD_LAST_ITEM =
-            "SELECT id,jid,creationDate,payload FROM ofPubsubItem " +
+            "SELECT id,jid,creationDate,payload,label FROM ofPubsubItem " +
             "WHERE serviceID=? AND nodeID=? ORDER BY creationDate DESC";
     private static final String ADD_ITEM =
-            "INSERT INTO ofPubsubItem (serviceID,nodeID,id,jid,creationDate,payload) " +
-            "VALUES (?,?,?,?,?,?)";
+            "INSERT INTO ofPubsubItem (serviceID,nodeID,id,jid,creationDate,payload,label) " +
+            "VALUES (?,?,?,?,?,?,?)";
     private static final String DELETE_ITEM =
             "DELETE FROM ofPubsubItem WHERE serviceID=? AND nodeID=? AND id=?";
     private static final String DELETE_ITEMS =
@@ -1368,6 +1368,7 @@ public class PubSubPersistenceManager {
                 pstmt.setString(4, item.getPublisher().toString());
                 pstmt.setString(5, StringUtils.dateToMillis(item.getCreationDate()));
                 pstmt.setString(6, item.getPayloadXML());
+                pstmt.setString(7, item.getSecurityLabelXML());
                 if (batch) { pstmt.addBatch(); }
                 else { 
                 	try { pstmt.execute(); }
@@ -1621,6 +1622,9 @@ public class PubSubPersistenceManager {
                 if (rs.getString(4) != null) {
                 	item.setPayloadXML(rs.getString(4));
                 }
+                if (rs.getString(5) != null) {
+                    item.setSecurityLabelXML(rs.getString(4));
+                }
                 // Add the published item to the node
 				if (descending)
 					results.add(item);
@@ -1676,7 +1680,10 @@ public class PubSubPersistenceManager {
                 item = new PublishedItem(node, publisher, itemID, creationDate);
                 // Add the extra fields to the published item
                 if (rs.getString(4) != null) {
-                	item.setPayloadXML(rs.getString(4));
+                    item.setPayloadXML(rs.getString(4));
+                }
+                if (rs.getString(5) != null) {
+                    item.setSecurityLabelXML(rs.getString(5));
                 }
             }
         }
@@ -1726,6 +1733,9 @@ public class PubSubPersistenceManager {
 	                        if (rs.getString(3) != null) {
 	                        	result.setPayloadXML(rs.getString(3));
 	                        }
+	                        if (rs.getString(4) != null) {
+                                result.setSecurityLabelXML(rs.getString(4));
+                            }
 	                        itemCache.put(itemKey, result);
 	                		log.debug("Loaded item into cache from DB");
 	                    }

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceManager.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceManager.java
@@ -1623,7 +1623,7 @@ public class PubSubPersistenceManager {
                 	item.setPayloadXML(rs.getString(4));
                 }
                 if (rs.getString(5) != null) {
-                    item.setSecurityLabelXML(rs.getString(4));
+                    item.setSecurityLabelXML(rs.getString(5));
                 }
                 // Add the published item to the node
 				if (descending)

--- a/src/java/org/jivesoftware/openfire/pubsub/PublishedItem.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PublishedItem.java
@@ -25,6 +25,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import org.dom4j.Element;
 import org.dom4j.io.SAXReader;
 import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.labelling.SecurityLabel;
 import org.jivesoftware.openfire.pep.PEPServiceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,6 +98,14 @@ public class PublishedItem implements Serializable {
      * XML representation of the payload (for serialization)
      */
     private String payloadXML;
+    /**
+     * Security Label (XEP-0314)
+     */
+    private volatile transient SecurityLabel securityLabel;
+    /**
+     * XML representation of the security label.
+     */
+    private String securityLabelXML;
     
     /**
      * Creates a published item
@@ -183,24 +192,24 @@ public class PublishedItem implements Serializable {
      * @return the payload included when publishing the item or <tt>null</tt> if none was found.
      */
     public Element getPayload() {
-    	if (payload == null && payloadXML != null) {
-    		synchronized (this) {
-				if (payload == null) {
-		    		// payload initialized as XML string from DB
-		            SAXReader xmlReader = null;
-		    		try {
-		    			xmlReader = xmlReaders.take();
-		    			payload = xmlReader.read(new StringReader(payloadXML)).getRootElement(); 
-		    		} catch (Exception ex) {
-		    			 log.error("Failed to parse payload XML", ex);
-		    		} finally {
-		    			if (xmlReader != null) {
-		    				xmlReaders.add(xmlReader);
-		    			}
-		    		}
-				}
-			}
-    	}
+        if (payload == null && payloadXML != null) {
+            synchronized (this) {
+                if (payload == null) {
+                    // payload initialized as XML string from DB
+                    SAXReader xmlReader = null;
+                    try {
+                        xmlReader = xmlReaders.take();
+                        payload = xmlReader.read(new StringReader(payloadXML)).getRootElement();
+                    } catch (Exception ex) {
+                        log.error("Failed to parse payload XML", ex);
+                    } finally {
+                        if (xmlReader != null) {
+                            xmlReaders.add(xmlReader);
+                        }
+                    }
+                }
+            }
+        }
         return payload;
     }
 
@@ -224,8 +233,8 @@ public class PublishedItem implements Serializable {
      *        if none was found.
      */
     void setPayloadXML(String payloadXML) {
-    	this.payloadXML = payloadXML;
-    	this.payload = null; // will be recreated only if needed
+        this.payloadXML = payloadXML;
+        this.payload = null; // will be recreated only if needed
     }
 
     /**
@@ -243,6 +252,71 @@ public class PublishedItem implements Serializable {
             payloadXML = null;
         } else {
             payloadXML = payload.asXML();
+        }
+    }
+
+    /**
+     * Returns the securityLabel included when publishing the item.
+     *
+     * @return the securityLabel included when publishing the item or <tt>null</tt> if none was found.
+     */
+    public SecurityLabel getSecurityLabel() {
+        if (securityLabel == null && securityLabelXML != null) {
+            synchronized (this) {
+                if (securityLabel == null) {
+                    // payload initialized as XML string from DB
+                    SAXReader xmlReader = null;
+                    try {
+                        xmlReader = xmlReaders.take();
+                        securityLabel = new SecurityLabel(xmlReader.read(new StringReader(securityLabelXML)).getRootElement());
+                    } catch (Exception ex) {
+                        log.error("Failed to parse payload XML", ex);
+                    } finally {
+                        if (xmlReader != null) {
+                            xmlReaders.add(xmlReader);
+                        }
+                    }
+                }
+            }
+        }
+        return securityLabel;
+    }
+
+    /**
+     * Returns a textual representation of the security label or <tt>null</tt> if no payload
+     * was specified with the item.
+     *
+     * @return a textual representation of the security label or null if no security label was specified
+     *         with the item.
+     */
+    public String getSecurityLabelXML() {
+        return securityLabelXML;
+    }
+
+    /**
+     * Sets the security label included when publishing the item.
+     *
+     * @param securityLabelXML the label included when publishing the item or <tt>null</tt>
+     *        if none was found.
+     */
+    void setSecurityLabelXML(String securityLabelXML) {
+        this.securityLabelXML = securityLabelXML;
+        this.securityLabel = null; // will be recreated only if needed
+    }
+
+    /**
+     * Sets the label included when publishing the item.
+     *
+     * @param securityLabel the label included when publishing the item or <tt>null</tt>
+     *        if none was found.
+     */
+    void setSecurityLabel(SecurityLabel securityLabel) {
+        this.securityLabel = securityLabel;
+        // Update XML representation of the payload
+        if (securityLabel == null) {
+            securityLabelXML = null;
+        } else {
+            securityLabelXML = securityLabel.getElement().asXML();
         }
     }
 

--- a/src/java/org/jivesoftware/openfire/user/User.java
+++ b/src/java/org/jivesoftware/openfire/user/User.java
@@ -24,13 +24,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.AbstractMap;
-import java.util.AbstractSet;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.jivesoftware.database.DbConnectionManager;
@@ -39,6 +33,7 @@ import org.jivesoftware.openfire.auth.AuthFactory;
 import org.jivesoftware.openfire.auth.ConnectionException;
 import org.jivesoftware.openfire.auth.InternalUnauthenticatedException;
 import org.jivesoftware.openfire.event.UserEventDispatcher;
+import org.jivesoftware.openfire.labelling.Clearance;
 import org.jivesoftware.openfire.roster.Roster;
 import org.jivesoftware.util.StringUtils;
 import org.jivesoftware.util.cache.CacheSizes;
@@ -48,6 +43,8 @@ import org.jivesoftware.util.cache.ExternalizableUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.resultsetmanagement.Result;
+
+import static org.jivesoftware.util.StringUtils.decodeBase64;
 
 /**
  * Encapsulates information about a user. New users are created using
@@ -88,6 +85,7 @@ public class User implements Cacheable, Externalizable, Result {
     private String email;
     private Date creationDate;
     private Date modificationDate;
+    private String clearance;
 
     private Map<String,String> properties = null;
 
@@ -226,6 +224,17 @@ public class User implements Cacheable, Externalizable, Result {
     
     public void setIterations(int iterations) {
     	this.iterations = iterations;
+    }
+
+    public String getClearance() {
+        if (this.clearance == null) {
+            this.clearance = getProperties().get("clearance");
+        }
+        return this.clearance;
+    }
+
+    public void setClearance(String clearance) {
+        this.clearance = clearance;
     }
 
     public String getName() {


### PR DESCRIPTION
This provides some basic concepts of labelling within the core of Openfire, such that a formal access control facility based on labelling (also known as a Policy Enforcement Point) can be written as a plugin. These are known as ACDFs, or Access Control Decision Functions.

A plugin built to this written around Spiffing is at surevine/openfire-spiffing.

Of note:

* Clearances are opaque strings. These are not interpreted in any way by Openfire, and simply passed onto the ACDF.
* Labels are XEP-0258 style blobs, where there is an outer format marker and human readable display marking, and an inner machine-readable label to be interpreted by the ACDF engine.

This WIP branch demonstrates basic message filtering and XEP-0314-like pubsub item filtering.

Missing from this is MAM filtering, MUC room (and similar) filtering, and so on.