### PR TITLE
OF-1431 Add null safety on packet.getType()

### DIFF
--- a/src/java/org/jivesoftware/openfire/handler/IQPingHandler.java
+++ b/src/java/org/jivesoftware/openfire/handler/IQPingHandler.java
@@ -56,7 +56,7 @@ public class IQPingHandler extends IQHandler implements ServerFeaturesProvider {
      */
     @Override
     public IQ handleIQ(IQ packet) {
-        if (packet.getType().equals(Type.get)) {
+        if (Type.get.equals(packet.getType())) {
             return IQ.createResultIQ(packet);
         }
         return null;


### PR DESCRIPTION
OpenFire was throwing a NPE when receiving a Ping request with the type attribute missing.

This PR will just make it return null, and not throw an exception.
