### PR TITLE
OF-35 Node config and Service config pages

### DIFF
--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -856,6 +856,7 @@ global.test=Test
 global.click_test=Click to test...
 global.csrf.failed=CSRF Error: No changes made, you'll need to retry.
 global.update=Update
+global.remove=Remove
 
 # Group Chat Service Properties Page
 
@@ -2778,9 +2779,7 @@ pubsub.form.user=User
 
 pubsub.form.not_valid="{0}" is not a valid {1}.
 pubsub.form.already_in_list={0} "{1}" already in list.
-pubsub.form.no_data=No values set
-
-pubsub.form.add=Add {0}:
+pubsub.form.action=Action
 
 
 # Plugins Admin Page

--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -553,6 +553,8 @@ tab.server.descr=Click to manage server settings
         sidebar.media-proxy=Media Proxy
         sidebar.media-proxy.descr=Click to view media proxy settings.
     sidebar.sidebar-pubsub=PubSub
+        sidebar.pubsub-service-summary=PubSub Service
+        sidebar.pubsub-service-summary.descr=Click to manage PubSub service
         sidebar.pubsub-node-summary=Node Summary
         sidebar.pubsub-node-summary.descr=Click to manage PubSub nodes
             sidebar.sidebar-node-options=Node Options
@@ -562,6 +564,8 @@ tab.server.descr=Click to manage server settings
                 sidebar.pubsub-node-affiliates.descr=Click to view the node affiliates
                 sidebar.pubsub-node-subscribers=Node Subscribers
                 sidebar.pubsub-node-subscribers.descr=Click to view the node&#39;s subscribers
+                sidebar.pubsub-node-edit=Edit Node
+                sidebar.pubsub-node-edit.descr=Click to edit the node
                 sidebar.pubsub-node-delete=Delete Node
                 sidebar.pubsub-node-delete.descr=Click to delete the node
 tab.tab-users=Users/Groups
@@ -851,6 +855,7 @@ global.unlimited=Unlimited
 global.test=Test
 global.click_test=Click to test...
 global.csrf.failed=CSRF Error: No changes made, you'll need to retry.
+global.update=Update
 
 # Group Chat Service Properties Page
 
@@ -2660,6 +2665,7 @@ pubsub.node.summary.sorted_id=Sorted by Node ID
 pubsub.node.summary.id=Node ID
 pubsub.node.summary.name=Name
 pubsub.node.summary.description=Description
+pubsub.node.summary.creator=Creator
 pubsub.node.summary.items=Items
 pubsub.node.summary.affiliates=Affiliates
 pubsub.node.summary.subscribers=Subscribers
@@ -2670,6 +2676,18 @@ pubsub.node.summary.created=Created On
 pubsub.node.summary.modified=Last Modified
 
 pubsub.node.summary.deleted=Node deleted successfully
+
+# PubSub Edit Node
+
+pubsub.node.edit.title=Edit Node
+pubsub.node.edit.info=Use the form to edit configuration for node
+pubsub.node.edit.details_title=Details
+pubsub.node.edit.updated=Node configuration successfully updated
+
+pubsub.node.edit.detail.roster_groups_allowed=This information is only used when using the 'Roster' access model.
+pubsub.node.edit.detail.owner=Users with owner permission on the node.
+pubsub.node.edit.detail.publisher=Users with publisher permission on the node.
+
 
 # PubSub Delete Node
 
@@ -2705,7 +2723,6 @@ pubsub.node.affiliates.table.no_affiliates=The Node has no affiliates.
 pubsub.node.affiliates.deleted=Deleted affiliation with {0} from the node.
 pubsub.node.affiliates.updated=Updated affiliation for {0}.
 
-
 pubsub.node.affiliates.delete.title=Delete Affiliate
 pubsub.node.affiliates.delete.info=Affiliation details:
 pubsub.node.affiliates.delete.info2=Current subscriptions for this affiliation (These will also be deleted):
@@ -2731,6 +2748,41 @@ pubsub.node.subscribers.expires=Expires
 pubsub.node.subscribers.table.info=Current node subscribers are listed in the following table:
 pubsub.node.subscribers.table.no_subscribers=The Node has no subscribers.
 pubsub.node.subscribers.deleted=Deleted subscription owned by {0} from the node.
+
+# PubSub service tab
+
+pubsub.service.summary.title=PubSub Service Configuration
+pubsub.service.summary.updated=Service configuration updated successfully
+pubsub.service.summary.info=Use the form below to update service settings.
+
+
+pubsub.service.form.serviceEnabled=Service Enabled
+
+pubsub.service.form.multipleSubscriptionsEnabled=Multiple Subscriptions Enabled
+pubsub.service.form.detail.multipleSubscriptionsEnabled=Flag that indicates if a user may have more than one subscription with the node. When multiple subscriptions is enabled each subscription request, event notification and unsubscription request should include a subid attribute.
+
+pubsub.service.form.nodeCreationRestricted=Node Creation Restricted
+pubsub.service.form.detail.nodeCreationRestricted=A true value means that not anyone can create a node, only the JIDs listed in 'Allowed to Create' are allowed to create nodes.
+
+pubsub.service.form.allowedToCreate=Allowed to Create
+pubsub.service.form.detail.allowedToCreate=Users that are allowed to create nodes. An empty list means that anyone can create nodes.
+
+pubsub.service.form.sysadmins=System Administrators
+pubsub.service.form.detail.sysadmins=Users that are system administrators of the PubSub service. A sysadmin has the same permissions as a node owner.
+
+# PubSub generated form
+
+pubsub.form.clearSelection=Clear Selection
+
+pubsub.form.group=Group
+pubsub.form.user=User
+
+pubsub.form.not_valid="{0}" is not a valid {1}.
+pubsub.form.already_in_list={0} "{1}" already in list.
+pubsub.form.no_data=No values set
+
+pubsub.form.add=Add {0}:
+
 
 # Plugins Admin Page
 

--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -2734,7 +2734,6 @@ pubsub.node.affiliates.edit.title=Edit Affiliate
 pubsub.node.affiliates.edit.info=Current Affiliation details:
 pubsub.node.affiliates.edit.info2=Current subscriptions for this affiliation:
 pubsub.node.affiliates.edit.info3=Enter new affiliation:
-pubsub.node.affiliates.edit.update=Update
 
 
 # PubSub Node Subscribers

--- a/src/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -1043,6 +1043,8 @@ public abstract class Node {
         if (isEditing) {
             formField.setType(FormField.Type.list_single);
             formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.itemreply"));
+            formField.addOption(null, ItemReplyPolicy.owner.name());
+            formField.addOption(null, ItemReplyPolicy.publisher.name());
         }
         if (replyPolicy != null) {
             formField.addValue(replyPolicy.name());

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -406,7 +406,7 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
         // Load the list of JIDs that are sysadmins of the PubSub service
         String property = JiveGlobals.getProperty("xmpp.pubsub.sysadmin.jid");
         String[] jids;
-        if (property != null) {
+        if (property != null && !property.isEmpty()) {
             jids = property.split(",");
             for (String jid : jids) {
                 sysadmins.add(jid.trim().toLowerCase());
@@ -415,7 +415,7 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
         nodeCreationRestricted = JiveGlobals.getBooleanProperty("xmpp.pubsub.create.anyone", false);
         // Load the list of JIDs that are allowed to create nodes
         property = JiveGlobals.getProperty("xmpp.pubsub.create.jid");
-        if (property != null) {
+        if (property != null && !property.isEmpty()) {
             jids = property.split(",");
             for (String jid : jids) {
                 allowedToCreate.add(jid.trim().toLowerCase());

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -315,17 +315,27 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
         return sysadmins;
     }
 
+    public void setSysadmins(Collection<String> userJIDs) {
+        sysadmins.clear();
+        for (String JID : userJIDs) {
+            sysadmins.add(JID.trim().toLowerCase());
+        }
+        updateSysadminProperty();
+    }
+
     public void addSysadmin(String userJID) {
         sysadmins.add(userJID.trim().toLowerCase());
         // Update the config.
-        String[] jids = new String[sysadmins.size()];
-        jids = sysadmins.toArray(jids);
-        JiveGlobals.setProperty("xmpp.pubsub.sysadmin.jid", fromArray(jids));
+        updateSysadminProperty();
     }
 
     public void removeSysadmin(String userJID) {
         sysadmins.remove(userJID.trim().toLowerCase());
         // Update the config.
+        updateSysadminProperty();
+    }
+
+    private void updateSysadminProperty() {
         String[] jids = new String[sysadmins.size()];
         jids = sysadmins.toArray(jids);
         JiveGlobals.setProperty("xmpp.pubsub.sysadmin.jid", fromArray(jids));
@@ -345,19 +355,29 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
         JiveGlobals.setProperty("xmpp.pubsub.create.anyone", Boolean.toString(nodeCreationRestricted));
     }
 
+    public void setUserAllowedToCreate(Collection<String> userJIDs) {
+        allowedToCreate.clear();
+        for (String JID : userJIDs) {
+            allowedToCreate.add(JID.trim().toLowerCase());
+        }
+        updateUserAllowedToCreateProperty();
+    }
+
     public void addUserAllowedToCreate(String userJID) {
         // Update the list of allowed JIDs to create nodes.
         allowedToCreate.add(userJID.trim().toLowerCase());
         // Update the config.
-        String[] jids = new String[allowedToCreate.size()];
-        jids = allowedToCreate.toArray(jids);
-        JiveGlobals.setProperty("xmpp.pubsub.create.jid", fromArray(jids));
+        updateUserAllowedToCreateProperty();
     }
 
     public void removeUserAllowedToCreate(String userJID) {
         // Update the list of allowed JIDs to create nodes.
         allowedToCreate.remove(userJID.trim().toLowerCase());
         // Update the config.
+        updateUserAllowedToCreateProperty();
+    }
+
+    private void updateUserAllowedToCreateProperty() {
         String[] jids = new String[allowedToCreate.size()];
         jids = allowedToCreate.toArray(jids);
         JiveGlobals.setProperty("xmpp.pubsub.create.jid", fromArray(jids));

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubServiceInfo.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubServiceInfo.java
@@ -149,40 +149,37 @@ public class PubSubServiceInfo {
         for (FormField field : form.getFields()) {
 
             if (excludedFields == null || !excludedFields.contains(field.getVariable())) {
+
+                FormField completedField = completedForm.addField(field.getVariable(), field.getLabel(), field.getType());
+
                 switch (field.getType()) {
                 case boolean_type:
-                    FormField boolField = completedForm.addField(field.getVariable(), field.getLabel(),
-                            field.getType());
-                    boolField.addValue(ParamUtils.getBooleanParameter(request, field.getVariable()));
+                    completedField.addValue(ParamUtils.getBooleanParameter(request, field.getVariable()));
                     break;
                 case jid_multi:
-                    FormField multiJidField = completedForm.addField(field.getVariable(), field.getLabel(),
-                            field.getType());
                     for (String param : ParamUtils.getParameters(request, field.getVariable())) {
-                        multiJidField.addValue(param);
+                        completedField.addValue(param);
                     }
                     break;
                 case list_multi:
-                    FormField multiListField = completedForm.addField(field.getVariable(), field.getLabel(),
-                            field.getType());
                     for (String param : ParamUtils.getParameters(request, field.getVariable())) {
-                        multiListField.addValue(param);
+                        completedField.addValue(param);
                     }
                     break;
                 case list_single:
-                    FormField listField = completedForm.addField(field.getVariable(), field.getLabel(),
-                            field.getType());
-                    listField.addValue(ParamUtils.getParameter(request, field.getVariable()));
+                    completedField.addValue(ParamUtils.getParameter(request, field.getVariable()));
                     break;
                 case text_single:
-                    FormField textField = completedForm.addField(field.getVariable(), field.getLabel(),
-                            field.getType());
-                    textField.addValue(ParamUtils.getParameter(request, field.getVariable()));
+                    completedField.addValue(ParamUtils.getParameter(request, field.getVariable()));
                     break;
                 default:
-                    completedForm.addField(field.getVariable(), field.getLabel(), field.getType());
                     break;
                 }
+
+                for(FormField.Option option: field.getOptions()) {
+                    completedField.addOption(option.getLabel(), option.getValue());
+                }
+
             }
         }
         return completedForm;

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubServiceInfo.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubServiceInfo.java
@@ -1,45 +1,277 @@
 package org.jivesoftware.openfire.pubsub;
 
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.group.Group;
+import org.jivesoftware.openfire.group.GroupManager;
+import org.jivesoftware.openfire.group.GroupNotFoundException;
+import org.jivesoftware.openfire.user.UserManager;
+import org.jivesoftware.util.LocaleUtils;
+import org.jivesoftware.util.ParamUtils;
+import org.xmpp.forms.DataForm;
+import org.xmpp.forms.FormField;
+import org.xmpp.packet.JID;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
-public class PubSubServiceInfo
-{
-	private PubSubService pubSubService;
+import javax.servlet.http.HttpServletRequest;
 
-	public PubSubServiceInfo( PubSubService pubSubService ) {
-	    if ( pubSubService == null )
-        {
-            throw new IllegalArgumentException( "Argument 'pubSubService' cannot be null." );
+public class PubSubServiceInfo {
+    private PubSubService pubSubService;
+
+    private PubSubModule pubSubModule;
+    private XMPPServer xmppServer;
+    private UserManager userManager;
+    private GroupManager groupManager;
+
+    private String labelPreFix = "pubsub.service.form.";
+    private String variablePreFix = "pubsub#";
+
+    public PubSubServiceInfo(PubSubService pubSubService) {
+        if (pubSubService == null) {
+            throw new IllegalArgumentException("Argument 'pubSubService' cannot be null.");
         }
         this.pubSubService = pubSubService;
-	}
 
-	public Collection<Node> getNodes() {
-		return pubSubService.getNodes();
-	}
+        xmppServer = XMPPServer.getInstance();
+        pubSubModule = xmppServer.getPubSubModule();
+        groupManager = GroupManager.getInstance();
+        userManager = xmppServer.getUserManager();
+    }
 
-	public Node getNode(String nodeID) {
-		return pubSubService.getNode(nodeID);
-	}
+    public Collection<Node> getNodes() {
+        return pubSubService.getNodes();
+    }
 
-	public List<Node> getLeafNodes() {
-		List<Node> leafNodes = new ArrayList<Node>();
-		for(Node node : pubSubService.getNodes()) {
-			if ( ! node.isCollectionNode() ) {
-				leafNodes.add(node);
-			}
-		}
-		return leafNodes;
-	}
+    public Node getNode(String nodeID) {
+        return pubSubService.getNode(nodeID);
+    }
 
-	public CollectionNode getRootCollectionNode() {
-		return pubSubService.getRootCollectionNode();
-	}
+    public List<Node> getLeafNodes() {
+        List<Node> leafNodes = new ArrayList<Node>();
+        for (Node node : pubSubService.getNodes()) {
+            if (!node.isCollectionNode()) {
+                leafNodes.add(node);
+            }
+        }
+        return leafNodes;
+    }
 
-	public String getServiceID() {
-		return pubSubService.getServiceID();
-	}
+    public CollectionNode getRootCollectionNode() {
+        return pubSubService.getRootCollectionNode();
+    }
+
+    public String getServiceID() {
+        return pubSubService.getServiceID();
+    }
+
+    /*
+     * Returns a DataForm for configuring the pubsub service. Configurable fields
+     * 'serviceEnabled', 'nodeCreationRestricted', 'allowedToCreate', 'sysadmins'
+     * Some fields which appear to be configurable on the PubSubService interface
+     * are not configurable due to the PubSubModule implementation these include:
+     * 'MultipleSubscriptionsEnabled', 'InstantNodeSupported',
+     * 'CollectionNodesSupported' they are therefore not included on the form.
+     */
+    public DataForm getServiceConfigurationForm() {
+
+        DataForm form = new DataForm(DataForm.Type.result);
+
+        FormField formField = form.addField();
+        formField.setVariable(variablePreFix + "serviceEnabled");
+        formField.setType(FormField.Type.boolean_type);
+        formField.setLabel(LocaleUtils.getLocalizedString(labelPreFix + "serviceEnabled"));
+        formField.addValue(pubSubModule.isServiceEnabled());
+
+        formField = form.addField();
+        formField.setVariable(variablePreFix + "nodeCreationRestricted");
+        formField.setType(FormField.Type.boolean_type);
+        formField.setLabel(LocaleUtils.getLocalizedString(labelPreFix + "nodeCreationRestricted"));
+        formField.addValue(pubSubModule.isNodeCreationRestricted());
+
+        formField = form.addField();
+        formField.setVariable(variablePreFix + "allowedToCreate");
+        formField.setType(FormField.Type.jid_multi);
+        formField.setLabel(LocaleUtils.getLocalizedString(labelPreFix + "allowedToCreate"));
+        for (String jid : pubSubModule.getUsersAllowedToCreate()) {
+            formField.addValue(jid);
+        }
+
+        formField = form.addField();
+        formField.setVariable(variablePreFix + "sysadmins");
+        formField.setType(FormField.Type.jid_multi);
+        formField.setLabel(LocaleUtils.getLocalizedString(labelPreFix + "sysadmins"));
+        for (String jid : pubSubModule.getSysadmins()) {
+            formField.addValue(jid);
+        }
+
+        return form;
+    }
+
+    public JID getValidJID(String username) {
+        if (username != null && !username.isEmpty()) {
+            try {
+                if (username.contains("@")) {
+                    JID jid = new JID(username);
+                    if (userManager.isRegisteredUser(jid)) {
+                        return jid;
+                    }
+                } else if (userManager.isRegisteredUser(username)) {
+                    return xmppServer.createJID(username, null);
+                }
+            } catch (IllegalArgumentException e) {
+            }
+        }
+        // Return null if JID is invalid or user not registered
+        return null;
+    }
+
+    public boolean isValidGroup(String groupName) {
+        if (groupName != null && !groupName.isEmpty()) {
+            try {
+                Group group = groupManager.getGroup(groupName);
+                if (group != null) {
+                    return true;
+                }
+            } catch (GroupNotFoundException e) {
+            }
+        }
+        return false;
+    }
+
+    public DataForm processForm(DataForm form, HttpServletRequest request, Collection<String> excludedFields) {
+
+        DataForm completedForm = new DataForm(DataForm.Type.submit);
+
+        for (FormField field : form.getFields()) {
+
+            if (excludedFields == null || !excludedFields.contains(field.getVariable())) {
+                switch (field.getType()) {
+                case boolean_type:
+                    FormField boolField = completedForm.addField(field.getVariable(), field.getLabel(),
+                            field.getType());
+                    boolField.addValue(ParamUtils.getBooleanParameter(request, field.getVariable()));
+                    break;
+                case jid_multi:
+                    FormField multiJidField = completedForm.addField(field.getVariable(), field.getLabel(),
+                            field.getType());
+                    for (String param : ParamUtils.getParameters(request, field.getVariable())) {
+                        multiJidField.addValue(param);
+                    }
+                    break;
+                case list_multi:
+                    FormField multiListField = completedForm.addField(field.getVariable(), field.getLabel(),
+                            field.getType());
+                    for (String param : ParamUtils.getParameters(request, field.getVariable())) {
+                        multiListField.addValue(param);
+                    }
+                    break;
+                case list_single:
+                    FormField listField = completedForm.addField(field.getVariable(), field.getLabel(),
+                            field.getType());
+                    listField.addValue(ParamUtils.getParameter(request, field.getVariable()));
+                    break;
+                case text_single:
+                    FormField textField = completedForm.addField(field.getVariable(), field.getLabel(),
+                            field.getType());
+                    textField.addValue(ParamUtils.getParameter(request, field.getVariable()));
+                    break;
+                default:
+                    completedForm.addField(field.getVariable(), field.getLabel(), field.getType());
+                    break;
+                }
+            }
+        }
+        return completedForm;
+    }
+
+    public void configureService(DataForm form) {
+
+        for (FormField field : form.getFields()) {
+            switch (field.getVariable().substring(field.getVariable().indexOf("#") + 1)) {
+            case "serviceEnabled":
+                if (field.getFirstValue() != null) {
+                    pubSubModule.setServiceEnabled("1".equals(field.getFirstValue()));
+                }
+                break;
+            case "nodeCreationRestricted":
+                if (field.getFirstValue() != null) {
+                    pubSubModule.setNodeCreationRestricted("1".equals(field.getFirstValue()));
+                }
+                break;
+            case "allowedToCreate":
+                pubSubModule.setUserAllowedToCreate(field.getValues());
+                break;
+            case "sysadmins":
+                pubSubModule.setSysadmins(field.getValues());
+                break;
+            default:
+                // Shouldn't end up here
+                break;
+            }
+        }
+    }
+
+    public void validateAdditions(DataForm form, HttpServletRequest request, Map<String, listType> listTypes,
+            Map<String, String> errors) {
+
+        for (FormField field : form.getFields()) {
+            if (listTypes.containsKey(field.getVariable())) {
+                switch (listTypes.get(field.getVariable())) {
+                case group:
+                    if (ParamUtils.getParameter(request, field.getVariable() + "-Add") != null) {
+                        String groupName = ParamUtils.getParameter(request, field.getVariable() + "-Additional");
+                        if (isValidGroup(groupName)) {
+
+                            if (!field.getValues().contains(groupName)) {
+                                field.addValue(groupName);
+                            } else {
+                                // Group already in list
+                                errors.put(field.getVariable(), LocaleUtils.getLocalizedString(
+                                        "pubsub.form.already_in_list",
+                                        Arrays.asList(LocaleUtils.getLocalizedString("pubsub.form.group"), groupName)));
+                            }
+                        } else {
+                            // Not a valid group
+                            errors.put(field.getVariable(), LocaleUtils.getLocalizedString("pubsub.form.not_valid",
+                                    Arrays.asList(groupName, LocaleUtils.getLocalizedString("pubsub.form.group"))));
+                        }
+                    }
+
+                    break;
+                case user:
+                    if (ParamUtils.getParameter(request, field.getVariable() + "-Add") != null) {
+                        String username = ParamUtils.getParameter(request, field.getVariable() + "-Additional");
+                        JID newUser = getValidJID(username);
+                        if (newUser != null) {
+
+                            if (!field.getValues().contains(newUser.toBareJID())) {
+                                field.addValue(newUser.toBareJID());
+                            } else {
+                                // User already in list
+                                errors.put(field.getVariable(), LocaleUtils.getLocalizedString(
+                                        "pubsub.form.already_in_list",
+                                        Arrays.asList(LocaleUtils.getLocalizedString("pubsub.form.user"), username)));
+                            }
+                        } else {
+                            // Not a valid username
+                            errors.put(field.getVariable(), LocaleUtils.getLocalizedString("pubsub.form.not_valid",
+                                    Arrays.asList(username, LocaleUtils.getLocalizedString("pubsub.form.user"))));
+                        }
+                    }
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+    }
+
+    public enum listType {
+        user, group;
+    }
 
 }

--- a/src/resources/jar/admin-sidebar.xml
+++ b/src/resources/jar/admin-sidebar.xml
@@ -285,6 +285,12 @@
 
         <!-- PubSub Node Administration -->
         <sidebar id="sidebar-pubsub" name="${sidebar.sidebar-pubsub}">
+
+            <!-- PubSub Service -->
+            <item id="pubsub-service-summary" name="${sidebar.pubsub-service-summary}"
+                  url="pubsub-service-summary.jsp"
+                  description="${sidebar.pubsub-service-summary.descr}"/>
+
             <!-- PubSub Node Summary -->
             <item id="pubsub-node-summary" name="${sidebar.pubsub-node-summary}"
                   url="pubsub-node-summary.jsp"
@@ -307,6 +313,11 @@
                     <item id="pubsub-node-subscribers" name="${sidebar.pubsub-node-subscribers}"
                           url="pubsub-node-subscribers.jsp"
                           description="${sidebar.pubsub-node-subscribers.descr}"/>
+
+                    <!-- Edit Node -->
+                    <item id="pubsub-node-edit" name="${sidebar.pubsub-node-edit}"
+                          url="pubsub-node-edit.jsp"
+                          description="${sidebar.pubsub-node-edit.descr}"/>
 
                     <!-- Delete Node -->
                     <item id="pubsub-node-delete" name="${sidebar.pubsub-node-delete}"

--- a/src/web/pubsub-form-table.jsp
+++ b/src/web/pubsub-form-table.jsp
@@ -53,29 +53,29 @@ detailPreFix - property prefix for additional detail to be displayed against the
 		<br>
 	</c:forEach>
 </c:if>
-<table cellpadding="3" cellspacing="0" border="0" width="100%">
+<table cellpadding="3" cellspacing="0" border="0" width="1%">
 	<tbody>
 		<c:forEach var="field" items="${requestScope.fields}">
 			<c:if
 				test="${not requestScope.nonDisplayFields.contains(field.variable)}">
 				<tr>
-					<td nowrap width="1%"><label for="${field.variable}">${field.label}</label></td>
+					<td nowrap style="min-width: 300px"><label
+						style="font-weight: bold" for="${field.variable}">${field.label}</label></td>
 					<c:set var="isList"
 						value="${field.type.name() eq 'list_multi' or field.type.name() eq 'jid_multi'}" />
 					<c:choose>
 						<c:when test="${field.type.name() eq 'boolean_type'}">
-							<td width="1%" colspan="2"><input type="checkbox"
+							<td width="1%" rowspan="2"><input type="checkbox"
 								name="${field.variable}" id="${field.variable}"
-								${field.firstValue == 1 ? 'checked="checked"' : '' } />
-							</td>
+								${field.firstValue == 1 ? 'checked="checked"' : '' } /></td>
 						</c:when>
 						<c:when test="${field.type.name() eq 'text_single'}">
-							<td width="1%" colspan="2"><input type="text"
+							<td width="1%" rowspan="2"><input type="text"
 								name="${field.variable}" id="${field.variable}"
 								value="${field.firstValue}" style="width: 200px;" /></td>
 						</c:when>
 						<c:when test="${field.type.name() eq 'list_single'}">
-							<td width="1%" colspan="2"><select name="${field.variable}"
+							<td width="1%" rowspan="2"><select name="${field.variable}"
 								id="${field.variable}" style="width: 200px;">
 									<c:forEach var="option" items="${field.options}">
 										<option value="${option.value}"
@@ -86,7 +86,7 @@ detailPreFix - property prefix for additional detail to be displayed against the
 							</select></td>
 						</c:when>
 						<c:when test="${isList and not empty field.options}">
-							<td width="1%" colspan="2"><select name="${field.variable}"
+							<td width="1%" rowspan="2"><select name="${field.variable}"
 								id="${field.variable}" style="width: 200px;" multiple>
 									<c:forEach var="option" items="${field.options}">
 										<option value="${option.value}"
@@ -101,23 +101,18 @@ detailPreFix - property prefix for additional detail to be displayed against the
 								</button></td>
 						</c:when>
 						<c:when test="${isList and empty field.options}">
-							<td>
+							<td rowspan="2">
 								<div class="jive-table">
 									<table id="${field.variable}" cellpadding="0" cellspacing="0"
 										border="0" width="100%">
 										<thead>
 											<tr>
-												<th scope="col">value</th>
-												<th scope="col">remove</th>
+												<th scope="col"><fmt:message
+														key="pubsub.form.${listTypes[field.variable]}" /></th>
+												<th scope="col"><fmt:message key="pubsub.form.action" /></th>
 											</tr>
 										</thead>
 										<tbody>
-											<c:if test="${empty field.values}">
-												<tr>
-													<td align="center" colspan="2"><fmt:message
-															key="pubsub.form.no_data" /></td>
-												</tr>
-											</c:if>
 											<c:forEach var="value" items="${field.values}"
 												varStatus="loop">
 												<tr id="${field.variable}${loop.index}">
@@ -129,23 +124,23 @@ detailPreFix - property prefix for additional detail to be displayed against the
 													</td>
 												</tr>
 											</c:forEach>
+											<tr>
+												<td><input type="text" style="width: 200px;"
+													id="${field.variable}-Additional"
+													name="${field.variable}-Additional"
+													onkeypress="detect_enter_keyboard(event)" /></td>
+												<td><input type="submit" id="${field.variable}-Add"
+													name="${field.variable}-Add"
+													value="<fmt:message key="global.add" />"></td>
+											</tr>
 										</tbody>
 									</table>
 								</div>
 							</td>
-							<td><fmt:message var="paramVal"
-									key="pubsub.form.${listTypes[field.variable]}" /> <fmt:message
-									key="pubsub.form.add">
-									<fmt:param value="${paramVal}" />
-								</fmt:message> <br> <input type="text" size="45"
-								id="${field.variable}-Additional"
-								name="${field.variable}-Additional"
-								onkeypress="detect_enter_keyboard(event)" /> <br> <input
-								type="submit" id="${field.variable}-Add"
-								name="${field.variable}-Add"
-								value="<fmt:message key="global.add" />"></td>
 						</c:when>
 					</c:choose>
+				</tr>
+				<tr>
 					<td><fmt:message var="detail"
 							key="${param.detailPreFix}.${fn:substringAfter(field.variable, '#')}" />
 						<c:if test="${not fn:startsWith(detail, '???')}">

--- a/src/web/pubsub-form-table.jsp
+++ b/src/web/pubsub-form-table.jsp
@@ -1,0 +1,158 @@
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>
+
+<!--
+Parameters:
+fields - fields from a data form (needs to be set as request scope)
+nonDisplayFields - a list of field names that shouldn't be displayed (needs to be set as request scope)
+listTypes - a map of field.variables to listType (user or group)
+errors - a map of field.variable to error strings
+detailPreFix - property prefix for additional detail to be displayed against the fields on the form
+ -->
+
+<script>
+	function clearSelected(id) {
+		var elements = document.getElementById(id).options;
+
+		for (var i = 0; i < elements.length; i++) {
+			elements[i].selected = false;
+		}
+	}
+
+	function deleteTableRow(rowId) {
+		var row = document.getElementById(rowId);
+		row.parentNode.removeChild(row);
+	}
+
+	function detect_enter_keyboard(event) {
+
+		var key_board_keycode = event.which || event.keyCode;
+		if (key_board_keycode == 13) {
+			event.preventDefault();
+			var target = event.target || event.srcElement;
+			var buttonId = target.id.split('-')[0] + '-Add';
+			document.getElementById(buttonId).click();
+		}
+	}
+</script>
+<c:if test="${not empty errors}">
+	<c:forEach var="error" items="${errors}">
+		<div class="jive-error">
+			<table cellpadding="0" cellspacing="0" border="0">
+				<tbody>
+					<tr>
+						<td class="jive-icon"><img src="images/error-16x16.gif"
+							width="16" height="16" border="0" alt=""></td>
+						<td class="jive-icon-label"><c:out value="${error.value}" />
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<br>
+	</c:forEach>
+</c:if>
+<table cellpadding="3" cellspacing="0" border="0" width="100%">
+	<tbody>
+		<c:forEach var="field" items="${requestScope.fields}">
+			<c:if
+				test="${not requestScope.nonDisplayFields.contains(field.variable)}">
+				<tr>
+					<td nowrap width="1%"><label for="${field.variable}">${field.label}</label></td>
+					<c:set var="isList"
+						value="${field.type.name() eq 'list_multi' or field.type.name() eq 'jid_multi'}" />
+					<c:choose>
+						<c:when test="${field.type.name() eq 'boolean_type'}">
+							<td width="1%" colspan="2"><input type="checkbox"
+								name="${field.variable}" id="${field.variable}"
+								${field.firstValue == 1 ? 'checked="checked"' : '' } />
+							</td>
+						</c:when>
+						<c:when test="${field.type.name() eq 'text_single'}">
+							<td width="1%" colspan="2"><input type="text"
+								name="${field.variable}" id="${field.variable}"
+								value="${field.firstValue}" style="width: 200px;" /></td>
+						</c:when>
+						<c:when test="${field.type.name() eq 'list_single'}">
+							<td width="1%" colspan="2"><select name="${field.variable}"
+								id="${field.variable}" style="width: 200px;">
+									<c:forEach var="option" items="${field.options}">
+										<option value="${option.value}"
+											${option.value == field.firstValue ? 'selected' : '' }>
+                                        ${option.label ? option.label : option.value }
+                                        </option>
+									</c:forEach>
+							</select></td>
+						</c:when>
+						<c:when test="${isList and not empty field.options}">
+							<td width="1%" colspan="2"><select name="${field.variable}"
+								id="${field.variable}" style="width: 200px;" multiple>
+									<c:forEach var="option" items="${field.options}">
+										<option value="${option.value}"
+											${ field.values.contains(option.value) ? 'selected' : '' }>
+                                        ${option.label ? option.label : option.value }
+                                        </option>
+									</c:forEach>
+							</select>
+								<button type="button"
+									onclick="clearSelected('${field.variable}')">
+									<fmt:message key="pubsub.form.clearSelection" />
+								</button></td>
+						</c:when>
+						<c:when test="${isList and empty field.options}">
+							<td>
+								<div class="jive-table">
+									<table id="${field.variable}" cellpadding="0" cellspacing="0"
+										border="0" width="100%">
+										<thead>
+											<tr>
+												<th scope="col">value</th>
+												<th scope="col">remove</th>
+											</tr>
+										</thead>
+										<tbody>
+											<c:if test="${empty field.values}">
+												<tr>
+													<td align="center" colspan="2"><fmt:message
+															key="pubsub.form.no_data" /></td>
+												</tr>
+											</c:if>
+											<c:forEach var="value" items="${field.values}"
+												varStatus="loop">
+												<tr id="${field.variable}${loop.index}">
+													<td><input type="hidden" name="${field.variable}"
+														value="${value}" />${value}</td>
+													<td>
+														<button type="button"
+															onclick="deleteTableRow('${field.variable}${loop.index}')">Remove</button>
+													</td>
+												</tr>
+											</c:forEach>
+										</tbody>
+									</table>
+								</div>
+							</td>
+							<td><fmt:message var="paramVal"
+									key="pubsub.form.${listTypes[field.variable]}" /> <fmt:message
+									key="pubsub.form.add">
+									<fmt:param value="${paramVal}" />
+								</fmt:message> <br> <input type="text" size="45"
+								id="${field.variable}-Additional"
+								name="${field.variable}-Additional"
+								onkeypress="detect_enter_keyboard(event)" /> <br> <input
+								type="submit" id="${field.variable}-Add"
+								name="${field.variable}-Add"
+								value="<fmt:message key="global.add" />"></td>
+						</c:when>
+					</c:choose>
+					<td><fmt:message var="detail"
+							key="${param.detailPreFix}.${fn:substringAfter(field.variable, '#')}" />
+						<c:if test="${not fn:startsWith(detail, '???')}">
+							<c:out value="${detail}" />
+						</c:if></td>
+				</tr>
+			</c:if>
+		</c:forEach>
+	</tbody>
+</table>

--- a/src/web/pubsub-node-affiliates-edit.jsp
+++ b/src/web/pubsub-node-affiliates-edit.jsp
@@ -78,6 +78,8 @@
         if (affiliate != null) {
             JID jid = new JID(affiliateJID);
 
+            String oldAffiliation = affiliate.getAffiliation().name();
+
             switch(NodeAffiliate.Affiliation.valueOf(affiliation)) {
 	            case outcast:
 	                node.addOutcast(jid);
@@ -105,7 +107,7 @@
             }
 
             // Log the event
-            webManager.logEvent("changed affiliation between Node: " + nodeID + ", and JID: " + affiliate, "Changed to " + affiliation);
+            webManager.logEvent("Changed affiliation between Node: " + nodeID + ", and JID: " + affiliateJID, "Changed from " + oldAffiliation +" to " + affiliation);
         }
         // Done, so redirect
         response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+nodeID+"&updateSuccess=true&affiliateJID="+affiliateJID);
@@ -235,7 +237,7 @@
 		<br>
 		<br>
 
-	    <input type="submit" name="update" value="<fmt:message key="pubsub.node.affiliates.edit.update" />">
+	    <input type="submit" name="update" value="<fmt:message key="global.update" />">
 	    <input type="submit" name="cancel" value="<fmt:message key="global.cancel" />">
 	</form>
 

--- a/src/web/pubsub-node-edit.jsp
+++ b/src/web/pubsub-node-edit.jsp
@@ -1,0 +1,209 @@
+<%@ page import="org.jivesoftware.util.*,
+                 org.jivesoftware.openfire.group.Group,
+                 org.jivesoftware.openfire.pubsub.Node,
+                 org.jivesoftware.openfire.pubsub.LeafNode,
+                 org.jivesoftware.openfire.pubsub.PubSubServiceInfo,
+                 org.jivesoftware.openfire.pubsub.PubSubServiceInfo.listType,
+                 org.jivesoftware.openfire.user.User,
+                 org.xmpp.forms.DataForm,
+                 org.xmpp.forms.FormField,
+                 org.xmpp.forms.FormField.Type,
+                 org.xmpp.packet.JID,
+                 java.net.URLEncoder,
+                 java.util.*"
+    errorPage="error.jsp"
+%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
+<% webManager.init(request, response, session, application, out ); %>
+
+<%  // Get parameters //
+    boolean cancel = ParamUtils.getParameter(request,"cancel") != null;
+    boolean update = ParamUtils.getParameter(request,"update") != null;
+    Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+    String csrfParam = ParamUtils.getParameter(request, "csrf");
+    boolean formSubmitted = false;
+    if (csrfParam != null) {
+        formSubmitted = true;
+    }
+
+    if (update) {
+        if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
+            update = false;
+        }
+    }
+    csrfParam = StringUtils.randomString(15);
+    CookieUtils.setCookie(request, response, "csrf", csrfParam, -1);
+    pageContext.setAttribute("csrf", csrfParam);
+
+    String nodeID = ParamUtils.getParameter(request,"nodeID");
+    String reason = ParamUtils.getParameter(request,"reason");
+
+    // Handle a cancel
+    if (cancel) {
+        response.sendRedirect("pubsub-node-summary.jsp");
+        return;
+    }
+
+    final PubSubServiceInfo pubSubServiceInfo = webManager.getPubSubInfo();
+
+    // Load the node object
+	Node node = pubSubServiceInfo.getNode(nodeID);
+
+	DataForm form = ((LeafNode) node).getConfigurationForm();
+
+	//Field that will not be returned to the server, i.e. cannot be edited on this page
+	ArrayList<String> nonReturnFields = new ArrayList<String>();
+	//This is the parent collection, this form is not a great way to edit this,
+	//and the back end has issues when the root Collection is the parent.
+	nonReturnFields.add("pubsub#collection");
+
+	//owner and publishers are more easily managed through the affiliates admin pages
+	nonReturnFields.add("pubsub#owner");
+	nonReturnFields.add("pubsub#publisher");
+
+	//replyto and replyroom were removed from XEP-60 at version 1.13
+	nonReturnFields.add("pubsub#replyto");
+	nonReturnFields.add("pubsub#replyroom");
+
+	//nodes that will not be displayed in the form.
+	ArrayList<String> nonDisplayFields = new ArrayList<String>();
+	//changing nodes from leaf to collection is a bad idea, but the value is required in the returned form.
+	nonDisplayFields.add("pubsub#node_type");
+
+	//fields not being returned are not shown
+	nonDisplayFields.addAll(nonReturnFields);
+
+    // Handle update:
+    if (update) {
+        // Delete the node
+        if (node != null) {
+
+            node.configure(pubSubServiceInfo.processForm(form, request, nonReturnFields));
+
+            // Log the event
+            webManager.logEvent("Configuration updated for " + nodeID, null);
+        }
+        // Done, so redirect
+        response.sendRedirect("pubsub-node-edit.jsp?nodeID=" + nodeID + "&updateSuccess=true");
+        return;
+    }
+
+	if (formSubmitted) {
+	    form = pubSubServiceInfo.processForm(form, request, nonReturnFields);
+	}
+
+    Map<String,listType> listTypes = new HashMap<>();
+
+    listTypes.put("pubsub#contact", listType.user);
+    listTypes.put("pubsub#replyto", listType.user);
+    listTypes.put("pubsub#roster_groups_allowed", listType.group);
+
+    Map<String,String> errors = new HashMap<>();
+
+	pubSubServiceInfo.validateAdditions(form, request, listTypes, errors);
+
+    pageContext.setAttribute("node", node);
+    pageContext.setAttribute("fields", form.getFields());
+    pageContext.setAttribute("nonDisplayFields", nonDisplayFields);
+    pageContext.setAttribute("listTypes", listTypes);
+    pageContext.setAttribute("errors", errors);
+
+%>
+
+<html>
+    <head>
+        <title><fmt:message key="pubsub.node.edit.title"/></title>
+        <meta name="subPageID" content="pubsub-node-edit"/>
+        <meta name="extraParams" content="nodeID=${node.nodeID}"/>
+        <script>
+        function clearSelected(name){
+            var elements = document.getElementById(name).options;
+
+            for(var i = 0; i < elements.length; i++){
+              elements[i].selected = false;
+            }
+          }
+        </script>
+    </head>
+    <body>
+
+<p>
+    <fmt:message key="pubsub.node.edit.info" />
+    <b>
+        <c:out value="${node.nodeID}"/>
+    </b>
+</p>
+
+<c:if test="${param.updateSuccess}">
+    <div class="jive-success">
+    <table cellpadding="0" cellspacing="0" border="0">
+    <tbody>
+        <tr><td class="jive-icon"><img src="images/success-16x16.gif" width="16" height="16" border="0" alt=""></td>
+        <td class="jive-icon-label">
+        <fmt:message key="pubsub.node.edit.updated" />
+        </td></tr>
+    </tbody>
+    </table>
+    </div><br>
+</c:if>
+
+    <div class="jive-table">
+    <table cellpadding="0" cellspacing="0" border="0" width="100%">
+    <thead>
+        <tr>
+            <th scope="col"><fmt:message key="pubsub.node.summary.id" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.creator" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.items" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.affiliates" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.subscribers" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.created" /></th>
+            <th scope="col"><fmt:message key="pubsub.node.summary.modified" /></th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><c:out value="${node.getNodeID()}"/></td>
+            <td><c:out value="${node.getCreator()}"/></td>
+            <td><c:out value="${node.getPublishedItems().size()}"/></td>
+            <td><c:out value="${node.getAllAffiliates().size()}"/></td>
+            <td><c:out value="${node.getAllSubscriptions().size()}"/></td>
+            <td><fmt:formatDate type="both" dateStyle="medium" timeStyle="short" value="${node.getCreationDate()}" /></td>
+            <td><fmt:formatDate type="both" dateStyle="medium" timeStyle="short" value="${node.getModificationDate()}" /></td>
+        </tr>
+    </tbody>
+    </table>
+    </div>
+
+
+<form action="pubsub-node-edit.jsp">
+    <input type="hidden" name="csrf" value="${csrf}">
+	<input type="hidden" name="nodeID" value="${node.nodeID}">
+    <br>
+
+<fieldset>
+    <legend><fmt:message key="pubsub.node.edit.details_title" /></legend>
+    <div>
+
+    <c:set var="fields" value="${fields}" scope="request"/>
+    <c:set var="nonDisplayFields" value="${nonDisplayFields}" scope="request"/>
+    <c:set var="listTypes" value="${listTypes}" scope="request"/>
+    <c:set var="errors" value="${errors}" scope="request"/>
+
+    <c:import url="pubsub-form-table.jsp">
+       <c:param name="detailPreFix" value ="pubsub.node.edit.detail"/>
+    </c:import>
+
+    </div>
+
+</fieldset>
+<br>
+        <input type="submit" name="update" value="<fmt:message key="global.update" />">
+        <input type="submit" name="cancel" value="<fmt:message key="global.cancel" />">
+</form>
+
+    </body>
+</html>

--- a/src/web/pubsub-node-summary.jsp
+++ b/src/web/pubsub-node-summary.jsp
@@ -44,6 +44,7 @@
         webManager.setRowsPerPage("pubsub-node-summary", range);
     }
 
+    boolean PEPMode = false;
     PubSubServiceInfo pubSubServiceInfo;
     if ( owner == null )
     {
@@ -51,6 +52,7 @@
     }
     else if ( new PEPServiceManager().getPEPService( owner.toBareJID() ) != null )
     {
+        PEPMode = true;
         pubSubServiceInfo = new PEPServiceInfo( owner );
     }
     else
@@ -94,6 +96,7 @@
     pageContext.setAttribute("maxNodeIndex", maxNodeIndex);
     pageContext.setAttribute("nodes", nodes.subList(start, maxNodeIndex));
     pageContext.setAttribute("owner", owner );
+    pageContext.setAttribute("PEPMode", PEPMode);
 
 %>
 <html>
@@ -171,6 +174,9 @@
         <th nowrap><fmt:message key="pubsub.node.summary.items" /></th>
         <th nowrap><fmt:message key="pubsub.node.summary.affiliates" /></th>
         <th nowrap><fmt:message key="pubsub.node.summary.subscribers" /></th>
+        <c:if test="${not PEPMode}" >
+            <th nowrap><fmt:message key="global.edit" /></th>
+        </c:if>
         <th nowrap><fmt:message key="global.delete" /></th>
     </tr>
 </thead>
@@ -178,7 +184,7 @@
 
 <c:if test="${nodeCount lt 1}">
     <tr>
-        <td align="center" colspan="7">
+        <td align="center" colspan="${PEPMode ? 8 : 9}">
             <fmt:message key="pubsub.node.summary.table.no_nodes" />
         </td>
     </tr>
@@ -226,6 +232,16 @@
                 <c:out value="${node.getAllSubscriptions().size()}" />
             </a>
         </td>
+        <c:if test="${not PEPMode}" >
+	        <td width="1%" align="center">
+	            <c:url value="pubsub-node-edit.jsp" var="url">
+	                <c:param name="nodeID" value="${node.getNodeID()}" />
+	            </c:url>
+	            <a href="${url}" title="<fmt:message key="global.click_edit" />">
+	                <img src="images/edit-16x16.gif" width="16" height="16" border="0" alt="">
+	            </a>
+	        </td>
+        </c:if>
         <td width="1%" align="center" style="border-right:1px #ccc solid;">
             <c:url value="pubsub-node-delete.jsp" var="url">
                 <c:param name="nodeID" value="${node.getNodeID()}" />

--- a/src/web/pubsub-node-summary.jsp
+++ b/src/web/pubsub-node-summary.jsp
@@ -194,7 +194,7 @@
 
     <tr class="${ (loop.index%2)==0 ? 'jive-even' : 'jive-odd'}">
         <td width="1%">
-            <c:out value="${loop.index}"/>
+            <c:out value="${start + 1 + loop.index}"/>
         </td>
         <td width="1%" valign="middle">
             <c:out value="${node.getNodeID()}"/>

--- a/src/web/pubsub-service-summary.jsp
+++ b/src/web/pubsub-service-summary.jsp
@@ -1,0 +1,126 @@
+<%@ page import="org.jivesoftware.util.*,
+                 org.jivesoftware.openfire.pubsub.Node,
+                 org.jivesoftware.openfire.pubsub.PubSubServiceInfo,
+                 org.jivesoftware.openfire.pubsub.PubSubServiceInfo.listType,
+                 org.xmpp.forms.DataForm,
+                 org.xmpp.forms.FormField,
+                 org.xmpp.forms.FormField.Type,
+                 java.net.URLEncoder,
+                 java.util.*"
+    errorPage="error.jsp"
+%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
+<% webManager.init(request, response, session, application, out ); %>
+
+<%  // Get parameters //
+    boolean cancel = ParamUtils.getParameter(request,"cancel") != null;
+    boolean update = ParamUtils.getParameter(request,"update") != null;
+    Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+    String csrfParam = ParamUtils.getParameter(request, "csrf");
+
+    boolean formSubmitted = false;
+    if (csrfParam != null) {
+        formSubmitted = true;
+    }
+
+    if (update) {
+        if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
+            update = false;
+        }
+    }
+    csrfParam = StringUtils.randomString(15);
+    CookieUtils.setCookie(request, response, "csrf", csrfParam, -1);
+    pageContext.setAttribute("csrf", csrfParam);
+
+    // Handle a cancel
+    if (cancel) {
+        response.sendRedirect("pubsub-node-summary.jsp");
+        return;
+    }
+
+    final PubSubServiceInfo pubSubServiceInfo = webManager.getPubSubInfo();
+
+    DataForm form = pubSubServiceInfo.getServiceConfigurationForm();
+
+    // Handle a service update:
+    if (update) {
+
+        pubSubServiceInfo.configureService(pubSubServiceInfo.processForm(form, request, null));
+
+        // Done, so redirect
+        response.sendRedirect("pubsub-service-summary.jsp?updateSuccess=true");
+        return;
+    }
+
+    if (formSubmitted) {
+        form = pubSubServiceInfo.processForm(form, request, null);
+    }
+
+    Map<String,listType> listTypes = new HashMap<>();
+
+    listTypes.put("pubsub#allowedToCreate", listType.user);
+    listTypes.put("pubsub#sysadmins", listType.user);
+
+    Map<String,String> errors = new HashMap<>();
+
+    pubSubServiceInfo.validateAdditions(form, request, listTypes, errors);
+
+    pageContext.setAttribute("fields", form.getFields());
+    pageContext.setAttribute("listTypes", listTypes);
+    pageContext.setAttribute("errors", errors);
+
+%>
+
+<html>
+    <head>
+        <title><fmt:message key="pubsub.service.summary.title"/></title>
+        <meta name="pageID" content="pubsub-service-summary"/>
+    </head>
+    <body>
+
+<p>
+    <fmt:message key="pubsub.service.summary.info" />
+</p>
+
+<c:if test="${param.updateSuccess}">
+    <div class="jive-success">
+    <table cellpadding="0" cellspacing="0" border="0">
+    <tbody>
+        <tr><td class="jive-icon"><img src="images/success-16x16.gif" width="16" height="16" border="0" alt=""></td>
+        <td class="jive-icon-label">
+        <fmt:message key="pubsub.service.summary.updated" />
+        </td></tr>
+    </tbody>
+    </table>
+    </div><br>
+</c:if>
+
+<form action="pubsub-service-summary.jsp">
+    <input type="hidden" name="csrf" value="${csrf}">
+
+<fieldset>
+    <legend><fmt:message key="pubsub.node.delete.details_title" /></legend>
+    <div>
+
+    <c:set var="fields" value="${fields}" scope="request"/>
+    <c:set var="listTypes" value="${listTypes}" scope="request"/>
+    <c:set var="errors" value="${errors}" scope="request"/>
+
+    <c:import url="pubsub-form-table.jsp">
+       <c:param name="detailPreFix" value ="pubsub.service.form.detail"/>
+    </c:import>
+
+    </div>
+</fieldset>
+
+<br><br>
+
+<input type="submit" name="update" value="<fmt:message key="global.update" />">
+<input type="submit" name="cancel" value="<fmt:message key="global.cancel" />">
+</form>
+
+    </body>
+</html>


### PR DESCRIPTION
Adding pages to configure the PubSub service and configure leafNodes.

Node configuration is based on existing Configuration forms mechanism, Data form is requested and a UI is generated from the form, the form is tailored slightly and there is some validation (on fields with users and groups). On submission the completed form goes back to the existing Node.configure() method.

Service configuration uses a similar mechanism in order to re-use form generation and processing code.

Note that these pages are (currently) only for PubSub and do not show up when viewing PEP nodes.

Second commit fixes a couple of bugs in previous OF-35 work including OF-1386.