### PR TITLE
OF-1468 Group Chat History returns one message too many

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
+++ b/src/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
@@ -197,7 +197,7 @@ public class HistoryStrategy {
                 // message because we want to preserve the room subject if
                 // possible.
                 Iterator<Message> historyIter = history.iterator();
-                while (historyIter.hasNext() && history.size() > strategyMaxNumber) {
+                while (historyIter.hasNext() && history.size() >= strategyMaxNumber) {
                     if (historyIter.next() != roomSubject) {
                         historyIter.remove();
                     }


### PR DESCRIPTION
When specifying “Show a Specific Number of Messages” for Group Chat
History Settings, the user get one message to many. For example, if 10
is specified. the user get the last eleven messages in the room.