### PR TITLE
OF-1331 Warn user during setup when a session failure occurs

### DIFF
--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -1844,6 +1844,7 @@ component.session.details.info=Below are details about the session with the exte
 # General Setup
 
 setup.title=Setup
+setup.invalid_session=A failure occurred while fetching your session from the server. This is typically a cookie issue.  Please either clear all cookies for this domain or try this URL again from an incognito browser session.
 
 # Setup environment check
 

--- a/src/web/setup/setup-profile-settings.jsp
+++ b/src/web/setup/setup-profile-settings.jsp
@@ -23,6 +23,7 @@
     boolean scramOnly = JiveGlobals.getBooleanProperty("user.scramHashedPasswordOnly");
     boolean requestedScramOnly = (request.getParameter("scramOnly") != null);
     boolean next = request.getParameter("continue") != null;
+    boolean sessionFailure = false;
     if (next) {
         // Figure out where to send the user.
         String mode = request.getParameter("mode");
@@ -31,28 +32,31 @@
             // Set to default providers by deleting any existing values.
             @SuppressWarnings("unchecked")
             Map<String,String> xmppSettings = (Map<String,String>)session.getAttribute("xmppSettings");
-
-            xmppSettings.put("provider.auth.className", JiveGlobals.getXMLProperty("provider.auth.className",
+            if (xmppSettings == null){
+                sessionFailure = true;
+            } else {
+                xmppSettings.put("provider.auth.className", JiveGlobals.getXMLProperty("provider.auth.className",
                     org.jivesoftware.openfire.auth.DefaultAuthProvider.class.getName()));
-            xmppSettings.put("provider.user.className", JiveGlobals.getXMLProperty("provider.user.className",
+                xmppSettings.put("provider.user.className", JiveGlobals.getXMLProperty("provider.user.className",
                     org.jivesoftware.openfire.user.DefaultUserProvider.class.getName()));
-            xmppSettings.put("provider.group.className", JiveGlobals.getXMLProperty("provider.group.className",
+                xmppSettings.put("provider.group.className", JiveGlobals.getXMLProperty("provider.group.className",
                     org.jivesoftware.openfire.group.DefaultGroupProvider.class.getName()));
-            xmppSettings.put("provider.vcard.className", JiveGlobals.getXMLProperty("provider.vcard.className",
+                xmppSettings.put("provider.vcard.className", JiveGlobals.getXMLProperty("provider.vcard.className",
                     org.jivesoftware.openfire.vcard.DefaultVCardProvider.class.getName()));
-            xmppSettings.put("provider.lockout.className", JiveGlobals.getXMLProperty("provider.lockout.className",
+                xmppSettings.put("provider.lockout.className", JiveGlobals.getXMLProperty("provider.lockout.className",
                     org.jivesoftware.openfire.lockout.DefaultLockOutProvider.class.getName()));
-            xmppSettings.put("provider.securityAudit.className", JiveGlobals.getXMLProperty("provider.securityAudit.className",
+                xmppSettings.put("provider.securityAudit.className", JiveGlobals.getXMLProperty("provider.securityAudit.className",
                     org.jivesoftware.openfire.security.DefaultSecurityAuditProvider.class.getName()));
-            xmppSettings.put("provider.admin.className", JiveGlobals.getXMLProperty("provider.admin.className",
+                xmppSettings.put("provider.admin.className", JiveGlobals.getXMLProperty("provider.admin.className",
                     org.jivesoftware.openfire.admin.DefaultAdminProvider.class.getName()));
-            if (requestedScramOnly) {
-                JiveGlobals.setProperty("user.scramHashedPasswordOnly", "true");
-            }
+                if (requestedScramOnly) {
+                    JiveGlobals.setProperty("user.scramHashedPasswordOnly", "true");
+                }
 
-            // Redirect
-            response.sendRedirect("setup-admin-settings.jsp");
-            return;
+                // Redirect
+                response.sendRedirect("setup-admin-settings.jsp");
+                return;
+            }
         }
         else if ("ldap".equals(mode)) {
             response.sendRedirect("setup-ldap-server.jsp");
@@ -74,6 +78,12 @@
 	<p>
 	<fmt:message key="setup.profile.description" />
 	</p>
+
+<% if (sessionFailure) { %>
+            <span class="jive-error-text">
+            <fmt:message key="setup.invalid_session" />
+            </span>
+<% } %>
 
 	<!-- BEGIN jive-contentBox -->
 	<div class="jive-contentBox">


### PR DESCRIPTION
This is a complex problem.  During setup, fetching xmppSettings from the session may fail due to an invalid session state maintained between the client browser and the server.  This is likely caused by a previous HTTPS session to the same server hostname setting a `JSESSIONID` that subsequently can not be overwritten by the current HTTP openfire-setup session.

This introduces i18n string `setup.invalid_session`