### PR TITLE
OF-1416: Ensure that hazelcast cache entries expire correctly

### DIFF
--- a/src/plugins/hazelcast/changelog.html
+++ b/src/plugins/hazelcast/changelog.html
@@ -44,6 +44,11 @@
 Hazelcast Clustering Plugin Changelog
 </h1>
 
+<p><b>2.2.4</b> -- October 26, 2017</p>
+<ul>
+    <li>[<a href='http://www.igniterealtime.org/issues/browse/OF-1416'>OF-1416</a>] - Dynamically created ClusteredCache entries not expiring</li>
+</ul>
+
 <p><b>2.2.3</b> -- September 15, 2017</p>
 <ul>
      <li>Use an event rather than an arbitrary delay before starting clustering</li>

--- a/src/plugins/hazelcast/plugin.xml
+++ b/src/plugins/hazelcast/plugin.xml
@@ -5,7 +5,7 @@
     <name>Hazelcast plugin</name>
     <description>Adds clustering support</description>
     <author>Tom Evans</author>
-    <version>2.2.3</version>
-    <date>09/15/2017</date>
+    <version>2.2.4</version>
+    <date>10/26/2017</date>
     <minServerVersion>4.2.0</minServerVersion>
 </plugin>

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCache.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCache.java
@@ -44,6 +44,7 @@ public class ClusteredCache implements Cache {
      * The map is used for distributed operations such as get, put, etc.
      */
     protected IMap map;
+    private final int hazelcastLifetimeInSeconds;
     private String name;
     private long numberOfGets = 0;
 
@@ -52,9 +53,11 @@ public class ClusteredCache implements Cache {
      *
      * @param name a name for the cache, which should be unique per vm.
      * @param cache the cache implementation
+     * @param hazelcastLifetimeInSeconds the lifetime of cache entries
      */
-    protected ClusteredCache(String name, IMap cache) {
+    protected ClusteredCache(String name, IMap cache, final int hazelcastLifetimeInSeconds) {
         map = cache;
+        this.hazelcastLifetimeInSeconds = hazelcastLifetimeInSeconds;
         setName(name);
     }
 
@@ -81,7 +84,7 @@ public class ClusteredCache implements Cache {
 
     public Object put(Object key, Object object) {
     	if (object == null) { return null; }
-        return map.put(key, object);
+        return map.put(key, object, hazelcastLifetimeInSeconds, TimeUnit.SECONDS);
     }
 
     public Object get(Object key) {

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -222,7 +222,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
         final MapConfig mapConfig = hazelcast.getConfig().getMapConfig(name);
         mapConfig.setTimeToLiveSeconds(hazelcastLifetimeInSeconds);
         mapConfig.setMaxSizeConfig(new MaxSizeConfig(hazelcastMaxCacheSize, MaxSizeConfig.MaxSizePolicy.USED_HEAP_SIZE));
-        return new ClusteredCache(name, hazelcast.getMap(name));
+        return new ClusteredCache(name, hazelcast.getMap(name), hazelcastLifetimeInSeconds);
     }
 
     public void destroyCache(Cache cache) {


### PR DESCRIPTION
This PR works around the issue caused by not being able to update IMap settings in Hazelcast 3.5.x. 

I think a proper fix would be to update to Hazelcast 3.9, but that's probably a significant chunk of work and should probably wait until after 4.2.