### PR TITLE
OF-1309 Route based on DomainPairs

### DIFF
--- a/src/java/org/jivesoftware/openfire/IQRouter.java
+++ b/src/java/org/jivesoftware/openfire/IQRouter.java
@@ -24,6 +24,7 @@ import org.jivesoftware.openfire.interceptor.PacketRejectedException;
 import org.jivesoftware.openfire.privacy.PrivacyList;
 import org.jivesoftware.openfire.privacy.PrivacyListManager;
 import org.jivesoftware.openfire.session.ClientSession;
+import org.jivesoftware.openfire.session.DomainPair;
 import org.jivesoftware.openfire.session.LocalClientSession;
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.openfire.user.UserManager;
@@ -314,7 +315,7 @@ public class IQRouter extends BasicModule {
         try {
             // Check for registered components, services or remote servers
             if (recipientJID != null &&
-                    (routingTable.hasComponentRoute(recipientJID) || routingTable.hasServerRoute(recipientJID))) {
+                    (routingTable.hasComponentRoute(recipientJID) || routingTable.hasServerRoute(new DomainPair(packet.getFrom().getDomain(), recipientJID.getDomain())))) {
                 // A component/service/remote server was found that can handle the Packet
                 routingTable.routePacket(recipientJID, packet, false);
                 return;

--- a/src/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/src/java/org/jivesoftware/openfire/RoutingTable.java
@@ -16,10 +16,7 @@
 
 package org.jivesoftware.openfire;
 
-import org.jivesoftware.openfire.session.ClientSession;
-import org.jivesoftware.openfire.session.LocalClientSession;
-import org.jivesoftware.openfire.session.LocalOutgoingServerSession;
-import org.jivesoftware.openfire.session.OutgoingServerSession;
+import org.jivesoftware.openfire.session.*;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 import org.xmpp.packet.Packet;
@@ -90,7 +87,7 @@ public interface RoutingTable {
      * @param route the address associated to the route.
      * @param destination the outgoing server session.
      */
-    void addServerRoute(JID route, LocalOutgoingServerSession destination);
+    void addServerRoute(DomainPair route, LocalOutgoingServerSession destination);
 
     /**
      * Adds a route to the routing table for the specified internal or external component. <p>
@@ -246,7 +243,7 @@ public interface RoutingTable {
      * @param jid the address of the session.
      * @return the outgoing server session associated to the specified XMPP address or null if none was found.
      */
-    OutgoingServerSession getServerRoute(JID jid);
+    OutgoingServerSession getServerRoute(DomainPair pair);
 
     /**
      * Returns a collection with the hostnames of the remote servers that currently may receive
@@ -256,6 +253,7 @@ public interface RoutingTable {
      *         packets sent from this server.
      */
     Collection<String> getServerHostnames();
+    Collection<DomainPair> getServerRoutes();
 
     /**
      * Returns the number of outgoing server sessions hosted in this JVM. When runing inside of
@@ -320,7 +318,7 @@ public interface RoutingTable {
      * @param route the route to remove.
      * @return true if the route was successfully removed.
      */
-    boolean removeServerRoute(JID route);
+    boolean removeServerRoute(DomainPair route);
 
     /**
      * Returns true if a route of a component has been successfully removed. Both internal

--- a/src/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/src/java/org/jivesoftware/openfire/RoutingTable.java
@@ -194,10 +194,10 @@ public interface RoutingTable {
      * as long as a node has a connection to the remote server a true value will be
      * returned.
      *
-     * @param jid JID that specifies the remote server address.
+     * @param pair DomainPair that specifies the local/remote server address.
      * @return true if an outgoing server session exists to the specified remote server.
      */
-    boolean hasServerRoute(JID jid);
+    boolean hasServerRoute(DomainPair pair);
 
     /**
      * Returns true if an internal or external component is hosting the specified address.

--- a/src/java/org/jivesoftware/openfire/SessionManager.java
+++ b/src/java/org/jivesoftware/openfire/SessionManager.java
@@ -897,11 +897,20 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
      * OutgoingServerSession an only send packets to the remote server but are not capable of
      * receiving packets from the remote server.
      *
-     * @param hostname the name of the remote server.
+     * @param pair DomainPair describing the local and remote servers.
      * @return a session that was originated from this server to a remote server.
      */
-    public OutgoingServerSession getOutgoingServerSession(String hostname) {
-        return routingTable.getServerRoute(new JID(null, hostname, null, true));
+    public OutgoingServerSession getOutgoingServerSession(DomainPair pair) {
+        return routingTable.getServerRoute(pair);
+    }
+    public List<OutgoingServerSession> getOutgoingServerSessions(String host) {
+        List<OutgoingServerSession> sessions = new LinkedList<>();
+        for (DomainPair pair : routingTable.getServerRoutes()) {
+            if (pair.getRemote().equals(host)) {
+                sessions.add(routingTable.getServerRoute(pair));
+            }
+        }
+        return sessions;
     }
 
     public Collection<ClientSession> getSessions(String username) {
@@ -1057,6 +1066,9 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
      */
     public Collection<String> getOutgoingServers() {
         return routingTable.getServerHostnames();
+    }
+    public Collection<DomainPair> getOutgoingDomainPairs() {
+        return routingTable.getServerRoutes();
     }
 
     /**
@@ -1344,7 +1356,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
             // Remove all the hostnames that were registered for this server session
             for (DomainPair domainPair : session.getOutgoingDomainPairs()) {
                 // Remove the route to the session using the hostname
-                server.getRoutingTable().removeServerRoute(new JID(null, domainPair.getRemote(), null, true));
+                server.getRoutingTable().removeServerRoute(domainPair);
             }
         }
     }

--- a/src/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/src/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -29,6 +29,7 @@ import org.jivesoftware.openfire.interceptor.PacketInterceptor;
 import org.jivesoftware.openfire.interceptor.PacketRejectedException;
 import org.jivesoftware.openfire.session.ClientSession;
 import org.jivesoftware.openfire.session.ConnectionSettings;
+import org.jivesoftware.openfire.session.DomainPair;
 import org.jivesoftware.openfire.session.LocalOutgoingServerSession;
 import org.jivesoftware.openfire.spi.RoutingTableImpl;
 import org.jivesoftware.util.JiveGlobals;
@@ -261,7 +262,7 @@ public class OutgoingSessionPromise implements RoutableChannelHandler {
                 lock.unlock();
             }
             if (created) {
-                if (!routingTable.hasServerRoute(packet.getTo())) {
+                if (!routingTable.hasServerRoute(new DomainPair(packet.getFrom().getDomain(), packet.getTo().getDomain()))) {
                     throw new Exception("Route created but not found!!!");
                 }
                 // A connection to the remote server was created so get the route and send the packet

--- a/src/java/org/jivesoftware/openfire/server/RemoteServerManager.java
+++ b/src/java/org/jivesoftware/openfire/server/RemoteServerManager.java
@@ -27,6 +27,7 @@ import org.jivesoftware.openfire.ConnectionManager;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.server.RemoteServerConfiguration.Permission;
 import org.jivesoftware.openfire.session.ConnectionSettings;
+import org.jivesoftware.openfire.session.DomainPair;
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.cache.Cache;
@@ -90,9 +91,12 @@ public class RemoteServerManager {
         for (Session session : SessionManager.getInstance().getIncomingServerSessions(domain)) {
             session.close();
         }
-        Session session = SessionManager.getInstance().getOutgoingServerSession(domain);
-        if (session != null) {
-            session.close();
+        // Can't just lookup a single remote server anymore, so check them all.
+        for (DomainPair domainPair : SessionManager.getInstance().getOutgoingDomainPairs()) {
+            if (domainPair.getRemote().equals(domain)) {
+                Session session = SessionManager.getInstance().getOutgoingServerSession(domainPair);
+                session.close();
+            }
         }
     }
 
@@ -348,9 +352,9 @@ public class RemoteServerManager {
                 }
             }
         }
-        for (String hostname : SessionManager.getInstance().getOutgoingServers()) {
-            if (!canAccess(hostname)) {
-                Session session = SessionManager.getInstance().getOutgoingServerSession(hostname);
+        for (DomainPair domainPair : SessionManager.getInstance().getOutgoingDomainPairs()) {
+            if (!canAccess(domainPair.getRemote())) {
+                Session session = SessionManager.getInstance().getOutgoingServerSession(domainPair);
                 session.close();
             }
         }

--- a/src/java/org/jivesoftware/openfire/session/DomainPair.java
+++ b/src/java/org/jivesoftware/openfire/session/DomainPair.java
@@ -3,9 +3,10 @@ package org.jivesoftware.openfire.session;
 /**
  * Holds a (possibly authenticated) domain pair.
  */
-public class DomainPair {
+public class DomainPair implements java.io.Serializable {
     private final String local;
     private final String remote;
+    private static final long serialVersionUID = 1L;
 
     public DomainPair(String local, String remote) {
         this.local = local;

--- a/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -130,6 +130,12 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                 return false;
             }
             session = sessionManager.getOutgoingServerSession(domainPair);
+            if (session != null && session.checkOutgoingDomainPair(localDomain, remoteDomain))
+            {
+                // Do nothing since the domain has already been authenticated.
+                log.debug( "Authentication successful (domain was already authenticated in the pre-existing session)." );
+                return true;
+            }
             if (session != null && !session.isUsingServerDialback() )
             {
                 log.debug( "Dialback was not used for '{}'. This session cannot be re-used.", domainPair );
@@ -672,15 +678,9 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
 
     @Override
     public void addOutgoingDomainPair(String localDomain, String remoteDomain) {
-        boolean found = false;
-        for (DomainPair domainPair : outgoingDomainPairs) {
-            if (domainPair.getRemote().equals(remoteDomain)) found = true;
-        }
         final DomainPair domainPair = new DomainPair(localDomain, remoteDomain);
         outgoingDomainPairs.add(domainPair);
-        if (!found) {
-            XMPPServer.getInstance().getRoutingTable().addServerRoute(domainPair, this);
-        }
+        XMPPServer.getInstance().getRoutingTable().addServerRoute(domainPair, this);
     }
 
     @Override

--- a/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -106,6 +106,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
      */
     public static boolean authenticateDomain(final String localDomain, final String remoteDomain) {
         final Logger log = LoggerFactory.getLogger( Log.getName() + "[Authenticate local domain: '" + localDomain + "' to remote domain: '" + remoteDomain + "']" );
+        final DomainPair domainPair = new DomainPair(localDomain, remoteDomain);
 
         log.debug( "Start domain authentication ..." );
         if (remoteDomain == null || remoteDomain.length() == 0 || remoteDomain.trim().indexOf(' ') > -1) {
@@ -128,10 +129,10 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                 log.warn( "Unable to authenticate: a SessionManager instance is not available. This should not occur unless Openfire is starting up or shutting down." );
                 return false;
             }
-            session = sessionManager.getOutgoingServerSession(remoteDomain);
+            session = sessionManager.getOutgoingServerSession(domainPair);
             if (session != null && !session.isUsingServerDialback() )
             {
-                log.debug( "Dialback was not used for '{}'. This session cannot be re-used.", remoteDomain );
+                log.debug( "Dialback was not used for '{}'. This session cannot be re-used.", domainPair );
                 session = null;
             }
 
@@ -145,7 +146,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                     for ( String otherRemoteDomain : incomingSession.getValidatedDomains() )
                     {
                         // See if there's an outgoing session to any of the (other) domains hosted by the remote domain.
-                        session = sessionManager.getOutgoingServerSession( otherRemoteDomain );
+                        session = sessionManager.getOutgoingServerSession( new DomainPair(localDomain, otherRemoteDomain) );
                         if (session != null)
                         {
                             log.debug( "An outgoing session to a different domain ('{}') hosted on the remote domain was found.", otherRemoteDomain );
@@ -675,9 +676,10 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
         for (DomainPair domainPair : outgoingDomainPairs) {
             if (domainPair.getRemote().equals(remoteDomain)) found = true;
         }
-        outgoingDomainPairs.add(new DomainPair(localDomain, remoteDomain));
+        final DomainPair domainPair = new DomainPair(localDomain, remoteDomain);
+        outgoingDomainPairs.add(domainPair);
         if (!found) {
-            XMPPServer.getInstance().getRoutingTable().addServerRoute(new JID(null, remoteDomain, null, true), this);
+            XMPPServer.getInstance().getRoutingTable().addServerRoute(domainPair, this);
         }
     }
 

--- a/src/java/org/jivesoftware/openfire/session/RemoteSessionLocator.java
+++ b/src/java/org/jivesoftware/openfire/session/RemoteSessionLocator.java
@@ -87,5 +87,5 @@ public interface RemoteSessionLocator {
      * @param address the address that uniquely identifies the session.
      * @return a session surrogate of an incoming server session hosted by a remote cluster node.
      */
-    OutgoingServerSession getOutgoingServerSession(byte[] nodeID, JID address);
+    OutgoingServerSession getOutgoingServerSession(byte[] nodeID, DomainPair address);
 }

--- a/src/java/org/jivesoftware/openfire/spi/LocalRoutingTable.java
+++ b/src/java/org/jivesoftware/openfire/spi/LocalRoutingTable.java
@@ -25,11 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.jivesoftware.openfire.RoutableChannelHandler;
 import org.jivesoftware.openfire.SessionManager;
-import org.jivesoftware.openfire.session.LocalClientSession;
-import org.jivesoftware.openfire.session.LocalOutgoingServerSession;
-import org.jivesoftware.openfire.session.LocalSession;
-import org.jivesoftware.openfire.session.OutgoingServerSession;
-import org.jivesoftware.openfire.session.Session;
+import org.jivesoftware.openfire.session.*;
 import org.jivesoftware.util.LocaleUtils;
 import org.jivesoftware.util.TaskEngine;
 import org.slf4j.Logger;
@@ -48,27 +44,30 @@ class LocalRoutingTable {
 	
 	private static final Logger Log = LoggerFactory.getLogger(LocalRoutingTable.class);
 
-    Map<String, RoutableChannelHandler> routes = new ConcurrentHashMap<>();
+    Map<DomainPair, RoutableChannelHandler> routes = new ConcurrentHashMap<>();
 
     /**
      * Adds a route of a local {@link RoutableChannelHandler}
      *
-     * @param address the string representation of the JID associated to the route.
+     * @param pair DomainPair associated to the route.
      * @param route the route hosted by this node.
      * @return true if the element was added or false if was already present.
      */
-    boolean addRoute(String address, RoutableChannelHandler route) {
-        return routes.put(address, route) != route;
+    boolean addRoute(DomainPair pair, RoutableChannelHandler route) {
+        return routes.put(pair, route) != route;
     }
 
     /**
      * Returns the route hosted by this node that is associated to the specified address.
      *
-     * @param address the string representation of the JID associated to the route.
+     * @param pair DomainPair associated to the route.
      * @return the route hosted by this node that is associated to the specified address.
      */
-    RoutableChannelHandler getRoute(String address) {
-        return routes.get(address);
+    RoutableChannelHandler getRoute(DomainPair pair) {
+        return routes.get(pair);
+    }
+    RoutableChannelHandler getRoute(JID jid) {
+        return routes.get(new DomainPair("", jid.toString()));
     }
 
     /**
@@ -119,10 +118,10 @@ class LocalRoutingTable {
     /**
      * Removes a route of a local {@link RoutableChannelHandler}
      *
-     * @param address the string representation of the JID associated to the route.
+     * @param pair DomainPair associated to the route.
      */
-    void removeRoute(String address) {
-        routes.remove(address);
+    void removeRoute(DomainPair pair) {
+        routes.remove(pair);
     }
 
     public void start() {
@@ -154,8 +153,11 @@ class LocalRoutingTable {
         }
     }
 
+    public boolean isLocalRoute(DomainPair pair) {
+        return routes.containsKey(pair);
+    }
     public boolean isLocalRoute(JID jid) {
-        return routes.containsKey(jid.toString());
+        return routes.containsKey(new DomainPair("", jid.toString()));
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -468,7 +468,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         }
 
         DomainPair pair = new DomainPair(packet.getFrom().getDomain(), jid.getDomain());
-		byte[] nodeID = serversCache.get(pair.toString());
+		byte[] nodeID = serversCache.get(pair);
 		if (nodeID != null) {
 		    if (server.getNodeID().equals(nodeID)) {
 		        // This is a route to a remote server connected from this node
@@ -786,7 +786,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             RemoteSessionLocator locator = server.getRemoteSessionLocator();
             if (locator != null) {
                 // Check if the session is hosted by other cluster node
-                byte[] nodeID = serversCache.get(jids.toString());
+                byte[] nodeID = serversCache.get(jids);
                 if (nodeID != null) {
                     session = locator.getOutgoingServerSession(nodeID, jids);
                 }
@@ -835,8 +835,8 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     }
 
     @Override
-    public boolean hasServerRoute(JID jid) {
-        return serversCache.containsKey(jid.getDomain());
+    public boolean hasServerRoute(DomainPair pair) {
+        return serversCache.containsKey(pair);
     }
 
     @Override

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -70,9 +70,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
     /**
      * Cache (unlimited, never expire) that holds outgoing sessions to remote servers from this server.
-     * Key: server domain, Value: nodeID
+     * Key: server domain pair, Value: nodeID
      */
-    private Cache<String, byte[]> serversCache;
+    private Cache<DomainPair, byte[]> serversCache;
     /**
      * Cache (unlimited, never expire) that holds components connected to the server.
      * Key: component domain, Value: list of nodeIDs hosting the component
@@ -115,8 +115,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     }
 
     @Override
-    public void addServerRoute(JID route, LocalOutgoingServerSession destination) {
-        String address = route.getDomain();
+    public void addServerRoute(DomainPair address, LocalOutgoingServerSession destination) {
         localRoutingTable.addRoute(address, destination);
         Lock lock = CacheFactory.getLock(address, serversCache);
         try {
@@ -130,8 +129,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
     @Override
     public void addComponentRoute(JID route, RoutableChannelHandler destination) {
+        DomainPair pair = new DomainPair("", route.getDomain());
         String address = route.getDomain();
-        localRoutingTable.addRoute(address, destination);
+        localRoutingTable.addRoute(pair, destination);
         Lock lock = CacheFactory.getLock(address, componentsCache);
         try {
             lock.lock();
@@ -150,7 +150,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     public boolean addClientRoute(JID route, LocalClientSession destination) {
         boolean added;
         boolean available = destination.getPresence().isAvailable();
-        localRoutingTable.addRoute(route.toString(), destination);
+        localRoutingTable.addRoute(new DomainPair("", route.toString()), destination);
         if (destination.getAuthToken().isAnonymous()) {
             Lock lockAn = CacheFactory.getLock(route.toString(), anonymousUsersCache);
             try {
@@ -341,7 +341,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                                             carbon.addExtension(new Received(new Forwarded(message)));
 
                                             try {
-                                                localRoutingTable.getRoute(route.toString()).process(carbon);
+                                                localRoutingTable.getRoute(route).process(carbon);
                                             } catch (UnauthorizedException e) {
                                                 Log.error("Unable to route packet " + packet.toXML(), e);
                                             }
@@ -353,7 +353,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
                         // This is a route to a local user hosted in this node
                         try {
-		                    localRoutingTable.getRoute(jid.toString()).process(packet);
+		                    localRoutingTable.getRoute(jid).process(packet);
 		                    routed = true;
 		                } catch (UnauthorizedException e) {
 		                    Log.error("Unable to route packet " + packet.toXML(), e);
@@ -397,7 +397,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 		}
 		
 		// First check if the component is being hosted in this JVM
-		RoutableChannelHandler route = localRoutingTable.getRoute(jid.getDomain());
+		RoutableChannelHandler route = localRoutingTable.getRoute(new JID(null, jid.getDomain(), null, true));
 		if (route != null) {
 		    try {
 		        route.process(packet);
@@ -415,7 +415,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 		                // This is a route to a local component hosted in this node (route
 		                // could have been added after our previous check)
 		                try {
-		                    RoutableChannelHandler localRoute = localRoutingTable.getRoute(jid.getDomain());
+		                    RoutableChannelHandler localRoute = localRoutingTable.getRoute(new JID(null, jid.getDomain(), null, true));
 		                    if (localRoute != null) {
 		                        localRoute.process(packet);
 		                        routed = true;
@@ -467,12 +467,13 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             }
         }
 
-		byte[] nodeID = serversCache.get(jid.getDomain());
+        DomainPair pair = new DomainPair(packet.getFrom().getDomain(), jid.getDomain());
+		byte[] nodeID = serversCache.get(pair.toString());
 		if (nodeID != null) {
 		    if (server.getNodeID().equals(nodeID)) {
 		        // This is a route to a remote server connected from this node
 		        try {
-		            localRoutingTable.getRoute(jid.getDomain()).process(packet);
+		            localRoutingTable.getRoute(pair).process(packet);
 		            routed = true;
 		        } catch (UnauthorizedException e) {
 		            Log.error("Unable to route packet " + packet.toXML(), e);
@@ -731,7 +732,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     @Override
     public ClientSession getClientRoute(JID jid) {
         // Check if this session is hosted by this cluster node
-        ClientSession session = (ClientSession) localRoutingTable.getRoute(jid.toString());
+        ClientSession session = (ClientSession) localRoutingTable.getRoute(jid);
         if (session == null) {
             // The session is not in this JVM so assume remote
             RemoteSessionLocator locator = server.getRemoteSessionLocator();
@@ -777,17 +778,17 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     }
 
     @Override
-    public OutgoingServerSession getServerRoute(JID jid) {
+    public OutgoingServerSession getServerRoute(DomainPair jids) {
         // Check if this session is hosted by this cluster node
-        OutgoingServerSession session = (OutgoingServerSession) localRoutingTable.getRoute(jid.getDomain());
+        OutgoingServerSession session = (OutgoingServerSession) localRoutingTable.getRoute(jids);
         if (session == null) {
             // The session is not in this JVM so assume remote
             RemoteSessionLocator locator = server.getRemoteSessionLocator();
             if (locator != null) {
                 // Check if the session is hosted by other cluster node
-                byte[] nodeID = serversCache.get(jid.getDomain());
+                byte[] nodeID = serversCache.get(jids.toString());
                 if (nodeID != null) {
-                    session = locator.getOutgoingServerSession(nodeID, jid);
+                    session = locator.getOutgoingServerSession(nodeID, jids);
                 }
             }
         }
@@ -796,6 +797,15 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
     @Override
     public Collection<String> getServerHostnames() {
+        Set<String> domains = new HashSet<>();
+        for (DomainPair pair : serversCache.keySet()) {
+            domains.add(pair.getRemote());
+        }
+        return domains;
+    }
+
+    @Override
+    public Collection<DomainPair> getServerRoutes() {
         return serversCache.keySet();
     }
 
@@ -936,13 +946,13 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                 lock.unlock();
             }
         }
-        localRoutingTable.removeRoute(address);
+        localRoutingTable.removeRoute(new DomainPair("", route.getDomain()));
         return clientRoute != null;
     }
 
     @Override
-    public boolean removeServerRoute(JID route) {
-        String address = route.getDomain();
+    public boolean removeServerRoute(DomainPair route) {
+        String address = route.toString();
         boolean removed = false;
         Lock lock = CacheFactory.getLock(address, serversCache);
         try {
@@ -952,7 +962,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         finally {
             lock.unlock();
         }
-        localRoutingTable.removeRoute(address);
+        localRoutingTable.removeRoute(route);
         return removed;
     }
 
@@ -976,7 +986,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         } finally {
             lock.unlock();
         }
-        localRoutingTable.removeRoute(address);
+        localRoutingTable.removeRoute(new DomainPair("", address));
         return removed;
     }
 
@@ -1080,14 +1090,14 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         Lock serverLock = CacheFactory.getLock(nodeID, serversCache);
         try {
         	serverLock.lock();
-	    	List<String> remoteServerDomains = new ArrayList<>();
-	    	for (Map.Entry<String, byte[]> entry : serversCache.entrySet()) {
+	    	List<DomainPair> remoteServerDomains = new ArrayList<>();
+	    	for (Map.Entry<DomainPair, byte[]> entry : serversCache.entrySet()) {
 	    		if (Arrays.equals(entry.getValue(), nodeID)) {
 	    			remoteServerDomains.add(entry.getKey());
 	    		}
 	    	}
-	    	for (String domain : remoteServerDomains) {
-	    		removeServerRoute(new JID(domain));
+	    	for (DomainPair pair : remoteServerDomains) {
+	    		removeServerRoute(pair);
 	    	}
         }
         finally {
@@ -1122,7 +1132,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     private void restoreCacheContent() {
         // Add outgoing server sessions hosted locally to the cache (using new nodeID)
         for (LocalOutgoingServerSession session : localRoutingTable.getServerRoutes()) {
-            addServerRoute(session.getAddress(), session);
+            for (DomainPair pair : session.getOutgoingDomainPairs()) {
+                addServerRoute(pair, session);
+            }
         }
 
         // Add component sessions hosted locally to the cache (using new nodeID) and remove traces to old nodeID

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -954,10 +954,10 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     public boolean removeServerRoute(DomainPair route) {
         String address = route.toString();
         boolean removed = false;
-        Lock lock = CacheFactory.getLock(address, serversCache);
+        Lock lock = CacheFactory.getLock(route, serversCache);
         try {
             lock.lock();
-            removed = serversCache.remove(address) != null;
+            removed = serversCache.remove(route) != null;
         }
         finally {
             lock.unlock();

--- a/src/java/org/jivesoftware/util/S2STestService.java
+++ b/src/java/org/jivesoftware/util/S2STestService.java
@@ -9,6 +9,7 @@ import org.jivesoftware.openfire.interceptor.InterceptorManager;
 import org.jivesoftware.openfire.interceptor.PacketInterceptor;
 import org.jivesoftware.openfire.interceptor.PacketRejectedException;
 import org.jivesoftware.openfire.server.RemoteServerManager;
+import org.jivesoftware.openfire.session.DomainPair;
 import org.jivesoftware.openfire.session.OutgoingServerSession;
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.util.cert.SANCertificateIdentityMapping;
@@ -56,6 +57,7 @@ public class S2STestService {
     public Map<String, String> run() throws Exception {
         waitUntil = new Semaphore(0);
         Map<String, String> results = new HashMap<>();
+        final DomainPair pair = new DomainPair(XMPPServer.getInstance().getServerInfo().getXMPPDomain(), domain);
 
         // Tear down existing routes.
         final SessionManager sessionManager = SessionManager.getInstance();
@@ -64,7 +66,7 @@ public class S2STestService {
             incomingServerSession.close();
         }
 
-        final Session outgoingServerSession = sessionManager.getOutgoingServerSession( domain );
+        final Session outgoingServerSession = sessionManager.getOutgoingServerSession( pair );
         if ( outgoingServerSession != null )
         {
             outgoingServerSession.close();
@@ -72,7 +74,7 @@ public class S2STestService {
 
         final IQ pingRequest = new IQ( Type.get );
         pingRequest.setChildElement( "ping", IQPingHandler.NAMESPACE );
-        pingRequest.setFrom( XMPPServer.getInstance().getServerInfo().getXMPPDomain() );
+        pingRequest.setFrom( pair.getLocal() );
         pingRequest.setTo( domain );
 
         // Intercept logging.
@@ -145,7 +147,8 @@ public class S2STestService {
      * Logs the status of the session.
      */
     private void logSessionStatus() {
-        OutgoingServerSession session = XMPPServer.getInstance().getSessionManager().getOutgoingServerSession(domain);
+        final DomainPair pair = new DomainPair(XMPPServer.getInstance().getServerInfo().getXMPPDomain(), domain);
+        OutgoingServerSession session = XMPPServer.getInstance().getSessionManager().getOutgoingServerSession(pair);
         if (session != null) {
             int connectionStatus = session.getStatus();
             switch(connectionStatus) {
@@ -168,7 +171,8 @@ public class S2STestService {
      * @return A String representation of the certificate chain for the connection to the domain under test.
      */
     private String getCertificates() {
-        Session session = XMPPServer.getInstance().getSessionManager().getOutgoingServerSession(domain);
+        final DomainPair pair = new DomainPair(XMPPServer.getInstance().getServerInfo().getXMPPDomain(), domain);
+        Session session = XMPPServer.getInstance().getSessionManager().getOutgoingServerSession(pair);
         StringBuilder certs = new StringBuilder();
         if (session != null) {
             Log.info("Successfully negotiated TLS connection.");

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/DeliverRawTextTask.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/DeliverRawTextTask.java
@@ -19,6 +19,7 @@ package org.jivesoftware.openfire.plugin.session;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.StreamID;
 import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.session.DomainPair;
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.openfire.spi.BasicStreamIDFactory;
 import org.jivesoftware.util.Log;
@@ -50,6 +51,7 @@ public class DeliverRawTextTask implements ClusterTask<Void> {
             this.sessionType = SessionType.client;
         }
         else if (remoteSession instanceof RemoteOutgoingServerSession) {
+            Log.error("OutgoingServerSession used with DeliverRawTextTask; should be using DeliverRawTextServerTask: " + remoteSession);
             this.sessionType = SessionType.outgoingServer;
         }
         else if (remoteSession instanceof RemoteComponentSession) {
@@ -114,7 +116,8 @@ public class DeliverRawTextTask implements ClusterTask<Void> {
             return SessionManager.getInstance().getConnectionMultiplexerSession(address);
         }
         else if (sessionType == SessionType.outgoingServer) {
-            return SessionManager.getInstance().getOutgoingServerSession(address.getDomain());
+            Log.error("Trying to write raw data to a server session across the cluster: " + address.toString());
+            return null;
         }
         else if (sessionType == SessionType.incomingServer) {
             return SessionManager.getInstance().getIncomingServerSession(streamID);

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/OutgoingServerSessionTask.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/OutgoingServerSessionTask.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.openfire.plugin.session;
 
 import org.jivesoftware.openfire.SessionManager;
+import org.jivesoftware.openfire.session.DomainPair;
 import org.jivesoftware.openfire.session.OutgoingServerSession;
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.util.cache.ExternalizableUtil;
@@ -33,18 +34,18 @@ import java.io.ObjectOutput;
  * @author Gaston Dombiak
  */
 public class OutgoingServerSessionTask extends RemoteSessionTask {
-    private JID address;
+    private DomainPair address;
 
     public OutgoingServerSessionTask() {
     }
 
-    protected OutgoingServerSessionTask(JID address, Operation operation) {
+    protected OutgoingServerSessionTask(DomainPair address, Operation operation) {
         super(operation);
         this.address = address;
     }
 
     Session getSession() {
-        return SessionManager.getInstance().getOutgoingServerSession(address.getDomain());
+        return SessionManager.getInstance().getOutgoingServerSession(address);
     }
 
     public void run() {
@@ -64,7 +65,7 @@ public class OutgoingServerSessionTask extends RemoteSessionTask {
 
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
         super.readExternal(in);
-        address = (JID) ExternalizableUtil.getInstance().readSerializable(in);
+        address = (DomainPair) ExternalizableUtil.getInstance().readSerializable(in);
     }
 
     public String toString() {

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/ProcessPacketTask.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/ProcessPacketTask.java
@@ -21,6 +21,7 @@ import org.dom4j.tree.DefaultElement;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.StreamID;
 import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.session.DomainPair;
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.openfire.spi.BasicStreamIDFactory;
 import org.jivesoftware.util.Log;
@@ -135,7 +136,8 @@ public class ProcessPacketTask implements ClusterTask<Void> {
             return SessionManager.getInstance().getConnectionMultiplexerSession(address);
         }
         else if (sessionType == SessionType.outgoingServer) {
-            return SessionManager.getInstance().getOutgoingServerSession(address.getDomain());
+            final DomainPair pair = new DomainPair(packet.getFrom().getDomain(), address.getDomain());
+            return SessionManager.getInstance().getOutgoingServerSession(pair);
         }
         else if (sessionType == SessionType.incomingServer) {
             return SessionManager.getInstance().getIncomingServerSession(streamID);

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/RemoteSessionLocator.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/session/RemoteSessionLocator.java
@@ -45,7 +45,7 @@ public class RemoteSessionLocator implements org.jivesoftware.openfire.session.R
         return new RemoteIncomingServerSession(nodeID, streamID);
     }
 
-    public OutgoingServerSession getOutgoingServerSession(byte[] nodeID, JID address) {
+    public OutgoingServerSession getOutgoingServerSession(byte[] nodeID, DomainPair address) {
         return new RemoteOutgoingServerSession(nodeID, address);
     }
 }

--- a/src/plugins/kraken/plugin.xml
+++ b/src/plugins/kraken/plugin.xml
@@ -8,9 +8,9 @@
     <name>Kraken IM Gateway</name>
     <description>Adds transports to other IM networks.</description>
     <author>Daniel Henninger</author>
-    <version>1.3.0</version>
-    <date>10/12/2015</date>
-    <minServerVersion>4.0.0</minServerVersion>
+    <version>1.3.1</version>
+    <date>11/14/2017</date>
+    <minServerVersion>4.2.0</minServerVersion>
     <databaseKey>gateway</databaseKey>
     <databaseVersion>12</databaseVersion>
     <licenseType>apache2</licenseType>

--- a/src/plugins/kraken/src/java/net/sf/kraken/TransportInstance.java
+++ b/src/plugins/kraken/src/java/net/sf/kraken/TransportInstance.java
@@ -15,12 +15,14 @@ import org.apache.log4j.Logger;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.session.Session;
+import org.jivesoftware.openfire.session.OutgoingServerSession;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.PropertyEventDispatcher;
 import org.jivesoftware.util.PropertyEventListener;
 import org.xmpp.component.ComponentManager;
 
 import java.util.Map;
+import java.util.List;
 
 /**
  * Transport Instance
@@ -157,10 +159,12 @@ public class TransportInstance<B extends TransportBuddy> implements PropertyEven
         }
 
         try {
-            Session sess = sessionManager.getOutgoingServerSession(fullJID);
-            if (sess != null) {
-                sess.close();
-                pause = true;
+            List<OutgoingServerSession> sessions = sessionManager.getOutgoingServerSessions(fullJID);
+            for (OutgoingServerSession sess : sessions) {
+                if (sess != null) {
+                    sess.close();
+                    pause = true;
+                }
             }
         }
         catch (Exception ignored) {

--- a/src/web/server-session-details.jsp
+++ b/src/web/server-session-details.jsp
@@ -26,6 +26,7 @@
 <%@ page import="java.util.Calendar" %>
 <%@ page import="java.util.Date" %>
 <%@ page import="java.util.List" %>
+<%@ page import="java.util.Collection" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -46,7 +47,7 @@
     // Get the session & address objects
     SessionManager sessionManager = webManager.getSessionManager();
     List<IncomingServerSession> inSessions = sessionManager.getIncomingServerSessions(hostname);
-    OutgoingServerSession outSession = sessionManager.getOutgoingServerSession(hostname);
+    List<OutgoingServerSession> outSessions = sessionManager.getOutgoingServerSessions(hostname);
 
     // Number dateFormatter for all numbers on this page:
     NumberFormat numFormatter = NumberFormat.getNumberInstance();
@@ -81,10 +82,10 @@
             <fmt:message key="server.session.label.connection" />
         </td>
         <td>
-        <% if (!inSessions.isEmpty() && outSession == null) { %>
+        <% if (!inSessions.isEmpty() && outSessions.isEmpty()) { %>
             <img src="images/incoming_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.incoming' />" alt="<fmt:message key='server.session.connection.incoming' />">
             <fmt:message key="server.session.connection.incoming" />
-        <% } else if (inSessions.isEmpty() && outSession != null) { %>
+        <% } else if (inSessions.isEmpty() && !outSessions.isEmpty()) { %>
             <img src="images/outgoing_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.outgoing' />" alt="<fmt:message key='server.session.connection.outgoing' />">
             <fmt:message key="server.session.connection.outgoing" />
         <% } else { %>
@@ -103,10 +104,10 @@
                 <%= inSessions.get(0).getHostAddress() %>
                 /
                 <%= inSessions.get(0).getHostName() %>
-	        <% } else if (outSession != null) { %>
-	            <%= outSession.getHostAddress() %>
+	        <% } else if (!outSessions.isEmpty()) { %>
+	            <%= outSessions.get(0).getHostAddress() %>
 	            /
-	            <%= outSession.getHostName() %>
+	            <%= outSessions.get(0).getHostName() %>
 	        <% }
 	       } catch (java.net.UnknownHostException e) { %>
                 Invalid session/connection
@@ -170,8 +171,8 @@
     <br>
 <%  } %>
 
-<%  // Show details of the incoming session
-    if (outSession != null) {
+<%  // Show details of the outgoing sessiona
+    for (OutgoingServerSession outSession : outSessions) {
 %>
     <b><fmt:message key="server.session.details.outgoing_session" /></b>
     <div class="jive-table">

--- a/src/web/server-session-row.jspf
+++ b/src/web/server-session-row.jspf
@@ -28,8 +28,13 @@
         }
     }
     // Check if outgoing session is secured (only if incoming sessions are secured)
-    if (isSecured && outSession != null) {
-        isSecured = outSession.isSecure();
+    if (isSecured) {
+        for (org.jivesoftware.openfire.session.OutgoingServerSession outSession : outSessions) {
+            if (!outSession.isSecure()) {
+                isSecured = false;
+                break;
+            }
+        }
     }
 %>
 <tr class="jive-<%= (((count % 2) == 0) ? "even" : "odd") %>">
@@ -49,12 +54,12 @@
      <% } else { %>
     <td width="1%"><img src="images/blank.gif" width="1" height="1" alt=""></td>
      <% } %>
-    <% if (!inSessions.isEmpty() && outSession == null) { %>
+    <% if (!inSessions.isEmpty() && outSessions.isEmpty()) { %>
         <td width="1%">
             <img src="images/incoming_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.incoming' />" alt="<fmt:message key='server.session.connection.incoming' />">
         </td>
         <td width="10%"><fmt:message key="server.session.connection.incoming" /></td>
-    <% } else if (inSessions.isEmpty() && outSession != null) { %>
+    <% } else if (inSessions.isEmpty() && !outSessions.isEmpty()) { %>
         <td width="1%">
             <img src="images/outgoing_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.outgoing' />" alt="<fmt:message key='server.session.connection.outgoing' />">
         </td>
@@ -68,35 +73,25 @@
 
     <% Date creationDate = null;
         Date lastActiveDate = null;
-        if (!inSessions.isEmpty() && outSession == null) {
-            for (IncomingServerSession inSession : inSessions) {
-                if (creationDate == null || creationDate.after(inSession.getCreationDate())) {
-                    // Use the creation date of the oldest incoming session
-                    creationDate = inSession.getCreationDate();
-                }
-                if (lastActiveDate == null || lastActiveDate.before(inSession.getLastActiveDate())) {
-                    // Use the last active date of the newest incoming session
-                    lastActiveDate = inSession.getLastActiveDate();
-                }
+        for (IncomingServerSession inSession : inSessions) {
+            if (creationDate == null || creationDate.after(inSession.getCreationDate())) {
+                // Use the creation date of the oldest incoming session
+                creationDate = inSession.getCreationDate();
+            }
+            if (lastActiveDate == null || lastActiveDate.before(inSession.getLastActiveDate())) {
+                // Use the last active date of the newest incoming session
+                lastActiveDate = inSession.getLastActiveDate();
             }
         }
-        else if (inSessions.isEmpty() && outSession != null) {
-            creationDate = outSession.getCreationDate();
-            lastActiveDate = outSession.getLastActiveDate();
-        }
-        else {
-            for (IncomingServerSession inSession : inSessions) {
-                if (creationDate == null || creationDate.after(inSession.getCreationDate())) {
-                    // Use the creation date of the oldest incoming session
-                    creationDate = inSession.getCreationDate();
-                }
-                if (lastActiveDate == null || lastActiveDate.before(inSession.getLastActiveDate())) {
-                    // Use the last active date of the newest incoming session
-                    lastActiveDate = inSession.getLastActiveDate();
-                }
+        for (OutgoingServerSession outSession : outSessions) {
+            if (creationDate == null || creationDate.after(outSession.getCreationDate())) {
+                // Use the creation date of the oldest outgoing session
+                creationDate = outSession.getCreationDate();
             }
-            creationDate = creationDate.before(outSession.getCreationDate()) ? creationDate : outSession.getCreationDate();
-            lastActiveDate = lastActiveDate.after(outSession.getLastActiveDate()) ? lastActiveDate : outSession.getLastActiveDate();
+            if (lastActiveDate == null || lastActiveDate.before(outSession.getLastActiveDate())) {
+                // Use the last active date of the newest outgoing session
+                lastActiveDate = outSession.getLastActiveDate();
+            }
         }
         Calendar creationCal = Calendar.getInstance();
         creationCal.setTime(creationDate);

--- a/src/web/server-session-summary.jsp
+++ b/src/web/server-session-summary.jsp
@@ -196,7 +196,7 @@
         for (String host : hostnames) {
             count++;
             List<IncomingServerSession> inSessions = sessionManager.getIncomingServerSessions(host);
-            Collection<OutgoingServerSession> outSessions = sessionManager.getOutgoingServerSessions(host);
+            List<OutgoingServerSession> outSessions = sessionManager.getOutgoingServerSessions(host);
             if (inSessions.isEmpty() && outSessions.isEmpty()) {
                 // If the connections were just closed then skip this host
                 continue;

--- a/src/web/server-session-summary.jsp
+++ b/src/web/server-session-summary.jsp
@@ -77,12 +77,14 @@
                 sess.close();
             }
 
-            Session sess = sessionManager.getOutgoingServerSession(hostname);
-            if (sess != null) {
-                sess.close();
+            Collection<OutgoingServerSession> sessions = sessionManager.getOutgoingServerSessions(hostname);
+            for (OutgoingServerSession sess : sessions) {
+                if (sess != null) {
+                    sess.close();
+                }
             }
             // Log the event
-            webManager.logEvent("closed server session for "+hostname, null);
+            webManager.logEvent("closed server sessions for "+hostname, null);
             // wait one second
             Thread.sleep(1000L);
         }
@@ -194,8 +196,8 @@
         for (String host : hostnames) {
             count++;
             List<IncomingServerSession> inSessions = sessionManager.getIncomingServerSessions(host);
-            OutgoingServerSession outSession = sessionManager.getOutgoingServerSession(host);
-            if (inSessions.isEmpty() && outSession == null) {
+            Collection<OutgoingServerSession> outSessions = sessionManager.getOutgoingServerSessions(host);
+            if (inSessions.isEmpty() && outSessions.isEmpty()) {
                 // If the connections were just closed then skip this host
                 continue;
             }


### PR DESCRIPTION
Because we cannot always multiplex outgoing sessions, we may have multiple outgoing routes to the same domain.

This means that when we have a route A->B, and try to send traffic for conference.A->B, the traffic is rejected and the session closed, and we can end up creating a new session which becomes the new route to B, unsuited to traffic from A itself. This has some interesting (read, confusing) side effects, beyond simple loss of communication.

For example, if a user at B has a user at A in their roster, the session B-A is typically open before the user can join a room at conference.B. When joining, the stanzas associated with the join are all sent "at once", and promptly rejected. Other users then see both an unavailable (ie, leaving) presence from the user at B, followed by a successful join - the user at B however sees absolutely nothing.

Meanwhile, the session A->B has now gone, and traffic from user@A will be initially lost to user@B before the session "flips" again.

This reworks routing such that the route tracked is not simply "to B", but "from A to B", allowing us to track multiple outgoing routes.