### PR TITLE
OF-1283 Handling xmppAddr in SSL cert being a type of ASN1TaggedObject

### DIFF
--- a/src/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
+++ b/src/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
@@ -235,6 +235,15 @@ public class SANCertificateIdentityMapping implements CertificateIdentityMapping
      */
     protected String parseOtherNameXmppAddr( ASN1Primitive xmppAddr )
     {
+        // Get the nested object if the value is an ASN1TaggedObject or a sub-type of it
+        if (ASN1TaggedObject.class.isAssignableFrom(xmppAddr.getClass())) {
+            ASN1TaggedObject taggedObject = (ASN1TaggedObject) xmppAddr;
+            ASN1Primitive objectPrimitive = taggedObject.getObject();
+            if (ASN1String.class.isAssignableFrom(objectPrimitive.getClass())) {
+                return ((ASN1String) objectPrimitive).getString();
+            }
+        }
+
         // RFC 6120 says that this should be a UTF8String. Lets be tolerant and allow all text-based values.
         return ( (ASN1String) xmppAddr ).getString();
     }


### PR DESCRIPTION
I'm seeing the following error on startup when using a certificate signed by our internal CA, and I've also reproduced it when using a self-signed certificate with OpenSSL.

```
2018.02.17 22:20:50 WARN  [pool-4-thread-1]: org.jivesoftware.util.cert.SANCertificateIdentityMapping - Unable to parse a byte array (of length 29) as a subjectAltName 'otherName'. It is ignored.
java.lang.ClassCastException: org.bouncycastle.asn1.DERTaggedObject cannot be cast to org.bouncycastle.asn1.ASN1String
        at org.jivesoftware.util.cert.SANCertificateIdentityMapping.parseOtherNameXmppAddr(SANCertificateIdentityMapping.java:239)
        at org.jivesoftware.util.cert.SANCertificateIdentityMapping.parseOtherName(SANCertificateIdentityMapping.java:168)
        at org.jivesoftware.util.cert.SANCertificateIdentityMapping.mapIdentity(SANCertificateIdentityMapping.java:83)
        at org.jivesoftware.util.CertificateManager.getServerIdentities(CertificateManager.java:175)
        at org.jivesoftware.openfire.keystore.IdentityStore.containsDomainCertificate(IdentityStore.java:416)
        at org.jivesoftware.openfire.http.HttpBindManager.createSSLConnector(HttpBindManager.java:286)
        at org.jivesoftware.openfire.http.HttpBindManager.start(HttpBindManager.java:207)
        at org.jivesoftware.openfire.spi.ConnectionManagerImpl.startListeners(ConnectionManagerImpl.java:310)
        at org.jivesoftware.openfire.spi.ConnectionManagerImpl.access$100(ConnectionManagerImpl.java:46)
        at org.jivesoftware.openfire.spi.ConnectionManagerImpl$1.pluginsMonitored(ConnectionManagerImpl.java:287)
        at org.jivesoftware.openfire.container.PluginManager.firePluginsMonitored(PluginManager.java:1221)
        at org.jivesoftware.openfire.container.PluginMonitor$MonitorTask.run(PluginMonitor.java:323)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:304)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:178)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
```

Based on the code currently in ```SANCertificateIdentityMapping```, it assumes that ```xmppAddr``` value is always an ```ASN1String```, whereas in this case it is a ```DERTaggedObject``` (a subclass of ```ASN1TaggedObject```) which contains an ```ASN1String``` instance within it.

```
protected String parseOtherNameXmppAddr( ASN1Primitive xmppAddr )
{
    // RFC 6120 says that this should be a UTF8String. Lets be tolerant and allow all text-based values.
    return ( (ASN1String) xmppAddr ).getString();
}
```

My proposed change is to handle the ```xmppAddr``` being a type of ```ASN1TaggedObject``` (i.e. ```DERTaggedObject```).

This should also fix: https://issues.igniterealtime.org/browse/OF-1283