### PR TITLE
Set correct sequence number in the <resumed/> element

### DIFF
--- a/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -442,7 +442,7 @@ public class StreamManager {
 	    Log.debug("Agreeing to resume");
 	    Element resumed = new DOMElement(QName.get("resumed", namespace));
 	    resumed.addAttribute("previd", StringUtils.encodeBase64( session.getAddress().getResource() + "\0" + session.getStreamID().getID()));
-	    resumed.addAttribute("h", Long.toString(clientProcessedStanzas));
+	    resumed.addAttribute("h", Long.toString(serverProcessedStanzas));
 	    session.getConnection().deliverRawText(resumed.asXML());
         Log.debug("Resuming session: Ack for {}", h);
         processClientAcknowledgement(h);


### PR DESCRIPTION
According to [XEP-0198](https://xmpp.org/extensions/xep-0198.html#resumption):
> If the server can resume the former stream, it MUST return a <resumed/> element, which MUST include a 'previd' attribute set to the SM-ID of the former stream and MUST also include an 'h' attribute set to the sequence number of the last handled stanza sent over the former stream **from the client to the server** (in the unlikely case that the server never received any stanzas, it would set 'h' to zero).

I'm using Smack client. Stream resumption was failing with StreamManagementCounterError because the number of stanzas sent **from the server to the client** was set in the <resumed/> element.