### PR TITLE
OF-1383: Changes to prepare for Java 9 onwards.

### DIFF
--- a/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/src/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -16,7 +16,6 @@
 
 package org.jivesoftware.openfire.ldap;
 
-import com.sun.jndi.ldap.LdapCtxFactory;
 import org.jivesoftware.openfire.group.GroupNotFoundException;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.util.JiveGlobals;
@@ -97,11 +96,7 @@ import java.util.regex.Pattern;
 public class LdapManager {
 
     private static final Logger Log = LoggerFactory.getLogger(LdapManager.class);
-    // Determine the name of the default LDAP context factory.
-    // NOTE: Extracting the name from the class rather than hard coding it allows the compiler to detect the use of this
-    // internal class and emit an appropriate warning ("warning: LdapCtxFactory is internal proprietary API and may be removed in a future release")
-    // This is deliberate, to highlight use of classes that may be removed in the future.
-    private static final String DEFAULT_LDAP_CONTEXT_FACTORY = LdapCtxFactory.class.getName();
+    private static final String DEFAULT_LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
 
     private static LdapManager instance;
     static {

--- a/src/web/security-certificate-details.jsp
+++ b/src/web/security-certificate-details.jsp
@@ -5,14 +5,12 @@
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType"%>
 <%@ page import="org.jivesoftware.util.ParamUtils"%>
 <%@ page import="org.jivesoftware.util.StringUtils"%>
-<%@ page import="javax.xml.bind.DatatypeConverter" %>
 <%@ page import="java.security.AlgorithmParameters" %>
 <%@ page import="java.security.cert.X509Certificate" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.util.CertificateManager" %>
-<%@ page import="org.bouncycastle.cert.X509CertificateHolder" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -21,6 +19,18 @@
 
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
 <jsp:useBean id="now" class="java.util.Date"/>
+<%!
+    private final static char[] hexArray = "0123456789ABCDEF".toCharArray();
+    public static String bytesToHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for ( int j = 0; j < bytes.length; j++ ) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+%>
 <%  webManager.init(request, response, session, application, out );
 
     final String alias            = ParamUtils.getParameter( request, "alias" );
@@ -430,7 +440,7 @@
                 <tr valign="top">
                     <%
                         final X509Certificate certificate = (X509Certificate) pageContext.getAttribute("certificate");
-                        final String hex = DatatypeConverter.printHexBinary( certificate.getSignature());
+                        final String hex = bytesToHex(certificate.getSignature());
                         final StringBuilder sb = new StringBuilder();
                         for (int i=0; i<hex.length(); i++) {
                             if (i != 0 && i != hex.length() - 1) {

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -26,17 +26,6 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <includes>
-                        <include>org/jivesoftware/openfire/starter/ServerStarter.java</include>
-                        <include>org/jivesoftware/openfire/starter/JiveClassLoader.java</include>
-                        <include>org/jivesoftware/openfire/launcher/*.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
         </plugins>
 
         <sourceDirectory>../src/java</sourceDirectory>
@@ -57,6 +46,55 @@
             </resource>
         </resources>
     </build>
+
+    <profiles>
+        <profile>
+            <id>pre-1.9</id>
+            <activation>
+                <jdk>(,1.8]</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>org/jivesoftware/openfire/starter/ServerStarter.java</include>
+                                <include>org/jivesoftware/openfire/starter/JiveClassLoader.java</include>
+                                <include>org/jivesoftware/openfire/launcher/*.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>post-1.8</id>
+            <activation>
+                <jdk>(1.8,]</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>org/jivesoftware/openfire/starter/ServerStarter.java</include>
+                                <include>org/jivesoftware/openfire/starter/JiveClassLoader.java</include>
+                                <include>org/jivesoftware/openfire/launcher/*.java</include>
+                            </includes>
+                            <compilerArgs>
+                                <arg>--add-modules</arg>
+                                <arg>java.xml.bind</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>

--- a/webadmintld/pom.xml
+++ b/webadmintld/pom.xml
@@ -10,21 +10,55 @@
     <name>Administration Interface Taglibs</name>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <includes>
-                        <include>org/jivesoftware/admin/*Tag.java</include>
-                        <include>org/jivesoftware/admin/JSTL*.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
-        </plugins>
-
         <sourceDirectory>../src/java</sourceDirectory>
     </build>
+
+    <profiles>
+        <profile>
+            <id>pre-1.9</id>
+            <activation>
+                <jdk>(,1.8]</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>org/jivesoftware/admin/*Tag.java</include>
+                                <include>org/jivesoftware/admin/JSTL*.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>post-1.8</id>
+            <activation>
+                <jdk>(1.8,]</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>org/jivesoftware/admin/*Tag.java</include>
+                                <include>org/jivesoftware/admin/JSTL*.java</include>
+                            </includes>
+                            <compilerArgs>
+                                <arg>--add-modules</arg>
+                                <arg>java.xml.bind</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -13,17 +13,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>org/jivesoftware/openfire/starter/JiveClassLoader.java</exclude>
-                        <exclude>org/jivesoftware/openfire/starter/ServerStarter.java</exclude>
-                        <exclude>org/jivesoftware/openfire/launcher/*.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
@@ -58,6 +47,55 @@
             </resource>
         </resources>
     </build>
+
+    <profiles>
+        <profile>
+            <id>pre-1.9</id>
+            <activation>
+                <jdk>(,1.8]</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>org/jivesoftware/openfire/starter/JiveClassLoader.java</exclude>
+                                <exclude>org/jivesoftware/openfire/starter/ServerStarter.java</exclude>
+                                <exclude>org/jivesoftware/openfire/launcher/*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>post-1.8</id>
+            <activation>
+                <jdk>(1.8,]</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>org/jivesoftware/openfire/starter/JiveClassLoader.java</exclude>
+                                <exclude>org/jivesoftware/openfire/starter/ServerStarter.java</exclude>
+                                <exclude>org/jivesoftware/openfire/launcher/*.java</exclude>
+                            </excludes>
+                            <compilerArgs>
+                                <arg>--add-modules</arg>
+                                <arg>java.xml.bind</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
         <!-- Ignite Realtime -->


### PR DESCRIPTION
This PR contains a couple of smaller changes that allow the code to be compiled with Java 10, while remaining compatible with Java 8.

Note that even with these changes, Openfire still will not run with Java 10. At the very least, a [runtime issue with Apache MINA needs to be resolved](https://issues.apache.org/jira/projects/DIRMINA/issues/DIRMINA-1088). There likely are other problems too.