### PR TITLE
OF-1545: Authtoken and anonymous authentication

### DIFF
--- a/src/java/org/jivesoftware/admin/AuthCheckFilter.java
+++ b/src/java/org/jivesoftware/admin/AuthCheckFilter.java
@@ -233,7 +233,7 @@ public class AuthCheckFilter implements Filter {
         loginLimitManager.recordSuccessfulAttempt(userFromRequest, request.getRemoteAddr());
 
         // Set the auth token
-        request.getSession().setAttribute("jive.admin.authToken", new AuthToken(userFromRequest));
+        request.getSession().setAttribute("jive.admin.authToken", AuthToken.generateUserToken( userFromRequest ));
 
         // And proceed
         return true;

--- a/src/java/org/jivesoftware/openfire/SessionManager.java
+++ b/src/java/org/jivesoftware/openfire/SessionManager.java
@@ -727,7 +727,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
         }
 
         // User sessions had negative presence before this change so deliver messages
-        if (session.canFloodOfflineMessages()) {
+        if (!session.isAnonymousUser() && session.canFloodOfflineMessages()) {
             OfflineMessageStore messageStore = server.getOfflineMessageStore();
             Collection<OfflineMessage> messages = messageStore.getMessages(session.getAuthToken().getUsername(), true);
             for (Message message : messages) {

--- a/src/java/org/jivesoftware/openfire/auth/AuthFactory.java
+++ b/src/java/org/jivesoftware/openfire/auth/AuthFactory.java
@@ -201,7 +201,7 @@ public class AuthFactory {
             throw new UnauthorizedException();
         }
         authProvider.authenticate(username, password);
-        return new AuthToken(username);
+        return AuthToken.generateUserToken( username );
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/auth/AuthToken.java
+++ b/src/java/org/jivesoftware/openfire/auth/AuthToken.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.auth;
 
+import org.jivesoftware.openfire.XMPPServerInfo;
 import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.util.JiveGlobals;
 
@@ -27,42 +28,71 @@ import org.jivesoftware.util.JiveGlobals;
  */
 public class AuthToken {
 
-    private static final long serialVersionUID = 01L;
-    private String username;
-    private String domain;
-    private Boolean anonymous;
+    private static final long serialVersionUID = 2L;
+    private final String username;
+
+    /**
+     * Constructs a new AuthToken that represents an authenticated user identified by
+     * the provider username.
+     *
+     * @param username the username to create an authToken token with.
+     */
+    public static AuthToken generateUserToken( String username )
+    {
+        if ( username == null || username.isEmpty() ) {
+            throw new IllegalArgumentException( "Argument 'username' cannot be null." );
+        }
+        return new AuthToken( username );
+    }
+
+    /**
+     * Constructs a new AuthToken that represents an authenticated, but anonymous user.
+     */
+    public static AuthToken generateAnonymousToken()
+    {
+        return new AuthToken( null );
+    }
 
     /**
      * Constucts a new AuthToken with the specified username.
      * The username can be either a simple username or a full JID.
      *
      * @param jid the username or bare JID to create an authToken token with.
+     * @deprecated replaced by {@link #generateUserToken(String)}
      */
+    @Deprecated
     public AuthToken(String jid) {
         if (jid == null) {
-            this.domain = JiveGlobals.getProperty("xmpp.domain");
+            this.username = null;
             return;
         }
         int index = jid.indexOf("@");
         if (index > -1) {
             this.username = jid.substring(0,index);
-            this.domain = jid.substring(index+1);
         } else {
             this.username = jid;
-            this.domain = JiveGlobals.getProperty("xmpp.domain");
         }
     }
 
+    /**
+     * Constucts a new AuthToken with the specified username.
+     * The username can be either a simple username or a full JID.
+     *
+     * @param jid the username or bare JID to create an authToken token with.
+     * @deprecated replaced by {@link #generateAnonymousToken()}
+     */
+    @Deprecated
     public AuthToken(String jid, Boolean anonymous) {
+        if (jid == null || (anonymous != null && anonymous) ) {
+            this.username = null;
+            return;
+        }
         int index = jid.indexOf("@");
         if (index > -1) {
             this.username = jid.substring(0,index);
-            this.domain = jid.substring(index+1);
         } else {
             this.username = jid;
-            this.domain = JiveGlobals.getProperty("xmpp.domain");
         }
-        this.anonymous = anonymous;
     }
 
     /**
@@ -79,9 +109,11 @@ public class AuthToken {
      * Returns the domain associated with this AuthToken.
      *
      * @return the domain associated with this AuthToken.
+     * @deprecated As Openfire serves only one domain, there's no need for a domain-specific token. Use {@link XMPPServerInfo#getXMPPDomain()} instead.
      */
+    @Deprecated
     public String getDomain() {
-        return domain;
+        return JiveGlobals.getProperty("xmpp.domain");
     }
 
     /**
@@ -90,9 +122,6 @@ public class AuthToken {
      * @return true if this token is the anonymous AuthToken.
      */
     public boolean isAnonymous() {
-        if (anonymous == null) {
-            anonymous = username == null || !UserManager.getInstance().isRegisteredUser(username);
-        }
-        return anonymous;
+        return username == null;
     }
 }

--- a/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/src/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -447,7 +447,14 @@ public class SASLAuthentication {
         sendElement(session, "success", successData);
         // We only support SASL for c2s
         if (session instanceof ClientSession) {
-            ((LocalClientSession) session).setAuthToken(new AuthToken(username));
+            final AuthToken authToken;
+            if (username == null) {
+                // AuthzId is null, which indicates that authentication was anonymous.
+                authToken = AuthToken.generateAnonymousToken();
+            } else {
+                authToken = AuthToken.generateUserToken(username);
+            }
+            ((LocalClientSession) session).setAuthToken(authToken);
         }
         else if (session instanceof IncomingServerSession) {
             String hostname = username;

--- a/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -691,9 +691,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
         String resource = getAddress().getResource();
         setAddress(new JID(resource, getServerName(), resource, true));
         setStatus(Session.STATUS_AUTHENTICATED);
-        if (authToken == null) {
-            authToken = new AuthToken(resource, true);
-        }
+        authToken = AuthToken.generateAnonymousToken();
         // Add session to the session manager. The session will be added to the routing table as well
         sessionManager.addSession(this);
     }

--- a/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -671,12 +671,20 @@ public class LocalClientSession extends LocalSession implements ClientSession {
      * @param resource the resource this session authenticated under.
      */
     public void setAuthToken(AuthToken auth, String resource) {
-        setAddress(new JID(auth.getUsername(), getServerName(), resource));
+        final JID jid;
+        if (auth.isAnonymous()) {
+            jid = new JID(resource, getServerName(), resource);
+        } else {
+            jid = new JID(auth.getUsername(), getServerName(), resource);
+        }
+        setAddress(jid);
         authToken = auth;
         setStatus(Session.STATUS_AUTHENTICATED);
 
         // Set default privacy list for this session
-        setDefaultList(PrivacyListManager.getInstance().getDefaultPrivacyList(auth.getUsername()));
+        if (!auth.isAnonymous()) {
+            setDefaultList( PrivacyListManager.getInstance().getDefaultPrivacyList( auth.getUsername() ) );
+        }
         // Add session to the session manager. The session will be added to the routing table as well
         sessionManager.addSession(this);
     }

--- a/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -242,7 +242,12 @@ public class StreamManager {
             sendUnexpectedError();
             return;
         }
-        JID fullJid = new JID(authToken.getUsername(), authToken.getDomain(), resource, true);
+        final JID fullJid;
+        if ( authToken.isAnonymous() ){
+            fullJid = new JID(resource, authToken.getDomain(), resource, true);
+        } else {
+            fullJid = new JID(authToken.getUsername(), authToken.getDomain(), resource, true);
+        }
         Log.debug("Resuming session {}", fullJid);
 
         // Locate existing session.


### PR DESCRIPTION
The 'isAnonymous' method need not do a user lookup to determine if the associated session is using anonymous authentication. This information is available when the token is created. By removing this lookup, load is reduced.

Additionally, the token implementation itself need not contain data that is guaranteed to be identical for each token (the XMPP domain name).

Lastly, the AuthToken javadoc defines that the containing username will be null for anonymous users. This means that there's no need to track that status in an additional field.

This above leads to a simplification of the AuthToken implementation (less complexity is good for maintenance). This PR also removes one instance where the username is set to the resource-part value of an anonymous session. The Javadoc of getUsername() clearly states that null values are to be expected (when anonymous authentication took place). This PR fixes a few instances where users of getUsername() assumed its return value to be non-null.