### PR TITLE
OF-1447: Improve Maven structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,8 @@
     <name>Parent</name>
     <packaging>pom</packaging>
 
+    <description>Openfire is a cross-platform real-time collaboration server based on the XMPP (Jabber) protocol.</description>
+
     <modules>
         <module>dbutil</module>
         <module>i18n</module>
@@ -126,21 +128,57 @@
     </properties>
 
     <profiles>
-        <!-- Generate JavaDoc to target/javadoc: mvn javadoc:aggregate -->
+        <!-- Disable Javadoc linting (which is very error prone) in versions of Java that have it enabled by default. -->
         <profile>
-            <id>javadoc</id>
+            <id>java8-doclint-disabled</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <additionalparam>-Xdoclint:none</additionalparam>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>release</id>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.3</version>
+                        <version>2.9.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
                                 <goals>
-                                    <!-- Create one JavaDoc which contains all modules -->
-                                    <goal>aggregate</goal>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
                                 </goals>
                             </execution>
                         </executions>
@@ -149,78 +187,6 @@
             </build>
         </profile>
 
-        <profile>
-            <id>dist.src</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-resources-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>Copy directories</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>copy-resources</goal>
-                                </goals>
-                                <configuration>
-                                    <outputDirectory>${openfireSource}</outputDirectory>
-                                    <resources>
-                                        <!-- Copy the build directory -->
-                                        <resources>
-                                            <targetPath>build</targetPath>
-                                            <directory>${project.basedir}/build</directory>
-                                        </resources>
-                                        <!-- Copy the documentation/dist -->
-                                        <resources>
-                                            <directory>${project.basedir}/documentation/dist</directory>
-                                        </resources>
-                                        <!-- Copy the documentation -->
-                                        <resources>
-                                            <targetPath>documentation</targetPath>
-                                            <directory>${project.basedir}/documentation/docs</directory>
-                                        </resources>
-                                        <!-- Copy i18n -->
-                                        <resource>
-                                            <targetPath>resources/i18n</targetPath>
-                                            <directory>${project.basedir}/src/i18n</directory>
-                                        </resource>
-                                        <!-- Copy src -->
-                                        <resource>
-                                            <targetPath>src</targetPath>
-                                            <directory>${project.basedir}/src</directory>
-                                        </resource>
-                                    </resources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <!-- Child modules should not create an assembly -->
-                        <inherited>false</inherited>
-                        <configuration>
-                            <descriptor>src/assembly/src.xml</descriptor>
-                            <finalName>openfire_src_${project.version}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <outputDirectory>${releaseDirectory}</outputDirectory>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>create-archive</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-
-        </profile>
     </profiles>
 
     <build>
@@ -228,38 +194,6 @@
         <pluginManagement>
 
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
-                    <configuration>
-                        <additionalparam>-Xdoclint:none</additionalparam>
-                        <quiet>true</quiet>
-                        <outputDirectory>${project.build.directory}</outputDirectory>
-                        <reportOutputDirectory>${project.build.directory}</reportOutputDirectory>
-                        <destDir>javadoc</destDir>
-                        <includeDependencySources>false</includeDependencySources>
-                        <includeTransitiveDependencySources>false</includeTransitiveDependencySources>
-                        <nodeprecated>false</nodeprecated>
-                        <nodeprecatedlist>false</nodeprecatedlist>
-                        <author>false</author>
-                        <notimestamp>true</notimestamp>
-                        <doctitle>Openfire ${project.version}</doctitle>
-                        <windowtitle>Openfire ${project.version}</windowtitle>
-                        <docfilessubdirs>true</docfilessubdirs>
-                        <show>public</show>
-                        <excludePackageNames>org.apache.*:org.dom4j.*</excludePackageNames>
-                        <overview>${project.basedir}/src/java/overview.html</overview>
-                    </configuration>
-                    <dependencies>
-                        <!-- Used to resolve MINA 2.0 bundle -->
-                        <dependency>
-                            <groupId>org.apache.felix</groupId>
-                            <artifactId>maven-bundle-plugin</artifactId>
-                            <version>3.0.0</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -279,10 +213,6 @@
                                 <MavenParentGroupId>${project.parent.groupId}</MavenParentGroupId>
                                 <MavenParentArtifactId>${project.parent.artifactId}</MavenParentArtifactId>
                                 <MavenParentVersion>${project.parent.version}</MavenParentVersion>
-                                <!--<BambooBuildKey>${bamboo.buildKey}</BambooBuildKey>-->
-                                <!--<BambooBuildNumber>${bamboo.buildNumber}</BambooBuildNumber>-->
-                                <!--<BambooCustomSVNRevisionNumber>${bamboo.custom.svn.revision.number}-->
-                                <!--</BambooCustomSVNRevisionNumber>-->
                             </manifestEntries>
                         </archive>
                     </configuration>
@@ -305,10 +235,6 @@
                                 <MavenParentGroupId>${project.parent.groupId}</MavenParentGroupId>
                                 <MavenParentArtifactId>${project.parent.artifactId}</MavenParentArtifactId>
                                 <MavenParentVersion>${project.parent.version}</MavenParentVersion>
-                                <!--<BambooBuildKey>${bamboo.buildKey}</BambooBuildKey>-->
-                                <!--<BambooBuildNumber>${bamboo.buildNumber}</BambooBuildNumber>-->
-                                <!--<BambooCustomSVNRevisionNumber>${bamboo.custom.svn.revision.number}-->
-                                <!--</BambooCustomSVNRevisionNumber>-->
                             </manifestEntries>
                         </archive>
                     </configuration>
@@ -520,4 +446,5 @@
             </snapshots>
         </pluginRepository>
     </pluginRepositories>
+
 </project>

--- a/src/plugins/pom.xml
+++ b/src/plugins/pom.xml
@@ -7,6 +7,90 @@
     <packaging>pom</packaging>
     <name>Openfire Plugins</name>
 
+    <description>Aggregate project for Openfire plugins.</description>
+    <url>http://www.igniterealtime.org/projects/openfire/</url>
+
+    <inceptionYear>2003</inceptionYear>
+
+    <issueManagement>
+        <system>jira</system>
+        <url>http://issues.igniterealtime.org/browse/OF</url>
+    </issueManagement>
+
+    <scm>
+        <connection>scm:svn:http://svn.igniterealtime.org/svn/repos/openfire/trunk/</connection>
+        <developerConnection>scm:svn:https://svn.igniterealtime.org/svn/repos/openfire/trunk/</developerConnection>
+        <url>http://fisheye.igniterealtime.org/viewrep/openfire/trunk/</url>
+    </scm>
+
+    <developers>
+        <developer>
+            <name>Guus der Kinderen</name>
+            <roles>
+                <role>Lead Developer</role>
+            </roles>
+            <email>guus.der.kinderen@gmail.com</email>
+            <timezone>+1</timezone>
+            <organization>Ignite Realtime</organization>
+            <organizationUrl>http://www.igniterealtime.org</organizationUrl>
+        </developer>
+        <developer>
+            <name>Robin Collier</name>
+            <roles>
+                <role>Developer</role>
+            </roles>
+            <email>robincollier@hotmail.com</email>
+            <timezone>-5</timezone>
+            <organization>Ignite Realtime</organization>
+            <organizationUrl>http://www.igniterealtime.org</organizationUrl>
+        </developer>
+        <developer>
+            <name>Matt Tucker</name>
+            <roles>
+                <role>Original Author</role>
+                <role>Developer (inactive)</role>
+            </roles>
+            <email>matt@jivesoftware.com</email>
+            <organization>Jive Software</organization>
+            <organizationUrl>http://www.jivesoftware.com</organizationUrl>
+            <timezone>-8</timezone>
+        </developer>
+        <developer>
+            <name>Gaston Dombiak</name>
+            <roles>
+                <role>Original Author</role>
+                <role>Lead Developer (inactive)</role>
+            </roles>
+            <email>gaston@jivesoftware.com</email>
+            <organization>Jive Software</organization>
+            <organizationUrl>http://www.jivesoftware.com</organizationUrl>
+            <timezone>-8</timezone>
+        </developer>
+        <developer>
+            <name>Daniel Henninger</name>
+            <roles>
+                <role>Developer (inactive)</role>
+            </roles>
+            <email>daniel@vorpalcloud.org</email>
+            <timezone>-5</timezone>
+            <organization>Ignite Realtime</organization>
+            <organizationUrl>http://www.igniterealtime.org</organizationUrl>
+        </developer>
+    </developers>
+
+    <contributors>
+        <contributor>
+            <name>Daryl Herzmann</name>
+            <roles>
+                <role>Community Organizer</role>
+            </roles>
+            <email>akrherz@iastate.edu</email>
+            <organization>Iowa State University</organization>
+            <organizationUrl>http://mesonet.agron.iastate.edu</organizationUrl>
+            <timezone>-6</timezone>
+        </contributor>
+    </contributors>
+
     <modules>
         <module>openfire-plugin-assembly-descriptor</module>
         <module>bookmarks</module>
@@ -79,6 +163,68 @@
         <!-- Versions -->
         <openfire.version>4.2.0</openfire.version>
     </properties>
+
+    <profiles>
+        <!-- Disable Javadoc linting (which is very error prone) in versions of Java that have it enabled by default. -->
+        <profile>
+            <id>java8-doclint-disabled</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <additionalparam>-Xdoclint:none</additionalparam>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.9.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 
     <build>
         <plugins>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -29,8 +29,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
-                    <outputDirectory>${openfireHome}/lib</outputDirectory>
-                    <finalName>openfire</finalName>
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
@@ -54,6 +52,24 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>2.10</version>
                 <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>${project.artifactId}</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>${project.packaging}</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${openfireHome}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>copy-dependencies</id>
                         <phase>package</phase>


### PR DESCRIPTION
This commit aims to make the Maven structure more compatible with Sonatypes guidelines for artifact distribution, as defined on http://central.sonatype.org/pages/ossrh-guide.html

A new Maven profile 'release' is added, that intends to produce all required artifacts. Usage: `mvn -P release clean verify`