### PR TITLE
 OF-1553: Allow MUC room creation to be limited to registered local users.

### DIFF
--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -1165,6 +1165,7 @@ muc.create.permission.specific_created=Only specific users/groups can create a c
 muc.create.permission.allowed_users=Allowed Users/Groups
 muc.create.permission.add_jid=Add User (JID):
 muc.create.permission.add_group=Select Group (one or more):
+muc.create.permission.allow_registered=All registered users can create a chat room.
 muc.create.permission.no_allowed_users=No allowed users, use the form above to add one.
 muc.create.permission.click_title=Click to delete...
 muc.create.permission.confirm_remove=Are you sure you want to remove this user/group from the list?

--- a/src/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
+++ b/src/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
@@ -108,8 +108,7 @@ public interface MultiUserChatService extends Component {
     void setRoomCreationRestricted(boolean roomCreationRestricted);
 
     /**
-     * Returns the collection of JIDs that are allowed to create MUC rooms. An empty list means that
-     * anyone can create a room. 
+     * Returns the collection of JIDs that are allowed to create MUC rooms.
      * 
      * @return a list of user/group JIDs.
      */

--- a/src/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
+++ b/src/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
@@ -100,16 +100,37 @@ public interface MultiUserChatService extends Component {
     boolean isRoomCreationRestricted();
 
     /**
-     * Sets if anyone can create rooms or if only the returned JIDs in
-     * <code>getUsersAllowedToCreate</code> are allowed to create rooms.
+     * Sets if anyone can create rooms. When set to true, users are allowed to
+     * create rooms only when <code>isAllRegisteredUsersAllowedToCreate</code>
+     * or <code>getUsersAllowedToCreate</code> (or both) allow them to.
      *
      * @param roomCreationRestricted whether anyone can create rooms or not.
      */
     void setRoomCreationRestricted(boolean roomCreationRestricted);
 
     /**
+     * Sets if all registered users of Openfire are allowed to create rooms.
+     *
+     * When true, anonymous users and users from other domains (through
+     * federation) are initially prohibited from creating rooms, but can still
+     * be allowed by registering their JIDs in <code>addUserAllowedToCreate</code>.
+     *
+     * @return true if all registered users are allowed to create rooms.
+     */
+    boolean isAllRegisteredUsersAllowedToCreate();
+
+    /**
+     * Sets if all registered users of Openfire are allowed to create rooms.
+     *
+     * @param allow whether all registered users can create rooms.
+     */
+    void setAllRegisteredUsersAllowedToCreate(boolean allow);
+
+    /**
      * Returns the collection of JIDs that are allowed to create MUC rooms.
-     * 
+     * When <code>isAllRegisteredUsersAllowedToCreate</code>, this method will
+     * not return a JID of every user in the system.
+     *
      * @return a list of user/group JIDs.
      */
     Collection<JID> getUsersAllowedToCreate();

--- a/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -55,6 +55,7 @@ import org.jivesoftware.openfire.muc.cluster.GetNumberConnectedUsers;
 import org.jivesoftware.openfire.muc.cluster.OccupantAddedEvent;
 import org.jivesoftware.openfire.muc.cluster.RoomAvailableEvent;
 import org.jivesoftware.openfire.muc.cluster.RoomRemovedEvent;
+import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.JiveProperties;
 import org.jivesoftware.util.LocaleUtils;
@@ -182,10 +183,17 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
 
     /**
      * Returns the permission policy for creating rooms. A true value means that not anyone can
-     * create a room, only the JIDs listed in <code>allowedToCreate</code> are allowed to create
-     * rooms.
+     * create a room. Users are allowed to create rooms only when
+     * <code>isAllRegisteredUsersAllowedToCreate</code> or <code>getUsersAllowedToCreate</code>
+     * (or both) allow them to.
      */
     private boolean roomCreationRestricted = false;
+
+    /**
+     * Determines if all registered users (as opposed to anonymous users, and users from other
+     * XMPP domains) are allowed to create rooms.
+     */
+    private boolean allRegisteredUsersAllowedToCreate = false;
 
     /**
      * Bare jids of users that are allowed to create MUC rooms. Might also include group jids.
@@ -647,7 +655,38 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
             }
         }
     }
- 
+
+    /**
+     * Checks if a particular JID is allowed to create rooms.
+     *
+     * @param jid The jid for which to check (cannot be null).
+     * @return true if the JID is allowed to create a room, otherwise false.
+     */
+    protected boolean isAllowedToCreate(JID jid) {
+        // If room creation is not restricted, everyone is allowed to create a room.
+        if (!isRoomCreationRestricted()) {
+            return true;
+        }
+
+        final JID bareJID = jid.asBareJID();
+
+        // System administrators are always allowed to create rooms.
+        if (sysadmins.includes(bareJID)) {
+            return true;
+        }
+
+        // If the JID of the user has explicitly been given permission, room creation is allowed.
+        if (allowedToCreate.includes(bareJID)) {
+            return true;
+        }
+
+        // Verify the policy that allows all local, registered users to create rooms.
+        if (allRegisteredUsersAllowedToCreate && UserManager.getInstance().isRegisteredUser(bareJID)) {
+            return true;
+        }
+
+        return false;
+    }
 
     @Override
     public MUCRoom getChatRoom(String roomName, JID userjid) throws NotAllowedException {
@@ -685,15 +724,8 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                     }
                     else {
                         // The room does not exist so check for creation permissions
-                        // Room creation is always allowed for sysadmin
-                        final JID bareJID = userjid.asBareJID();
-                        if (isRoomCreationRestricted() && !sysadmins.includes(bareJID)) {
-                            // The room creation is only allowed for certain JIDs
-                            if (!allowedToCreate.includes(bareJID)) {
-                                // The user is not in the list of allowed JIDs to create a room so raise
-                                // an exception
-                                throw new NotAllowedException();
-                            }
+                        if (!isAllowedToCreate(userjid)) {
+                            throw new NotAllowedException();
                         }
                         room.addFirstOwner(userjid);
                         created = true;
@@ -1093,6 +1125,17 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     }
 
     @Override
+    public boolean isAllRegisteredUsersAllowedToCreate() {
+        return allRegisteredUsersAllowedToCreate;
+    }
+
+    @Override
+    public void setAllRegisteredUsersAllowedToCreate( final boolean allow ) {
+        this.allRegisteredUsersAllowedToCreate = allow;
+        MUCPersistenceManager.setProperty(chatServiceName, "create.all-registered", Boolean.toString(allow));
+    }
+
+    @Override
     public void addUsersAllowedToCreate(Collection<JID> userJIDs) {
         boolean listChanged = false;
 
@@ -1184,6 +1227,8 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                 MUCPersistenceManager.getBooleanProperty(chatServiceName, "discover.membersOnly", true);
         roomCreationRestricted =
                 MUCPersistenceManager.getBooleanProperty(chatServiceName, "create.anyone", false);
+        allRegisteredUsersAllowedToCreate =
+                MUCPersistenceManager.getBooleanProperty(chatServiceName, "create.all-registered", false );
         // Load the list of JIDs that are allowed to create a MUC room
         property = MUCPersistenceManager.getProperty(chatServiceName, "create.jid");
         allowedToCreate.clear();

--- a/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -188,8 +188,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     private boolean roomCreationRestricted = false;
 
     /**
-     * Bare jids of users that are allowed to create MUC rooms. An empty list means that anyone can
-     * create a room. Might also include group jids.
+     * Bare jids of users that are allowed to create MUC rooms. Might also include group jids.
      */
     private GroupAwareList<JID> allowedToCreate = new ConcurrentGroupList<>();
 

--- a/src/web/muc-create-permission.jsp
+++ b/src/web/muc-create-permission.jsp
@@ -35,6 +35,7 @@
 <%  // Get parameters
     String userJID = ParamUtils.getParameter(request,"userJID");
     String[] groupNames = ParamUtils.getParameters(request, "groupNames");
+    boolean allowAllRegisteredUsers =  ParamUtils.getBooleanParameter(request,"allowAllRegisteredUsers");
     boolean add = request.getParameter("add") != null;
     boolean save = request.getParameter("save") != null;
     boolean success = request.getParameter("success") != null;
@@ -125,12 +126,14 @@
         // Handle an add
         if (add) {
             mucService.addUsersAllowedToCreate(allowedJIDs);
+            mucService.setAllRegisteredUsersAllowedToCreate(allowAllRegisteredUsers);
             // Log the event
             webManager.logEvent("updated MUC room creation permissions for service "+mucname, null);
             response.sendRedirect("muc-create-permission.jsp?addsuccess=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
             return;
         }
-    
+
+        // Handle delete
         if (delete) {
             // Remove the user from the allowed list
             mucService.removeUserAllowedToCreate(GroupJID.fromString(userJID));
@@ -249,6 +252,10 @@
         <fmt:message key="muc.create.permission.allowed_users" />
     </div>
     <div class="jive-contentBox">
+        <p>
+            <input type="checkbox" id="allowAllRegisteredUsers" name="allowAllRegisteredUsers" <%=mucService.isAllRegisteredUsersAllowedToCreate()?"checked":""%> onChange="this.form.submit()">
+            <label for="allowAllRegisteredUsers"><fmt:message key="muc.create.permission.allow_registered" /></label>
+        </p>
         <p>
         <label for="groupJIDs"><fmt:message key="muc.create.permission.add_group" /></label><br/>
         <select name="groupNames" size="6" multiple style="width:400px;font-family:verdana,arial,helvetica,sans-serif;font-size:8pt;" 


### PR DESCRIPTION
The existing options that allow an administrator to configure who is allowed to create new group chat rooms should get an additional option: allow all locally registered users to create rooms. This could be used to prevent anonymous users, and users from other XMPP domains, from creating rooms.