### PR TITLE
HZ-8: Preserve Hazelcast network settings between plugin upgrades

### DIFF
--- a/src/plugins/hazelcast/classes/hazelcast-cache-config.xml
+++ b/src/plugins/hazelcast/classes/hazelcast-cache-config.xml
@@ -18,10 +18,7 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-3.9.xsd">
-    <group>
-        <name>openfire</name>
-        <password>openfire</password>
-    </group>
+    <import resource="${openfireHome}/conf/hazelcast-local-config.xml"/>
     <properties>
       <property name="hazelcast.logging.type">slf4j</property>
       <property name="hazelcast.operation.call.timeout.millis">30000</property>
@@ -29,42 +26,6 @@
       <property name="hazelcast.rest.enabled">false</property>
     </properties>
     <management-center enabled="false"/>
-    <network>
-        <port auto-increment="true" port-count="100">5701</port>
-        <outbound-ports>
-            <ports>0</ports>
-        </outbound-ports>
-        <join>
-            <multicast enabled="true">
-                <multicast-group>224.2.2.3</multicast-group>
-                <multicast-port>54327</multicast-port>
-            </multicast>
-            <tcp-ip enabled="false"/>
-            <aws enabled="false"/>
-        </join>
-        <interfaces enabled="false">
-            <interface>10.10.1.*</interface>
-        </interfaces>
-        <ssl enabled="false"/>
-        <socket-interceptor enabled="false"/>
-        <symmetric-encryption enabled="false">
-            <!--
-               encryption algorithm such as
-               DES/ECB/PKCS5Padding,
-               PBEWithMD5AndDES,
-               AES/CBC/PKCS5Padding,
-               Blowfish,
-               DESede
-            -->
-            <algorithm>PBEWithMD5AndDES</algorithm>
-            <!-- salt value to use when generating the secret key -->
-            <salt>thesalt</salt>
-            <!-- pass phrase to use when generating the secret key -->
-            <password>thepass</password>
-            <!-- iteration count to use when generating the secret key -->
-            <iteration-count>19</iteration-count>
-        </symmetric-encryption>
-    </network>
     <partition-group enabled="false"/>
     <executor-service name="default">
         <pool-size>16</pool-size>

--- a/src/plugins/hazelcast/classes/hazelcast-local-config.xml.template
+++ b/src/plugins/hazelcast/classes/hazelcast-local-config.xml.template
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.9.xsd">
+    <group>
+        <name>openfire</name>
+        <password>openfire</password>
+    </group>
+    <network>
+        <port auto-increment="true" port-count="100">5701</port>
+        <outbound-ports>
+            <ports>0</ports>
+        </outbound-ports>
+        <!-- The following enables multicast discovery of cluster members
+                See http://docs.hazelcast.org/docs/3.9.2/manual/html-single/index.html#discovering-members-by-multicast
+        -->
+        <join>
+            <multicast enabled="true">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
+            <tcp-ip enabled="false"/>
+        </join>
+        <!-- The following enables TCP/IP based discovery of cluster members
+                See http://docs.hazelcast.org/docs/3.9.2/manual/html-single/index.html#discovering-members-by-tcp
+        -->
+        <!--
+        <join>
+            <multicast enabled="false"/>
+            <tcp-ip enabled="true">
+                <member>10.10.1.1:5701</member>
+				<member>10.10.1.2:5701</member>
+            </tcp-ip>
+        </join>
+        -->
+        <interfaces enabled="false">
+            <interface>10.10.1.*</interface>
+        </interfaces>
+        <ssl enabled="false"/>
+        <socket-interceptor enabled="false"/>
+        <symmetric-encryption enabled="false">
+            <!--
+               encryption algorithm such as
+               DES/ECB/PKCS5Padding,
+               PBEWithMD5AndDES,
+               AES/CBC/PKCS5Padding,
+               Blowfish,
+               DESede
+            -->
+            <algorithm>PBEWithMD5AndDES</algorithm>
+            <!-- salt value to use when generating the secret key -->
+            <salt>thesalt</salt>
+            <!-- pass phrase to use when generating the secret key -->
+            <password>thepass</password>
+            <!-- iteration count to use when generating the secret key -->
+            <iteration-count>19</iteration-count>
+        </symmetric-encryption>
+    </network>
+</hazelcast>

--- a/src/plugins/hazelcast/readme.html
+++ b/src/plugins/hazelcast/readme.html
@@ -204,17 +204,20 @@ the Hazelcast cluster if JMX has been enabled via the Openfire admin console.
 Refer to the <a href="http://docs.hazelcast.org/docs/3.9.2/manual/html-single/index.html#monitoring-with-jmx">
 Hazelcast JMX docs</a> for additional information.</li>
 </ol>
+<em>Note:</em> The default <code>hazelcast-cache-config.xml</code> file included with the plugin will include a file
+<code>conf/hazelcast-local-config.xml</code> that will be preserved between plugin updates. It is recommended that
+local changes are kept in this file.
 <p>The Hazelcast plugin uses the <a href="http://docs.hazelcast.org/docs/3.9.2/manual/html-single/index.html#configuring-declaratively">
-XML configuration builder</a> to initialize the cluster from the XML file described above.
-By default the cluster members will attempt to discover each other via multicast at the
+XML configuration builder</a> to initialize the cluster from the XML file <code>conf/hazelcast-local-config.xml</code>.
+By default the cluster members will attempt to discover each other via UDP multicast at the
 following location:
 </p>
 <ul>
 <li>IP Address: 224.2.2.3</li>
 <li>Port: 54327</li>
 </ul>
-Note that these values can be overridden in the plugin's /classes/hazelcast-cache-config.xml
-file (via the multicast-group and multicast-port elements). Many other initialization and
+These values can be overridden in the <code>conf/hazelcast-local-config.xml</code>
+file via the multicast-group and multicast-port elements. Many other initialization and
 discovery options exist, as documented in the Hazelcast configuration docs noted above. For
 example, to set up a two-node cluster using well-known DNS name/port values, try the
 following alternative:
@@ -223,10 +226,9 @@ following alternative:
 &lt;join&gt;
     &lt;multicast enabled="false"/&gt;
     &lt;tcp-ip enabled="true"&gt;
-      &lt;member&gt;of-node-a.example.com:5701&lt;/member&gt;
-      &lt;member&gt;of-node-b.example.com:5701&lt;/member&gt;
+      &lt;member&gt;of-node-a.example.com&lt;/member&gt;
+      &lt;member&gt;of-node-b.example.com&lt;/member&gt;
     &lt;/tcp-ip&gt;
-    &lt;aws enabled="false"/&gt;
 &lt;/join&gt;
 ...
 </pre>


### PR DESCRIPTION
If it doesn't already exist, the Hazelcast plugin will create a file conf/hazelcast-local-config.xml that contains default network settings, etc.

This file is not replaced when the plugin is upgraded, thus preserving local configuration..