### PR TITLE
OF-1334 Don't do CSRF check unless actions are requested

### DIFF
--- a/src/plugins/monitoring/changelog.html
+++ b/src/plugins/monitoring/changelog.html
@@ -43,6 +43,11 @@
 <h1>
 Monitoring Plugin Changelog
 </h1>
+<p><b>1.5.7</b> -- May 19, 2017</p>
+<ul>
+    <li>[<a href='https://issues.igniterealtime.org/browse/OF-1334'>OF-1334</a>] - Monitoring Plugin displays "Archive index rebuild failed"</li>
+</ul>
+
 <p><b>1.5.6</b> -- February 16, 2016</p>
 <ul>
     <li>[<a href='https://igniterealtime.org/issues/browse/OF-1288'>OF-1288</a>] - Add missing queryid and id attributes</li>

--- a/src/plugins/monitoring/plugin.xml
+++ b/src/plugins/monitoring/plugin.xml
@@ -5,9 +5,9 @@
     <name>Monitoring Service</name>
     <description>Monitors conversations and statistics of the server.</description>
     <author>IgniteRealtime // Jive Software</author>
-    <version>1.5.6</version>
-    <date>2/16/2017</date>
-    <minServerVersion>4.0.99</minServerVersion><!-- Allows the beta 4.1.0 -->
+    <version>1.5.7</version>
+    <date>5/19/2017</date>
+    <minServerVersion>4.1.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>4</databaseVersion>
 

--- a/src/plugins/monitoring/src/web/archiving-settings.jsp
+++ b/src/plugins/monitoring/src/web/archiving-settings.jsp
@@ -176,11 +176,11 @@
     Map errors = new HashMap();
     String errorMessage = "";
 
-    if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
+    if ((rebuildIndex || update) && (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam))) {
         rebuildIndex = false;
         update = false;
+        errorMessage = "CSRF Failure.";
         errors.put("csrf", "");
-        errorMessage = "Archive Index rebuild failed.";
     }
     csrfParam = StringUtils.randomString(16);
     CookieUtils.setCookie(request, response, "csrf", csrfParam, -1);

--- a/src/plugins/monitoring/src/web/archiving-settings.jsp
+++ b/src/plugins/monitoring/src/web/archiving-settings.jsp
@@ -27,7 +27,6 @@
 <head>
 <title><fmt:message key="archive.settings.title"/></title>
 <meta name="pageID" content="archiving-settings"/>
-<link rel="stylesheet" type="text/css" href="style/global.css">
 <script src="dwr/engine.js" type="text/javascript"></script>
 <script src="dwr/util.js" type="text/javascript"></script>
 <script src="dwr/interface/conversations.js" type="text/javascript"></script>


### PR DESCRIPTION
The CSRF check was armed by default, which does not make sense when first visiting the page and no actions are requested.  This would result in an error shown that the 'Archive Index rebuild failed".  I also removed an unused css import