### PR TITLE
OF-1254 drop ofMucConvLog_msg_id index prior to creating it

### DIFF
--- a/src/database/upgrade/25/openfire_db2.sql
+++ b/src/database/upgrade/25/openfire_db2.sql
@@ -1,3 +1,5 @@
+DROP INDEX ofMucConvLog_msg_id IF EXISTS;
+
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
 UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/src/database/upgrade/25/openfire_hsqldb.sql
+++ b/src/database/upgrade/25/openfire_hsqldb.sql
@@ -1,3 +1,5 @@
+DROP INDEX ofMucConvLog_msg_id IF EXISTS;
+
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
 UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/src/database/upgrade/25/openfire_mysql.sql
+++ b/src/database/upgrade/25/openfire_mysql.sql
@@ -1,3 +1,7 @@
-ALTER TABLE ofMucConversationLog ADD INDEX ofMucConvLog_msg_id (messageID);
+
+set @exist := (select count(*) from information_schema.statistics where table_name = 'ofMucConversationLog' and index_name = 'ofMucConvLog_msg_id' and table_schema = database());
+set @sqlstmt := if( @exist > 0, 'select ''INFO: Index already exists.''', 'create index ofMucConvLog_msg_id on ofMucConversationLog (messageID)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
 
 UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/src/database/upgrade/25/openfire_oracle.sql
+++ b/src/database/upgrade/25/openfire_oracle.sql
@@ -1,3 +1,5 @@
+DROP INDEX IF EXISTS ofMucConvLog_msg_id;
+
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
 UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/src/database/upgrade/25/openfire_postgresql.sql
+++ b/src/database/upgrade/25/openfire_postgresql.sql
@@ -1,3 +1,5 @@
+DROP INDEX IF EXISTS ofMucConvLog_msg_id;
+
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
 UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/src/database/upgrade/25/openfire_sqlserver.sql
+++ b/src/database/upgrade/25/openfire_sqlserver.sql
@@ -1,3 +1,5 @@
+DROP INDEX IF EXISTS ofMucConvLog_msg_id;
+
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
 UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/src/database/upgrade/25/openfire_sybase.sql
+++ b/src/database/upgrade/25/openfire_sybase.sql
@@ -1,3 +1,5 @@
+DROP INDEX IF EXISTS ofMucConvLog_msg_id;
+
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
 UPDATE ofVersion SET version = 25 WHERE name = 'openfire';


### PR DESCRIPTION
This is an attempt to workaround an issue introduced whereby the database schema version is incorrect.  More info is here
https://discourse.igniterealtime.org/t/79916

I did not test this with mysql yet, as it has the most complex change to try dropping an index.