### PR TITLE
OF-1437 Try to stop sessions having their routes removed

### DIFF
--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -150,7 +150,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     public boolean addClientRoute(JID route, LocalClientSession destination) {
         boolean added;
         boolean available = destination.getPresence().isAvailable();
-        Log.debug("Adding client route {}", route.toString());
+        Log.debug("Adding client route {}", route);
         localRoutingTable.addRoute(new DomainPair("", route.toString()), destination);
         if (destination.getAuthToken().isAnonymous()) {
             Lock lockAn = CacheFactory.getLock(route.toString(), anonymousUsersCache);
@@ -947,7 +947,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                 lock.unlock();
             }
         }
-        Log.debug("Removing client route {}", route.toString());
+        Log.debug("Removing client route {}", route);
         localRoutingTable.removeRoute(new DomainPair("", route.toString()));
         return clientRoute != null;
     }

--- a/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -206,7 +206,7 @@ public class StreamManager {
     }
 
     private void startResume(String namespace, String previd, long h) {
-        Log.debug("Attempting resumption.");
+        Log.debug("Attempting resumption for {}, h={}", previd, h);
         this.namespace = namespace;
         // Ensure that resource binding has NOT occurred.
         if (!allowResume() ) {
@@ -239,7 +239,7 @@ public class StreamManager {
             return;
         }
         JID fullJid = new JID(authToken.getUsername(), authToken.getDomain(), resource, true);
-        Log.debug("Resuming session {}", fullJid.toString());
+        Log.debug("Resuming session {}", fullJid);
 
         // Locate existing session.
         LocalClientSession otherSession = (LocalClientSession)XMPPServer.getInstance().getRoutingTable().getClientRoute(fullJid);


### PR DESCRIPTION
This patch adds a lot of debug logging, plus stops the
console NPE'ing when you try to view a detached session.
    
It also detaches a session before trying to reattach it, to
avoid it being unrouted when the connection is closed.

