### PR TITLE
OF-1481: Don't attempt to send over a non-existing connection.

### DIFF
--- a/src/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -410,6 +410,11 @@ public abstract class LocalSession implements Session {
 
     @Override
     public void deliverRawText(String text) {
+        if ( conn == null )
+        {
+            Log.debug( "Unable to deliver raw text in session, as its connection is null. Dropping: " + text );
+            return;
+        }
         conn.deliverRawText(text);
     }
 


### PR DESCRIPTION
I've found this after a round of testing by Daniel (of Conversations fame). I'm assuming, but was unable to verify, that this condition is caused by our recent addition of Stream Management - which leaves a session open, outliving its connection, perhaps.