### PR TITLE
OF-1441: Ensure only the necessary JAR files are included in the dist…

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -65,6 +65,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>
@@ -326,11 +327,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-pool2</artifactId>
-            <version>2.3</version>
-        </dependency>
-        <dependency>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
             <version>3.1</version>
@@ -376,6 +372,11 @@
             <artifactId>jsmpp</artifactId>
             <version>2.2.4</version>
         </dependency>
+        <dependency>
+            <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
+            <artifactId>concurrentlinkedhashmap-lru</artifactId>
+            <version>1.0</version>
+        </dependency>
 
         <!-- Database Drivers -->
         <dependency>
@@ -399,12 +400,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-            <artifactId>concurrentlinkedhashmap-lru</artifactId>
-            <version>1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
…ribution

A couple of additional notes; 

I removed a duplicate dependency on commons-pool2, which IntelliJ correctly picked up as being included twice. 

The scope of concurrentlinkedhashmap-lru was changed from test to runtime, as it is actually used. 

The resulting difference is just 6 jar files;

byte-buddy-1.7.4.jar
byte-buddy-agent-1.7.4.jar
hamcrest-core-1.3.jar
junit-4.11.jar
mockito-core-2.10.0.jar
objenesis-2.6.jar