### PR TITLE
OF-1376 Use an event rather than an arbitrary delay before starting clustering

### DIFF
--- a/src/plugins/hazelcast/changelog.html
+++ b/src/plugins/hazelcast/changelog.html
@@ -44,6 +44,16 @@
 Hazelcast Clustering Plugin Changelog
 </h1>
 
+<p><b>2.2.3</b> -- September 5, 2017</p>
+<ul>
+     <li>Use an event rather than an arbitrary delay before starting clustering</li>
+</ul>
+
+<p><b>2.2.2</b> -- August 3, 2017</p>
+<ul>
+     <li>Ensure that Hazelcast backed Cache objects have the correct settings</li>
+</ul>
+
 <p><b>2.2.1</b> -- November 4, 2016</p>
 <ul>
      <li>[<a href='http://www.igniterealtime.org/issues/browse/OF-1210'>OF-1210</a>] - correct time-to-live-seconds and MaxLifetime settings for hazelcast</li>

--- a/src/plugins/hazelcast/plugin.xml
+++ b/src/plugins/hazelcast/plugin.xml
@@ -5,7 +5,7 @@
     <name>Hazelcast plugin</name>
     <description>Adds clustering support</description>
     <author>Tom Evans</author>
-    <version>2.2.2</version>
-    <date>08/03/2017</date>
+    <version>2.2.3</version>
+    <date>09/05/2017</date>
     <minServerVersion>4.0.0</minServerVersion>
 </plugin>


### PR DESCRIPTION
This PR switches to using a PluginManagerListener to wait for the plugins to load before attempting to start Hazelcast clustering, instead of an arbitrary delay of 5 seconds. 

We came across this when we were getting inconsistent behaviour on plugin startup; plugin A*** was working just fine, plugin W*** would, sometimes, get confused as clustering was started in the middle of it's plugin initialisation. Possibly less of an issue in OF version 4.2 as plugins will be loaded in parallel, but even so ...

I also added a missing changelog entry for version 2.2.2.