### PR TITLE
OF-1474_hazelcast_rest_api_create_room_npe

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -2723,7 +2723,12 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         ExternalizableUtil.getInstance().writeSafeUTF(out, subject);
         ExternalizableUtil.getInstance().writeLong(out, roomID);
         ExternalizableUtil.getInstance().writeLong(out, creationDate.getTime());
-        ExternalizableUtil.getInstance().writeLong(out, modificationDate.getTime());
+        if (modificationDate!=null) {
+            ExternalizableUtil.getInstance().writeLong(out, modificationDate.getTime());
+        }
+        else {
+            ExternalizableUtil.getInstance().writeLong(out, creationDate.getTime());
+        }
         ExternalizableUtil.getInstance().writeBoolean(out, emptyDate != null);
         if (emptyDate != null) {
             ExternalizableUtil.getInstance().writeLong(out, emptyDate.getTime());

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -2723,11 +2723,9 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         ExternalizableUtil.getInstance().writeSafeUTF(out, subject);
         ExternalizableUtil.getInstance().writeLong(out, roomID);
         ExternalizableUtil.getInstance().writeLong(out, creationDate.getTime());
-        if (modificationDate!=null) {
+        ExternalizableUtil.getInstance().writeBoolean(out, modificationDate != null);
+        if (modificationDate != null) {
             ExternalizableUtil.getInstance().writeLong(out, modificationDate.getTime());
-        }
-        else {
-            ExternalizableUtil.getInstance().writeLong(out, creationDate.getTime());
         }
         ExternalizableUtil.getInstance().writeBoolean(out, emptyDate != null);
         if (emptyDate != null) {
@@ -2765,7 +2763,9 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         subject = ExternalizableUtil.getInstance().readSafeUTF(in);
         roomID = ExternalizableUtil.getInstance().readLong(in);
         creationDate = new Date(ExternalizableUtil.getInstance().readLong(in));
-        modificationDate = new Date(ExternalizableUtil.getInstance().readLong(in));
+        if (ExternalizableUtil.getInstance().readBoolean(in)) {
+            modificationDate = new Date(ExternalizableUtil.getInstance().readLong(in));
+        }
         if (ExternalizableUtil.getInstance().readBoolean(in)) {
             emptyDate = new Date(ExternalizableUtil.getInstance().readLong(in));
         }


### PR DESCRIPTION
Upon External Serialization, do a null check on modificationDate. It is possible that the modificationDate is null, if the room was just created through REST API and Hazelcast enabled with more than 1 node in the cluster.  That results in an NPE, partial room creation, and failure in communicating the room updated event via hazelcast.

If modification date is null, send the creationDate value instead for the hazelcast room updated event

see https://discourse.igniterealtime.org/t/openfire-hazelcast-clustering-rest-api-room-creation-npe-when-no-modificaitondate-sent/80619/2