### PR TITLE
OF-1493: Admin console: Show PEM representation of certificate.

### DIFF
--- a/src/java/org/jivesoftware/util/CertificateManager.java
+++ b/src/java/org/jivesoftware/util/CertificateManager.java
@@ -31,6 +31,7 @@ import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.*;
+import org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder;
 import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
@@ -251,6 +252,24 @@ public class CertificateManager {
         pemWriter.close();
 
         return string.toString();
+    }
+
+    /**
+     * Generates a PEM representation of the input argument.
+     *
+     * @param object the input argument (cannot be null).
+     * @return PEM representation of the input argument.
+     * @throws IOException When a PEM representation of the input could not be created.
+     */
+    public static String toPemRepresentation( Object object ) throws IOException
+    {
+        final StringWriter result = new StringWriter();
+        try ( final PemWriter pemWriter = new PemWriter(result) )
+        {
+            final PemObjectGenerator objGen = new JcaMiscPEMGenerator ( object );
+            pemWriter.writeObject( objGen );
+        }
+        return result.toString();
     }
 
     public static PrivateKey parsePrivateKey(String pemRepresentation, String passPhrase) throws IOException {

--- a/src/web/security-certificate-details.jsp
+++ b/src/web/security-certificate-details.jsp
@@ -11,6 +11,8 @@
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
+<%@ page import="org.jivesoftware.util.CertificateManager" %>
+<%@ page import="org.bouncycastle.cert.X509CertificateHolder" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -445,6 +447,30 @@
                     <td class="c1"><fmt:message key="ssl.certificates.signature"/></td>
                     <td style="font-family: monospace;"><%=sb.toString()%></td>
                 </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <br/>
+
+    <div class="jive-table">
+        <table cellpadding="0" cellspacing="0" border="0" width="100%">
+            <thead>
+            <tr>
+                <th>
+                    PEM representation
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <%
+                    final String pemRepresentation = CertificateManager.toPemRepresentation( (X509Certificate) pageContext.getAttribute( "certificate" ) );
+                %>
+                <td class="c1" align="center">
+                    <textarea readonly cols="72" rows="<%= pemRepresentation.split( "\n" ).length + 5 %>"><%= pemRepresentation %></textarea>
+                </td>
+            </tr>
             </tbody>
         </table>
     </div>


### PR DESCRIPTION
When displaying the details of a certificate, the admin console now also shows
its PEM representation. This is convenient for copy/pasting the certificate into
other tools.