### PR TITLE
Ensure that Hazelcast backed Cache objects have the correct settings

### DIFF
--- a/src/java/org/jivesoftware/util/cache/Cache.java
+++ b/src/java/org/jivesoftware/util/cache/Cache.java
@@ -72,6 +72,9 @@ public interface Cache<K,V> extends java.util.Map<K,V> {
      * than the max size, the least frequently used items will be removed. If
      * the max cache size is set to -1, there is no size limit.
      *
+     *<p><strong>Note:</strong> If using the Hazelcast clustering plugin, this will not take
+     * effect until the next time the cache is created</p>
+     *
      * @param maxSize the maximum size of the cache in bytes.
      */
     void setMaxCacheSize(int maxSize);
@@ -79,7 +82,7 @@ public interface Cache<K,V> extends java.util.Map<K,V> {
     /**
      * Returns the maximum number of milliseconds that any object can live
      * in cache. Once the specified number of milliseconds passes, the object
-     * will be automatically expried from cache. If the max lifetime is set
+     * will be automatically expired from cache. If the max lifetime is set
      * to -1, then objects never expire.
      *
      * @return the maximum number of milliseconds before objects are expired.
@@ -89,8 +92,11 @@ public interface Cache<K,V> extends java.util.Map<K,V> {
     /**
      * Sets the maximum number of milliseconds that any object can live
      * in cache. Once the specified number of milliseconds passes, the object
-     * will be automatically expried from cache. If the max lifetime is set
+     * will be automatically expired from cache. If the max lifetime is set
      * to -1, then objects never expire.
+     *
+     *<p><strong>Note:</strong> If using the Hazelcast clustering plugin, this will not take
+     * effect until the next time the cache is created</p>
      *
      * @param maxLifetime the maximum number of milliseconds before objects are expired.
      */

--- a/src/plugins/hazelcast/plugin.xml
+++ b/src/plugins/hazelcast/plugin.xml
@@ -5,7 +5,7 @@
     <name>Hazelcast plugin</name>
     <description>Adds clustering support</description>
     <author>Tom Evans</author>
-    <version>2.2.1</version>
-    <date>11/04/2016</date>
+    <version>2.2.2</version>
+    <date>08/03/2017</date>
     <minServerVersion>4.0.0</minServerVersion>
 </plugin>

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -16,6 +16,33 @@
 
 package org.jivesoftware.openfire.plugin.util.cache;
 
+import com.hazelcast.config.ClasspathXmlConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.core.Cluster;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
+import org.jivesoftware.openfire.JMXManager;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.cluster.ClusterNodeInfo;
+import org.jivesoftware.openfire.cluster.NodeID;
+import org.jivesoftware.openfire.plugin.session.RemoteSessionLocator;
+import org.jivesoftware.openfire.plugin.util.cluster.ClusterPacketRouter;
+import org.jivesoftware.openfire.plugin.util.cluster.HazelcastClusterNodeInfo;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.StringUtils;
+import org.jivesoftware.util.cache.Cache;
+import org.jivesoftware.util.cache.CacheFactory;
+import org.jivesoftware.util.cache.CacheFactoryStrategy;
+import org.jivesoftware.util.cache.CacheWrapper;
+import org.jivesoftware.util.cache.ClusterTask;
+import org.jivesoftware.util.cache.ExternalizableUtil;
+import org.jivesoftware.util.cache.ExternalizableUtilStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -33,31 +60,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
-
-import org.jivesoftware.openfire.JMXManager;
-import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.openfire.cluster.ClusterNodeInfo;
-import org.jivesoftware.openfire.cluster.NodeID;
-import org.jivesoftware.openfire.plugin.session.RemoteSessionLocator;
-import org.jivesoftware.openfire.plugin.util.cluster.ClusterPacketRouter;
-import org.jivesoftware.openfire.plugin.util.cluster.HazelcastClusterNodeInfo;
-import org.jivesoftware.util.JiveGlobals;
-import org.jivesoftware.util.StringUtils;
-import org.jivesoftware.util.cache.Cache;
-import org.jivesoftware.util.cache.CacheFactoryStrategy;
-import org.jivesoftware.util.cache.CacheWrapper;
-import org.jivesoftware.util.cache.ClusterTask;
-import org.jivesoftware.util.cache.ExternalizableUtil;
-import org.jivesoftware.util.cache.ExternalizableUtilStrategy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.hazelcast.config.ClasspathXmlConfig;
-import com.hazelcast.config.Config;
-import com.hazelcast.core.Cluster;
-import com.hazelcast.core.Hazelcast;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.Member;
 
 /**
  * CacheFactory implementation to use when using Hazelcast in cluster mode.
@@ -211,6 +213,15 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
         if (state == State.stopped) {
             throw new IllegalStateException("Cannot create clustered cache when not in a cluster");
         }
+        // Determine the time to live. Note that in Hazelcast 0 means "forever", not -1
+        final long openfireLifetimeInMilliseconds = CacheFactory.getMaxCacheLifetime(name);
+        final int hazelcastLifetimeInSeconds = openfireLifetimeInMilliseconds < 0 ? 0 : (int) (openfireLifetimeInMilliseconds / 1000);
+        // Determine the max cache size. Note that in Hazelcast the max cache size must be positive
+        final long openfireMaxCacheSize = CacheFactory.getMaxCacheSize(name);
+        final int hazelcastMaxCacheSize = openfireMaxCacheSize < 0 ? Integer.MAX_VALUE : (int) openfireMaxCacheSize;
+        final MapConfig mapConfig = hazelcast.getConfig().getMapConfig(name);
+        mapConfig.setTimeToLiveSeconds(hazelcastLifetimeInSeconds);
+        mapConfig.setMaxSizeConfig(new MaxSizeConfig(hazelcastMaxCacheSize, MaxSizeConfig.MaxSizePolicy.USED_HEAP_SIZE));
         return new ClusteredCache(name, hazelcast.getMap(name));
     }
 


### PR DESCRIPTION
[NB. This is a re-submit of a previous pull request without superfluous commits]

I recently came across an issue whereby if you set a cache size/lifetime using Cache.setMaxCacheSize() / Cache.setMaxLifetime() it has no effect on Hazelcast backed Caches - configuration is taken solely from the hazelcast-cache-config.xml file.

This PR configures the underlying Hazelcast IMap based on the values that were previously set by these methods, defaulting to the values in hazelcast-cache-config.xml if not present. Some discussion on this can be found at https://groups.google.com/forum/#!topic/hazelcast/DYmHGo-sCnI

Note; currently it's not possible to modify these values after an IMap has been created -
the Javadoc for Cache has been updated to reflect this. hazelcast/hazelcast#592 suggests that this ability is coming in Hazelcast 3.9.