### PR TITLE
OF-1363: Fix NPE on User Properties screen

### DIFF
--- a/src/web/user-properties.jsp
+++ b/src/web/user-properties.jsp
@@ -301,34 +301,37 @@
 </table>
 </div>
 
-<br>
-<div class="jive-table">
-	<table cellpadding="0" cellspacing="0" border="0" width="100%">
-		<thead>
-			<tr>
-				<th colspan="2"><fmt:message key="user.properties.additional_properties" /></th>
-			</tr>
-		</thead>
-		<tbody>
-			<% for(Map.Entry<String, String> properties : user.getProperties().entrySet()) { %>
-			<tr>
-				<td class="c1"><%= StringUtils.escapeHTMLTags(properties.getKey()) %>:</td>
-				<td><%= StringUtils.escapeHTMLTags(properties.getValue()) %></td>
-			</tr>
-			<% } %>
-		</tbody>
-	</table>
-</div>
+<% if (user != null) { %>
+    <br>
+    <div class="jive-table">
+        <table cellpadding="0" cellspacing="0" border="0" width="100%">
+            <thead>
+                <tr>
+                    <th colspan="2"><fmt:message key="user.properties.additional_properties" /></th>
+                </tr>
+            </thead>
+            <tbody>
+                <% for(Map.Entry<String, String> properties : user.getProperties().entrySet()) { %>
+                <tr>
+                    <td class="c1"><%= StringUtils.escapeHTMLTags(properties.getKey()) %>:</td>
+                    <td><%= StringUtils.escapeHTMLTags(properties.getValue()) %></td>
+                </tr>
+                <% } %>
+            </tbody>
+        </table>
+    </div>
 
-<br><br>
 
-<% if (user != null && !UserManager.getUserProvider().isReadOnly()) { %>
+    <% if (!UserManager.getUserProvider().isReadOnly()) { %>
 
-<form action="user-edit-form.jsp">
-<input type="hidden" name="username" value="<%= StringUtils.escapeForXML(user.getUsername()) %>">
-<input type="submit" value="<fmt:message key="global.edit_properties" />">
-</form>
+        <br><br>
 
+        <form action="user-edit-form.jsp">
+        <input type="hidden" name="username" value="<%= StringUtils.escapeForXML(user.getUsername()) %>">
+        <input type="submit" value="<fmt:message key="global.edit_properties" />">
+        </form>
+
+    <% } %>
 <% } %>
 
 </body>


### PR DESCRIPTION
This fixes a NPE that can present itself on the User Properties screen

Steps to reproduce:
- Attempt to view the User Properties for a user that does not exist, e.g. by accessing http://<server>:9090/user-properties.jsp?username=foobar

Expected results
- An indication is presented that the requested user does not exist

Actual results
- A stack trace is presented 
```
Exception:
java.lang.NullPointerException
  	at org.jivesoftware.openfire.admin.user_002dproperties_jsp._jspService(user_002dproperties_jsp.java:394)
	at org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:70)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:812)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1669)
```