### PR TITLE
Add enforcer:enforce goal to check for SNAPSHOT dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,28 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-no-snapshots</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rules>
+                        <requireReleaseDeps>
+                            <message>No Snapshots Allowed!</message>
+                            <onlyWhenRelease>true</onlyWhenRelease>
+                        </requireReleaseDeps>
+                    </rules>
+                    <fail>true</fail>
+                </configuration>
+            </plugin>
             <!--<plugin>-->
             <!--<groupId>org.codehaus.mojo</groupId>-->
             <!--<artifactId>findbugs-maven-plugin</artifactId>-->

--- a/src/plugins/bookmarks/plugin.xml
+++ b/src/plugins/bookmarks/plugin.xml
@@ -8,8 +8,8 @@
     <name>Bookmarks</name>
     <description>Allows clients to store URL and group chat bookmarks (XEP-0048)</description>
     <author>Ignite Realtime</author>
-    <version>1.0.0</version>
-    <date>1/11/2015</date>
+    <version>1.0.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
 
     <!-- Keep the 'clientcontrol' database key for backwards compatibility. Client control itself does not have any database. -->

--- a/src/plugins/bookmarks/pom.xml
+++ b/src/plugins/bookmarks/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>bookmarks</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>Bookmarks Plugin</name>
     <description>Allows clients to store URL and group chat bookmarks (XEP-0048)</description>
 

--- a/src/plugins/broadcast/plugin.xml
+++ b/src/plugins/broadcast/plugin.xml
@@ -8,8 +8,8 @@
     <name>Broadcast</name>
     <description>Broadcasts messages to users.</description>
     <author>Jive Software</author>
-    <version>1.9.0</version>
-    <date>9/13/2013</date>
+    <version>1.9.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <url>http://www.igniterealtime.org</url>
-    <minServerVersion>3.9.0</minServerVersion>
+    <minServerVersion>4.0.0</minServerVersion>
 </plugin>

--- a/src/plugins/broadcast/pom.xml
+++ b/src/plugins/broadcast/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>broadcast</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1-SNAPSHOT</version>
     <name>Broadcast Plugin</name>
     <description>Broadcasts messages to users.</description>
 

--- a/src/plugins/callbackOnOffline/plugin.xml
+++ b/src/plugins/callbackOnOffline/plugin.xml
@@ -6,8 +6,8 @@
     <name>CallbackOnOffline</name>
     <description>Url is called when recipient is offline</description>
     <author>Pavel Goski / Krzysztof Misztal</author>
-    <version>1.2.0</version>
-    <date>12/15/2017</date>
-    <minServerVersion>2.3.0</minServerVersion>
+    <version>1.2.1-SNAPSHOT</version>
+    <date>tbc.</date>
+    <minServerVersion>4.0.0</minServerVersion>
 
 </plugin>

--- a/src/plugins/callbackOnOffline/pom.xml
+++ b/src/plugins/callbackOnOffline/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>callbackOnOffline</artifactId>
-    <version>1.2</version>
+    <version>1.2.1-SNAPSHOT</version>
     <name>Callback on Offline Plugin</name>
     <description>Url is called when recipient is offline</description>
 

--- a/src/plugins/candy/plugin.xml
+++ b/src/plugins/candy/plugin.xml
@@ -4,8 +4,8 @@
     <name>Candy</name>
     <description>Adds the (third-party) Candy web client to Openfire.</description>
     <author>Guus der Kinderen</author>
-    <version>2.2.0 Release 2</version>
-    <date>07/10/2017</date>
+    <version>2.2.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.1.5</minServerVersion>
     <adminconsole>
         <tab id="tab-webclients" name="${admin.sidebar.webclients.name}" description="${admin.sidebar.webclients.description}" url="candy-config.jsp">    

--- a/src/plugins/candy/pom.xml
+++ b/src/plugins/candy/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>candy</artifactId>
     <name>Candy Webchat Plugin</name>
-    <version>2.2.0-release-2</version>
+    <version>2.2.1-SNAPSHOT</version>
 
     <build>
         <sourceDirectory>src/java</sourceDirectory>

--- a/src/plugins/clientControl/plugin.xml
+++ b/src/plugins/clientControl/plugin.xml
@@ -8,8 +8,8 @@
     <name>Client Control</name>
     <description>Controls clients allowed to connect and available features</description>
     <author>Jive Software</author>
-    <version>2.1.3</version>
-    <date>7/30/2017</date>
+    <version>2.1.4-SNAPSHOT</version>
+    <date>tbc</date>
     <minServerVersion>4.0.0</minServerVersion>
 
     <!-- UI extension -->

--- a/src/plugins/clientControl/pom.xml
+++ b/src/plugins/clientControl/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>clientControl</artifactId>
-    <version>2.1.2</version>
+    <version>2.1.4-SNAPSHOT</version>
     <name>ClientControl Plugin</name>
     <description>Controls clients allowed to connect and available features</description>
 

--- a/src/plugins/contentFilter/plugin.xml
+++ b/src/plugins/contentFilter/plugin.xml
@@ -8,8 +8,8 @@
     <name>Content Filter</name>
     <description>Scans message packets for defined patterns</description>
     <author>Conor Hayes</author>
-    <version>1.8.0</version>
-    <date>10/12/2015</date>
+    <version>1.8.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     
     <!-- UI extension -->

--- a/src/plugins/contentFilter/pom.xml
+++ b/src/plugins/contentFilter/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>contentFilter</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1-SNAPSHOT</version>
     <name>ContentFilter Plugin</name>
     <description>Scans message packets for defined patterns</description>
 

--- a/src/plugins/dbaccess/plugin.xml
+++ b/src/plugins/dbaccess/plugin.xml
@@ -5,8 +5,8 @@
     <name>DB Access</name>
     <description>Provides administrators with a simple direct access interface to their Openfire DB.</description>
     <author>Daniel Henninger</author>
-    <version>1.2.0</version>
-    <date>10/12/2015</date>
+    <version>1.2.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
 
     <adminconsole>

--- a/src/plugins/dbaccess/pom.xml
+++ b/src/plugins/dbaccess/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>dbaccess</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <name>DB Access Plugin</name>
     <description>Provides administrators with a simple direct access interface to their Openfire DB.</description>
 

--- a/src/plugins/emailListener/plugin.xml
+++ b/src/plugins/emailListener/plugin.xml
@@ -9,8 +9,8 @@
     <description>Listens for emails and sends alerts to specific users.</description>
     <author>Jive Software</author>
     <url>http://www.igniterealtime.org</url>
-    <version>1.2.0</version>
-    <date>10/12/2015</date>
+    <version>1.2.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
 
     <adminconsole>

--- a/src/plugins/emailListener/pom.xml
+++ b/src/plugins/emailListener/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>emailListener</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <name>Email Listener Plugin</name>
     <description>Listens for emails and sends alerts to specific users.</description>
 

--- a/src/plugins/emailOnAway/plugin.xml
+++ b/src/plugins/emailOnAway/plugin.xml
@@ -6,8 +6,8 @@
     <name>Email on Away</name>
     <description>Messages sent to alternate location when recipient is away</description>
     <author>Nick Mossie</author>
-    <version>1.0.3</version>
-    <date>04/10/2016</date>
-    <minServerVersion>2.3.0</minServerVersion>
+    <version>1.0.4-SNAPSHOT</version>
+    <date>tbc.</date>
+    <minServerVersion>4.0.0</minServerVersion>
 
 </plugin>

--- a/src/plugins/emailOnAway/pom.xml
+++ b/src/plugins/emailOnAway/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>emailOnAway</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
     <name>Email On Away Plugin</name>
     <description>Messages sent to alternate location when recipient is away</description>
 

--- a/src/plugins/externalservicediscovery/plugin.xml
+++ b/src/plugins/externalservicediscovery/plugin.xml
@@ -4,8 +4,9 @@
     <name>External Service Discovery</name>
     <description>Allows XMPP entities to discover services external to the XMPP network, such as STUN and TURN servers.</description>
     <author>Guus der Kinderen</author>
-    <version>1.0.0</version>
-    <date>01/26/2018</date>
+    <version>1.0.1-SNAPSHOT</version>
+    <date>tbc.</date>
+    <minServerVersion>4.2.0</minServerVersion>
 
     <databaseKey>externalservicediscovery</databaseKey>
     <databaseVersion>1</databaseVersion>

--- a/src/plugins/externalservicediscovery/pom.xml
+++ b/src/plugins/externalservicediscovery/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>externalservicediscovery</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <name>External Service Discovery Plugin</name>
     <description>Openfire plugin that implements XEP-0215: External Service Discovery, allowing XMPP entities to discover services external to the XMPP network.</description>

--- a/src/plugins/fastpath/plugin.xml
+++ b/src/plugins/fastpath/plugin.xml
@@ -5,8 +5,8 @@
     <name>Fastpath Service</name>
     <description>Support for managed queued chat requests, such as a support team might use.</description>
     <author>Jive Software</author>
-    <version>4.4.3</version>
-    <date>1/3/2018</date>
+    <version>4.4.4-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.1.0</minServerVersion>
     <databaseKey>fastpath</databaseKey>
     <databaseVersion>0</databaseVersion>

--- a/src/plugins/fastpath/pom.xml
+++ b/src/plugins/fastpath/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>fastpath</artifactId>
-    <version>4.4.2</version>
+    <version>4.4.4-SNAPSHOT</version>
     <name>Fastpath Plugin</name>
     <description>Support for managed queued chat requests, such as a support team might use.</description>
 

--- a/src/plugins/gojara/plugin.xml
+++ b/src/plugins/gojara/plugin.xml
@@ -9,7 +9,7 @@
     <description>XEP-0321: Remote Roster Management support
     </description>
     <author>Holger Bergunde / Daniel Henninger / Axel-F. Brand</author>
-    <version>2.2.1</version>
+    <version>2.2.2-SNAPSHOT</version>
     <date>11/17/2017</date>
     <databaseKey>gojara</databaseKey>
     <databaseVersion>1</databaseVersion>

--- a/src/plugins/gojara/pom.xml
+++ b/src/plugins/gojara/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>gojara</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.2-SNAPSHOT</version>
     <name>Gojara Plugin</name>
     <description>XEP-0321: Remote Roster Management support</description>
 

--- a/src/plugins/inverse/plugin.xml
+++ b/src/plugins/inverse/plugin.xml
@@ -4,8 +4,8 @@
     <name>inVerse</name>
     <description>Adds the (third-party) inVerse web client to Openfire.</description>
     <author>Guus der Kinderen</author>
-    <version>3.3.4 Release 1</version>
-    <date>03/15/2018</date>
+    <version>3.3.5-SNAPSHOT</version>
+    <date>tbc</date>
     <minServerVersion>4.1.5</minServerVersion>
     <adminconsole>
         <tab id="tab-webclients" name="${admin.sidebar.webclients.name}" description="${admin.sidebar.webclients.description}" url="inverse-config.jsp">

--- a/src/plugins/inverse/pom.xml
+++ b/src/plugins/inverse/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>inverse</artifactId>
     <name>Inverse Webchat Plugin</name>
-    <version>3.3.4-release-1</version>
+    <version>3.3.5-SNAPSHOT</version>
 
     <build>
         <sourceDirectory>src/java</sourceDirectory>

--- a/src/plugins/justmarried/plugin.xml
+++ b/src/plugins/justmarried/plugin.xml
@@ -5,8 +5,8 @@
    <name>Just married</name>
    <description>Allows admins to rename or copy users</description>
    <author>Holger Bergunde</author>
-    <version>1.2.2</version>
-    <date>10/26/2017</date>
+    <version>1.2.3-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
    
    <adminconsole>

--- a/src/plugins/justmarried/pom.xml
+++ b/src/plugins/justmarried/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>justmarried</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3-SNAPSHOT</version>
     <name>JustMarried Plugin</name>
     <description>Allows admins to rename or copy users</description>
 

--- a/src/plugins/loadStats/plugin.xml
+++ b/src/plugins/loadStats/plugin.xml
@@ -5,7 +5,7 @@
     <name>Load Statistic</name>
     <description>Logs load statistics to a file</description>
     <author>Jive Software</author>
-    <version>1.2.0</version>
-    <date>9/13/2013</date>
+    <version>1.2.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>3.9.0</minServerVersion>
 </plugin>

--- a/src/plugins/loadStats/pom.xml
+++ b/src/plugins/loadStats/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>loadStats</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <name>LoadStats Plugin</name>
     <description>Logs load statistics to a file</description>
 

--- a/src/plugins/motd/plugin.xml
+++ b/src/plugins/motd/plugin.xml
@@ -5,8 +5,8 @@
    <name>MotD (Message of the Day)</name>
    <description>Allows admins to have a message sent to users each time they log in.</description>
    <author>Ryan Graham</author>
-   <version>1.2.1</version>
-   <date>04/14/2017</date>
+   <version>1.2.2-SNAPSHOT</version>
+   <date>tbc.</date>
    <minServerVersion>4.0.0</minServerVersion>
 
    <adminconsole>

--- a/src/plugins/motd/pom.xml
+++ b/src/plugins/motd/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>motd</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2-SNAPSHOT</version>
     <name>Message of the Day Plugin</name>
     <description>Allows admins to have a message sent to users each time they log in.</description>
 

--- a/src/plugins/mucservice/plugin.xml
+++ b/src/plugins/mucservice/plugin.xml
@@ -5,7 +5,7 @@
     <name>MUC Service</name>
     <description>(Deprecated) Please use the REST API Plugin. MUC administration over REST Interface</description>
     <author>Roman Soldatow</author>
-    <version>0.2.3</version>
-    <date>10.1.2014</date>
+    <version>0.2.4-SNAPSHOT</version>
+    <date>tbc</date>
     <minServerVersion>3.9.1</minServerVersion>
 </plugin>

--- a/src/plugins/mucservice/pom.xml
+++ b/src/plugins/mucservice/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>mucservice</artifactId>
-    <version>0.2.3</version>
+    <version>0.2.4-SNAPSHOT</version>
     <name>(deprecated) MUC Service Plugin</name>
     <description>(Deprecated) Please use the REST API Plugin. MUC administration over REST Interface</description>
 

--- a/src/plugins/nodejs/plugin.xml
+++ b/src/plugins/nodejs/plugin.xml
@@ -5,8 +5,8 @@
     <name>NodeJs</name>
     <description>Integrates NodeJs Applications with Openfire.</description>
     <licenseType>Apache 2.0</licenseType>
-    <version>0.1.0</version>
-    <date>10/12/2015</date>
+    <version>0.1.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
 
    <adminconsole>

--- a/src/plugins/nodejs/pom.xml
+++ b/src/plugins/nodejs/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>nodejs</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1-SNAPSHOT</version>
     <name>NodeJS Plugin</name>
     <description>Integrates NodeJs Applications with Openfire.</description>
 

--- a/src/plugins/nonSaslAuthentication/plugin.xml
+++ b/src/plugins/nonSaslAuthentication/plugin.xml
@@ -5,7 +5,7 @@
     <name>Non-SASL Authentication</name>
     <description>This plugin implements a the (obsolete!) XEP-0078 specification for authentication using the jabber:iq:auth namespace.</description>
     <author>Guus der Kinderen</author>
-    <version>1.0.0</version>
-    <date>3/3/2016</date>
+    <version>1.0.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.1.0 Alpha</minServerVersion>
 </plugin>

--- a/src/plugins/nonSaslAuthentication/pom.xml
+++ b/src/plugins/nonSaslAuthentication/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>nonSaslAuthentication</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>non-SASL Authentication Plugin</name>
     <description>This plugin implements a the (obsolete!) XEP-0078 specification for authentication using the jabber:iq:auth namespace.</description>
 

--- a/src/plugins/packetFilter/plugin.xml
+++ b/src/plugins/packetFilter/plugin.xml
@@ -7,8 +7,8 @@
     <name>Packet Filter</name>
     <description>Rules to enforce ethical communication</description>
     <author>Nate Putnam</author>
-    <version>3.3.0</version>
-    <date>10/12/2015</date>
+    <version>3.3.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>packetfilter</databaseKey>
     <databaseVersion>2</databaseVersion>

--- a/src/plugins/packetFilter/pom.xml
+++ b/src/plugins/packetFilter/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>packetFilter</artifactId>
-    <version>3.3.0</version>
+    <version>3.3.1-SNAPSHOT</version>
     <name>PacketFilter Plugin</name>
     <description>Rules to enforce ethical communication</description>
 

--- a/src/plugins/pom.xml
+++ b/src/plugins/pom.xml
@@ -243,6 +243,28 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-no-snapshots</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rules>
+                        <requireReleaseDeps>
+                            <message>No Snapshots Allowed!</message>
+                            <onlyWhenRelease>true</onlyWhenRelease>
+                        </requireReleaseDeps>
+                    </rules>
+                    <fail>true</fail>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/src/plugins/presence/plugin.xml
+++ b/src/plugins/presence/plugin.xml
@@ -5,8 +5,8 @@
     <name>Presence Service</name>
     <description>Exposes presence information through HTTP.</description>
     <author>Jive Software</author>
-    <version>1.7.0</version>
-    <date>10/12/2015</date>
+    <version>1.7.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     
     <adminconsole>		

--- a/src/plugins/presence/pom.xml
+++ b/src/plugins/presence/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>presence</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1-SNAPSHOT</version>
     <name>Presence Plugin</name>
     <description>Exposes presence information through HTTP.</description>
 

--- a/src/plugins/registration/plugin.xml
+++ b/src/plugins/registration/plugin.xml
@@ -5,8 +5,8 @@
     <name>Registration</name>
     <description>Performs various actions whenever a new user account is created.</description>
     <author>Ryan Graham</author>
-    <version>1.7.2</version>
-    <date>12/19/2017</date>
+    <version>1.7.3-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     
     <adminconsole>

--- a/src/plugins/registration/pom.xml
+++ b/src/plugins/registration/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>registration</artifactId>
     <name>Registration Plugin</name>
-    <version>1.7.2</version>
+    <version>1.7.3-SNAPSHOT</version>
 
     <build>
         <sourceDirectory>src/java</sourceDirectory>

--- a/src/plugins/restAPI/plugin.xml
+++ b/src/plugins/restAPI/plugin.xml
@@ -5,8 +5,8 @@
     <name>REST API</name>
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
-    <version>1.3.3</version>
-    <date>04/26/2018</date>
+    <version>1.3.4-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.1.0</minServerVersion>
     <adminconsole>
         <tab id="tab-server">

--- a/src/plugins/restAPI/pom.xml
+++ b/src/plugins/restAPI/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>restAPI</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.4-SNAPSHOT</version>
     <name>Rest API Plugin</name>
     <description>Allows administration over a RESTful API.</description>
     

--- a/src/plugins/stunserver/plugin.xml
+++ b/src/plugins/stunserver/plugin.xml
@@ -5,8 +5,8 @@
     <name>STUN server plugin</name>
     <description>Adds STUN functionality to Openfire</description>
     <author>Ignite Realtime</author>
-    <version>1.2.2</version>
-    <date>05/11/2017</date>
+    <version>1.2.3-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     
     <adminconsole>

--- a/src/plugins/stunserver/pom.xml
+++ b/src/plugins/stunserver/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>stunserver</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3-SNAPSHOT</version>
     <name>STUN Server Plugin</name>
     <description>Adds STUN functionality to Openfire</description>
 

--- a/src/plugins/subscription/plugin.xml
+++ b/src/plugins/subscription/plugin.xml
@@ -5,8 +5,8 @@
    <name>Subscription</name>
    <description>Automatically accepts or rejects subscription requests</description>
    <author>Ryan Graham</author>
-   <version>1.4.0</version>
-   <date>10/12/2015</date>
+   <version>1.4.1-SNAPSHOT</version>
+   <date>tbc.</date>
    <url>http://www.igniterealtime.org</url>
    <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/subscription/pom.xml
+++ b/src/plugins/subscription/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>subscription</artifactId>
     <name>Subscription Plugin</name>
     <description>Automatically accepts or rejects subscription requests</description>
-    <version>1.4.0</version>
+    <version>1.4.1-SNAPSHOT</version>
 
     <developers>
         <developer>

--- a/src/plugins/tikitoken/plugin.xml
+++ b/src/plugins/tikitoken/plugin.xml
@@ -3,7 +3,7 @@
     <name>TikiToken</name>
     <description>Allows users to authenticate with a Tiki token.</description>
     <author>Tiki Wiki CMS Groupware</author>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
     <date>04/24/2017</date>
     <url>https://dev.tiki.org/OpenFire</url>
     <minServerVersion>4.1.3</minServerVersion>

--- a/src/plugins/tikitoken/pom.xml
+++ b/src/plugins/tikitoken/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>tikitoken</artifactId>
-    <version>0.2</version>
+    <version>0.2.1-SNAPSHOT</version>
     <name>TikiToken Plugin</name>
     <description>Allows users to authenticate with a Tiki token.</description>
 

--- a/src/plugins/userCreation/plugin.xml
+++ b/src/plugins/userCreation/plugin.xml
@@ -8,10 +8,10 @@
     <name>User Creation</name>
     <description>Creates users and populates rosters.</description>
     <author>Jive Software</author>
-    <version>1.3.0</version>
-    <date>10/12/2015</date>
+    <version>1.3.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <url>http://www.igniterealtime.org</url>
-    <minServerVersion>4.0.0</minServerVersion>
+    <minServerVersion>4.3.0</minServerVersion>
 
     <adminconsole>
         <tab id="tab-users">

--- a/src/plugins/userCreation/pom.xml
+++ b/src/plugins/userCreation/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>userCreation</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
     <name>UserCreation Plugin</name>
     <description>Creates users and populates rosters.</description>
 

--- a/src/plugins/userImportExport/plugin.xml
+++ b/src/plugins/userImportExport/plugin.xml
@@ -6,8 +6,8 @@
    <name>User Import Export</name>
    <description>Enables import and export of user data</description>
    <author>Ryan Graham</author>
-   <version>2.6.2</version>
-   <date>10/02/2017</date>
+   <version>2.6.3-SNAPSHOT</version>
+   <date>tbc.</date>
    <minServerVersion>4.0.0</minServerVersion>
 
    <adminconsole>

--- a/src/plugins/userImportExport/pom.xml
+++ b/src/plugins/userImportExport/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>userImportExport</artifactId>
-    <version>2.6.2</version>
+    <version>2.6.3-SNAPSHOT</version>
     <name>UserImportExport Plugin</name>
     <description>Enables import and export of user data</description>
 

--- a/src/plugins/userStatus/plugin.xml
+++ b/src/plugins/userStatus/plugin.xml
@@ -8,8 +8,8 @@
     <name>User Status Plugin</name>
     <description>Openfire plugin to save the user status to the database.</description>
     <author>Stefan Reuter</author>
-    <version>1.2.0</version>
-    <date>12/13/2017</date>
+    <version>1.2.1-SNAPSHOT</version>
+    <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>user-status</databaseKey>
     <databaseVersion>0</databaseVersion>

--- a/src/plugins/userStatus/pom.xml
+++ b/src/plugins/userStatus/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>userstatus</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <name>UserStatus Plugin</name>
     <description>Openfire plugin to save the user status to the database</description>
 

--- a/src/plugins/userservice/plugin.xml
+++ b/src/plugins/userservice/plugin.xml
@@ -5,7 +5,7 @@
     <name>User Service</name>
     <description>(Deprecated) Please use the REST API Plugin. Allows administration of users via HTTP requests.</description>
     <author>Roman Soldatow, Justin Hunt</author>
-    <version>2.1.0</version>
+    <version>2.1.1-SNAPSHOT</version>
     <date>10/12/2015</date>
     <minServerVersion>4.0.0</minServerVersion>
     

--- a/src/plugins/userservice/pom.xml
+++ b/src/plugins/userservice/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>userservice</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1-SNAPSHOT</version>
     <name>(deprecated) UserService Plugin</name>
     <description>(Deprecated) Please use the REST API Plugin. Allows administration of users via HTTP requests.</description>
 


### PR DESCRIPTION
This adds a new enforcer:enforce goal that prevents anything being released with SNAPSHOT dependencies. Note - this PR alone will do nothing; it's necessary to add the enforcer:enforce goal to the CI server that does the builds.

And /then/ the builds will start failing ;)