### PR TITLE
OF-1566: Fix for archive search with password protected chatrooms

### DIFF
--- a/src/plugins/monitoring/changelog.html
+++ b/src/plugins/monitoring/changelog.html
@@ -44,6 +44,11 @@
 Monitoring Plugin Changelog
 </h1>
 
+<p><b>1.6.1</b> -- June 28, 2018</p>
+<ul>
+    <li>Fix for archive search with password protected chatrooms.</li>
+</ul>
+
 <p><b>1.6.0</b> -- March 5, 2018</p>
 <ul>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-1486'>OF-1486</a>] - MAM RSM queries for MUC should allow for 'backwards-paging'.</li>

--- a/src/plugins/monitoring/changelog.html
+++ b/src/plugins/monitoring/changelog.html
@@ -46,7 +46,7 @@ Monitoring Plugin Changelog
 
 <p><b>1.6.1</b> -- June 28, 2018</p>
 <ul>
-    <li>Fix for archive search with password protected chatrooms.</li>
+    <li>[<a href='https://issues.igniterealtime.org/browse/OF-1566'>OF-1566</a>] - Fix for archive search with password protected chatrooms.</li>
 </ul>
 
 <p><b>1.6.0</b> -- March 5, 2018</p>

--- a/src/plugins/monitoring/plugin.xml
+++ b/src/plugins/monitoring/plugin.xml
@@ -6,7 +6,7 @@
     <description>Monitors conversations and statistics of the server.</description>
     <author>IgniteRealtime // Jive Software</author>
     <version>1.6.1</version>
-    <date>03/05/2018</date>
+    <date>28/06/2018</date>
     <minServerVersion>4.1.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>
     <databaseVersion>4</databaseVersion>

--- a/src/plugins/monitoring/plugin.xml
+++ b/src/plugins/monitoring/plugin.xml
@@ -5,7 +5,7 @@
     <name>Monitoring Service</name>
     <description>Monitors conversations and statistics of the server.</description>
     <author>IgniteRealtime // Jive Software</author>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <date>03/05/2018</date>
     <minServerVersion>4.1.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>

--- a/src/plugins/monitoring/pom.xml
+++ b/src/plugins/monitoring/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>monitoring</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <name>Monitoring Plugin</name>
     <description>Monitors conversations and statistics of the server.</description>
 

--- a/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler.java
+++ b/src/plugins/monitoring/src/java/com/reucon/openfire/plugin/archive/xep0313/IQQueryHandler.java
@@ -156,6 +156,18 @@ abstract class IQQueryHandler extends AbstractIQHandler implements
                 Log.debug("Unable to process query as requestor '{}' is forbidden to retrieve archive for room '{}'.", requestor, archiveJid);
                 return buildForbiddenResponse(packet);
             }
+
+            // Password protected room
+            if (room.isPasswordProtected())  {
+				// check whether requestor is occupant in the room
+				MUCRole occupant = room.getOccupantByFullJID(packet.getFrom());
+
+				if (occupant == null) {
+					// no occupant so currently not authenticated to query archive
+				    Log.debug("Unable to process query as requestor '{}' is currently not authenticated for this password protected room '{}'.", requestor, archiveJid);
+                    return buildForbiddenResponse(packet);
+				}
+            }
         } else if(!archiveJid.equals(requestor)) { // Not user's own
             // ... disallow unless admin.
             if (!XMPPServer.getInstance().getAdmins().contains(requestor)) {


### PR DESCRIPTION
Fix for preventing users to access message history (archive search) of a chatroom when they are no occupant in the chatroom at the moment of search.
The fix results in a Forbidden response being send when the requestor of the archive search is not an occupant in the chatroom.

See [Openfire 4.2.3 monitoring service 1.6.0 does not check user has the right to enter the archive] (https://discourse.igniterealtime.org/t/openfire-4-2-3-monitoring-service-1-6-0-does-not-check-user-has-the-right-to-enter-the-archive/82037)