### PR TITLE
Update CollectionNode.java

### DIFF
--- a/src/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
@@ -246,7 +246,9 @@ public class CollectionNode extends Node {
         // Build packet to broadcast to subscribers
         Message message = new Message();
         Element event = message.addChildElement("event", "http://jabber.org/protocol/pubsub#event");
-        Element item = event.addElement("items").addElement("item");
+        Element items = event.addElement("items");
+        items.addAttribute("node", getNodeID()); 
+        Element item = items.addElement("item");
         item.addAttribute("id", child.getNodeID());
         if (deliverPayloads) {
             item.add(child.getMetadataForm().getElement());


### PR DESCRIPTION
To be according XEP-0060, the element "items" must contain attribute "node", because it is required.

  <xs:element name='items'>
    <xs:complexType>
      <xs:choice>
        <xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/>
        <xs:element ref='retract' minOccurs='0' maxOccurs='unbounded'/>
      </xs:choice>
      <xs:attribute name='node' type='xs:string' use='required'/>
    </xs:complexType>
  </xs:element>