### PR TITLE
OF-1134 - Update copied users nickname on other users rosters

### DIFF
--- a/src/plugins/justmarried/changelog.html
+++ b/src/plugins/justmarried/changelog.html
@@ -44,6 +44,11 @@
 Just married Plugin Changelog
 </h1>
 
+<p><b>1.2.2</b> -- October 26, 2017</p>
+<ul>
+    <li>When copying a user, the new user's nickname will be updated on other users rosters</li>
+</ul>
+
 <p><b>1.2.1</b> -- May 31, 2017</p>
 <ul>
     <li>Updated to match new API in Openfire 4.2.0</li>

--- a/src/plugins/justmarried/plugin.xml
+++ b/src/plugins/justmarried/plugin.xml
@@ -5,8 +5,8 @@
    <name>Just married</name>
    <description>Allows admins to rename or copy users</description>
    <author>Holger Bergunde</author>
-    <version>1.2.1</version>
-    <date>05/31/2017</date>
+    <version>1.2.2</version>
+    <date>10/26/2017</date>
     <minServerVersion>4.0.0</minServerVersion>
    
    <adminconsole>

--- a/src/plugins/justmarried/src/java/org/jivesoftware/openfire/plugin/married/JustMarriedPlugin.java
+++ b/src/plugins/justmarried/src/java/org/jivesoftware/openfire/plugin/married/JustMarriedPlugin.java
@@ -157,7 +157,7 @@ public class JustMarriedPlugin implements Plugin {
 
 						RosterItem justCreated = otherRoster.createRosterItem(
 								XMPPServer.getInstance().createJID(newUser.getUsername(), null),
-								oldUserOnOthersRoster.getNickname(), oldUserOnOthersRoster.getGroups(), true, true);
+								oldUserOnOthersRoster.getName(), oldUserOnOthersRoster.getGroups(), true, true);
 						justCreated.setAskStatus(oldUserOnOthersRoster.getAskStatus());
 						justCreated.setRecvStatus(oldUserOnOthersRoster.getRecvStatus());
 						justCreated.setSubStatus(oldUserOnOthersRoster.getSubStatus());

--- a/src/plugins/justmarried/src/java/org/jivesoftware/openfire/plugin/married/JustMarriedPlugin.java
+++ b/src/plugins/justmarried/src/java/org/jivesoftware/openfire/plugin/married/JustMarriedPlugin.java
@@ -157,7 +157,7 @@ public class JustMarriedPlugin implements Plugin {
 
 						RosterItem justCreated = otherRoster.createRosterItem(
 								XMPPServer.getInstance().createJID(newUser.getUsername(), null),
-								oldUserOnOthersRoster.getName(), oldUserOnOthersRoster.getGroups(), true, true);
+								newUser.getName(), oldUserOnOthersRoster.getGroups(), true, true);
 						justCreated.setAskStatus(oldUserOnOthersRoster.getAskStatus());
 						justCreated.setRecvStatus(oldUserOnOthersRoster.getRecvStatus());
 						justCreated.setSubStatus(oldUserOnOthersRoster.getSubStatus());


### PR DESCRIPTION
Still works as intended if you are just renaming a user.

Now, if you are using it to copy a user, the new users nickname, on other people rosters, will reflect the new name and not the old users nickname.