### PR TITLE
OF-1464: Fix plugin updates via admin console.

### DIFF
--- a/src/web/plugin-admin.jsp
+++ b/src/web/plugin-admin.jsp
@@ -300,14 +300,14 @@ tr.lowerhalf > td:last-child {
     function download(url, hashCode) {
         document.getElementById(hashCode + "-row").style.display = 'none';
         document.getElementById(hashCode + "-update").style.display = '';
-        downloader.downloadPlugin(downloadComplete, url);
+        downloader.installPlugin(url, hashCode, downloadComplete);
     }
 
-    function downloadComplete(update) {
-        document.getElementById(update.hashCode + "-row").style.display = 'none';
-        document.getElementById(update.hashCode + "-update").style.display = '';
-        document.getElementById(update.hashCode + "-image").innerHTML = '<img src="images/success-16x16.gif" border="0" alt=""/>';
-        document.getElementById(update.hashCode + "-text").innerHTML = '<fmt:message key="plugin.admin.update.complete" />';
+    function downloadComplete(status) {
+        document.getElementById(status.hashCode + "-row").style.display = 'none';
+        document.getElementById(status.hashCode + "-update").style.display = '';
+        document.getElementById(status.hashCode + "-image").innerHTML = '<img src="images/success-16x16.gif" border="0" alt=""/>';
+        document.getElementById(status.hashCode + "-text").innerHTML = '<fmt:message key="plugin.admin.update.complete" />';
     }
 </script>
 </head>


### PR DESCRIPTION
I've replaced usage of `PluginDownloadManager.downloadPlugin` (in which we had the argument order backwards) with `PluginDownloadManager.installPlugin` (which is also used when initially installing, rather than updating, a plugin).

Simply fixing the argument order `PluginDownloadManager.downloadPlugin` would have done the trick, but introduced a UI issue. As the callback did not refer to the hashCode of the plugin that was modified, the update-spinner never got cancelled. By switching to `installPlugin`, we get this value immediately.

There are small functional differences between `downloadPlugin` and `installPlugin`, but they don't appear to affect the user experience at all.
