### PR TITLE
WebSocket endpoint should allow null path.

### DIFF
--- a/src/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/src/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -625,7 +625,7 @@ public final class HttpBindManager implements CertificateEventListener, Property
     protected Handler createWebsocketHandler()
     {
         final ServletContextHandler context = new ServletContextHandler( null, "/ws", ServletContextHandler.SESSIONS );
-
+        context.setAllowNullPathInfo(true);
         // Add the functionality-providers.
         context.addServlet( new ServletHolder( new OpenfireWebSocketServlet() ), "/*" );
 


### PR DESCRIPTION
Currently the endpoint is only available via ws://host:port/ws/

It will now also be available via ws://host:port/ws

(note the lack of the trailing slash).

URLs without trailing slash seem to be the standard for BOSH and WebSockets and are also used by XEP-0156.

 This commit increases interoperability.