### PR TITLE
OF-1208: Disallow (by default) S2S for anonymous users.

### DIFF
--- a/src/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/src/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -59,6 +59,7 @@ public final class ConnectionSettings {
 
         public static final String PERMISSION_SETTINGS = "xmpp.server.permission";
         public static final String AUTH_PER_CLIENTCERT_POLICY = "xmpp.server.cert.policy";
+        public static final String ALLOW_ANONYMOUS_OUTBOUND_DATA = "xmpp.server.allow-anonymous-outbound-data";
     }
 
     public static final class Multiplex {

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -467,36 +467,36 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             }
         }
 
-        byte[] nodeID = serversCache.get(jid.getDomain());
-        if (nodeID != null) {
-            if (server.getNodeID().equals(nodeID)) {
-                // This is a route to a remote server connected from this node
-                try {
-                    localRoutingTable.getRoute(jid.getDomain()).process(packet);
-                    routed = true;
-                } catch (UnauthorizedException e) {
-                    Log.error("Unable to route packet " + packet.toXML(), e);
-                }
-            }
-            else {
-                // This is a route to a remote server connected from other node
-                if (remotePacketRouter != null) {
-                    routed = remotePacketRouter.routePacket(nodeID, jid, packet);
-                }
-            }
-        }
-        else if (!RemoteServerManager.canAccess(jid.getDomain())) { // Check if the remote domain is in the blacklist
-            Log.info( "Will not route: Remote domain {} is not accessible according to our configuration (typical causes: server federation is disabled, or domain is blacklisted).", jid.getDomain() );
-            routed = false;
-        }
-        else {
-            // Return a promise of a remote session. This object will queue packets pending
-            // to be sent to remote servers
-            OutgoingSessionPromise.getInstance().process(packet);
-            routed = true;
-        }
-        return routed;
-    }
+		byte[] nodeID = serversCache.get(jid.getDomain());
+		if (nodeID != null) {
+			if (server.getNodeID().equals(nodeID)) {
+				// This is a route to a remote server connected from this node
+				try {
+					localRoutingTable.getRoute(jid.getDomain()).process(packet);
+					routed = true;
+				} catch (UnauthorizedException e) {
+					Log.error("Unable to route packet " + packet.toXML(), e);
+				}
+			}
+			else {
+				// This is a route to a remote server connected from other node
+				if (remotePacketRouter != null) {
+					routed = remotePacketRouter.routePacket(nodeID, jid, packet);
+				}
+			}
+		}
+		else if (!RemoteServerManager.canAccess(jid.getDomain())) { // Check if the remote domain is in the blacklist
+			Log.info( "Will not route: Remote domain {} is not accessible according to our configuration (typical causes: server federation is disabled, or domain is blacklisted).", jid.getDomain() );
+			routed = false;
+		}
+		else {
+			// Return a promise of a remote session. This object will queue packets pending
+			// to be sent to remote servers
+			OutgoingSessionPromise.getInstance().process(packet);
+			routed = true;
+		}
+		return routed;
+	}
 	
     /**
      * Returns true if the specified packet must only be route to available client sessions.

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -454,13 +454,12 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 	 * @return <tt>true</tt> if the packet was routed successfully,
 	 *         <tt>false</tt> otherwise.
 	 */
-	private boolean routeToRemoteDomain(JID jid, Packet packet, boolean routed)
+    private boolean routeToRemoteDomain(JID jid, Packet packet, boolean routed)
     {
-		if ( JiveGlobals.getBooleanProperty( ConnectionSettings.Server.ALLOW_ANONYMOUS_OUTBOUND_DATA, false ) )
+        if ( JiveGlobals.getBooleanProperty( ConnectionSettings.Server.ALLOW_ANONYMOUS_OUTBOUND_DATA, false ) )
         {
-            // Disallow anonymous users to send data to other domains than the local domain.
-            final ClientSession clientSession = SessionManager.getInstance().getSession( packet.getFrom() );
-            if ( clientSession != null && clientSession.isAnonymousUser() )
+            // Disallow anonymous local users to send data to other domains than the local domain.
+            if ( isAnonymousRoute( packet.getFrom() ) )
             {
                 Log.info( "The anonymous user '{}' attempted to send data to '{}', which is on a remote domain. Openfire is configured to not allow anonymous users to send data to remote domains.", packet.getFrom(), jid );
                 routed = false;
@@ -497,8 +496,8 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                 routed = true;
             }
         }
-		return routed;
-	}
+        return routed;
+    }
 	
     /**
      * Returns true if the specified packet must only be route to available client sessions.

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -469,31 +469,31 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
 		byte[] nodeID = serversCache.get(jid.getDomain());
 		if (nodeID != null) {
-			if (server.getNodeID().equals(nodeID)) {
-				// This is a route to a remote server connected from this node
-				try {
-					localRoutingTable.getRoute(jid.getDomain()).process(packet);
-					routed = true;
-				} catch (UnauthorizedException e) {
-					Log.error("Unable to route packet " + packet.toXML(), e);
-				}
-			}
-			else {
-				// This is a route to a remote server connected from other node
-				if (remotePacketRouter != null) {
-					routed = remotePacketRouter.routePacket(nodeID, jid, packet);
-				}
-			}
+		    if (server.getNodeID().equals(nodeID)) {
+		        // This is a route to a remote server connected from this node
+		        try {
+		            localRoutingTable.getRoute(jid.getDomain()).process(packet);
+		            routed = true;
+		        } catch (UnauthorizedException e) {
+		            Log.error("Unable to route packet " + packet.toXML(), e);
+		        }
+		    }
+		    else {
+		        // This is a route to a remote server connected from other node
+		        if (remotePacketRouter != null) {
+		            routed = remotePacketRouter.routePacket(nodeID, jid, packet);
+		        }
+		    }
 		}
 		else if (!RemoteServerManager.canAccess(jid.getDomain())) { // Check if the remote domain is in the blacklist
-			Log.info( "Will not route: Remote domain {} is not accessible according to our configuration (typical causes: server federation is disabled, or domain is blacklisted).", jid.getDomain() );
-			routed = false;
-		}
-		else {
-			// Return a promise of a remote session. This object will queue packets pending
-			// to be sent to remote servers
-			OutgoingSessionPromise.getInstance().process(packet);
-			routed = true;
+            Log.info( "Will not route: Remote domain {} is not accessible according to our configuration (typical causes: server federation is disabled, or domain is blacklisted).", jid.getDomain() );
+            routed = false;
+        }
+        else {
+		    // Return a promise of a remote session. This object will queue packets pending
+		    // to be sent to remote servers
+		    OutgoingSessionPromise.getInstance().process(packet);
+		    routed = true;
 		}
 		return routed;
 	}

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -456,7 +456,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 	 */
     private boolean routeToRemoteDomain(JID jid, Packet packet, boolean routed)
     {
-        if ( JiveGlobals.getBooleanProperty( ConnectionSettings.Server.ALLOW_ANONYMOUS_OUTBOUND_DATA, false ) )
+        if ( !JiveGlobals.getBooleanProperty( ConnectionSettings.Server.ALLOW_ANONYMOUS_OUTBOUND_DATA, false ) )
         {
             // Disallow anonymous local users to send data to other domains than the local domain.
             if ( isAnonymousRoute( packet.getFrom() ) )


### PR DESCRIPTION
A new properyt, 'xmpp.server.allow-anonymous-outbound-data' controls if client sessions that are anonymous can send data to remote domains. By default, they cannot.