### PR TITLE
OF-1326: Allow for missing static web content.

### DIFF
--- a/src/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -175,7 +175,11 @@ public final class HttpBindManager implements CertificateEventListener, Property
 
         // When everything else fails, use the static content handler. This one should be last, as it is mapping to the root context.
         // This means that it will catch everything and prevent the invocation of later handlers.
-        this.handlerList.addHandler( createStaticContentHandler() );
+        final Handler staticContentHandler = createStaticContentHandler();
+        if ( staticContentHandler != null )
+        {
+            this.handlerList.addHandler( staticContentHandler );
+        }
     }
 
     public void start() {


### PR DESCRIPTION
The static web content handler is allowed to be null (when there's no static content to be served). In such case, the null-handler shouldn't be loaded in Jetty (which will throws nullpointers).