### PR TITLE
OF-1430 SCRAM should just be used when supported

### DIFF
--- a/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -548,15 +548,15 @@ public class SASLAuthentication {
                     // Check if the user provider in use supports passwords retrieval. Access to the users passwords will be required by the CallbackHandler.
                     if ( !AuthFactory.supportsPasswordRetrieval() )
                     {
-                        Log.trace( "Cannot support '{}' as the AuthFactory that's in used does not support password retrieval.", mechanism );
+                        Log.trace( "Cannot support '{}' as the AuthFactory that's in use does not support password retrieval.", mechanism );
                         it.remove();
                     }
                     break;
 
                 case "SCRAM-SHA-1":
-                    if ( !AuthFactory.supportsPasswordRetrieval() || !AuthFactory.supportsScram() )
+                    if ( AuthFactory.supportsScram() )
                     {
-                        Log.trace( "Cannot support '{}' as the AuthFactory that's in used does not support password retrieval nor SCRAM.", mechanism );
+                        Log.trace( "Cannot support '{}' as the AuthFactory that's in use does not support SCRAM.", mechanism );
                         it.remove();
                     }
                     break;


### PR DESCRIPTION
The logic here was wrong, but trying to handle SCRAM when we
could read the password, or there was native support. However,
the existing SCRAM code doesn't perform any fallback - instead
that's left to the AuthProviders themselves to implement.

So the new logic just assumes that an AuthProvider which can
provide that fallback will advertise it. If we later make this
support generic, it can go into the AuthFactory level.