### PR TITLE
OF-1540 Rest API, delete room should send RoomRemovedEvent to cluster

### DIFF
--- a/src/plugins/restAPI/changelog.html
+++ b/src/plugins/restAPI/changelog.html
@@ -44,6 +44,11 @@
 REST API Plugin Changelog
 </h1>
 
+<p><b>1.3.3</b> -- April 26, 2018</p>
+<ul>
+    <li>Fixed: Delete Room now propagated to other cluster nodes <a href="https://issues.igniterealtime.org/browse/OF-1540">OF-1540</a></li>
+</ul>
+
 <p><b>1.3.2</b> -- April 25th, 2018</p>
 <ul>
      <li>Added: GZIP compression</li>

--- a/src/plugins/restAPI/plugin.xml
+++ b/src/plugins/restAPI/plugin.xml
@@ -5,8 +5,8 @@
     <name>REST API</name>
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
-    <version>1.3.2</version>
-    <date>04/25/2018</date>
+    <version>1.3.3</version>
+    <date>04/26/2018</date>
     <minServerVersion>4.1.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">

--- a/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/src/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -18,6 +18,7 @@ import org.jivesoftware.openfire.muc.MUCRoom;
 import org.jivesoftware.openfire.muc.NotAllowedException;
 import org.jivesoftware.openfire.muc.cluster.RoomAvailableEvent;
 import org.jivesoftware.openfire.muc.cluster.RoomUpdatedEvent;
+import org.jivesoftware.openfire.muc.cluster.RoomRemovedEvent;
 import org.jivesoftware.openfire.muc.spi.LocalMUCRoom;
 import org.jivesoftware.openfire.plugin.rest.entity.MUCChannelType;
 import org.jivesoftware.openfire.plugin.rest.entity.MUCRoomEntities;
@@ -124,6 +125,9 @@ public class MUCRoomController {
 
         if (chatRoom != null) {
             chatRoom.destroyRoom(null, null);
+            if (ClusterManager.isClusteringStarted()) {
+                CacheFactory.doClusterTask(new RoomRemovedEvent((LocalMUCRoom) chatRoom));
+            }
         } else {
             throw new ServiceException("Could not remove the channel", roomName, ExceptionType.ROOM_NOT_FOUND, Response.Status.NOT_FOUND);
         }


### PR DESCRIPTION
Rest API and Multi-node Hazelcast cluster - Delete Room not propagated to other nodes
With this change, all nodes in the cluster are aware of room deletion.