### PR TITLE
OF-1460, Session Row jspf has a Hazelcast related, type casting bug

### DIFF
--- a/src/web/session-row.jspf
+++ b/src/web/session-row.jspf
@@ -169,16 +169,16 @@
 
     <td width="1%" nowrap>
         <%
-            LocalClientSession localSession = (LocalClientSession) sess;
-            if (localSession != null && localSession.isDetached()) { %>
+            if (sess instanceof LocalClientSession && ((LocalClientSession)sess).isDetached()) { %>
                 <fmt:message key="session.details.sm-detached"/>
             <% } else {
                 try { %>
-                <%= sess.getHostAddress() %>
-            <% } catch (java.net.UnknownHostException e) { %>
-                Invalid session/connection
+                    <%= sess.getHostAddress() %>
+                <% } catch (java.net.UnknownHostException e) { %>
+                    Invalid session/connection
             <% }
             } %>
+
     </td>
 
     <td width="1%" nowrap align="center" style="border-right:1px #ccc solid;">


### PR DESCRIPTION
It assumes that all sessions are LocalClientSessions. But, in a multi-node hazelcast enabled openfire environment,

there may be remote (not local) sessions as well.  The bug is a cast of sess to LocalClientSession, but that isn't always appropriate. Session Details and Session Summary jspf pages use this jspf file