### PR TITLE
OF-1527: Update to Jetty 9.4.10.v20180503

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Versions -->
-        <jetty.version>9.4.10.v20180503</jetty.version>
+        <jetty.version>9.4.11.v20180605</jetty.version>
         <mina.version>2.0.7</mina.version>
         <bouncycastle.version>1.53</bouncycastle.version>
         <slf4j.version>1.7.7</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Versions -->
-        <jetty.version>9.2.14.v20151106</jetty.version>
+        <jetty.version>9.4.10.v20180503</jetty.version>
         <mina.version>2.0.7</mina.version>
         <bouncycastle.version>1.53</bouncycastle.version>
         <slf4j.version>1.7.7</slf4j.version>

--- a/src/plugins/jmxweb/plugin.xml
+++ b/src/plugins/jmxweb/plugin.xml
@@ -4,9 +4,9 @@
     <class>com.ifsoft.jmxweb.plugin.JmxWebPlugin</class>
     <name>JmxWeb Plugin</name>
     <description>JmxWeb plugin is web based platform for managing and monitoring openfire via JMX.</description>
-    <version>0.0.8</version>
+    <version>0.0.9-SNAPSHOT</version>
     <licenseType>Apache 2.0</licenseType>    
-    <date>12/14/2017</date>
+    <date>05/09/2018</date>
     <minServerVersion>4.3.0</minServerVersion>
     <author>igniterealtime.org</author>   
 </plugin>

--- a/src/plugins/jmxweb/pom.xml
+++ b/src/plugins/jmxweb/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>jmxweb</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9-SNAPSHOT</version>
     <name>JMXWeb Plugin</name>
     <description>JmxWeb plugin is web based platform for managing and monitoring openfire via JMX.</description>
 

--- a/src/plugins/jmxweb/src/java/com/ifsoft/jmxweb/plugin/OpenfireLoginService.java
+++ b/src/plugins/jmxweb/src/java/com/ifsoft/jmxweb/plugin/OpenfireLoginService.java
@@ -16,26 +16,21 @@
 
 package com.ifsoft.jmxweb.plugin;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.security.Principal;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import javax.security.auth.Subject;
+import javax.servlet.ServletRequest;
 
 import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
-import org.eclipse.jetty.util.security.Credential;
 import org.eclipse.jetty.security.*;
 
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.auth.AuthToken;
 import org.jivesoftware.openfire.auth.AuthFactory;
 import org.jivesoftware.openfire.admin.AdminManager;
-import org.jivesoftware.openfire.user.User;
-import org.jivesoftware.openfire.user.UserAlreadyExistsException;
 import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.openfire.XMPPServer;
@@ -118,7 +113,7 @@ public class OpenfireLoginService extends AbstractLifeCycle implements LoginServ
         return this.getClass().getSimpleName()+"["+_name+"]";
     }
 
-    public UserIdentity login(String userName, Object credential)
+    public UserIdentity login(String userName, Object credential, ServletRequest request)
     {
         UserIdentity identity = null;
 

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -132,11 +132,6 @@
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty.spdy</groupId>
-            <artifactId>spdy-http-server</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-server</artifactId>
             <version>${jetty.version}</version>


### PR DESCRIPTION
In addition to simply changing the dependent version of Jetty, this PR includes;

1. Removing references to the long deprecated SPDY protocol
2. Use the GzipHandler instead of the deprecated GzipFilter for the BOSH handler
3. Modify the OpenfireLoginService in the JmxWeb plugin to comply with the updated interface for the Jetty LoginService

1) I am confident works
2) I don't have an easy way to test this, unfortunately
3) I don't even know where to begin on this plugin - but compiling is nearly the same as working, right? @deleolajide you may want to check that this still does what you expect. 