### PR TITLE
Make hazelcast a SNAPSHOT version as it depends on a SNAPSHOT Openfire

### DIFF
--- a/src/plugins/hazelcast/plugin.xml
+++ b/src/plugins/hazelcast/plugin.xml
@@ -5,7 +5,7 @@
     <name>Hazelcast plugin</name>
     <description>Adds clustering support</description>
     <author>Tom Evans</author>
-    <version>2.4.0</version>
-    <date>07/16/2018</date>
-    <minServerVersion>4.0.0</minServerVersion>
+    <version>2.4.1-SNAPSHOT</version>
+    <date>tbc</date>
+    <minServerVersion>4.3.0</minServerVersion>
 </plugin>

--- a/src/plugins/hazelcast/pom.xml
+++ b/src/plugins/hazelcast/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>hazelcast</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1-SNAPSHOT</version>
     <name>Hazelcast Plugin</name>
     <description>Adds clustering support</description>
 


### PR DESCRIPTION
(overlapping, unrelated commits meant thiis wasn't caught before the merge to master)