### PR TITLE
OF-1433 / OF-454: Reflect presence updates

### DIFF
--- a/src/java/org/jivesoftware/openfire/SessionManager.java
+++ b/src/java/org/jivesoftware/openfire/SessionManager.java
@@ -655,13 +655,22 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
     }
 
     /**
+     * @deprecated Use {@link #broadcastPresenceToResources(JID, Presence)} instead.
+     */
+    @Deprecated
+    public void broadcastPresenceToOtherResources(JID originatingResource, Presence presence)
+    {
+        broadcastPresenceToResources(originatingResource, presence);
+    }
+
+    /**
      * Broadcasts presence updates from the originating user's resource to any of the user's
-     * existing available resources (if any).
+     * existing available resources (including the resource from where the update originates).
      *
      * @param originatingResource the full JID of the session that sent the presence update.
      * @param presence the presence.
      */
-    public void broadcastPresenceToOtherResources(JID originatingResource, Presence presence) {
+    public void broadcastPresenceToResources( JID originatingResource, Presence presence) {
         // RFC 6121 4.4.2 says we always send to the originating resource.
         // Also RFC 6121 4.2.2 for updates.
         presence.setTo(originatingResource);

--- a/src/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/src/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -143,24 +143,28 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
                     Log.warn("Rejected available presence: " + presence + " - " + session);
                     return;
                 }
-                broadcastUpdate(presence.createCopy());
+
                 if (session != null) {
                     session.setPresence(presence);
-                    if (!session.isInitialized()) {
-                        initSession(session);
-                        session.setInitialized(true);
-                    }
                 }
+
+                broadcastUpdate(presence.createCopy());
+
+                if (session != null && !session.isInitialized()) {
+                    initSession(session);
+                    session.setInitialized(true);
+                }
+
                 // Notify the presence manager that the user is now available. The manager may
                 // remove the last presence status sent by the user when he went offline.
                 presenceManager.userAvailable(presence);
             }
             else if (Presence.Type.unavailable == type) {
-                broadcastUpdate(presence.createCopy());
-                broadcastUnavailableForDirectedPresences(presence);
                 if (session != null) {
                     session.setPresence(presence);
                 }
+                broadcastUpdate(presence.createCopy());
+                broadcastUnavailableForDirectedPresences(presence);
                 // Notify the presence manager that the user is now unavailable. The manager may
                 // save the last presence status sent by the user and keep track when the user
                 // went offline.

--- a/src/java/org/jivesoftware/openfire/roster/Roster.java
+++ b/src/java/org/jivesoftware/openfire/roster/Roster.java
@@ -624,8 +624,8 @@ public class Roster implements Cacheable, Externalizable {
             }
         }
         if (from != null) {
-            // Broadcast presence to other user's resources
-            SessionManager.getInstance().broadcastPresenceToOtherResources(from, packet);
+            // Broadcast presence to all resources of the user.
+            SessionManager.getInstance().broadcastPresenceToResources( from, packet);
         }
     }
 


### PR DESCRIPTION
I don't think the fix for OF-454 ever completely worked. It is based on a presence broadcast that sends a presence update to all subscribed entities, as well as all resources of the same user that are available.

The problem lies in the fact that the presence update was 'recorded' in the client session only after this broadcast was done. When iterating over all client session to find resources that are available, the session from where the update originated, is still reporting the previous presence state (in case of a new session: unavailable).

To me, re-ordering events seem logical, and desirable for other reasons. It makes sense to first store the presence update in the client session, and only then broadcast the update.