### PR TITLE
Fix for time assurance test

### DIFF
--- a/src/test/java/org/jivesoftware/util/StringUtilsTest.java
+++ b/src/test/java/org/jivesoftware/util/StringUtilsTest.java
@@ -5,9 +5,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.util.Locale;
+
+import org.junit.Before;
 import org.junit.Test;
 
 public class StringUtilsTest {
+    
+    @Before
+    public void setUp() {
+        JiveGlobals.setLocale(Locale.ENGLISH);
+    }
     
     @Test
     public void testValidDomainNames() {


### PR DESCRIPTION
Test was looking trying to assure that after some time a number of seconds will pass, but with time units like "30 seconds". That was causing problems while I was building Openfire in Polish version of OS and units were named in Polish (e.g. second - sekunda). Credit for this to Guus but I was asked to PR this.