### PR TITLE
OF-1362: Websocket plugin has been broken since Openfire 4.1.4. This PR implem…

### DIFF
--- a/src/plugins/websocket/plugin.xml
+++ b/src/plugins/websocket/plugin.xml
@@ -8,8 +8,8 @@
     <name>Openfire WebSocket</name>
     <description>Provides WebSocket support for Openfire.</description>
     <author>Tom Evans</author>
-    <version>1.2.0</version>
-    <date>05/08/2017</date>
+    <version>1.2.1</version>
+    <date>06/30/2017</date>
     <url>https://tools.ietf.org/html/rfc7395</url>
-    <minServerVersion>4.2.0 Alpha</minServerVersion>
+    <minServerVersion>4.1.5</minServerVersion>
 </plugin>


### PR DESCRIPTION
…ents the missing code and fixes the issue

    @Override
   public ConnectionConfiguration getConfiguration()
   {
       // TODO Here we run into an issue with the ConnectionConfiguration introduced in Openfire 4:
       //      it is not extensible in the sense that unforeseen connection types can be added.
       //      For now, null is returned, as this object is likely to be unused (its lifecycle is
       //      not managed by a ConnectionListener instance).
       return null;
   }