### PR TITLE
OF-1348: Can't use SortedSet without Comparable items.

### DIFF
--- a/src/java/org/jivesoftware/openfire/auth/AuthorizationBasedAuthProviderMapper.java
+++ b/src/java/org/jivesoftware/openfire/auth/AuthorizationBasedAuthProviderMapper.java
@@ -20,8 +20,8 @@ import org.jivesoftware.openfire.admin.AdminManager;
 import org.jivesoftware.util.ClassUtils;
 import org.jivesoftware.util.JiveGlobals;
 
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * A {@link AuthProviderMapper} that can be used to draw administrative users from another source than the regular, non-
@@ -110,9 +110,9 @@ public class AuthorizationBasedAuthProviderMapper implements AuthProviderMapper
     }
 
     @Override
-    public SortedSet<AuthProvider> getAuthProviders()
+    public Set<AuthProvider> getAuthProviders()
     {
-        final SortedSet<AuthProvider> result = new TreeSet<>();
+        final Set<AuthProvider> result = new LinkedHashSet<>();
         result.add( adminProvider );
         result.add( userProvider );
 

--- a/src/java/org/jivesoftware/openfire/user/AuthorizationBasedUserProviderMapper.java
+++ b/src/java/org/jivesoftware/openfire/user/AuthorizationBasedUserProviderMapper.java
@@ -19,8 +19,8 @@ package org.jivesoftware.openfire.user;
 import org.jivesoftware.openfire.admin.AdminManager;
 import org.jivesoftware.util.JiveGlobals;
 
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * A {@link UserProviderMapper} that can be used to draw administrative users from another source than the regular, non-
@@ -98,9 +98,9 @@ public class AuthorizationBasedUserProviderMapper implements UserProviderMapper
     }
 
     @Override
-    public SortedSet<UserProvider> getUserProviders()
+    public Set<UserProvider> getUserProviders()
     {
-        final SortedSet<UserProvider> result = new TreeSet<>();
+        final Set<UserProvider> result = new LinkedHashSet<>();
         result.add( adminProvider );
         result.add( userProvider );
 


### PR DESCRIPTION
This commit fixes a runtime problem caused by SortedSet usage with providers that are not Comparable. By using a different Set implementation, iteration order is predictable, without there being a need for providers being Comparable.