### PR TITLE
OF 35 - Affiliates pages for pub sub admin console.

### DIFF
--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -555,13 +555,15 @@ tab.server.descr=Click to manage server settings
     sidebar.sidebar-pubsub=PubSub
         sidebar.pubsub-node-summary=Node Summary
         sidebar.pubsub-node-summary.descr=Click to manage PubSub nodes
-        sidebar.sidebar-node-options=Node Options
-        sidebar.pubsub-node-items=Published Items
-        sidebar.pubsub-node-items.descr=Click to view items published to the node
-        sidebar.pubsub-node-subscribers=Node Subscribers
-        sidebar.pubsub-node-subscribers.descr=Click to view the node&#39;s subscribers
-        sidebar.pubsub-node-delete=Delete Node
-        sidebar.pubsub-node-delete.descr=Click to delete the node
+            sidebar.sidebar-node-options=Node Options
+                sidebar.pubsub-node-items=Published Items
+                sidebar.pubsub-node-items.descr=Click to view items published to the node
+                sidebar.pubsub-node-affiliates=Node Affiliates
+                sidebar.pubsub-node-affiliates.descr=Click to view the node affiliates
+                sidebar.pubsub-node-subscribers=Node Subscribers
+                sidebar.pubsub-node-subscribers.descr=Click to view the node&#39;s subscribers
+                sidebar.pubsub-node-delete=Delete Node
+                sidebar.pubsub-node-delete.descr=Click to delete the node
 tab.tab-users=Users/Groups
 tab.tab-users.descr=Click to manage users and groups
     sidebar.sidebar-users=Users
@@ -2658,9 +2660,11 @@ pubsub.node.summary.id=Node ID
 pubsub.node.summary.name=Name
 pubsub.node.summary.description=Description
 pubsub.node.summary.items=Items
+pubsub.node.summary.affiliates=Affiliates
 pubsub.node.summary.subscribers=Subscribers
 pubsub.node.summary.no_nodes=No leaf nodes in the PubSub service.
 pubsub.node.summary.table.info=Node summary is show in the following table:
+pubsub.node.summary.table.no_nodes=No leaf nodes in the PubSub service.
 pubsub.node.summary.created=Created On
 pubsub.node.summary.modified=Last Modified
 
@@ -2684,22 +2688,48 @@ pubsub.node.items.id=Item ID
 pubsub.node.items.publisher=Publisher
 pubsub.node.items.created=Created On
 pubsub.node.items.payload=Payload
-
 pubsub.node.items.table.info=Current published items are listed in the following table:
+pubsub.node.items.table.no_items=No items currently published to the node.
 pubsub.node.items.deleted=Deleted item published by {0} from the node.
+
+# PubSub Node Affiliates
+
+pubsub.node.affiliates.title=Affiliates
+pubsub.node.affiliates.jid=JID
+pubsub.node.affiliates.affiliation=Affiliation
+pubsub.node.affiliates.subscriptions=Subscriptions
+pubsub.node.affiliates.no_affiliates=The Node has no affiliates.
+pubsub.node.affiliates.table.info=Current node affiliates are listed in the following table:
+pubsub.node.affiliates.table.no_affiliates=The Node has no affiliates.
+pubsub.node.affiliates.deleted=Deleted affiliation with {0} from the node.
+pubsub.node.affiliates.updated=Updated affiliation for {0}.
+
+
+pubsub.node.affiliates.delete.title=Delete Affiliate
+pubsub.node.affiliates.delete.info=Affiliation details:
+pubsub.node.affiliates.delete.info2=Current subscriptions for this affiliation (These will also be deleted):
+pubsub.node.affiliates.delete.info3=Are you sure you want to delete the affiliation?
+pubsub.node.affiliates.delete.table.no_subscriptions=This Affiliate has no subscriptions to the Node.
+pubsub.node.affiliates.delete.delete_affiliate=Delete Affiliate
+
+pubsub.node.affiliates.edit.title=Edit Affiliate
+pubsub.node.affiliates.edit.info=Current Affiliation details:
+pubsub.node.affiliates.edit.info2=Current subscriptions for this affiliation:
+pubsub.node.affiliates.edit.info3=Enter new affiliation:
+pubsub.node.affiliates.edit.update=Update
 
 
 # PubSub Node Subscribers
 
 pubsub.node.subscribers.title=Subscribers
-pubsub.node.subscribers.owner=Owner
+pubsub.node.subscribers.owner=JID
 pubsub.node.subscribers.resource=Resource
+pubsub.node.subscribers.affiliation=Affiliation
 pubsub.node.subscribers.status=Status
 pubsub.node.subscribers.expires=Expires
 pubsub.node.subscribers.table.info=Current node subscribers are listed in the following table:
+pubsub.node.subscribers.table.no_subscribers=The Node has no subscribers.
 pubsub.node.subscribers.deleted=Deleted subscription owned by {0} from the node.
-
-
 
 # Plugins Admin Page
 

--- a/src/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -348,7 +348,7 @@ public abstract class Node {
     private void removeAffiliation(JID jid, NodeAffiliate.Affiliation affiliation) {
         // Get the current affiliation of the specified JID
         NodeAffiliate affiliate = getAffiliate(jid);
-        // Check if the current affiliatin of the user is the one to remove
+        // Check if the current affiliation of the user is the one to remove
         if (affiliate != null && affiliation == affiliate.getAffiliation()) {
             removeAffiliation(affiliate);
         }
@@ -415,6 +415,16 @@ public abstract class Node {
         } else {
             return subscriptionsByJID.values();
         }
+    }
+
+    /**
+     * Returns all affiliates of the node.
+     *
+     * @return All affiliates of the node.
+     */
+    public Collection<NodeAffiliate> getAllAffiliates() {
+
+        return affiliates;
     }
 
     /**

--- a/src/resources/jar/admin-sidebar.xml
+++ b/src/resources/jar/admin-sidebar.xml
@@ -298,6 +298,11 @@
                           url="pubsub-node-items.jsp"
                           description="${sidebar.pubsub-node-items.descr}"/>
 
+                    <!-- Node Affiliates -->
+                    <item id="pubsub-node-affiliates" name="${sidebar.pubsub-node-affiliates}"
+                          url="pubsub-node-affiliates.jsp"
+                          description="${sidebar.pubsub-node-affiliates.descr}"/>
+
                     <!-- Node Subscribers -->
                     <item id="pubsub-node-subscribers" name="${sidebar.pubsub-node-subscribers}"
                           url="pubsub-node-subscribers.jsp"

--- a/src/web/pubsub-node-affiliates-delete.jsp
+++ b/src/web/pubsub-node-affiliates-delete.jsp
@@ -1,0 +1,216 @@
+<%@page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
+                org.jivesoftware.openfire.pubsub.NodeAffiliate,
+                org.jivesoftware.openfire.pubsub.NodeSubscription,
+                org.jivesoftware.openfire.pubsub.PubSubServiceInfo,
+                org.jivesoftware.util.*,
+                org.jivesoftware.openfire.pubsub.Node,
+                org.jivesoftware.openfire.XMPPServer,
+                org.xmpp.packet.JID,
+                java.net.URLEncoder"
+    errorPage="error.jsp"
+%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="admin" prefix="admin" %>
+
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
+<% webManager.init(request, response, session, application, out ); %>
+
+<%  // Get parameters //
+    boolean cancel = ParamUtils.getParameter(request,"cancel") != null;
+    boolean delete = ParamUtils.getParameter(request,"delete") != null;
+    Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+    String csrfParam = ParamUtils.getParameter(request, "csrf");
+    String nodeID = ParamUtils.getParameter(request,"nodeID");
+    String affiliateJID = ParamUtils.getParameter(request,"affiliateJID");
+
+    String ownerString = ParamUtils.getParameter( request, "owner" );
+    if ( ownerString == null )
+    {
+        ownerString = ParamUtils.getParameter( request, "username" );
+    }
+
+    JID owner = null;
+    if (ownerString != null)
+    {
+        if ( ownerString.contains( "@" ) )
+        {
+            owner = new JID( ownerString ).asBareJID();
+        }
+        else
+        {
+            owner = XMPPServer.getInstance().createJID( ownerString, null );
+        }
+    }
+
+    if (delete) {
+        if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
+            delete = false;
+        }
+    }
+
+    // Handle a cancel
+    if (cancel) {
+        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+nodeID
+                + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : ""));
+        return;
+    }
+
+    PubSubServiceInfo pubSubServiceInfo;
+    if ( owner == null )
+    {
+        pubSubServiceInfo = webManager.getPubSubInfo();
+    }
+    else
+    {
+        pubSubServiceInfo = new PEPServiceInfo( owner );
+    }
+
+    // Load the node object
+	Node node = pubSubServiceInfo.getNode(nodeID);
+    NodeAffiliate affiliate = node.getAffiliate(new JID(affiliateJID));
+
+    // Handle a affiliate delete:
+    if (delete) {
+        if (affiliate != null) {
+            JID jid = new JID(affiliateJID);
+
+            for (NodeSubscription subscription: affiliate.getSubscriptions()) {
+                node.cancelSubscription(subscription);
+            }
+
+            switch(affiliate.getAffiliation()) {
+	            case outcast:
+	                node.removeOutcast(jid);
+	                break;
+	            case publisher:
+	                node.removePublisher(jid);
+	                break;
+	            case owner:
+	                node.removeOwner(jid);
+	                break;
+	            case none:
+	                //None affiliation will have been removed as a result of removing the subscriptions.
+	                break;
+            }
+
+            // Log the event
+            webManager.logEvent("Deleted Affiliation for : " + affiliate + ", from Node " + nodeID, null);
+        }
+        // Done, so redirect
+        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+nodeID
+                + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : "")
+                +"&deleteSuccess=true&affiliateJID="+affiliateJID);
+        return;
+    }
+
+    csrfParam = StringUtils.randomString(15);
+    CookieUtils.setCookie(request, response, "csrf", csrfParam, -1);
+    pageContext.setAttribute("csrf", csrfParam);
+
+    pageContext.setAttribute("node", node);
+    pageContext.setAttribute("affiliate", affiliate);
+    pageContext.setAttribute("owner", owner);
+
+%>
+
+<html>
+    <head>
+        <title><fmt:message key="pubsub.node.affiliates.delete.title"/></title>
+        <c:choose>
+            <c:when test="${not empty owner and owner.domain eq webManager.serverInfo.XMPPDomain}">
+                <meta name="subPageID" content="user-pep-node-summary"/>
+                <meta name="extraParams" content="username=${admin:urlEncode(owner.node)}&nodeID=${admin:urlEncode(node.nodeID)}" />
+            </c:when>
+            <c:otherwise>
+                <meta name="subPageID" content="pubsub-node-affiliates"/>
+                <meta name="extraParams" content="nodeID=${admin:urlEncode(node.nodeID)}"/>
+            </c:otherwise>
+        </c:choose>
+    </head>
+    <body>
+
+	<p>
+	    <fmt:message key="pubsub.node.affiliates.delete.info" />
+	</p>
+
+    <div class="jive-table">
+	    <table cellpadding="3" cellspacing="0" border="0" width="100%">
+		    <thead>
+		        <tr>
+		            <th scope="col"><fmt:message key="pubsub.node.summary.id" /></th>
+		            <th scope="col"><fmt:message key="pubsub.node.affiliates.jid" /></th>
+                    <th scope="col"><fmt:message key="pubsub.node.affiliates.affiliation" /></th>
+		        </tr>
+		    </thead>
+		    <tbody>
+		        <tr>
+		            <td><c:out value="${node.getNodeID()}"/></td>
+		            <td><c:out value="${affiliate.getJID().toBareJID()}"/></td>
+		            <td><c:out value="${affiliate.getAffiliation().name()}"/></td>
+		        </tr>
+		    </tbody>
+	    </table>
+    </div>
+    <br>
+    <br>
+    <p>
+        <fmt:message key="pubsub.node.affiliates.delete.info2" />
+    </p>
+
+    <div class="jive-table">
+        <table cellpadding="3" cellspacing="0" border="0" width="100%">
+            <thead>
+                <tr>
+		            <th scope="col"><fmt:message key="pubsub.node.subscribers.owner" /></th>
+		            <th scope="col"><fmt:message key="pubsub.node.subscribers.resource" /></th>
+		            <th scope="col"><fmt:message key="pubsub.node.subscribers.status" /></th>
+		            <th scope="col"><fmt:message key="pubsub.node.subscribers.expires" /></th>
+                </tr>
+            </thead>
+            <tbody>
+                <c:if test="${empty affiliate.getSubscriptions()}">
+			        <tr>
+			            <td align="center" colspan="4">
+			                <fmt:message key="pubsub.node.affiliates.delete.table.no_subscriptions" />
+			            </td>
+			        </tr>
+                </c:if>
+		        <c:forEach var="subscription" items="${affiliate.getSubscriptions()}">
+			        <tr>
+			            <td>
+			            <c:out value="${subscription.getOwner().toBareJID()}"/>
+			            </td>
+			            <td>
+			            <c:out value="${subscription.getJID().getResource()}"/>
+			            </td>
+			            <td>
+			            <c:out value="${subscription.getState().name()}"/>
+			            </td>
+			            <td>
+			            <fmt:formatDate type="both" dateStyle="medium" timeStyle="short" value="${subscription.getExpire()}" />
+			            </td>
+			        </tr>
+		        </c:forEach>
+            </tbody>
+        </table>
+    </div>
+    <br>
+    <br>
+    <p>
+        <fmt:message key="pubsub.node.affiliates.delete.info3" />
+    </p>
+
+	<form action="pubsub-node-affiliates-delete.jsp">
+	    <input type="hidden" name="csrf" value="${csrf}">
+		<input type="hidden" name="nodeID" value="${node.nodeID}">
+		<input type="hidden" name="owner" value="${owner}">
+		<input type="hidden" name="affiliateJID" value="${affiliate.getJID().toBareJID()}">
+
+	    <input type="submit" name="delete" value="<fmt:message key="pubsub.node.affiliates.delete.delete_affiliate" />">
+	    <input type="submit" name="cancel" value="<fmt:message key="global.cancel" />">
+	</form>
+
+    </body>
+</html>

--- a/src/web/pubsub-node-affiliates-edit.jsp
+++ b/src/web/pubsub-node-affiliates-edit.jsp
@@ -1,0 +1,243 @@
+<%@page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
+                org.jivesoftware.openfire.pubsub.NodeAffiliate,
+                org.jivesoftware.openfire.pubsub.NodeAffiliate.Affiliation,
+                org.jivesoftware.openfire.pubsub.NodeSubscription,
+                org.jivesoftware.openfire.pubsub.PubSubServiceInfo,
+                org.jivesoftware.util.*,
+                org.jivesoftware.openfire.pubsub.Node,
+                org.jivesoftware.openfire.XMPPServer,
+                org.xmpp.packet.JID,
+                java.net.URLEncoder"
+    errorPage="error.jsp"
+%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="admin" prefix="admin" %>
+
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
+<% webManager.init(request, response, session, application, out ); %>
+
+<%  // Get parameters //
+    boolean cancel = ParamUtils.getParameter(request,"cancel") != null;
+    boolean update = ParamUtils.getParameter(request,"update") != null;
+    Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+    String csrfParam = ParamUtils.getParameter(request, "csrf");
+    String nodeID = ParamUtils.getParameter(request,"nodeID");
+    String affiliateJID = ParamUtils.getParameter(request,"affiliateJID");
+    String affiliation = ParamUtils.getParameter(request,"affiliation");
+
+    String ownerString = ParamUtils.getParameter( request, "owner" );
+    if ( ownerString == null )
+    {
+        ownerString = ParamUtils.getParameter( request, "username" );
+    }
+
+    JID owner = null;
+    if (ownerString != null)
+    {
+        if ( ownerString.contains( "@" ) )
+        {
+            owner = new JID( ownerString ).asBareJID();
+        }
+        else
+        {
+            owner = XMPPServer.getInstance().createJID( ownerString, null );
+        }
+    }
+
+    if (update) {
+        if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
+            update = false;
+        }
+    }
+
+    // Handle a cancel
+    if (cancel) {
+        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+nodeID
+                + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : ""));
+        return;
+    }
+
+    PubSubServiceInfo pubSubServiceInfo;
+    if ( owner == null )
+    {
+        pubSubServiceInfo = webManager.getPubSubInfo();
+    }
+    else
+    {
+        pubSubServiceInfo = new PEPServiceInfo( owner );
+    }
+
+    // Load the affiliate object
+	Node node = pubSubServiceInfo.getNode(nodeID);
+    NodeAffiliate affiliate = node.getAffiliate(new JID(affiliateJID));
+
+    // Handle a affiliation update:
+    if (update) {
+        if (affiliate != null) {
+            JID jid = new JID(affiliateJID);
+
+            switch(NodeAffiliate.Affiliation.valueOf(affiliation)) {
+	            case outcast:
+	                node.addOutcast(jid);
+	                break;
+	            case publisher:
+	                node.addPublisher(jid);
+	                break;
+	            case owner:
+	                node.addOwner(jid);
+	                break;
+	            case none:
+	                switch(affiliate.getAffiliation()) {
+	                case outcast:
+	                    node.removeOutcast(jid);
+	                    break;
+	                case publisher:
+	                    node.removePublisher(jid);
+	                    break;
+	                case owner:
+	                    node.removeOwner(jid);
+	                    break;
+	                case none:
+	                    break;
+	                }
+            }
+
+            // Log the event
+            webManager.logEvent("changed affiliation between Node: " + nodeID + ", and JID: " + affiliate, "Changed to " + affiliation);
+        }
+        // Done, so redirect
+        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+nodeID+"&updateSuccess=true&affiliateJID="+affiliateJID);
+        return;
+    }
+
+    csrfParam = StringUtils.randomString(15);
+    CookieUtils.setCookie(request, response, "csrf", csrfParam, -1);
+    pageContext.setAttribute("csrf", csrfParam);
+
+    pageContext.setAttribute("node", node);
+    pageContext.setAttribute("affiliate", affiliate);
+    pageContext.setAttribute("affiliations", Affiliation.values());
+    pageContext.setAttribute("owner", owner);
+
+%>
+
+<html>
+    <head>
+        <title><fmt:message key="pubsub.node.affiliates.edit.title"/></title>
+        <c:choose>
+	        <c:when test="${not empty owner and owner.domain eq webManager.serverInfo.XMPPDomain}">
+	            <meta name="subPageID" content="user-pep-node-summary"/>
+	            <meta name="extraParams" content="username=${admin:urlEncode(owner.node)}&nodeID=${admin:urlEncode(node.nodeID)}" />
+	        </c:when>
+	        <c:otherwise>
+	            <meta name="subPageID" content="pubsub-node-affiliates"/>
+	            <meta name="extraParams" content="nodeID=${admin:urlEncode(node.nodeID)}"/>
+	        </c:otherwise>
+	    </c:choose>
+    </head>
+    <body>
+
+	<p>
+	    <fmt:message key="pubsub.node.affiliates.edit.info" />
+	</p>
+
+    <div class="jive-table">
+	    <table cellpadding="3" cellspacing="0" border="0" width="100%">
+		    <thead>
+		        <tr>
+		            <th scope="col"><fmt:message key="pubsub.node.summary.id" /></th>
+		            <th scope="col"><fmt:message key="pubsub.node.affiliates.jid" /></th>
+                    <th scope="col"><fmt:message key="pubsub.node.affiliates.affiliation" /></th>
+		        </tr>
+		    </thead>
+		    <tbody>
+		        <tr>
+		            <td><c:out value="${node.getNodeID()}"/></td>
+		            <td><c:out value="${affiliate.getJID().toBareJID()}"/></td>
+		            <td><c:out value="${affiliate.getAffiliation().name()}"/></td>
+		        </tr>
+		    </tbody>
+	    </table>
+    </div>
+    <br>
+    <br>
+    <p>
+        <fmt:message key="pubsub.node.affiliates.edit.info2" />
+    </p>
+
+    <div class="jive-table">
+        <table cellpadding="3" cellspacing="0" border="0" width="100%">
+            <thead>
+                <tr>
+		            <th scope="col"><fmt:message key="pubsub.node.subscribers.owner" /></th>
+		            <th scope="col"><fmt:message key="pubsub.node.subscribers.resource" /></th>
+		            <th scope="col"><fmt:message key="pubsub.node.subscribers.status" /></th>
+		            <th scope="col"><fmt:message key="pubsub.node.subscribers.expires" /></th>
+                </tr>
+            </thead>
+            <tbody>
+                <c:if test="${empty affiliate.getSubscriptions()}">
+			        <tr>
+			            <td align="center" colspan="4">
+			                <fmt:message key="pubsub.node.affiliates.delete.table.no_subscriptions" />
+			            </td>
+			        </tr>
+                </c:if>
+		        <c:forEach var="subscription" items="${affiliate.getSubscriptions()}">
+			        <tr>
+			            <td>
+			            <c:out value="${subscription.getOwner().toBareJID()}"/>
+			            </td>
+			            <td>
+			            <c:out value="${subscription.getJID().getResource()}"/>
+			            </td>
+			            <td>
+			            <c:out value="${subscription.getState().name()}"/>
+			            </td>
+			            <td>
+			            <fmt:formatDate type="both" dateStyle="medium" timeStyle="short" value="${subscription.getExpire()}" />
+			            </td>
+			        </tr>
+		        </c:forEach>
+            </tbody>
+        </table>
+    </div>
+    <br>
+    <br>
+    <p>
+        <fmt:message key="pubsub.node.affiliates.edit.info3" />
+    </p>
+
+	<form action="pubsub-node-affiliates-edit.jsp">
+	    <input type="hidden" name="csrf" value="${csrf}">
+		<input type="hidden" name="nodeID" value="${node.nodeID}">
+		<input type="hidden" name="owner" value="${owner}">
+		<input type="hidden" name="affiliateJID" value="${affiliate.getJID().toBareJID()}">
+
+		<fieldset>
+
+        <select name="affiliation">
+        <c:forEach var="value" items="${affiliations}">
+            <c:choose>
+            <c:when test="${value eq affiliate.getAffiliation()}">
+                <option value="${value.name()}" selected>${value.name()}</option>
+            </c:when>
+            <c:otherwise>
+                <option value="${value.name()}">${value.name()}</option>
+            </c:otherwise>
+            </c:choose>
+        </c:forEach>
+        </select>
+
+		</fieldset>
+		<br>
+		<br>
+
+	    <input type="submit" name="update" value="<fmt:message key="pubsub.node.affiliates.edit.update" />">
+	    <input type="submit" name="cancel" value="<fmt:message key="global.cancel" />">
+	</form>
+
+    </body>
+</html>

--- a/src/web/pubsub-node-affiliates.jsp
+++ b/src/web/pubsub-node-affiliates.jsp
@@ -1,0 +1,246 @@
+<%@ page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
+                 org.jivesoftware.openfire.pubsub.Node,
+                 org.jivesoftware.openfire.pubsub.NodeAffiliate,
+                 org.jivesoftware.openfire.pubsub.NodeSubscription,
+                 org.jivesoftware.openfire.pubsub.PubSubServiceInfo,
+                 org.jivesoftware.openfire.XMPPServer,
+                 org.jivesoftware.util.ParamUtils,
+                 org.jivesoftware.util.StringUtils,
+                 org.jivesoftware.util.CookieUtils,
+                 org.xmpp.packet.JID,
+                 java.net.URLEncoder,
+                 java.text.DateFormat,
+                 java.util.*"
+    errorPage="error.jsp"
+%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="admin" prefix="admin" %>
+
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
+<% webManager.init(request, response, session, application, out); %>
+
+<%  // Get parameters
+    String nodeID = ParamUtils.getParameter(request,"nodeID");
+	String deleteID = ParamUtils.getParameter(request,"deleteID");
+	String ownerString = ParamUtils.getParameter( request, "owner" );
+	if ( ownerString == null )
+	{
+	    ownerString = ParamUtils.getParameter( request, "username" );
+	}
+	
+	JID owner = null;
+	if (ownerString != null)
+	{
+	    if ( ownerString.contains( "@" ) )
+	    {
+	        owner = new JID( ownerString ).asBareJID();
+	    }
+	    else
+	    {
+	        owner = XMPPServer.getInstance().createJID( ownerString, null );
+	    }
+	}
+    Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+    String csrfParam = ParamUtils.getParameter(request, "csrf");
+
+    if (deleteID != null) {
+        if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
+             deleteID = null;
+        }
+    }
+
+    PubSubServiceInfo pubSubServiceInfo;
+    if ( owner == null )
+    {
+        pubSubServiceInfo = webManager.getPubSubInfo();
+    }
+    else
+    {
+        pubSubServiceInfo = new PEPServiceInfo( owner );
+    }
+    
+    // Load the node object
+    Node node = pubSubServiceInfo.getNode(nodeID);
+    if (node == null) {
+        // The requested node does not exist so return to the list of the existing node
+        response.sendRedirect("pubsub-node-summary.jsp" + (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : ""));
+        return;
+    }
+
+    List<NodeAffiliate> affiliates = new ArrayList<NodeAffiliate>(node.getAllAffiliates());
+
+    Collections.sort(affiliates, new Comparator<NodeAffiliate>() {
+        public int compare(NodeAffiliate affiliate1, NodeAffiliate affiliate2) {
+
+            // Sort by Emum ordinal which gives order: owner, publisher, none, outcast
+            int affiliateComp = affiliate1.getAffiliation().compareTo(affiliate2.getAffiliation());
+
+            //if affiliations match then sort by full JID
+            if(affiliateComp != 0) {
+                return affiliateComp;
+            } else {
+                return affiliate1.getJID().toFullJID().toLowerCase().compareTo(affiliate2.getJID().toFullJID().toLowerCase());
+            }
+
+        }
+    });
+
+    csrfParam = StringUtils.randomString(15);
+    CookieUtils.setCookie(request, response, "csrf", csrfParam, -1);
+    pageContext.setAttribute("csrf", csrfParam);
+
+    pageContext.setAttribute("node", node);
+    pageContext.setAttribute("owner", owner );
+    pageContext.setAttribute("affiliates", affiliates);
+%>
+
+<html>
+<head>
+	<title><fmt:message key="pubsub.node.affiliates.title"/></title>
+	<c:choose>
+	    <c:when test="${not empty owner and owner.domain eq webManager.serverInfo.XMPPDomain}">
+	        <meta name="subPageID" content="user-pep-node-summary"/>
+	        <meta name="extraParams" content="username=${admin:urlEncode(owner.node)}&nodeID=${admin:urlEncode(node.nodeID)}" />
+	    </c:when>
+	    <c:otherwise>
+	        <meta name="subPageID" content="pubsub-node-affiliates"/>
+	        <meta name="extraParams" content="nodeID=${admin:urlEncode(node.nodeID)}"/>
+	    </c:otherwise>
+	</c:choose>
+</head>
+<body>
+
+    <p>
+    <fmt:message key="pubsub.node.summary.table.info" />
+    </p>
+
+    <c:if test="${param.deleteSuccess}">
+        <div class="jive-success">
+        <table cellpadding="0" cellspacing="0" border="0">
+        <tbody>
+            <tr><td class="jive-icon"><img src="images/success-16x16.gif" width="16" height="16" border="0" alt=""></td>
+            <td class="jive-icon-label">
+            <fmt:message key="pubsub.node.affiliates.deleted">
+                <fmt:param value="${param.affiliateJID}"/>
+            </fmt:message>
+            </td></tr>
+        </tbody>
+        </table>
+        </div><br>
+    </c:if>
+
+    <c:if test="${param.updateSuccess}">
+        <div class="jive-success">
+        <table cellpadding="0" cellspacing="0" border="0">
+        <tbody>
+            <tr><td class="jive-icon"><img src="images/success-16x16.gif" width="16" height="16" border="0" alt=""></td>
+            <td class="jive-icon-label">
+            <fmt:message key="pubsub.node.affiliates.updated">
+                <fmt:param value="${param.affiliateJID}"/>
+            </fmt:message>
+            </td></tr>
+        </tbody>
+        </table>
+        </div><br>
+    </c:if>
+
+    <div class="jive-table">
+    <table cellpadding="0" cellspacing="0" border="0" width="100%">
+    <thead>
+        <tr>
+            <th scope="col"><fmt:message key="pubsub.node.summary.id" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.name" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.description" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.items" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.affiliates" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.subscribers" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.created" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.modified" /></th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><c:out value="${node.getNodeID()}"/></td>
+            <td><c:out value="${node.getName()}"/></td>
+            <td><c:out value="${node.getDescription()}"/></td>
+            <td><c:out value="${node.getPublishedItems().size()}"/></td>
+            <td><c:out value="${node.getAllAffiliates().size()}"/></td>
+            <td><c:out value="${node.getAllSubscriptions().size()}"/></td>
+            <td><fmt:formatDate type="both" dateStyle="medium" timeStyle="short" value="${node.getCreationDate()}" /></td>
+            <td><fmt:formatDate type="both" dateStyle="medium" timeStyle="short" value="${node.getModificationDate()}" /></td>
+        </tr>
+    </tbody>
+    </table>
+    </div>
+
+    <br>
+    <p>
+        <fmt:message key="pubsub.node.affiliates.table.info" />
+    </p>
+
+    <div class="jive-table">
+    <table cellpadding="0" cellspacing="0" border="0" width="100%">
+    <thead>
+        <tr>
+            <th scope="col"><fmt:message key="pubsub.node.affiliates.jid" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.affiliates.affiliation" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.affiliates.subscriptions" /></th>
+            <th scope="col"><fmt:message key="global.edit" /></th>
+            <th scope="col"><fmt:message key="global.delete" /></th>
+        </tr>
+    </thead>
+    <tbody>
+        <c:if test="${empty affiliates}">
+        <tr>
+            <td align="center" colspan="4">
+                <fmt:message key="pubsub.node.affiliates.table.no_affiliates" />
+            </td>
+        </tr>
+        </c:if>
+        <c:forEach var="affiliate" items="${affiliates}">
+        <tr>
+            <td>
+            <c:out value="${affiliate.getJID().toBareJID()}"/>
+            </td>
+            <td>
+            <c:out value="${affiliate.getAffiliation().name()}"/>
+            </td>
+            <td width="1%" align="center">
+                <c:url value="pubsub-node-subscribers.jsp" var="url">
+                    <c:param name="nodeID" value="${node.getNodeID()}" />
+                    <c:param name="owner" value="${owner}" />
+                </c:url>
+                <a href="${url}">
+                     <c:out value="${affiliate.getSubscriptions().size()}"/>
+                </a>
+            </td>
+            <td width="1%" align="center">
+                <c:url value="pubsub-node-affiliates-edit.jsp" var="url">
+                    <c:param name="nodeID" value="${node.getNodeID()}" />
+                    <c:param name="owner" value="${owner}" />
+                    <c:param name="affiliateJID" value="${affiliate.getJID().toBareJID()}" />
+                </c:url>
+                <a href="${url}" title="<fmt:message key="global.click_edit" />">
+                    <img src="images/edit-16x16.gif" width="16" height="16" border="0" alt="">
+                </a>
+            </td>
+            <td width="1%" align="center" style="border-right:1px #ccc solid;">
+	            <c:url value="pubsub-node-affiliates-delete.jsp" var="url">
+	                <c:param name="nodeID" value="${node.getNodeID()}" />
+                    <c:param name="owner" value="${owner}" />
+                    <c:param name="affiliateJID" value="${affiliate.getJID().toBareJID()}" />
+	            </c:url>
+	            <a href="${url}" title="<fmt:message key="global.click_delete" />">
+	                <img src="images/delete-16x16.gif" width="16" height="16" border="0" alt="">
+	            </a>
+	        </td>
+        </tr>
+        </c:forEach>
+    </tbody>
+    </table>
+    </div>
+
+    </body>
+</html>

--- a/src/web/pubsub-node-delete.jsp
+++ b/src/web/pubsub-node-delete.jsp
@@ -82,7 +82,7 @@
             webManager.logEvent("destroyed PubSub Node " + nodeID, "reason = " + reason );
         }
         // Done, so redirect
-        response.sendRedirect("pubsub-node-summary.jsp?deletesuccess=true"
+        response.sendRedirect("pubsub-node-summary.jsp?deleteSuccess=true"
             + (owner != null ? "&owner=" + URLEncoder.encode( owner.toBareJID(), "UTF-8") : "") );
         return;
     }

--- a/src/web/pubsub-node-delete.jsp
+++ b/src/web/pubsub-node-delete.jsp
@@ -1,19 +1,19 @@
-<%@ page import="org.jivesoftware.openfire.pubsub.Node,
+<%@ page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
+                 org.jivesoftware.openfire.pubsub.Node,
+                 org.jivesoftware.openfire.pubsub.PubSubServiceInfo,
+                 org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.util.CookieUtils,
-                 org.jivesoftware.util.ParamUtils"
+                 org.jivesoftware.util.ParamUtils,
+                 org.jivesoftware.util.StringUtils,
+                 org.xmpp.packet.JID,
+                 java.net.URLEncoder"
     errorPage="error.jsp"
 %>
-<%@ page import="org.jivesoftware.util.StringUtils" %>
-<%@ page import="java.net.URLDecoder" %>
-<%@ page import="org.xmpp.packet.JID" %>
-<%@ page import="org.jivesoftware.openfire.pep.PEPServiceInfo" %>
-<%@ page import="org.jivesoftware.openfire.pubsub.PubSubServiceInfo" %>
-<%@ page import="java.net.URLEncoder" %>
-<%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="admin" prefix="admin" %>
+
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
 <% webManager.init(request, response, session, application, out ); %>
 
@@ -29,14 +29,13 @@
     JID owner = null;
     if (ownerString != null)
     {
-        final String ownerValue = URLDecoder.decode( ownerString, "UTF-8" );
-        if ( ownerValue.contains( "@" ) )
+        if ( ownerString.contains( "@" ) )
         {
-            owner = new JID( ownerValue ).asBareJID();
+            owner = new JID( ownerString ).asBareJID();
         }
         else
         {
-            owner = XMPPServer.getInstance().createJID( ownerValue, null );
+            owner = XMPPServer.getInstance().createJID( ownerString, null );
         }
     }
 
@@ -57,7 +56,7 @@
 
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("pubsub-node-summary.jsp");
+        response.sendRedirect("pubsub-node-summary.jsp"+ (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : ""));
         return;
     }
 
@@ -83,11 +82,13 @@
             webManager.logEvent("destroyed PubSub Node " + nodeID, "reason = " + reason );
         }
         // Done, so redirect
-        response.sendRedirect("pubsub-node-summary.jsp?deletesuccess=true&owner=" + (owner != null ? URLEncoder.encode( owner.toBareJID(), "UTF-8") : "") );
+        response.sendRedirect("pubsub-node-summary.jsp?deletesuccess=true"
+            + (owner != null ? "&owner=" + URLEncoder.encode( owner.toBareJID(), "UTF-8") : "") );
         return;
     }
 
     pageContext.setAttribute("node", node);
+    pageContext.setAttribute("owner", owner);
 
 %>
 
@@ -97,11 +98,11 @@
         <c:choose>
             <c:when test="${not empty owner and owner.domain eq webManager.serverInfo.XMPPDomain}">
                 <meta name="subPageID" content="user-pep-node-summary"/>
-                <meta name="extraParams" content="username=${admin:urlEncode(owner.node)}&nodeID=${node.nodeID}" />
+                <meta name="extraParams" content="username=${admin:urlEncode(owner.node)}&nodeID=${admin:urlEncode(node.nodeID)}" />
             </c:when>
             <c:otherwise>
                 <meta name="subPageID" content="pubsub-node-delete"/>
-                <meta name="extraParams" content="nodeID=${node.nodeID}"/>
+                <meta name="extraParams" content="nodeID=${admin:urlEncode(node.nodeID)}"/>
             </c:otherwise>
         </c:choose>
     </head>
@@ -118,6 +119,7 @@
 <form action="pubsub-node-delete.jsp">
     <input type="hidden" name="csrf" value="${csrf}">
 	<input type="hidden" name="nodeID" value="${node.nodeID}">
+	<input type="hidden" name="owner" value="${owner}">
 
 <fieldset>
     <legend><fmt:message key="pubsub.node.delete.details_title" /></legend>

--- a/src/web/pubsub-node-items.jsp
+++ b/src/web/pubsub-node-items.jsp
@@ -141,6 +141,7 @@
             <th scope="col"><fmt:message key="pubsub.node.summary.name" /></th>
             <th scope="col"><fmt:message key="pubsub.node.summary.description" /></th>
             <th scope="col"><fmt:message key="pubsub.node.summary.items" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.affiliates" /></th>
             <th scope="col"><fmt:message key="pubsub.node.summary.subscribers" /></th>
             <th scope="col"><fmt:message key="pubsub.node.summary.created" /></th>
             <th scope="col"><fmt:message key="pubsub.node.summary.modified" /></th>
@@ -152,6 +153,7 @@
             <td><c:out value="${node.getName()}"/></td>
             <td><c:out value="${node.getDescription()}"/></td>
             <td><c:out value="${node.getPublishedItems().size()}"/></td>
+            <td><c:out value="${node.getAllAffiliates().size()}"/></td>
             <td><c:out value="${node.getAllSubscriptions().size()}"/></td>
             <td><fmt:formatDate type="both" dateStyle="medium" timeStyle="short" value="${node.getCreationDate()}" /></td>
             <td><fmt:formatDate type="both" dateStyle="medium" timeStyle="short" value="${node.getModificationDate()}" /></td>
@@ -177,6 +179,13 @@
         </tr>
     </thead>
     <tbody>
+        <c:if test="${empty node.getPublishedItems()}">
+        <tr>
+            <td align="center" colspan="5">
+                <fmt:message key="pubsub.node.items.table.no_items" />
+            </td>
+        </tr>
+        </c:if>
         <c:forEach var="item" items="${node.getPublishedItems()}">
         <tr>
             <td>

--- a/src/web/pubsub-node-subscribers.jsp
+++ b/src/web/pubsub-node-subscribers.jsp
@@ -137,6 +137,7 @@
             <th scope="col"><fmt:message key="pubsub.node.summary.name" /></th>
             <th scope="col"><fmt:message key="pubsub.node.summary.description" /></th>
             <th scope="col"><fmt:message key="pubsub.node.summary.items" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.affiliates" /></th>
             <th scope="col"><fmt:message key="pubsub.node.summary.subscribers" /></th>
             <th scope="col"><fmt:message key="pubsub.node.summary.created" /></th>
             <th scope="col"><fmt:message key="pubsub.node.summary.modified" /></th>
@@ -148,6 +149,7 @@
             <td><c:out value="${node.getName()}"/></td>
             <td><c:out value="${node.getDescription()}"/></td>
             <td><c:out value="${node.getPublishedItems().size()}"/></td>
+            <td><c:out value="${node.getAllAffiliates().size()}"/></td>
             <td><c:out value="${node.getAllSubscriptions().size()}"/></td>
             <td><fmt:formatDate type="both" dateStyle="medium" timeStyle="short" value="${node.getCreationDate()}" /></td>
             <td><fmt:formatDate type="both" dateStyle="medium" timeStyle="short" value="${node.getModificationDate()}" /></td>
@@ -167,12 +169,21 @@
         <tr>
             <th scope="col"><fmt:message key="pubsub.node.subscribers.owner" /></th>
             <th scope="col"><fmt:message key="pubsub.node.subscribers.resource" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.subscribers.affiliation" /></th>
             <th scope="col"><fmt:message key="pubsub.node.subscribers.status" /></th>
             <th scope="col"><fmt:message key="pubsub.node.subscribers.expires" /></th>
             <th scope="col"><fmt:message key="global.delete" /></th>
         </tr>
     </thead>
     <tbody>
+        <c:if test="${empty node.getAllSubscriptions()}">
+        <tr>
+            <td align="center" colspan="6">
+                <fmt:message key="pubsub.node.subscribers.table.no_subscribers" />
+            </td>
+        </tr>
+        </c:if>
+
         <c:forEach var="subscription" items="${node.getAllSubscriptions()}">
         <tr>
             <td>
@@ -180,6 +191,9 @@
             </td>
             <td>
             <c:out value="${subscription.getJID().getResource()}"/>
+            </td>
+            <td>
+            <c:out value="${subscription.getAffiliate().getAffiliation().name()}"/>
             </td>
             <td>
             <c:out value="${subscription.getState().name()}"/>

--- a/src/web/pubsub-node-summary.jsp
+++ b/src/web/pubsub-node-summary.jsp
@@ -1,21 +1,21 @@
-<%@ page import="org.jivesoftware.openfire.pubsub.Node,
+<%@ page import="org.jivesoftware.openfire.pep.PEPService,
+                 org.jivesoftware.openfire.pep.PEPServiceInfo,
+                 org.jivesoftware.openfire.pep.PEPServiceManager,
+                 org.jivesoftware.openfire.pubsub.Node,
                  org.jivesoftware.openfire.pubsub.PubSubServiceInfo,
+                 org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.util.ParamUtils,
-                 java.util.Collections"
+                 org.xmpp.packet.JID,
+                 java.util.Collections,
+                 java.util.Comparator,
+                 java.util.List"
     errorPage="error.jsp"
 %>
-<%@ page import="java.util.Comparator" %>
-<%@ page import="java.util.List" %>
-<%@ page import="org.xmpp.packet.JID" %>
-<%@ page import="org.jivesoftware.openfire.pep.PEPServiceInfo" %>
-<%@ page import="java.net.URLDecoder" %>
-<%@ page import="org.jivesoftware.openfire.XMPPServer" %>
-<%@ page import="org.jivesoftware.openfire.pep.PEPService" %>
-<%@ page import="org.jivesoftware.openfire.pep.PEPServiceManager" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="admin" prefix="admin" %>
+
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager"  />
 <% webManager.init(request, response, session, application, out ); %>
 
@@ -30,14 +30,13 @@
     JID owner = null;
     if (ownerString != null)
     {
-        final String ownerValue = URLDecoder.decode( ownerString, "UTF-8" );
-        if ( ownerValue.contains( "@" ) )
+        if ( ownerString.contains( "@" ) )
         {
-            owner = new JID( ownerValue ).asBareJID();
+            owner = new JID( ownerString ).asBareJID();
         }
         else
         {
-            owner = XMPPServer.getInstance().createJID( ownerValue, null );
+            owner = XMPPServer.getInstance().createJID( ownerString, null );
         }
     }
 
@@ -103,7 +102,7 @@
         <c:choose>
             <c:when test="${not empty owner and owner.domain eq webManager.serverInfo.XMPPDomain}">
                 <meta name="subPageID" content="user-pep-node-summary"/>
-                <meta name="extraParams" content="username=${admin:urlEncode( owner.node)}" />
+                <meta name="extraParams" content="username=${admin:urlEncode(owner.node)}" />
             </c:when>
             <c:otherwise>
                 <meta name="pageID" content="pubsub-node-summary"/>
@@ -148,7 +147,7 @@
     <c:forEach begin="1" end="${numPages}" varStatus="loop">
         <c:url value="pubsub-node-summary.jsp" var="url">
             <c:param name="start" value="${(loop.index-1)*range}" />
-            <c:param name="owner" value="${not empty owner ? admin:urlEncode(owner) : ''}"/>
+            <c:param name="owner" value="${owner}"/>
         </c:url>
         <a href="${url}" class="${ loop.index == curPage ? 'jive-current' : ''}">
             <c:out value="${loop.index}"/>
@@ -202,7 +201,7 @@
         <td width="1%" align="center">
             <c:url value="pubsub-node-items.jsp" var="url">
                 <c:param name="nodeID" value="${node.getNodeID()}" />
-                <c:param name="owner" value="${not empty owner ? admin:urlEncode(owner) : ''}" />
+                <c:param name="owner" value="${owner}" />
             </c:url>
             <a href="${url}">
                 <c:out value="${node.getPublishedItems().size()}" />
@@ -211,7 +210,7 @@
         <td width="1%" align="center">
             <c:url value="pubsub-node-subscribers.jsp" var="url">
                 <c:param name="nodeID" value="${node.getNodeID()}" />
-                <c:param name="owner" value="${not empty owner ? admin:urlEncode(owner) : ''}" />
+                <c:param name="owner" value="${owner}" />
             </c:url>
             <a href="${url}">
                 <c:out value="${node.getAllSubscriptions().size()}" />
@@ -220,7 +219,7 @@
         <td width="1%" align="center" style="border-right:1px #ccc solid;">
             <c:url value="pubsub-node-delete.jsp" var="url">
                 <c:param name="nodeID" value="${node.getNodeID()}" />
-                <c:param name="owner" value="${not empty owner ? admin:urlEncode(owner) : ''}" />
+                <c:param name="owner" value="${owner}" />
             </c:url>
             <a href="${url}" title="<fmt:message key="global.click_delete" />">
                 <img src="images/delete-16x16.gif" width="16" height="16" border="0" alt="">
@@ -241,7 +240,7 @@
     <c:forEach begin="1" end="${numPages}" varStatus="loop">
         <c:url value="pubsub-node-summary.jsp" var="url">
             <c:param name="start" value="${(loop.index-1)*range}" />
-            <c:param name="owner" value="${not empty owner ? admin:urlEncode(owner) : ''}" />
+            <c:param name="owner" value="${owner}" />
         </c:url>
         <a href="${url}" class="${ loop.index == curPage ? 'jive-current' : ''}">
             <c:out value="${loop.index}"/>

--- a/src/web/pubsub-node-summary.jsp
+++ b/src/web/pubsub-node-summary.jsp
@@ -115,7 +115,7 @@
 <fmt:message key="pubsub.node.summary.info" />
 </p>
 
-<c:if test="${param.deletesuccess}">
+<c:if test="${param.deleteSuccess}">
     <div class="jive-success">
     <table cellpadding="0" cellspacing="0" border="0">
     <tbody>
@@ -169,6 +169,7 @@
         <th nowrap><fmt:message key="pubsub.node.summary.name" /></th>
         <th nowrap><fmt:message key="pubsub.node.summary.description" /></th>
         <th nowrap><fmt:message key="pubsub.node.summary.items" /></th>
+        <th nowrap><fmt:message key="pubsub.node.summary.affiliates" /></th>
         <th nowrap><fmt:message key="pubsub.node.summary.subscribers" /></th>
         <th nowrap><fmt:message key="global.delete" /></th>
     </tr>
@@ -178,7 +179,7 @@
 <c:if test="${nodeCount lt 1}">
     <tr>
         <td align="center" colspan="7">
-            <fmt:message key="pubsub.node.summary.no_nodes" />
+            <fmt:message key="pubsub.node.summary.table.no_nodes" />
         </td>
     </tr>
 </c:if>
@@ -192,7 +193,7 @@
         <td width="1%" valign="middle">
             <c:out value="${node.getNodeID()}"/>
         </td>
-        <td width="1%" valign="middle">
+        <td nowrap width="1%" valign="middle">
             <c:out value="${node.getName()}"/>
         </td>
         <td valign="middle">
@@ -205,6 +206,15 @@
             </c:url>
             <a href="${url}">
                 <c:out value="${node.getPublishedItems().size()}" />
+            </a>
+        </td>
+        <td width="1%" align="center">
+            <c:url value="pubsub-node-affiliates.jsp" var="url">
+                <c:param name="nodeID" value="${node.getNodeID()}" />
+                <c:param name="owner" value="${owner}" />
+            </c:url>
+            <a href="${url}">
+                <c:out value="${node.getAllAffiliates().size()}" />
             </a>
         </td>
         <td width="1%" align="center">


### PR DESCRIPTION
* Page for viewing existing affiliates
* Ability to delete affiliates (will remove all subscriptions)
* Ability to edit the affiliation type (subscriptions are updated
  as appropriate)

Rebased on top of the PEP stuff so works there as well.

Note: I am not proud of the nested switch statement in pubsub-node-affiliates-edit.jsp, but it is just a reflection of how the current affiliate implementation works and I didn't want to mess with that.