### PR TITLE
OF-1365: Don't allow caches that do not expire to be purged.

### DIFF
--- a/src/web/system-cache.jsp
+++ b/src/web/system-cache.jsp
@@ -198,6 +198,8 @@
             hitPercent = percentFormat.format(hitValue) + "%";
             lowEffec = (hits > 500 && hitValue < 85.0 && freeMem < 20.0);
         }
+        // OF-1365: Don't allow caches that do not expire to be purged. Many of these caches store data that cannot be recovered again.
+        final boolean canPurge = cache.getMaxLifetime() > -1;
 %>
     <tr class="<%= (lowEffec ? "jive-error" : "") %>">
         <td class="c1">
@@ -229,7 +231,11 @@
             <%= hitPercent%>
         </td>
 
-        <td width="1%" class="c5"><input type="checkbox" name="cacheID" value="<%= i %>" onclick="updateControls(this.form);toggleHighlight(this);"></td>
+        <td width="1%" class="c5">
+            <% if ( canPurge ) {%>
+            <input type="checkbox" name="cacheID" value="<%= i %>" onclick="updateControls(this.form);toggleHighlight(this);">
+            <% } %>
+        </td>
     </tr>
 
 <%  } %>


### PR DESCRIPTION
The Admin Console allows caches to be emptied. This should not be allowed for all caches.
Openfire uses caches for two distinct purposes:

- To improve performance, where it's expensive to obtain certain data
- To share information in the cluster

It is possible that information that cannot be re-retrieved is stored in a cache (with the intend to share it in the cluster). Purging such a cache would irrecoverably delete information, almost certainly introducing problems. The internals of the routing table are based on such caches.

Openfire should not allow that caches are purged, when those caches store information that cannot be retrieved again.