### PR TITLE
OF-1579: Add support for XEP-0368 "SRV records for XMPP over TLS"

### DIFF
--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -1597,6 +1597,7 @@ server.props.name=Server Host Name (FQDN):
 server.props.valid_hostname=Please enter a valid server host name or
 server.props.valid_hostname1=restore the default
 server.props.server_port=Server-to-Server Port:
+server.props.server_ssl_port=Server-to-Server SSL Port:
 server.props.component_port=Component Port:
 server.props.port=Client Port:
 server.props.valid_port=Please enter a valid port number or
@@ -1613,7 +1614,8 @@ server.props.admin_secure_port=Secure Admin Console Port:
 server.props.jmx_enabled=JMX Enabled:
 server.props.jmx_secure=JMX Require Admin User:
 server.props.jmx_port=JMX Connector Port:
-
+server.props.jmx_valid=Please enter a valid port number or
+server.props.jmx_valid1=restore the default
 # Server stopped Page
 
 server.stopped.title_restarting=Restarting Server
@@ -2301,6 +2303,9 @@ ssl.settings.server.label_notrequired=Optional
 ssl.settings.server.label_notrequired_info=Connections between servers may use secured connections.
 ssl.settings.server.label_custom=Custom
 ssl.settings.server.label_custom_info=Advanced configuration
+ssl.settings.server.legacymode.boxtitle=Encrypted (legacy-mode) connections
+ssl.settings.server.legacymode.info=Connections of this type are established using encryption immediately (as opposed to using STARTTLS). This type of connectivity is commonly referred to as the "legacy" method of establishing encrypted communications.
+ssl.settings.server.legacymode.label_enable=Enabled
 ssl.settings.server.dialback=Server Dialback:
 ssl.settings.server.customTLS=TLS method:
 

--- a/src/java/org/jivesoftware/openfire/Connection.java
+++ b/src/java/org/jivesoftware/openfire/Connection.java
@@ -331,39 +331,16 @@ public interface Connection extends Closeable {
      * connection the server requesting the TLS negotiation will be the client and the other server
      * will be the server during the TLS negotiation. Therefore, the server requesting the TLS
      * negotiation must pass <code>true</code> in the <tt>clientMode</tt> parameter and the server
-     * receiving the TLS request must pass <code>false</code> in the <tt>clientMode</tt> parameter.
-     * Both servers should specify the xmpp domain of the other server in the <tt>remoteServer</tt>
-     * parameter.<p>
-     *
-     * In the case of client-2-server the XMPP server must pass <code>false</code> in the
-     * <tt>clientMode</tt> parameter since it will behave as the server in the TLS negotiation. The
-     * <tt>remoteServer</tt> parameter will always be <tt>null</tt>.
-     *
-     * @param clientMode boolean indicating if this entity is a client or a server in the TLS negotiation.
-     * @param remoteServer xmpp domain of the remote server or <tt>null</tt>. When null a
-     *       {@link org.jivesoftware.openfire.net.ClientTrustManager} will be used for verifying certificates
-     *       otherwise a {@link org.jivesoftware.openfire.net.ServerTrustManager} will be used.
-     * @param authentication policy to use for authenticating the remote peer.
-     * @throws Exception if an error occured while securing the connection.
-     * @deprecated Use {@link #startTLS(boolean)} instead.
-     */
-    @Deprecated
-    void startTLS(boolean clientMode, String remoteServer, ClientAuth authentication) throws Exception;
-
-    /**
-     * Secures the plain connection by negotiating TLS with the other peer. In a server-2-server
-     * connection the server requesting the TLS negotiation will be the client and the other server
-     * will be the server during the TLS negotiation. Therefore, the server requesting the TLS
-     * negotiation must pass <code>true</code> in the <tt>clientMode</tt> parameter and the server
      * receiving the TLS request must pass <code>false</code> in the <tt>clientMode</tt> parameter.<p>
      *
      * In the case of client-2-server the XMPP server must pass <code>false</code> in the
      * <tt>clientMode</tt> parameter since it will behave as the server in the TLS negotiation.
      *
      * @param clientMode boolean indicating if this entity is a client or a server in the TLS negotiation.
+     * @param directTLS boolean indicating if the negotiation is directTLS (true) or startTLS (false).
      * @throws Exception if an error occured while securing the connection.
      */
-    void startTLS(boolean clientMode) throws Exception;
+    void startTLS(boolean clientMode, boolean directTLS) throws Exception;
 
     /**
      * Adds the compression filter to the connection but only filter incoming traffic. Do not filter

--- a/src/java/org/jivesoftware/openfire/ConnectionManager.java
+++ b/src/java/org/jivesoftware/openfire/ConnectionManager.java
@@ -47,9 +47,14 @@ public interface ConnectionManager {
     int DEFAULT_COMPONENT_SSL_PORT = 5276;
 
     /**
-     * The default XMPP port for server2server communication.
+     * The default XMPP port for server2server communication, optionally using StartTLS.
      */
     int DEFAULT_SERVER_PORT = 5269;
+
+    /**
+     * The default XMPP port for server2server communication using Direct TLS.
+     */
+    int DEFAULT_SERVER_SSL_PORT = 5270;
 
     /**
      * The default XMPP port for connection multiplex.
@@ -216,6 +221,22 @@ public interface ConnectionManager {
      * @return the port to use for remote servers.
      */
     int getServerListenerPort();
+
+    /**
+     * Sets the port to use for remote servers. This port is used for remote servers to connect
+     * to this server, using direct TLS. Default port: 5270.
+     *
+     * @param port the port to use for remote servers.
+     */
+    void setServerSslListenerPort( int port );
+
+    /**
+     * Returns the port to use for remote servers. This port is used for remote servers to connect
+     * to this server, using direct TLS. Default port: 5270.
+     *
+     * @return the port to use for remote servers.
+     */
+    int getServerSslListenerPort();
 
     /**
      * Sets the port to use for connection managers. This port is used for connection managers

--- a/src/java/org/jivesoftware/openfire/net/BlockingAcceptingMode.java
+++ b/src/java/org/jivesoftware/openfire/net/BlockingAcceptingMode.java
@@ -36,8 +36,8 @@ class BlockingAcceptingMode extends SocketAcceptingMode {
 
     private static final Logger Log = LoggerFactory.getLogger(BlockingAcceptingMode.class);
 
-    protected BlockingAcceptingMode(int tcpPort, InetAddress bindInterface) throws IOException {
-        super();
+    protected BlockingAcceptingMode(int tcpPort, InetAddress bindInterface, boolean directTLS) throws IOException {
+        super(directTLS);
         serverSocket = new ServerSocket(tcpPort, -1, bindInterface);
     }
 

--- a/src/java/org/jivesoftware/openfire/net/BlockingReadingMode.java
+++ b/src/java/org/jivesoftware/openfire/net/BlockingReadingMode.java
@@ -18,6 +18,7 @@ package org.jivesoftware.openfire.net;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.Socket;
 import java.net.SocketException;
@@ -55,8 +56,14 @@ class BlockingReadingMode extends SocketReadingMode {
     @Override
     public void run() {
         try {
+            final InputStream inputStream;
+            if (socketReader.directTLS ) {
+                inputStream = socketReader.connection.getTLSStreamHandler().getInputStream();
+            } else {
+                inputStream = socket.getInputStream();
+            }
             socketReader.reader.getXPPParser().setInput(new InputStreamReader(
-                    ServerTrafficCounter.wrapInputStream(socket.getInputStream()), CHARSET));
+                    ServerTrafficCounter.wrapInputStream(inputStream), CHARSET));
 
             // Read in the opening tag and prepare for packet stream
             try {

--- a/src/java/org/jivesoftware/openfire/net/ClientStanzaHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/ClientStanzaHandler.java
@@ -111,6 +111,6 @@ public class ClientStanzaHandler extends StanzaHandler {
 
     @Override
     void startTLS() throws Exception {
-        connection.startTLS(false);
+        connection.startTLS(false, false);
     }
 }

--- a/src/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
@@ -191,7 +191,7 @@ public class ComponentStanzaHandler extends StanzaHandler {
 
     @Override
     void startTLS() throws Exception {
-        connection.startTLS(false);
+        connection.startTLS(false, false);
     }
 
     @Override

--- a/src/java/org/jivesoftware/openfire/net/DNSUtil.java
+++ b/src/java/org/jivesoftware/openfire/net/DNSUtil.java
@@ -212,7 +212,6 @@ public class DNSUtil {
 
         // _service._proto.name.
         final String lookup = (service + proto + name).toLowerCase();
-
         try {
             Attributes dnsLookup =
                     context.getAttributes(lookup, new String[]{"SRV"});
@@ -222,8 +221,9 @@ public class DNSUtil {
                 return Collections.emptyList();
             }
             WeightedHostAddress[] hosts = new WeightedHostAddress[srvRecords.size()];
+            final boolean directTLS = lookup.startsWith( "_xmpps-" ); // XEP-0368
             for (int i = 0; i < srvRecords.size(); i++) {
-                hosts[i] = new WeightedHostAddress(((String)srvRecords.get(i)).split(" "));
+                hosts[i] = new WeightedHostAddress(((String)srvRecords.get(i)).split(" "), directTLS);
             }
 
             return prioritize(hosts);
@@ -387,10 +387,10 @@ public class DNSUtil {
         private final int priority;
         private final int weight;
 
-        private WeightedHostAddress(String [] srvRecordEntries) {
+        private WeightedHostAddress(String[] srvRecordEntries, boolean directTLS) {
             super(srvRecordEntries[srvRecordEntries.length-1],
                   Integer.parseInt(srvRecordEntries[srvRecordEntries.length-2]),
-                  srvRecordEntries[0].startsWith( "_xmpps-" ) // XEP-0368
+                  directTLS
             );
             weight = Integer.parseInt(srvRecordEntries[srvRecordEntries.length-3]);
             priority = Integer.parseInt(srvRecordEntries[srvRecordEntries.length-4]);

--- a/src/java/org/jivesoftware/openfire/net/DNSUtil.java
+++ b/src/java/org/jivesoftware/openfire/net/DNSUtil.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.net;
 
+import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,7 +105,11 @@ public class DNSUtil {
         // Attempt the SRV lookup.
         final List<WeightedHostAddress> srvLookups = new LinkedList<>();
         srvLookups.addAll(srvLookup("xmpp-server", "tcp", domain ) );
-        srvLookups.addAll(srvLookup("xmpps-server", "tcp", domain ) );
+
+        final boolean allowTLS = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ENABLED, true);
+        if (allowTLS) {
+            srvLookups.addAll(srvLookup("xmpps-server", "tcp", domain));
+        }
         if (!srvLookups.isEmpty()) {
             // we have to re-prioritize the combination of both lookups.
             results.addAll( prioritize( srvLookups.toArray( new WeightedHostAddress[0] ) ) );

--- a/src/java/org/jivesoftware/openfire/net/DNSUtil.java
+++ b/src/java/org/jivesoftware/openfire/net/DNSUtil.java
@@ -63,21 +63,29 @@ public class DNSUtil {
     }
 
     /**
-     * Returns a sorted list of host names and ports that the specified XMPP domain
-     * can be reached at for server-to-server communication. A DNS lookup for a SRV
-     * record in the form "_xmpp-server._tcp.example.com" is attempted, according
-     * to section 14.4 of RFC 3920. If that lookup fails, a lookup in the older form
-     * of "_jabber._tcp.example.com" is attempted since servers that implement an
-     * older version of the protocol may be listed using that notation. If that
-     * lookup fails as well, it's assumed that the XMPP server lives at the
-     * host resolved by a DNS lookup at the specified domain on the specified default port.<p>
+     * Returns a sorted list of host names and ports that the specified XMPP
+     * domain can be reached at for server-to-server communication.
+     *
+     * DNS lookups for a SRV records in the form "_xmpp-server._tcp.example.com"
+     * and "_xmpps-server._tcp.example.com" are attempted, in line with section
+     * 3.2 of XMPP Core and XEP-0368.
+     *
+     * If those lookup fail to provide any records, a lookup in the older form
+     * of "_jabber._tcp.example.com" is attempted since servers that implement
+     * an older version of the protocol may be listed using that notation.
+     *
+     * If that lookup fails as well, it's assumed that the XMPP server lives at
+     * the host resolved by a DNS A lookup at the specified domain on the
+     * specified default port.<p>
      *
      * As an example, a lookup for "example.com" may return "im.example.com:5269".
      *
      * @param domain the domain.
      * @param defaultPort default port to return if the DNS look up fails.
-     * @return a list of  HostAddresses, which encompasses the hostname and port that the XMPP
-     *      server can be reached at for the specified domain.
+     * @return a list of  HostAddresses, which encompasses the hostname and port
+     *         that the XMPP server can be reached at for the specified domain.
+     * @see <a href="https://tools.ietf.org/html/rfc6120#section-3.2">XMPP CORE</a>
+     * @see <a href="https://xmpp.org/extensions/xep-0368.html">XEP-0368</a>
      */
     public static List<HostAddress> resolveXMPPDomain(String domain, int defaultPort) {
         // Check if there is an entry in the internal DNS for the specified domain
@@ -94,14 +102,21 @@ public class DNSUtil {
         }
 
         // Attempt the SRV lookup.
-        results.addAll(srvLookup("xmpp-server", "tcp", domain ) );
+        final List<WeightedHostAddress> srvLookups = new LinkedList<>();
+        srvLookups.addAll(srvLookup("xmpp-server", "tcp", domain ) );
+        srvLookups.addAll(srvLookup("xmpps-server", "tcp", domain ) );
+        if (!srvLookups.isEmpty()) {
+            // we have to re-prioritize the combination of both lookups.
+            results.addAll( prioritize( srvLookups.toArray( new WeightedHostAddress[0] ) ) );
+        }
+
         if (results.isEmpty()) {
             results.addAll(srvLookup( "jabber", "tcp", domain ) );
         }
 
         // Use domain and default port as fallback.
         if (results.isEmpty()) {
-            results.add(new HostAddress(domain, defaultPort));
+            results.add(new HostAddress(domain, defaultPort, false));
         }
         return results;
     }
@@ -152,7 +167,7 @@ public class DNSUtil {
         StringTokenizer st = new StringTokenizer(encodedValue, "{},:");
         while (st.hasMoreElements()) {
             String key = st.nextToken();
-            answer.put(key, new HostAddress(st.nextToken(), Integer.parseInt(st.nextToken())));
+            answer.put(key, new HostAddress(st.nextToken(), Integer.parseInt(st.nextToken()), false));
         }
         return answer;
     }
@@ -260,8 +275,9 @@ public class DNSUtil {
 
         private final String host;
         private final int port;
+        private boolean directTLS;
 
-        private HostAddress(String host, int port) {
+        private HostAddress(String host, int port, boolean directTLS) {
             // Host entries in DNS should end with a ".".
             if (host.endsWith(".")) {
                 this.host = host.substring(0, host.length()-1);
@@ -270,6 +286,7 @@ public class DNSUtil {
                 this.host = host;
             }
             this.port = port;
+            this.directTLS = directTLS;
         }
 
         /**
@@ -288,6 +305,11 @@ public class DNSUtil {
          */
         public int getPort() {
             return port;
+        }
+
+        public boolean isDirectTLS()
+        {
+            return directTLS;
         }
 
         @Override
@@ -367,13 +389,15 @@ public class DNSUtil {
 
         private WeightedHostAddress(String [] srvRecordEntries) {
             super(srvRecordEntries[srvRecordEntries.length-1],
-                    Integer.parseInt(srvRecordEntries[srvRecordEntries.length-2]));
+                  Integer.parseInt(srvRecordEntries[srvRecordEntries.length-2]),
+                  srvRecordEntries[0].startsWith( "_xmpps-" ) // XEP-0368
+            );
             weight = Integer.parseInt(srvRecordEntries[srvRecordEntries.length-3]);
             priority = Integer.parseInt(srvRecordEntries[srvRecordEntries.length-4]);
         }
 
-        WeightedHostAddress(String host, int port, int priority, int weight) {
-            super(host, port);
+        WeightedHostAddress(String host, int port, boolean directTLS, int priority, int weight) {
+            super(host, port, directTLS);
             this.priority = priority;
             this.weight = weight;
         }

--- a/src/java/org/jivesoftware/openfire/net/MultiplexerStanzaHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/MultiplexerStanzaHandler.java
@@ -159,6 +159,6 @@ public class MultiplexerStanzaHandler extends StanzaHandler {
 
     @Override
     void startTLS() throws Exception {
-        connection.startTLS(false);
+        connection.startTLS(false, false);
     }
 }

--- a/src/java/org/jivesoftware/openfire/net/ServerSocketReader.java
+++ b/src/java/org/jivesoftware/openfire/net/ServerSocketReader.java
@@ -191,7 +191,7 @@ public class ServerSocketReader extends SocketReader {
             IOException {
         if ("jabber:server".equals(namespace)) {
             // The connected client is a server so create an IncomingServerSession
-            session = LocalIncomingServerSession.createSession(serverName, reader, connection);
+            session = LocalIncomingServerSession.createSession(serverName, reader, connection, directTLS);
             return true;
         }
         return false;

--- a/src/java/org/jivesoftware/openfire/net/ServerSocketReader.java
+++ b/src/java/org/jivesoftware/openfire/net/ServerSocketReader.java
@@ -55,8 +55,8 @@ public class ServerSocketReader extends SocketReader {
     private static final Logger Log = LoggerFactory.getLogger(ServerSocketReader.class);
 
     public ServerSocketReader(PacketRouter router, RoutingTable routingTable, String serverName,
-            Socket socket, SocketConnection connection, boolean useBlockingMode) {
-        super(router, routingTable, serverName, socket, connection, useBlockingMode);
+            Socket socket, SocketConnection connection, boolean useBlockingMode, boolean directTLS) {
+        super(router, routingTable, serverName, socket, connection, useBlockingMode, directTLS);
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
+++ b/src/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
@@ -113,7 +113,7 @@ public class ServerStanzaHandler extends StanzaHandler {
                 JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY, true) &&
                 !JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false);
         //needed ? Connection.ClientAuth.needed : Connection.ClientAuth.wanted
-        connection.startTLS(false);
+        connection.startTLS(false, false);
     }
     @Override
     protected void processIQ(IQ packet) throws UnauthorizedException {

--- a/src/java/org/jivesoftware/openfire/net/SocketAcceptThread.java
+++ b/src/java/org/jivesoftware/openfire/net/SocketAcceptThread.java
@@ -39,17 +39,19 @@ public class SocketAcceptThread extends Thread {
      */
     private final int tcpPort;
     private InetAddress bindInterface;
+    private final boolean directTLS;
 
     private SocketAcceptingMode acceptingMode;
 
-    public SocketAcceptThread( int tcpPort, InetAddress bindInterface )
+    public SocketAcceptThread( int tcpPort, InetAddress bindInterface, boolean directTLS )
             throws IOException {
-        super("Socket Listener at port " + tcpPort);
+        super("Socket Listener at port " + tcpPort + ( directTLS ? " (direct TLS)" : ""));
         this.tcpPort = tcpPort;
         this.bindInterface = bindInterface;
+        this.directTLS = directTLS;
 
         // Set the blocking reading mode to use
-        acceptingMode = new BlockingAcceptingMode(tcpPort, bindInterface);
+        acceptingMode = new BlockingAcceptingMode(tcpPort, bindInterface, directTLS);
     }
 
     /**
@@ -67,7 +69,17 @@ public class SocketAcceptThread extends Thread {
      * @return information about the port on which the server is listening for connections.
      */
     public ServerPort getServerPort() {
-        return new ServerPort(tcpPort, null, bindInterface.getHostName(), false, null, ServerPort.Type.server);
+        return new ServerPort(tcpPort, null, bindInterface.getHostName(), directTLS, null, ServerPort.Type.server);
+    }
+
+    /**
+     * Returns if the port expects sockets to be encrypted immediately (direct
+     * TLS).
+     *
+     * @return true when direct TLS is expected, otherwise false.
+     */
+    public boolean isDirectTLS() {
+        return directTLS;
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/net/SocketAcceptingMode.java
+++ b/src/java/org/jivesoftware/openfire/net/SocketAcceptingMode.java
@@ -84,8 +84,8 @@ abstract class SocketAcceptingMode {
         final PacketDeliverer deliverer = server.getPacketDeliverer();
         final SocketConnection conn = new SocketConnection(deliverer, sock, isSecure);
         if (directTLS) {
-            conn.startTLS( false );
+            conn.startTLS( false, directTLS );
         }
-        return new ServerSocketReader(router, routingTable, serverName, sock, conn, useBlockingMode);
+        return new ServerSocketReader(router, routingTable, serverName, sock, conn, useBlockingMode, directTLS);
     }
 }

--- a/src/java/org/jivesoftware/openfire/net/SocketAcceptingMode.java
+++ b/src/java/org/jivesoftware/openfire/net/SocketAcceptingMode.java
@@ -41,7 +41,23 @@ abstract class SocketAcceptingMode {
      */
     protected ServerSocket serverSocket;
 
-    protected SocketAcceptingMode() {
+    /**
+     * true if data is to be encrypted directly (as opposed to StartTLS).
+     */
+    protected final boolean directTLS;
+
+    protected SocketAcceptingMode(boolean directTLS) {
+        this.directTLS = directTLS;
+    }
+
+    /**
+     * Returns if the port expects sockets to be encrypted immediately (direct
+     * TLS).
+     *
+     * @return true when direct TLS is expected, otherwise false.
+     */
+    public boolean isDirectTLS() {
+        return directTLS;
     }
 
     public abstract void run();
@@ -67,6 +83,9 @@ abstract class SocketAcceptingMode {
         final RoutingTable routingTable = server.getRoutingTable();
         final PacketDeliverer deliverer = server.getPacketDeliverer();
         final SocketConnection conn = new SocketConnection(deliverer, sock, isSecure);
+        if (directTLS) {
+            conn.startTLS( false );
+        }
         return new ServerSocketReader(router, routingTable, serverName, sock, conn, useBlockingMode);
     }
 }

--- a/src/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/src/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -166,12 +166,7 @@ public class SocketConnection implements Connection {
         return tlsStreamHandler;
     }
 
-    @Deprecated
-    public void startTLS(boolean clientMode, String remoteServer, ClientAuth authentication) throws Exception {
-        startTLS( clientMode );
-    }
-
-    public void startTLS(boolean clientMode) throws IOException {
+    public void startTLS(boolean clientMode, boolean directTLS) throws IOException {
         if (!secure) {
             secure = true;
 
@@ -186,7 +181,7 @@ public class SocketConnection implements Connection {
                 clientAuth = ClientAuth.wanted;
             }
             tlsStreamHandler = new TLSStreamHandler(socket, getConfiguration(), clientMode);
-            if (!clientMode) {
+            if (!clientMode && !directTLS) {
                 // Indicate the client that the server is ready to negotiate TLS
                 deliverRawText("<proceed xmlns=\"urn:ietf:params:xml:ns:xmpp-tls\"/>");
             }

--- a/src/java/org/jivesoftware/openfire/net/SocketReader.java
+++ b/src/java/org/jivesoftware/openfire/net/SocketReader.java
@@ -82,6 +82,11 @@ public abstract class SocketReader implements Runnable {
     protected String serverName;
 
     /**
+     * Indicates if sockets initially will be plain text (false), or ecnrypted (true).
+     */
+    protected boolean directTLS;
+
+    /**
      * Router used to route incoming packets to the correct channels.
      */
     private PacketRouter router;
@@ -114,13 +119,15 @@ public abstract class SocketReader implements Runnable {
      * @param socket the socket to read from.
      * @param connection the connection being read.
      * @param useBlockingMode true means that the server will use a thread per connection.
+     * @param directTLS false means that the socket initially is a plaintext connection.
      */
     public SocketReader(PacketRouter router, RoutingTable routingTable, String serverName,
-            Socket socket, SocketConnection connection, boolean useBlockingMode) {
+            Socket socket, SocketConnection connection, boolean useBlockingMode, boolean directTLS ) {
         this.serverName = serverName;
         this.router = router;
         this.routingTable = routingTable;
         this.connection = connection;
+        this.directTLS = directTLS;
 
         connection.setSocketReader(this);
 

--- a/src/java/org/jivesoftware/openfire/net/SocketReadingMode.java
+++ b/src/java/org/jivesoftware/openfire/net/SocketReadingMode.java
@@ -80,7 +80,7 @@ abstract class SocketReadingMode {
         // Client requested to secure the connection using TLS. Negotiate TLS.
         try {
             // This code is only used for s2s
-            socketReader.connection.startTLS(false);
+            socketReader.connection.startTLS(false, false);
         }
         catch (SSLHandshakeException e) {
             // RFC3620, section 5.4.3.2 "STARTTLS Failure" - close the socket *without* sending any more data (<failure/> nor </stream>).

--- a/src/java/org/jivesoftware/openfire/net/SocketUtil.java
+++ b/src/java/org/jivesoftware/openfire/net/SocketUtil.java
@@ -7,7 +7,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Utility class to generate Socket instances.
@@ -35,7 +37,7 @@ public class SocketUtil
      * @return a Socket instance that is connected, or null.
      * @see DNSUtil#resolveXMPPDomain(String, int)
      */
-    public static Socket createSocketToXmppDomain( String xmppDomain, int port )
+    public static Map.Entry<Socket, Boolean> createSocketToXmppDomain( String xmppDomain, int port )
     {
         Log.debug( "Creating a socket connection to XMPP domain '{}' ...", xmppDomain );
 
@@ -49,6 +51,7 @@ public class SocketUtil
         {
             final String realHostname = remoteHost.getHost();
             final int realPort = remoteHost.getPort();
+            final boolean directTLS = remoteHost.isDirectTLS();
 
             try
             {
@@ -58,7 +61,7 @@ public class SocketUtil
                 Log.debug( "Trying to create socket connection to XMPP domain '{}' using remote host: {}:{} (blocks up to {} ms) ...", xmppDomain, realHostname, realPort, socketTimeout );
                 socket.connect( new InetSocketAddress( realHostname, realPort ), socketTimeout );
                 Log.debug( "Successfully created socket connection to XMPP domain '{}' using remote host: {}:{}!", xmppDomain, realHostname, realPort );
-                return socket;
+                return new AbstractMap.SimpleEntry<>(socket, directTLS);
             }
             catch ( Exception e )
             {

--- a/src/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/src/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -139,13 +139,7 @@ public abstract class VirtualConnection implements Connection {
         return null;
     }
 
-    @Deprecated
-    @Override
-    public void startTLS(boolean clientMode, String remoteServer, ClientAuth authentication) throws Exception {
-        //Ignore
-    }
-
-    public void startTLS(boolean clientMode) throws Exception {
+    public void startTLS(boolean clientMode, boolean directTLS) throws Exception {
         //Ignore
     }
 

--- a/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
+++ b/src/java/org/jivesoftware/openfire/nio/NIOConnection.java
@@ -364,13 +364,7 @@ public class NIOConnection implements Connection {
         }
     }
 
-    @Deprecated
-    @Override
-    public void startTLS(boolean clientMode, String remoteServer, ClientAuth authentication) throws Exception {
-        startTLS( clientMode );
-    }
-
-    public void startTLS(boolean clientMode) throws Exception {
+    public void startTLS(boolean clientMode, boolean directTLS) throws Exception {
 
         final EncryptionArtifactFactory factory = new EncryptionArtifactFactory( configuration );
         final SslFilter filter;
@@ -384,9 +378,13 @@ public class NIOConnection implements Connection {
         }
 
         ioSession.getFilterChain().addBefore(EXECUTOR_FILTER_NAME, TLS_FILTER_NAME, filter);
-        ioSession.setAttribute(SslFilter.DISABLE_ENCRYPTION_ONCE, Boolean.TRUE);
 
-        if ( !clientMode ) {
+        if (!directTLS)
+        {
+            ioSession.setAttribute( SslFilter.DISABLE_ENCRYPTION_ONCE, Boolean.TRUE );
+        }
+
+        if ( !clientMode && !directTLS ) {
             // Indicate the client that the server is ready to negotiate TLS
             deliverRawText( "<proceed xmlns=\"urn:ietf:params:xml:ns:xmpp-tls\"/>" );
         }

--- a/src/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/src/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -34,6 +34,8 @@ public final class ConnectionSettings {
 
         public static final String SOCKET_ACTIVE = "xmpp.server.socket.active";
         public static final String PORT = "xmpp.server.socket.port";
+        public static final String OLD_SSLPORT = "xmpp.server.socket.ssl.port";
+        public static final String ENABLE_OLD_SSLPORT = "xmpp.server.socket.ssl.active";
         public static final String REMOTE_SERVER_PORT = "xmpp.server.socket.remotePort";
         public static final String SOCKET_READ_TIMEOUT = "xmpp.server.read.timeout";
 

--- a/src/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/src/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -96,6 +96,7 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
      * @param serverName hostname of this server.
      * @param reader reader on the new established connection with the remote server.
      * @param connection the new established connection with the remote server.
+     * @param directTLS true of connections are immediately encrypted (as opposed to plain text / startls).
      * @return a new session that will receive packets or null if a problem occured while
      *         authenticating the remote server or when acting as the Authoritative Server during
      *         a Server Dialback authentication process.
@@ -103,7 +104,7 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
      * @throws java.io.IOException if an input/output error occurs while using the connection.
      */
     public static LocalIncomingServerSession createSession(String serverName, XMPPPacketReader reader,
-            SocketConnection connection) throws XmlPullParserException, IOException {
+            SocketConnection connection, boolean directTLS) throws XmlPullParserException, IOException {
         XmlPullParser xpp = reader.getXPPParser();
                 
         String version = xpp.getAttributeValue("", "version");
@@ -174,7 +175,7 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
                 // Don't offer stream-features to pre-1.0 servers, as it confuses them. Sending features to Openfire < 3.7.1 confuses it too - OF-443) 
                 sb.append("<stream:features>");
 
-                if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ENABLED, true)) {
+                if (!directTLS && JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ENABLED, true)) {
                     sb.append("<starttls xmlns=\"urn:ietf:params:xml:ns:xmpp-tls\">");
                     if (!ServerDialback.isEnabled()) {
                         // Server dialback is disabled so TLS is required

--- a/src/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/src/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -52,7 +52,7 @@ public class ConnectionListener
 
     /**
      * Name of property that configures the maximum amount (in bytes) of IO data can be cached, pending processing.
-     * 'null' indicates that the cache size is unbounded. Unbounded caches should be used for high-volume and/or trusted
+     * 'nll' indicates that the cache size is unbounded. Unbounded caches should be used for high-volume and/or trusted
      * connections only (if at all).
      */
     private final String maxReadBufferPropertyName; // Max buffer size

--- a/src/java/org/jivesoftware/openfire/spi/LegacyConnectionAcceptor.java
+++ b/src/java/org/jivesoftware/openfire/spi/LegacyConnectionAcceptor.java
@@ -1,5 +1,6 @@
 package org.jivesoftware.openfire.spi;
 
+import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.net.SocketAcceptThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +51,7 @@ public class LegacyConnectionAcceptor extends ConnectionAcceptor
         }
 
         try {
-            socketAcceptThread = new SocketAcceptThread(configuration.getPort(), configuration.getBindAddress());
+            socketAcceptThread = new SocketAcceptThread(configuration.getPort(), configuration.getBindAddress(), configuration.getTlsPolicy() == Connection.TLSPolicy.legacyMode);
             socketAcceptThread.setDaemon(true);
             socketAcceptThread.setPriority(Thread.MAX_PRIORITY);
             socketAcceptThread.start();

--- a/src/test/java/org/jivesoftware/openfire/net/DNSUtilTest.java
+++ b/src/test/java/org/jivesoftware/openfire/net/DNSUtilTest.java
@@ -31,9 +31,9 @@ public class DNSUtilTest {
     @Test
     public void testJabberDotOrgMock() throws Exception {
         // setup
-        final DNSUtil.WeightedHostAddress fallback = new DNSUtil.WeightedHostAddress("fallback.jabber.org", 5269, 31, 31);
-        final DNSUtil.WeightedHostAddress hermes6  = new DNSUtil.WeightedHostAddress("hermes6.jabber.org",  5269, 30, 30);
-        final DNSUtil.WeightedHostAddress hermes   = new DNSUtil.WeightedHostAddress("hermes.jabber.org",   5269, 30, 30);
+        final DNSUtil.WeightedHostAddress fallback = new DNSUtil.WeightedHostAddress("fallback.jabber.org", 5269, false, 31, 31);
+        final DNSUtil.WeightedHostAddress hermes6  = new DNSUtil.WeightedHostAddress("hermes6.jabber.org",  5269, false, 30, 30);
+        final DNSUtil.WeightedHostAddress hermes   = new DNSUtil.WeightedHostAddress("hermes.jabber.org",   5269, false, 30, 30);
 
         // do magic
         final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{fallback, hermes6, hermes});
@@ -52,7 +52,7 @@ public class DNSUtilTest {
     @Test
     public void testOneHost() throws Exception {
         // setup
-        final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, 1, 1);
+        final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, false, 1, 1);
 
         // do magic
         final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{host});
@@ -68,7 +68,7 @@ public class DNSUtilTest {
     @Test
     public void testOneHostZeroPiority() throws Exception {
         // setup
-        final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, 0, 1);
+        final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, false, 0, 1);
 
         // do magic
         final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{host});
@@ -84,7 +84,7 @@ public class DNSUtilTest {
     @Test
     public void testOneHostZeroWeight() throws Exception {
         // setup
-        final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, 1, 0);
+        final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, false, 1, 0);
 
         // do magic
         final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{host});
@@ -102,9 +102,9 @@ public class DNSUtilTest {
     @Test
     public void testDifferentPriorities() throws Exception {
         // setup
-        final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, 1, 1);
-        final DNSUtil.WeightedHostAddress hostB = new DNSUtil.WeightedHostAddress("hostB", 5222, 3, 1);
-        final DNSUtil.WeightedHostAddress hostC = new DNSUtil.WeightedHostAddress("hostC", 5222, 2, 1);
+        final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, false, 1, 1);
+        final DNSUtil.WeightedHostAddress hostB = new DNSUtil.WeightedHostAddress("hostB", 5222, false, 3, 1);
+        final DNSUtil.WeightedHostAddress hostC = new DNSUtil.WeightedHostAddress("hostC", 5222, false, 2, 1);
 
         // do magic
         final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{hostA, hostB, hostC});
@@ -122,9 +122,9 @@ public class DNSUtilTest {
     @Test
     public void testZeroPriority() throws Exception {
         // setup
-        final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, 0, 1);
-        final DNSUtil.WeightedHostAddress hostB = new DNSUtil.WeightedHostAddress("hostB", 5222, 2, 1);
-        final DNSUtil.WeightedHostAddress hostC = new DNSUtil.WeightedHostAddress("hostC", 5222, 1, 1);
+        final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, false, 0, 1);
+        final DNSUtil.WeightedHostAddress hostB = new DNSUtil.WeightedHostAddress("hostB", 5222, false, 2, 1);
+        final DNSUtil.WeightedHostAddress hostC = new DNSUtil.WeightedHostAddress("hostC", 5222, false, 1, 1);
 
         // do magic
         final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{hostA, hostB, hostC});
@@ -145,8 +145,8 @@ public class DNSUtilTest {
     @Test
     public void testSameWeights() throws Exception {
         // setup
-        final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, 1, 10);
-        final DNSUtil.WeightedHostAddress hostB = new DNSUtil.WeightedHostAddress("hostB", 5222, 1, 10);
+        final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, false, 1, 10);
+        final DNSUtil.WeightedHostAddress hostB = new DNSUtil.WeightedHostAddress("hostB", 5222, false, 1, 10);
         final DNSUtil.WeightedHostAddress[] hosts = new DNSUtil.WeightedHostAddress[] { hostA, hostB };
 
         // do magic
@@ -183,8 +183,8 @@ public class DNSUtilTest {
     @Test
     public void testZeroWeights() throws Exception {
         // setup
-        final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, 1, 0);
-        final DNSUtil.WeightedHostAddress hostB = new DNSUtil.WeightedHostAddress("hostB", 5222, 1, 0);
+        final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, false, 1, 0);
+        final DNSUtil.WeightedHostAddress hostB = new DNSUtil.WeightedHostAddress("hostB", 5222, false, 1, 0);
         final DNSUtil.WeightedHostAddress[] hosts = new DNSUtil.WeightedHostAddress[] { hostA, hostB };
 
         // do magic

--- a/src/web/connection-settings-socket-s2s.jsp
+++ b/src/web/connection-settings-socket-s2s.jsp
@@ -24,6 +24,7 @@
     pageContext.setAttribute("permissionPolicy", RemoteServerManager.getPermissionPolicy().toString());
 
     final ConnectionConfiguration plaintextConfiguration  = manager.getListener( connectionType, false ).generateConnectionConfiguration();
+    final ConnectionConfiguration legacymodeConfiguration = manager.getListener( connectionType, true  ).generateConnectionConfiguration();
 
     boolean update = request.getParameter( "update" ) != null;
     boolean closeSettings = request.getParameter( "closeSettings" ) != null;
@@ -56,14 +57,22 @@
         final boolean plaintextEnabled = ParamUtils.getBooleanParameter( request, "plaintext-enabled" );
         final int plaintextTcpPort = ParamUtils.getIntParameter( request, "plaintext-tcpPort", plaintextConfiguration.getPort() );
 
+        // legacymode
+        final boolean legacymodeEnabled      = ParamUtils.getBooleanParameter( request, "legacymode-enabled" );
+        final int legacymodeTcpPort          = ParamUtils.getIntParameter( request, "legacymode-tcpPort", legacymodeConfiguration.getPort() );
+
         // Apply
         final ConnectionListener plaintextListener = manager.getListener( connectionType, false );
+        final ConnectionListener legacymodeListener = manager.getListener( connectionType, true  );
 
         plaintextListener.enable( plaintextEnabled );
         plaintextListener.setPort( plaintextTcpPort );
 
+        legacymodeListener.enable( legacymodeEnabled );
+        legacymodeListener.setPort( legacymodeTcpPort );
+
         // Log the event
-        webManager.logEvent( "Updated connection settings for " + connectionType, "plain: enabled=" + plaintextEnabled + ", port=" + plaintextTcpPort);
+        webManager.logEvent( "Updated connection settings for " + connectionType, "plain: enabled=" + plaintextEnabled + ", port=" + plaintextTcpPort + "\nlegacy: enabled=" + legacymodeEnabled+ ", port=" + legacymodeTcpPort+ "\n" );
         response.sendRedirect( "connection-settings-socket-s2s.jsp?success=update" );
     }
     else if ( permissionUpdate && errors.isEmpty() )
@@ -206,6 +215,7 @@
 
     pageContext.setAttribute( "errors",                  errors );
     pageContext.setAttribute( "plaintextConfiguration",  plaintextConfiguration );
+    pageContext.setAttribute( "legacymodeConfiguration", legacymodeConfiguration );
     // pageContext.setAttribute( "clientIdle",              JiveGlobals.getIntProperty(     ConnectionSettings.Client.IDLE_TIMEOUT,    6*60*1000 ) );
     // pageContext.setAttribute( "pingIdleClients",         JiveGlobals.getBooleanProperty( ConnectionSettings.Client.KEEP_ALIVE_PING, true) );
 
@@ -243,7 +253,7 @@
         // Ensure that the various elements are set properly when the page is loaded.
         window.onload = function()
         {
-            //applyDisplayable( "plaintext" );
+            applyDisplayable( "plaintext" );
             applyDisplayable( "legacymode" );
         };
     </script>
@@ -305,7 +315,27 @@
                 <td width="99%"><input type="text" name="plaintext-tcpPort" id="plaintext-tcpPort" value="${plaintextConfiguration.port}"/></td>
             </tr>
             <tr valign="middle">
-                <td colspan="2"><a href="./connection-settings-advanced.jsp?connectionType=SOCKET_S2S&connectionMode=plain"><fmt:message key="ssl.settings.client.label_custom_info"/>...</a></td>
+                <td colspan="2"><a href="./connection-settings-advanced.jsp?connectionType=SOCKET_S2S&connectionMode=plain"><fmt:message key="ssl.settings.server.label_custom_info"/>...</a></td>
+            </tr>
+        </table>
+
+    </admin:contentBox>
+
+    <fmt:message key="ssl.settings.server.legacymode.boxtitle" var="legacymodeboxtitle"/>
+    <admin:contentBox title="${legacymodeboxtitle}">
+
+        <p><fmt:message key="ssl.settings.server.legacymode.info"/></p>
+
+        <table cellpadding="3" cellspacing="0" border="0">
+            <tr valign="middle">
+                <td colspan="2"><input type="checkbox" name="legacymode-enabled" id="legacymode-enabled" onclick="applyDisplayable('legacymode')" ${legacymodeConfiguration.enabled ? 'checked' : ''}/><label for="legacymode-enabled"><fmt:message key="ssl.settings.server.legacymode.label_enable"/></label></td>
+            </tr>
+            <tr valign="middle">
+                <td width="1%" nowrap><label for="legacymode-tcpPort"><fmt:message key="ports.port"/></label></td>
+                <td width="99%"><input type="text" name="legacymode-tcpPort" id="legacymode-tcpPort" value="${legacymodeConfiguration.port}"></td>
+            </tr>
+            <tr valign="middle">
+                <td colspan="2"><a href="./connection-settings-advanced.jsp?connectionType=SOCKET_S2S&connectionMode=legacy"><fmt:message key="ssl.settings.server.label_custom_info"/>...</a></td>
             </tr>
         </table>
 

--- a/src/web/index.jsp
+++ b/src/web/index.jsp
@@ -545,7 +545,14 @@
                         <fmt:param></a></fmt:param>
                     </fmt:message>
                 </c:when>
-                <c:when test="${connectionListener.type eq 'SOCKET_S2S'}">
+                <c:when test="${connectionListener.type eq 'SOCKET_S2S' and connectionListener.TLSPolicy ne 'legacyMode'}" >
+                    <fmt:message key="ports.server_to_server.desc"/>
+                    <fmt:message key="ports.plaintext.desc">
+                        <fmt:param><a href='connection-settings-socket-s2s.jsp'></fmt:param>
+                        <fmt:param></a></fmt:param>
+                    </fmt:message>
+                </c:when>
+                <c:when test="${connectionListener.type eq 'SOCKET_S2S' and connectionListener.TLSPolicy eq 'legacyMode'}" >
                     <fmt:message key="ports.server_to_server.desc"/>
                     <fmt:message key="ports.legacymode.desc">
                         <fmt:param><a href='connection-settings-socket-s2s.jsp'></fmt:param>

--- a/src/web/server-props.jsp
+++ b/src/web/server-props.jsp
@@ -47,6 +47,7 @@
     boolean sslEnabled = ParamUtils.getBooleanParameter(request, "sslEnabled");
     int componentPort = ParamUtils.getIntParameter(request, "componentPort", -1);
     int serverPort = ParamUtils.getIntParameter(request, "serverPort", -1);
+    int serverSslPort = ParamUtils.getIntParameter(request, "serverSslPort", -1);
     boolean jmxEnabled = ParamUtils.getBooleanParameter(request, "jmxEnabled");
     boolean jmxSecure = ParamUtils.getBooleanParameter(request, "jmxSecure");
     int jmxPort = ParamUtils.getIntParameter(request, "jmxPort", -1);
@@ -65,6 +66,7 @@
         sslPort = ConnectionManager.DEFAULT_SSL_PORT;
         componentPort = ConnectionManager.DEFAULT_COMPONENT_PORT;
         serverPort = ConnectionManager.DEFAULT_SERVER_PORT;
+        serverSslPort = ConnectionManager.DEFAULT_SERVER_SSL_PORT;
         embeddedPort = 9090;
         embeddedSecurePort = 9091;
         sslEnabled = true;
@@ -110,6 +112,9 @@
         if (serverPort < 1) {
             errors.put("serverPort", "");
         }
+        if (serverSslPort < 1) {
+            errors.put("serverSslPort", "");
+        }
         if (XMPPServer.getInstance().isStandAlone()) {
             if (embeddedPort < 1) {
                 errors.put("embeddedPort", "");
@@ -131,6 +136,11 @@
                 errors.put("portsEqual", "");
             }
         }
+        if (serverPort > 0 && serverSslPort > 0) {
+            if (serverPort == serverSslPort) {
+                errors.put("serverPortsEqual", "");
+            }
+        }
         if (jmxPort < 1 && jmxEnabled) {
             errors.put("jmxPort", "");
         }
@@ -145,6 +155,7 @@
             connectionManager.setClientSSLListenerPort(sslPort);
             connectionManager.setComponentListenerPort(componentPort);
             connectionManager.setServerListenerPort(serverPort);
+            connectionManager.setServerSslListenerPort(serverSslPort);
             if (!String.valueOf(embeddedPort).equals(JiveGlobals.getXMLProperty("adminConsole.port"))) {
                 JiveGlobals.setXMLProperty("adminConsole.port", String.valueOf(embeddedPort));
                 needRestart = true;
@@ -158,7 +169,7 @@
             JMXManager.setPort(jmxPort);
 
             // Log the event
-            webManager.logEvent("edit server properties", "serverName = "+serverName+"\nport = "+port+"\nsslPort = "+sslPort+"\ncomponentPort = "+componentPort+"\nserverPort = "+serverPort+"\nembeddedPort = "+embeddedPort+"\nembeddedSecurePort = "+embeddedSecurePort);
+            webManager.logEvent("edit server properties", "serverName = "+serverName+"\nport = "+port+"\nsslPort = "+sslPort+"\ncomponentPort = "+componentPort+"\nserverPort = "+serverPort+"\nserverSslPort = "+serverSslPort+"\nembeddedPort = "+embeddedPort+"\nembeddedSecurePort = "+embeddedSecurePort);
             if (needRestart) {
                 response.sendRedirect("server-props.jsp?success=true&restart=true");
             } else {
@@ -173,6 +184,7 @@
         sslPort = connectionManager.getClientSSLListenerPort();
         componentPort = connectionManager.getComponentListenerPort();
         serverPort = connectionManager.getServerListenerPort();
+        serverSslPort = connectionManager.getServerSslListenerPort();
         try {
             embeddedPort = Integer.parseInt(JiveGlobals.getXMLProperty("adminConsole.port"));
         } catch (Exception ignored) {
@@ -266,6 +278,23 @@
                 <fmt:message key="server.props.valid_port" />
                 <a href="#" onclick="document.editform.serverPort.value='<%=ConnectionManager.DEFAULT_SERVER_PORT%>';"
                  ><fmt:message key="server.props.valid_port1" /></a>.
+                </span>
+            <%  } %>
+        </td>
+    </tr>
+    <tr>
+        <td class="c1">
+            <fmt:message key="server.props.server_ssl_port" />
+        </td>
+        <td class="c2">
+            <input type="text" name="serverSslPort" value="<%= (serverSslPort > 0 ? String.valueOf(serverSslPort) : "") %>"
+                   size="5" maxlength="5">
+            <%  if (errors.containsKey("serverSslPort")) { %>
+            <br>
+            <span class="jive-error-text">
+                <fmt:message key="server.props.valid_port" />
+                <a href="#" onclick="document.editform.serverPort.value='<%=ConnectionManager.DEFAULT_SERVER_SSL_PORT%>';"
+                ><fmt:message key="server.props.valid_port1" /></a>.
                 </span>
             <%  } %>
         </td>


### PR DESCRIPTION
This adds support for doing 'direct' TLS (as opposed to StartTLS) when performing server-to-server communication (federation).

With this PR, Openfire can establish direct TLS s2s connections, and also can accept such connections.