### PR TITLE
OF-1422 Handle rejoins with nick-sharing

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -585,7 +585,8 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
                     // Nickname is already used, and not by the same JID
                     throw new UserAlreadyExistsException();
                 }
-                if (occupant.getUserAddress().equals(user.getAddress())) {
+                // Is this client already joined?
+                if (occupantsByFullJID.containsKey(user.getAddress())) {
                     clientOnlyJoin = true; // This user is already an occupant. The client thinks it isn't. (Or else this is a broken gmail).
                 }
             }


### PR DESCRIPTION
This checks to see if any occupant exists with
the same full jid, and if so treats this as a
clientOnlyJoin (ie, rejoin).