### PR TITLE
OF-1533: Use a random IV for each new encrypted property

### DIFF
--- a/src/database/openfire_db2.sql
+++ b/src/database/openfire_db2.sql
@@ -115,6 +115,7 @@ CREATE TABLE ofProperty (
   name        VARCHAR(100) NOT NULL,
   propValue   VARCHAR(3000) NOT NULL,
   encrypted   INTEGER,
+  iv          CHAR(24),
   CONSTRAINT ofProperty_pk PRIMARY KEY (name)
 );
 
@@ -384,7 +385,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 28);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_hsqldb.sql
+++ b/src/database/openfire_hsqldb.sql
@@ -115,6 +115,7 @@ CREATE TABLE ofProperty (
   name        VARCHAR(100)  NOT NULL,
   propValue   VARCHAR(4000) NOT NULL,
   encrypted   INTEGER,
+  iv          CHAR(24),
   CONSTRAINT ofProperty_pk PRIMARY KEY (name)
 );
 
@@ -370,7 +371,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 28);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
 
 // Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_mysql.sql
+++ b/src/database/openfire_mysql.sql
@@ -105,6 +105,7 @@ CREATE TABLE ofProperty (
   name        VARCHAR(100)              NOT NULL,
   propValue   TEXT                      NOT NULL,
   encrypted   INTEGER,
+  iv          CHAR(24),
   PRIMARY KEY (name)
 );
 
@@ -360,7 +361,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 28);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
 
 # Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_oracle.sql
+++ b/src/database/openfire_oracle.sql
@@ -113,6 +113,7 @@ CREATE TABLE ofProperty (
   name        VARCHAR2(100) NOT NULL,
   propValue   VARCHAR2(4000) NOT NULL,
   encrypted   INTEGER,
+  iv          CHAR(24),
   CONSTRAINT ofProperty_pk PRIMARY KEY (name)
 );
 
@@ -368,7 +369,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 28);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_postgresql.sql
+++ b/src/database/openfire_postgresql.sql
@@ -120,6 +120,7 @@ CREATE TABLE ofProperty (
   name        VARCHAR(100) NOT NULL,
   propValue   VARCHAR(4000) NOT NULL,
   encrypted   INTEGER,
+  iv          CHAR(24),
   CONSTRAINT ofProperty_pk PRIMARY KEY (name)
 );
 
@@ -376,7 +377,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 28);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_sqlserver.sql
+++ b/src/database/openfire_sqlserver.sql
@@ -118,6 +118,7 @@ CREATE TABLE ofProperty (
   name        NVARCHAR(100) NOT NULL,
   propValue   NTEXT NOT NULL,
   encrypted   INTEGER,
+  iv          CHAR(24),
   CONSTRAINT ofProperty_pk PRIMARY KEY (name)
 );
 
@@ -373,7 +374,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 28);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/openfire_sybase.sql
+++ b/src/database/openfire_sybase.sql
@@ -118,6 +118,7 @@ CREATE TABLE ofProperty (
   name         NVARCHAR(100) NOT NULL,
   propValue    TEXT NOT NULL,
   encrypted    INTEGER,
+  iv           CHAR(24),
   CONSTRAINT ofProperty_pk PRIMARY KEY (name)
 );
 
@@ -374,7 +375,7 @@ INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 28);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/src/database/upgrade/29/openfire_db2.sql
+++ b/src/database/upgrade/29/openfire_db2.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
+UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/src/database/upgrade/29/openfire_hsqldb.sql
+++ b/src/database/upgrade/29/openfire_hsqldb.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
+UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/src/database/upgrade/29/openfire_mysql.sql
+++ b/src/database/upgrade/29/openfire_mysql.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
+UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/src/database/upgrade/29/openfire_oracle.sql
+++ b/src/database/upgrade/29/openfire_oracle.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
+UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/src/database/upgrade/29/openfire_postgresql.sql
+++ b/src/database/upgrade/29/openfire_postgresql.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
+UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/src/database/upgrade/29/openfire_sqlserver.sql
+++ b/src/database/upgrade/29/openfire_sqlserver.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
+UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/src/database/upgrade/29/openfire_sybase.sql
+++ b/src/database/upgrade/29/openfire_sybase.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
+UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/src/java/org/jivesoftware/database/SchemaManager.java
+++ b/src/java/org/jivesoftware/database/SchemaManager.java
@@ -67,7 +67,7 @@ public class SchemaManager {
     /**
      * Current Openfire database schema version.
      */
-    private static final int DATABASE_VERSION = 28;
+    private static final int DATABASE_VERSION = 29;
 
     /**
      * Checks the Openfire database schema to ensure that it's installed and up to date.

--- a/src/java/org/jivesoftware/util/AesEncryptor.java
+++ b/src/java/org/jivesoftware/util/AesEncryptor.java
@@ -57,21 +57,29 @@ public class AesEncryptor implements Encryptor {
      * @see org.jivesoftware.util.Encryptor#encrypt(java.lang.String)
      */
     @Override
-    public String encrypt(String value)
-    {
+    public String encrypt(String value) {
+        return encrypt(value, null);
+    }
+
+    @Override
+    public String encrypt(String value, byte[] iv) {
         if (value == null) { return null; }
         byte [] bytes = value.getBytes(StandardCharsets.UTF_8);
-        return Base64.encodeBytes( cipher(bytes, getKey(), Cipher.ENCRYPT_MODE) );
+        return Base64.encodeBytes(cipher(bytes, getKey(), iv == null ? INIT_PARM : iv, Cipher.ENCRYPT_MODE));
     }
 
     /* (non-Javadoc)
      * @see org.jivesoftware.util.Encryptor#decrypt(java.lang.String)
      */
     @Override
-    public String decrypt(String value)
-    {
+    public String decrypt(String value) {
+        return decrypt(value, null);
+    }
+
+    @Override
+    public String decrypt(String value, byte[] iv) {
         if (value == null) { return null; }
-        byte [] bytes = cipher(Base64.decode(value), getKey(), Cipher.DECRYPT_MODE);
+        byte [] bytes = cipher(Base64.decode(value), getKey(), iv == null ? INIT_PARM : iv, Cipher.DECRYPT_MODE);
         if (bytes == null) { return null; }
         return new String(bytes, StandardCharsets.UTF_8);
     }
@@ -84,7 +92,7 @@ public class AesEncryptor implements Encryptor {
      * @param mode The cipher mode (encrypt or decrypt)
      * @return The converted attribute, or null if conversion fails
      */
-    private byte [] cipher(byte [] attribute, byte [] key, int mode)
+    private byte [] cipher(byte [] attribute, byte [] key, byte[] iv, int mode)
     {
         byte [] result = null;
         try
@@ -96,7 +104,7 @@ public class AesEncryptor implements Encryptor {
             Cipher aesCipher = Cipher.getInstance(ALGORITHM);
 
             // Initialize AES Cipher and convert
-            aesCipher.init(mode, aesKey, new IvParameterSpec(INIT_PARM));
+            aesCipher.init(mode, aesKey, new IvParameterSpec(iv));
             result = aesCipher.doFinal(attribute);
         }
         catch (Exception e)

--- a/src/java/org/jivesoftware/util/Blowfish.java
+++ b/src/java/org/jivesoftware/util/Blowfish.java
@@ -1485,8 +1485,18 @@ public class Blowfish implements Encryptor {
     }
 
     @Override
+    public String encrypt(String value, byte[] iv) {
+        return encrypt(value);
+    }
+
+    @Override
     public String decrypt(String value) {
         return this.decryptString(value);
+    }
+
+    @Override
+    public String decrypt(String value, byte[] iv) {
+        return decrypt(value);
     }
 
     @Override

--- a/src/java/org/jivesoftware/util/Encryptor.java
+++ b/src/java/org/jivesoftware/util/Encryptor.java
@@ -3,12 +3,21 @@ package org.jivesoftware.util;
 public interface Encryptor {
 
     /**
-     * Encrypt a clear text String. 
+     * Encrypt a clear text String.
      *
      * @param value The clear text attribute
      * @return The encrypted attribute, or null
      */
     String encrypt( String value );
+
+    /**
+     * Encrypt a clear text String.
+     *
+     * @param value The clear text attribute
+     * @param iv The IV to use, or null for the default IV
+     * @return The encrypted attribute, or null
+     */
+    String encrypt( String value, byte[] iv );
 
     /**
      * Decrypt an encrypted String. 
@@ -17,6 +26,15 @@ public interface Encryptor {
      * @return The clear text attribute, or null
      */
     String decrypt( String value );
+
+    /**
+     * Decrypt an encrypted String.
+     *
+     * @param value The encrypted attribute in Base64 encoding
+     * @param iv The IV to use, or null for the default IV
+     * @return The clear text attribute, or null
+     */
+    String decrypt( String value, byte[] iv );
 
     /**
      * Set the encryption key. This will apply the user-defined key,

--- a/src/test/java/org/jivesoftware/util/AesEncryptorTest.java
+++ b/src/test/java/org/jivesoftware/util/AesEncryptorTest.java
@@ -3,9 +3,9 @@ package org.jivesoftware.util;
 import java.util.UUID;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.*;
 
 public class AesEncryptorTest {
 
@@ -56,4 +56,32 @@ public class AesEncryptorTest {
         
         assertNull(b64Encrypted);
     }
+
+    @Test
+    public void testEncryptionWithKeyAndIV() {
+
+        final String plainText = UUID.randomUUID().toString();
+        final byte[] iv = "0123456789abcdef".getBytes();
+        final Encryptor encryptor = new AesEncryptor(UUID.randomUUID().toString());
+        final String encryptedText = encryptor.encrypt(plainText, iv);
+
+        final String decryptedText = encryptor.decrypt(encryptedText, iv);
+
+        assertThat(decryptedText, is(plainText));
+    }
+
+    @Test
+    public void testEncryptionWithKeyAndBadIV() {
+
+        final String plainText = UUID.randomUUID().toString();
+        final byte[] iv = "0123456789abcdef".getBytes();
+        final Encryptor encryptor = new AesEncryptor(UUID.randomUUID().toString());
+        final String encryptedText = encryptor.encrypt(plainText, iv);
+
+        final String decryptedText = encryptor.decrypt(encryptedText);
+
+        assertThat(decryptedText, is(not(plainText)));
+
+    }
+
 }


### PR DESCRIPTION
Note 1; this only applies to the properties in the database. Encrypted properties in the `openfire.xml` all share the same, default IV. But as there are only two, and the only place they are used is in the same folder where we could save the IV (`security.xml`), there's no practical security advantage.

Note 2; If the Blowfish algorithm is used, an random IV is generated and saved, but it's not actually used during the decryption process.