### PR TITLE
Determine the class name from the class, rather than hard-coding it

### DIFF
--- a/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -84,6 +84,10 @@ import java.util.regex.Pattern;
 public class LdapManager {
 
     private static final Logger Log = LoggerFactory.getLogger(LdapManager.class);
+    // Determine the name of the default LDAP context factory.
+    // NOTE: Extracting the name from the class rather than hard coding it allows the compiler to detect the use of this
+    // internal class and emit an appropriate warning ("warning: LdapCtxFactory is internal proprietary API and may be removed in a future release")
+    // This is deliberate, to highlight use of classes that may be removed in the future.
     private static final String DEFAULT_LDAP_CONTEXT_FACTORY = LdapCtxFactory.class.getName();
 
     private static LdapManager instance;

--- a/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -16,6 +16,8 @@
 
 package org.jivesoftware.openfire.ldap;
 
+import com.sun.jndi.ldap.LdapCtxFactory;
+
 import org.jivesoftware.openfire.group.GroupNotFoundException;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.util.JiveGlobals;
@@ -82,6 +84,7 @@ import java.util.regex.Pattern;
 public class LdapManager {
 
     private static final Logger Log = LoggerFactory.getLogger(LdapManager.class);
+    private static final String DEFAULT_LDAP_CONTEXT_FACTORY = LdapCtxFactory.class.getName();
 
     private static LdapManager instance;
     static {
@@ -409,12 +412,12 @@ public class LdapManager {
             catch (ClassNotFoundException cnfe) {
                 Log.error("Initial context factory class failed to load: " + initialContextFactory +
                         ".  Using default initial context factory class instead.");
-                initialContextFactory = "com.sun.jndi.ldap.LdapCtxFactory";
+                initialContextFactory = DEFAULT_LDAP_CONTEXT_FACTORY;
             }
         }
         // Use default value if none was set.
         else {
-            initialContextFactory = "com.sun.jndi.ldap.LdapCtxFactory";
+            initialContextFactory = DEFAULT_LDAP_CONTEXT_FACTORY;
         }
 
         StringBuilder buf = new StringBuilder();


### PR DESCRIPTION
This PR actually does very little; instead of hardcoding the class name - `"com.sun.jndi.ldap.LdapCtxFactory"` it is determined from the class itself - `LdapCtxFactory.class.getName()`

The only reason for this is to deliberately introduce an explicit warning at compile time, as the compiler now knows we're using an internal API. 

```
[of.javac] Openfire\src\java\org\jivesoftware\openfire\ldap\LdapManager.java:87: warning: LdapCtxFactory is internal proprietary API and may be removed in a future release
[of.javac]     private static final String DEFAULT_LDAP_CONTEXT_FACTORY = LdapCtxFactory.class.getName();
```

This may become more of an issue if/when Openfire moves to Java 9.