### PR TITLE
OF-1467, Check nodeRoutes.containsKeys(key) to avoid NPE 

### DIFF
--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
@@ -279,13 +279,15 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
         }
 
         // Remove outgoing server sessions hosted in node that left the cluster
-        Set<DomainPair> remoteServers = nodeRoutes.get(key);
-        if (!remoteServers.isEmpty()) {
-            for (DomainPair domainPair : remoteServers) {
-                routingTable.removeServerRoute(domainPair);
+        if (nodeRoutes.containsKey(key)) {
+            Set<DomainPair> remoteServers = nodeRoutes.get(key);
+            if (!remoteServers.isEmpty()) {
+                for (DomainPair domainPair : remoteServers) {
+                    routingTable.removeServerRoute(domainPair);
+                }
             }
+            nodeRoutes.remove(key);
         }
-        nodeRoutes.remove(key);
 
         Set<String> components = lookupJIDList(key, componentsCache.getName());
         if (!components.isEmpty()) {

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusterListener.java
@@ -279,15 +279,14 @@ public class ClusterListener implements MembershipListener, LifecycleListener {
         }
 
         // Remove outgoing server sessions hosted in node that left the cluster
-        if (nodeRoutes.containsKey(key)) {
-            Set<DomainPair> remoteServers = nodeRoutes.get(key);
-            if (!remoteServers.isEmpty()) {
-                for (DomainPair domainPair : remoteServers) {
-                    routingTable.removeServerRoute(domainPair);
-                }
+        Set<DomainPair> remoteServers = nodeRoutes.get(key);
+        if (remoteServers!=null) {
+            for (DomainPair domainPair : remoteServers) {
+                routingTable.removeServerRoute(domainPair);
             }
-            nodeRoutes.remove(key);
         }
+        nodeRoutes.remove(key);
+
 
         Set<String> components = lookupJIDList(key, componentsCache.getName());
         if (!components.isEmpty()) {


### PR DESCRIPTION
Avoid NPE Exception in ClusterListener, nodeCleanup, when there are no sessions on the node to cleanup