### PR TITLE
OF-1368 Display more-useful admin console msg on user@ login failures

### DIFF
--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -1088,6 +1088,9 @@ login.failed.unauthorized=Login failed: make sure your username and password are
         or moderator.
 login.failed.connection=Login failed: make sure your the user and group system is up and running.
 login.failed.authentication=Login failed: Openfire wasn&#39;t able to authenticate itself to the users system.
+login.failed.lookslikeemail=Login failed: You provided what appears to be an email address, consider \
+		using just the user part (everything before the @). Typical installations use just &#39;admin&#39; \
+		as the username.
 login.username=username
 login.password=password
 login.login=Login

--- a/src/web/login.jsp
+++ b/src/web/login.jsp
@@ -1,6 +1,3 @@
-<%--
---%>
-
 <%@ page import="org.jivesoftware.admin.AdminConsole,
                  org.jivesoftware.openfire.admin.AdminManager"
     errorPage="error.jsp"
@@ -144,8 +141,13 @@
         catch (UnauthorizedException ue) {
             Log.debug(ue);
             LoginLimitManager.getInstance().recordFailedAttempt(username, request.getRemoteAddr());
-            errors.put("unauthorized", LocaleUtils.getLocalizedString("login.failed.unauthorized"));
-        }
+            // Provide a special message if the user provided something containing @
+            if (username.contains("@")){
+        	    errors.put("unauthorized", LocaleUtils.getLocalizedString("login.failed.lookslikeemail"));            	
+            } else {
+        	    errors.put("unauthorized", LocaleUtils.getLocalizedString("login.failed.unauthorized"));
+            }
+    	}
     }
 
     // Escape HTML tags in username to prevent cross-site scripting attacks. This


### PR DESCRIPTION
Here's the message displayed with the username contains '@'

> Login failed: You provided what appears to be an email address, consider using just the user part (everything before the @). Typical installations use just 'admin' as the username.
