### PR TITLE
OF-1437 Try to stop sessions having their routes removed

### DIFF
--- a/src/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -449,11 +449,17 @@ public abstract class LocalSession implements Session {
 
     @Override
     public String getHostAddress() throws UnknownHostException {
+        if (conn == null) {
+            throw new UnknownHostException("Detached session");
+        }
         return conn.getHostAddress();
     }
 
     @Override
     public String getHostName() throws UnknownHostException {
+        if (conn == null) {
+            throw new UnknownHostException("Detached session");
+        }
         return conn.getHostName();
     }
 

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -150,6 +150,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     public boolean addClientRoute(JID route, LocalClientSession destination) {
         boolean added;
         boolean available = destination.getPresence().isAvailable();
+        Log.debug("Adding client route {}", route.toString());
         localRoutingTable.addRoute(new DomainPair("", route.toString()), destination);
         if (destination.getAuthToken().isAnonymous()) {
             Lock lockAn = CacheFactory.getLock(route.toString(), anonymousUsersCache);
@@ -946,6 +947,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                 lock.unlock();
             }
         }
+        Log.debug("Removing client route {}", route.toString());
         localRoutingTable.removeRoute(new DomainPair("", route.toString()));
         return clientRoute != null;
     }

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -150,7 +150,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     public boolean addClientRoute(JID route, LocalClientSession destination) {
         boolean added;
         boolean available = destination.getPresence().isAvailable();
-        Log.debug("Adding client route {}", route.toString());
+        Log.debug("Adding client route {}", route);
         localRoutingTable.addRoute(new DomainPair("", route.toString()), destination);
         if (destination.getAuthToken().isAnonymous()) {
             Lock lockAn = CacheFactory.getLock(route.toString(), anonymousUsersCache);
@@ -947,7 +947,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                 lock.unlock();
             }
         }
-        Log.debug("Removing client route {}", route.toString());
+        Log.debug("Removing client route {}", route);
         localRoutingTable.removeRoute(new DomainPair("", route.toString()));
         return clientRoute != null;
     }

--- a/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -206,6 +206,7 @@ public class StreamManager {
     }
 
     private void startResume(String namespace, String previd, long h) {
+        Log.debug("Attempting resumption.");
         this.namespace = namespace;
         // Ensure that resource binding has NOT occurred.
         if (!allowResume() ) {
@@ -238,6 +239,7 @@ public class StreamManager {
             return;
         }
         JID fullJid = new JID(authToken.getUsername(), authToken.getDomain(), resource, true);
+        Log.debug("Resuming session {}", fullJid.toString());
 
         // Locate existing session.
         LocalClientSession otherSession = (LocalClientSession)XMPPServer.getInstance().getRoutingTable().getClientRoute(fullJid);
@@ -249,6 +251,7 @@ public class StreamManager {
             sendError(new PacketError(PacketError.Condition.item_not_found));
             return;
         }
+        Log.debug("Found existing session, checking status");
         // Previd identifies proper session. Now check SM status
         if (!otherSession.getStreamManager().namespace.equals(namespace)) {
             sendError(new PacketError(PacketError.Condition.unexpected_request));
@@ -259,8 +262,12 @@ public class StreamManager {
             return;
         }
         if (!otherSession.isDetached()) {
+            Log.debug("Existing session is not detached; detaching.");
+            Connection oldConnection = otherSession.getConnection();
             otherSession.setDetached();
+            oldConnection.close();
         }
+        Log.debug("Attaching to other session.");
         // If we're all happy, disconnect this session.
         Connection conn = session.getConnection();
         session.setDetached();
@@ -283,6 +290,10 @@ public class StreamManager {
      */
     public void sendServerAcknowledgement() {
         if(isEnabled()) {
+            if (session.isDetached()) {
+                Log.debug("Session is detached, won't request an ack.");
+                return;
+            }
             String ack = String.format("<a xmlns='%s' h='%s' />", namespace, serverProcessedStanzas & mask);
             session.deliverRawText( ack );
         }

--- a/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -206,7 +206,7 @@ public class StreamManager {
     }
 
     private void startResume(String namespace, String previd, long h) {
-        Log.debug("Attempting resumption.");
+        Log.debug("Attempting resumption for {}, h={}", previd, h);
         this.namespace = namespace;
         // Ensure that resource binding has NOT occurred.
         if (!allowResume() ) {
@@ -239,7 +239,7 @@ public class StreamManager {
             return;
         }
         JID fullJid = new JID(authToken.getUsername(), authToken.getDomain(), resource, true);
-        Log.debug("Resuming session {}", fullJid.toString());
+        Log.debug("Resuming session {}", fullJid);
 
         // Locate existing session.
         LocalClientSession otherSession = (LocalClientSession)XMPPServer.getInstance().getRoutingTable().getClientRoute(fullJid);

--- a/src/web/session-details.jsp
+++ b/src/web/session-details.jsp
@@ -165,6 +165,7 @@
         </td>
     </tr>
     <%
+        boolean detached = false;
         if (currentSess instanceof LocalClientSession) {
             LocalClientSession s = (LocalClientSession)currentSess;
 
@@ -176,6 +177,7 @@
         <td>
             <%
                 if (s.isDetached()) {
+                    detached = true;
                     %><fmt:message key="session.details.sm-detached"/><%
                 } else if (s.getStreamManager().isEnabled()) {
                     if (s.getStreamManager().getResume()) {
@@ -343,14 +345,16 @@
             <fmt:message key="session.details.hostname" />
         </td>
         <td>
-            <% try { %>
-                <%= currentSess.getHostAddress() %>
-                /
-                <%= currentSess.getHostName() %>
-            <% } catch (java.net.UnknownHostException e) { %>
-                Invalid session/connection
-            <% } %>
-        </td>
+                <%
+            if (detached) { %>
+            <fmt:message key="session.details.sm-detached"/>
+                <% } else {
+                try { %>
+                <%= currentSess.getHostAddress() %> / <%= currentSess.getHostName() %>
+                <% } catch (java.net.UnknownHostException e) { %>
+            Invalid session/connection
+                <% }
+            } %>
     </tr>
 </tbody>
 </table>
@@ -369,6 +373,7 @@
         <th>&nbsp;</th>
         <th><fmt:message key="session.details.name" /></th>
         <th><fmt:message key="session.details.resource" /></th>
+        <th nowrap><fmt:message key="session.details.node" /></th>
         <th nowrap colspan="2"><fmt:message key="session.details.status" /></th>
         <th nowrap colspan="2"><fmt:message key="session.details.if_presence" /></th>
         <th><fmt:message key="session.details.priority" /></th>

--- a/src/web/session-row.jspf
+++ b/src/web/session-row.jspf
@@ -168,11 +168,17 @@
     </td>
 
     <td width="1%" nowrap>
-        <% try { %>
-            <%= sess.getHostAddress() %>
-        <% } catch (java.net.UnknownHostException e) { %>
-            Invalid session/connection
-        <% } %>
+        <%
+            LocalClientSession localSession = (LocalClientSession) sess;
+            if (localSession != null && localSession.isDetached()) { %>
+                <fmt:message key="session.details.sm-detached"/>
+            <% } else {
+                try { %>
+                <%= sess.getHostAddress() %>
+            <% } catch (java.net.UnknownHostException e) { %>
+                Invalid session/connection
+            <% }
+            } %>
     </td>
 
     <td width="1%" nowrap align="center" style="border-right:1px #ccc solid;">


### PR DESCRIPTION
This patch adds a lot of debug logging, plus stops the
console NPE'ing when you try to view a detached session.
    
It also detaches a session before trying to reattach it, to
avoid it being unrouted when the connection is closed.

