### PR TITLE
OF-1442: Exclude the old version of dom4j

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -107,6 +107,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion> <!-- Exclude the older dom4j dependency that's defined in Tinder -->
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Caused by the groupId changing from dom4j to org.dom4j between the two versions - so the older version needs to be specifically excluded.