### PR TITLE
HZ-9: Ensure clustering works properly when enabled through the admin UI

### DIFF
--- a/src/java/org/jivesoftware/openfire/cluster/ClusterManager.java
+++ b/src/java/org/jivesoftware/openfire/cluster/ClusterManager.java
@@ -28,6 +28,7 @@ import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.JiveProperties;
 import org.jivesoftware.util.PropertyEventDispatcher;
 import org.jivesoftware.util.PropertyEventListener;
+import org.jivesoftware.util.TaskEngine;
 import org.jivesoftware.util.cache.CacheFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,15 +58,20 @@ public class ClusterManager {
             @Override
             public void xmlPropertyDeleted(String property, Map<String, Object> params) { /* ignore */ }
             @Override
-            public void xmlPropertySet(String property, Map<String, Object> params) {
+            public void xmlPropertySet(final String property, final Map<String, Object> params) {
                 if (ClusterManager.CLUSTER_PROPERTY_NAME.equals(property)) {
-                    if (Boolean.parseBoolean((String) params.get("value"))) {
-                        // Reload/sync all Jive properties
-                        JiveProperties.getInstance().init();
-                        ClusterManager.startup();
-                    } else {
-                        ClusterManager.shutdown();
-                    }
+                    TaskEngine.getInstance().submit(new Runnable() {
+                        @Override
+                        public void run() {
+                            if (Boolean.parseBoolean((String) params.get("value"))) {
+                                // Reload/sync all Jive properties
+                                JiveProperties.getInstance().init();
+                                ClusterManager.startup();
+                            } else {
+                                ClusterManager.shutdown();
+                            }
+                        }
+                    });
                 }
             }
         });

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -109,6 +109,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
 
     @Override
     public boolean startCluster() {
+        logger.info("Starting hazelcast clustering");
         state = State.starting;
 
         // Set the serialization strategy to use for transmitting objects between node clusters
@@ -146,6 +147,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
                 clusterListener = new ClusterListener(cluster);
                 lifecycleListener = hazelcast.getLifecycleService().addLifecycleListener(clusterListener);
                 membershipListener = cluster.addMembershipListener(clusterListener);
+                logger.info("Hazelcast clustering started");
                 break;
             } catch (Exception e) {
                 cluster = null;


### PR DESCRIPTION
This turned out to be because the clustering didn't like being enabled as part of the Jetty thread - so it was necessary to start it in another thread, and wait for it to complete. 

I suggest it's a candidate for 4.2.3 as well as 4.3.0