### PR TITLE
Revert "OF-1376 Use an event rather than an arbitrary delay before starting clustering"

### DIFF
--- a/src/plugins/hazelcast/changelog.html
+++ b/src/plugins/hazelcast/changelog.html
@@ -44,16 +44,6 @@
 Hazelcast Clustering Plugin Changelog
 </h1>
 
-<p><b>2.2.3</b> -- September 5, 2017</p>
-<ul>
-     <li>Use an event rather than an arbitrary delay before starting clustering</li>
-</ul>
-
-<p><b>2.2.2</b> -- August 3, 2017</p>
-<ul>
-     <li>Ensure that Hazelcast backed Cache objects have the correct settings</li>
-</ul>
-
 <p><b>2.2.1</b> -- November 4, 2016</p>
 <ul>
      <li>[<a href='http://www.igniterealtime.org/issues/browse/OF-1210'>OF-1210</a>] - correct time-to-live-seconds and MaxLifetime settings for hazelcast</li>

--- a/src/plugins/hazelcast/plugin.xml
+++ b/src/plugins/hazelcast/plugin.xml
@@ -5,7 +5,7 @@
     <name>Hazelcast plugin</name>
     <description>Adds clustering support</description>
     <author>Tom Evans</author>
-    <version>2.2.3</version>
-    <date>09/05/2017</date>
+    <version>2.2.2</version>
+    <date>08/03/2017</date>
     <minServerVersion>4.0.0</minServerVersion>
 </plugin>

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/HazelcastPlugin.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/HazelcastPlugin.java
@@ -18,13 +18,14 @@ package org.jivesoftware.openfire.plugin;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.util.TimerTask;
 
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
-import org.jivesoftware.openfire.container.PluginManagerListener;
 import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.TaskEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,23 +37,21 @@ import org.slf4j.LoggerFactory;
  * @author Tom Evans
  * @author Matt Tucker
  */
-public class HazelcastPlugin implements Plugin {
+public class HazelcastPlugin extends TimerTask implements Plugin {
 
     private static Logger logger = LoggerFactory.getLogger(HazelcastPlugin.class);
 
-    public void initializePlugin(final PluginManager manager, final File pluginDirectory) {
-        logger.info("Waiting for other plugins to initialize before initializing clustering");
-        manager.addPluginManagerListener(new PluginManagerListener() {
-            @Override
-            public void pluginsMonitored() {
-                manager.removePluginManagerListener(this);
-                initializeClustering();
-            }
-        });
+    private static final long CLUSTER_STARTUP_DELAY_TIME = 
+    		JiveGlobals.getLongProperty("hazelcast.startup.delay.seconds", 5);
+    
+    public void initializePlugin(PluginManager manager, File pluginDirectory) {
+    	// start cluster using a separate thread after a short delay
+    	// this will allow other plugins to initialize during startup
+    	TaskEngine.getInstance().schedule(this, CLUSTER_STARTUP_DELAY_TIME*1000);
     }
 
-	private void initializeClustering() {
-        logger.info("All plugins have initialized; initializing clustering");
+	@Override
+	public void run() {
         // Check if another cluster is installed and stop loading this plugin if found
         File pluginDir = new File(JiveGlobals.getHomeDirectory(), "plugins");
         File[] jars = pluginDir.listFiles(new FileFilter() {


### PR DESCRIPTION
Reverts igniterealtime/Openfire#860

Reverting this change, as it appears to break the plugin. This is likely related to #824.