### PR TITLE
OF-1434 Check if sender is a component first in PubSubEngine::createNodeHelper

### DIFF
--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -1151,7 +1151,7 @@ public class PubSubEngine {
         // Get sender of the IQ packet
         JID from = iq.getFrom();
         // Verify that sender has permissions to create nodes
-        if (!service.canCreateNode(from) || (!UserManager.getInstance().isRegisteredUser(from) && !isComponent(from)) ) {
+        if (!service.canCreateNode(from) || (!isComponent(from) && !UserManager.getInstance().isRegisteredUser(from))) {
             // The user is not allowed to create nodes so return an error
             return new CreateNodeResponse(PacketError.Condition.forbidden, null, null);
         }


### PR DESCRIPTION
There is no point in calling `isRegisteredUser` (and thus making a `disco#info` query) if the sender is a component.

There is a bigger [issue](https://discourse.igniterealtime.org/t/calling-usermanager-isregistereduser-jid-from-i-o-handler-thread/79779) related to calling `isRegisteredUser` from the I/O handler thread. Beside optimization this fix avoids it for the components.