### PR TITLE
Ensure that Hazelcast backed Cache objects have the correct settings

### DIFF
--- a/src/java/org/jivesoftware/util/cache/Cache.java
+++ b/src/java/org/jivesoftware/util/cache/Cache.java
@@ -72,6 +72,9 @@ public interface Cache<K,V> extends java.util.Map<K,V> {
      * than the max size, the least frequently used items will be removed. If
      * the max cache size is set to -1, there is no size limit.
      *
+     * <p><strong>Note:</strong> If using the Hazelcast clustering plugin, this will not take
+     * effect until the next time the cache is created</p>
+     *
      * @param maxSize the maximum size of the cache in bytes.
      */
     void setMaxCacheSize(int maxSize);
@@ -79,7 +82,7 @@ public interface Cache<K,V> extends java.util.Map<K,V> {
     /**
      * Returns the maximum number of milliseconds that any object can live
      * in cache. Once the specified number of milliseconds passes, the object
-     * will be automatically expried from cache. If the max lifetime is set
+     * will be automatically expired from cache. If the max lifetime is set
      * to -1, then objects never expire.
      *
      * @return the maximum number of milliseconds before objects are expired.
@@ -89,8 +92,11 @@ public interface Cache<K,V> extends java.util.Map<K,V> {
     /**
      * Sets the maximum number of milliseconds that any object can live
      * in cache. Once the specified number of milliseconds passes, the object
-     * will be automatically expried from cache. If the max lifetime is set
+     * will be automatically expired from cache. If the max lifetime is set
      * to -1, then objects never expire.
+     *
+     * <p><strong>Note:</strong> If using the Hazelcast clustering plugin, this will not take
+     * effect until the next time the cache is created</p>
      *
      * @param maxLifetime the maximum number of milliseconds before objects are expired.
      */

--- a/src/plugins/hazelcast/plugin.xml
+++ b/src/plugins/hazelcast/plugin.xml
@@ -5,7 +5,7 @@
     <name>Hazelcast plugin</name>
     <description>Adds clustering support</description>
     <author>Tom Evans</author>
-    <version>2.2.1</version>
-    <date>11/04/2016</date>
+    <version>2.2.2</version>
+    <date>08/03/2016</date>
     <minServerVersion>4.0.0</minServerVersion>
 </plugin>


### PR DESCRIPTION
I recently came across an issue whereby if you set a cache size/lifetime using `Cache.setMaxCacheSize()` / `Cache.setMaxLifetime()` it has no effect on Hazelcast backed Caches - configuration is taken solely from the hazelcast-cache-config.xml file. 

This PR configures the underlying Hazelcast IMap based on the values that were previously set by these methods, defaulting to the values in hazelcast-cache-config.xml if not present. Some discussion on this can be found at https://groups.google.com/forum/#!topic/hazelcast/DYmHGo-sCnI

Note; currently it's not possible to modify these values after an IMap has been created -
 the Javadoc for Cache has been updated to reflect this. https://github.com/hazelcast/hazelcast/issues/592 suggests that this ability be coming in Hazelcast 3.9