### PR TITLE
OF-1477: Sorting order should be based of bare JID

### DIFF
--- a/src/web/pubsub-node-affiliates.jsp
+++ b/src/web/pubsub-node-affiliates.jsp
@@ -81,7 +81,7 @@
             if(affiliateComp != 0) {
                 return affiliateComp;
             } else {
-                return affiliate1.getJID().toFullJID().toLowerCase().compareTo(affiliate2.getJID().toFullJID().toLowerCase());
+                return affiliate1.getJID().compareTo(affiliate2.getJID());
             }
 
         }


### PR DESCRIPTION
When comparing JID to determine the order to show, do not assume full JID's. A affiliation is linked to a bare JID.