### PR TITLE
Use the version from the pom.xml to set the version in plugin.xml

### DIFF
--- a/src/plugins/bookmarks/plugin.xml
+++ b/src/plugins/bookmarks/plugin.xml
@@ -3,10 +3,10 @@
 
     <!-- Main plugin class -->
     <class>org.igniterealtime.openfire.plugin.BookmarksPlugin</class>
-    
+
     <!-- Plugin meta-data -->
-    <name>Bookmarks</name>
-    <description>Allows clients to store URL and group chat bookmarks (XEP-0048)</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
     <date>tbc.</date>
@@ -17,9 +17,10 @@
     <databaseVersion>0</databaseVersion>
 
     <!-- UI extension -->
-    <adminconsole>		
+    <adminconsole>
         <tab id="tab-server">
-            <sidebar id="bookmarks" name="${admin.sidebar.bookmarks.name}" description="${admin.sidebar.bookmarks.description}">
+            <sidebar id="bookmarks" name="${admin.sidebar.bookmarks.name}"
+                     description="${admin.sidebar.bookmarks.description}">
                 <item id="groupchat-bookmarks" name="${admin.item.groupchat-bookmarks.name}"
                       url="groupchat-bookmarks.jsp"
                       description="${admin.item.groupchat-bookmarks.description}"/>
@@ -29,5 +30,5 @@
             </sidebar>
         </tab>
     </adminconsole>
-    
+
 </plugin>

--- a/src/plugins/bookmarks/plugin.xml
+++ b/src/plugins/bookmarks/plugin.xml
@@ -8,7 +8,7 @@
     <name>Bookmarks</name>
     <description>Allows clients to store URL and group chat bookmarks (XEP-0048)</description>
     <author>Ignite Realtime</author>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/broadcast/plugin.xml
+++ b/src/plugins/broadcast/plugin.xml
@@ -8,7 +8,7 @@
     <name>Broadcast</name>
     <description>Broadcasts messages to users.</description>
     <author>Jive Software</author>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <url>http://www.igniterealtime.org</url>
     <minServerVersion>4.0.0</minServerVersion>

--- a/src/plugins/broadcast/plugin.xml
+++ b/src/plugins/broadcast/plugin.xml
@@ -5,8 +5,8 @@
 -->
 <plugin>
     <class>org.jivesoftware.openfire.plugin.BroadcastPlugin</class>
-    <name>Broadcast</name>
-    <description>Broadcasts messages to users.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Jive Software</author>
     <version>${project.version}</version>
     <date>tbc.</date>

--- a/src/plugins/callbackOnOffline/plugin.xml
+++ b/src/plugins/callbackOnOffline/plugin.xml
@@ -6,7 +6,7 @@
     <name>CallbackOnOffline</name>
     <description>Url is called when recipient is offline</description>
     <author>Pavel Goski / Krzysztof Misztal</author>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/callbackOnOffline/plugin.xml
+++ b/src/plugins/callbackOnOffline/plugin.xml
@@ -3,8 +3,8 @@
     <!-- Main plugin class -->
     <class>com.fotsum.CallbackOnOffline</class>
 
-    <name>CallbackOnOffline</name>
-    <description>Url is called when recipient is offline</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Pavel Goski / Krzysztof Misztal</author>
     <version>${project.version}</version>
     <date>tbc.</date>

--- a/src/plugins/candy/plugin.xml
+++ b/src/plugins/candy/plugin.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin>
     <class>org.igniterealtime.openfire.plugin.candy.CandyPlugin</class>
-    <name>Candy</name>
-    <description>Adds the (third-party) Candy web client to Openfire.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.1.5</minServerVersion>
     <adminconsole>
-        <tab id="tab-webclients" name="${admin.sidebar.webclients.name}" description="${admin.sidebar.webclients.description}" url="candy-config.jsp">    
-            <sidebar id="tab-candy" name="${admin.sidebar.webclients.item.candy.name}" description="${admin.sidebar.webclients.item.candy.description}">
-                <item id="candy-config" name="${admin.sidebar.webclients.item.settings.name}" description="${admin.sidebar.webclients.item.settings.description}" url="candy-config.jsp"/>
+        <tab id="tab-webclients" name="${admin.sidebar.webclients.name}"
+             description="${admin.sidebar.webclients.description}" url="candy-config.jsp">
+            <sidebar id="tab-candy" name="${admin.sidebar.webclients.item.candy.name}"
+                     description="${admin.sidebar.webclients.item.candy.description}">
+                <item id="candy-config" name="${admin.sidebar.webclients.item.settings.name}"
+                      description="${admin.sidebar.webclients.item.settings.description}" url="candy-config.jsp"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/candy/plugin.xml
+++ b/src/plugins/candy/plugin.xml
@@ -4,7 +4,7 @@
     <name>Candy</name>
     <description>Adds the (third-party) Candy web client to Openfire.</description>
     <author>Guus der Kinderen</author>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.1.5</minServerVersion>
     <adminconsole>

--- a/src/plugins/certificateManager/plugin.xml
+++ b/src/plugins/certificateManager/plugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin>
     <class>org.igniterealtime.openfire.plugins.certificatemanager.CertificateManagerPlugin</class>
-    <name>Certificate Manager</name>
-    <description>Adds certificate management features.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
     <date>11/24/2017</date>

--- a/src/plugins/certificateManager/plugin.xml
+++ b/src/plugins/certificateManager/plugin.xml
@@ -4,7 +4,7 @@
     <name>Certificate Manager</name>
     <description>Adds certificate management features.</description>
     <author>Guus der Kinderen</author>
-    <version>1.0.0</version>
+    <version>${project.version}</version>
     <date>11/24/2017</date>
     <minServerVersion>4.0.0</minServerVersion>
     <adminconsole>

--- a/src/plugins/clientControl/plugin.xml
+++ b/src/plugins/clientControl/plugin.xml
@@ -8,7 +8,7 @@
     <name>Client Control</name>
     <description>Controls clients allowed to connect and available features</description>
     <author>Jive Software</author>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc</date>
     <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/clientControl/plugin.xml
+++ b/src/plugins/clientControl/plugin.xml
@@ -3,17 +3,17 @@
 
     <!-- Main plugin class -->
     <class>org.jivesoftware.openfire.plugin.ClientControlPlugin</class>
-    
+
     <!-- Plugin meta-data -->
-    <name>Client Control</name>
-    <description>Controls clients allowed to connect and available features</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Jive Software</author>
     <version>${project.version}</version>
     <date>tbc</date>
     <minServerVersion>4.0.0</minServerVersion>
 
     <!-- UI extension -->
-    <adminconsole>		
+    <adminconsole>
         <tab id="tab-server">
             <sidebar id="client" name="${admin.sidebar.client.name}" description="${admin.sidebar.client.description}">
                 <item id="client-features" name="${admin.item.client-features.name}"
@@ -31,5 +31,5 @@
             </sidebar>
         </tab>
     </adminconsole>
-    
+
 </plugin>

--- a/src/plugins/contentFilter/plugin.xml
+++ b/src/plugins/contentFilter/plugin.xml
@@ -3,24 +3,24 @@
 
     <!-- Main plugin class -->
     <class>org.jivesoftware.openfire.plugin.ContentFilterPlugin</class>
-    
+
     <!-- Plugin meta-data -->
-    <name>Content Filter</name>
-    <description>Scans message packets for defined patterns</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Conor Hayes</author>
     <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
-    
+
     <!-- UI extension -->
-    <adminconsole>		
+    <adminconsole>
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">
                 <item id="contentfilter-props-edit-form" name="Content Filter"
-                    url="contentfilter-props-edit-form.jsp"
-                    description="Click to configure content filter" />
+                      url="contentfilter-props-edit-form.jsp"
+                      description="Click to configure content filter"/>
             </sidebar>
         </tab>
     </adminconsole>
-    
+
 </plugin>

--- a/src/plugins/contentFilter/plugin.xml
+++ b/src/plugins/contentFilter/plugin.xml
@@ -8,7 +8,7 @@
     <name>Content Filter</name>
     <description>Scans message packets for defined patterns</description>
     <author>Conor Hayes</author>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     

--- a/src/plugins/dbaccess/plugin.xml
+++ b/src/plugins/dbaccess/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.DbAccessPlugin</class>
-    <name>DB Access</name>
-    <description>Provides administrators with a simple direct access interface to their Openfire DB.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Daniel Henninger</author>
     <version>${project.version}</version>
     <date>tbc.</date>
@@ -13,8 +13,8 @@
         <tab id="tab-server">
             <sidebar id="sidebar-server-manager">
                 <item id="db-access" name="DB Access"
-                    url="db-access.jsp"
-                    description="Direct database manipulation tool." />
+                      url="db-access.jsp"
+                      description="Direct database manipulation tool."/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/dbaccess/plugin.xml
+++ b/src/plugins/dbaccess/plugin.xml
@@ -5,7 +5,7 @@
     <name>DB Access</name>
     <description>Provides administrators with a simple direct access interface to their Openfire DB.</description>
     <author>Daniel Henninger</author>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/emailListener/plugin.xml
+++ b/src/plugins/emailListener/plugin.xml
@@ -9,7 +9,7 @@
     <description>Listens for emails and sends alerts to specific users.</description>
     <author>Jive Software</author>
     <url>http://www.igniterealtime.org</url>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/emailListener/plugin.xml
+++ b/src/plugins/emailListener/plugin.xml
@@ -5,8 +5,8 @@
 -->
 <plugin>
     <class>org.jivesoftware.openfire.plugin.EmailListenerPlugin</class>
-    <name>Email Listener</name>
-    <description>Listens for emails and sends alerts to specific users.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Jive Software</author>
     <url>http://www.igniterealtime.org</url>
     <version>${project.version}</version>
@@ -17,7 +17,7 @@
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">
                 <item id="email-listener" name="Email Listener" url="email-listener.jsp"
-                     description="Click to configure email listener" />
+                      description="Click to configure email listener"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/emailOnAway/plugin.xml
+++ b/src/plugins/emailOnAway/plugin.xml
@@ -6,7 +6,7 @@
     <name>Email on Away</name>
     <description>Messages sent to alternate location when recipient is away</description>
     <author>Nick Mossie</author>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/emailOnAway/plugin.xml
+++ b/src/plugins/emailOnAway/plugin.xml
@@ -3,8 +3,8 @@
     <!-- Main plugin class -->
     <class>com.tempstop.emailOnAway</class>
 
-    <name>Email on Away</name>
-    <description>Messages sent to alternate location when recipient is away</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Nick Mossie</author>
     <version>${project.version}</version>
     <date>tbc.</date>

--- a/src/plugins/externalservicediscovery/plugin.xml
+++ b/src/plugins/externalservicediscovery/plugin.xml
@@ -4,7 +4,7 @@
     <name>External Service Discovery</name>
     <description>Allows XMPP entities to discover services external to the XMPP network, such as STUN and TURN servers.</description>
     <author>Guus der Kinderen</author>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.2.0</minServerVersion>
 

--- a/src/plugins/externalservicediscovery/plugin.xml
+++ b/src/plugins/externalservicediscovery/plugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin>
     <class>org.igniterealtime.openfire.plugins.externalservicediscovery.ExternalServiceDiscoveryPlugin</class>
-    <name>External Service Discovery</name>
-    <description>Allows XMPP entities to discover services external to the XMPP network, such as STUN and TURN servers.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
     <date>tbc.</date>

--- a/src/plugins/fastpath/plugin.xml
+++ b/src/plugins/fastpath/plugin.xml
@@ -2,74 +2,74 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.fastpath.FastpathPlugin</class>
-    <name>Fastpath Service</name>
-    <description>Support for managed queued chat requests, such as a support team might use.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Jive Software</author>
     <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.1.0</minServerVersion>
     <databaseKey>fastpath</databaseKey>
     <databaseVersion>0</databaseVersion>
-    
+
     <adminconsole>
         <tab id="workgroup-tab" name="Fastpath"
-                url="workgroup-summary.jsp"
-                description="Click to manage FastPath.">
-               <sidebar id="workgroup-sidebar" name="Workgroups Manager">
-                   <item id="workgroup-summary" name="View Workgroups"
-                         url="workgroup-summary.jsp"
-                         description="Click to view all Workgroups"/>
-                   <item id="workgroup-settings" name="Manage Settings"
-                         url="workgroup-settings.jsp"
-                         description="Click to configure global settings"/>
-                   <item id="workgroup-create" name="Create Workgroup"
-                         url="workgroup-create.jsp"
-                         description="Click to create a Workgroup">
-                       <sidebar id="workgroup-setting-options" name="Workgroup Settings">
-                           <item id="workgroup-queues" name="Manage Queues"
-                                 url="workgroup-queues.jsp"
-                                 description="Click to edit workgroup Queue(s)"/>
-                           <item id="workgroup-macros" name="Canned Responses"
-                                 url="workgroup-macros.jsp"
-                                 description="Click to edit the Workgroup Canned Responses"/>
-                           <item id="workgroup-monitors" name="Room Monitors"
-                                 url="workgroup-monitors.jsp"
-                                 description="Click to Manage Room Monitors"/>
-                           <item id="workgroup-offline" name="Offline Settings"
-                                 url="workgroup-offline.jsp"
-                                 description="Click to edit Offline instructions"/>
-                           <item id="workgroup-transcript-config" name="Transcripts"
-                                 url="workgroup-transcript-config.jsp"
-                                 description="Click to edit Transcript settings"/>
-                           <item id="workgroup-forms" name="Form UI"
-                                 url="forms/workgroup-dataform.jsp"
-                                 description="Click to create or edit the Form used for this workgroup"/>
-                           <item id="workgroup-variables" name="Form Variables"
-                                 url="workgroup-variables.jsp"
-                                 description="Click to create or edit the Variables to retrieve for this workgroup"/>
-                           <item id="workgroup-image-settings"
-                                 name="Images"
-                                 url="workgroup-image-settings.jsp"
-                                 description="Click to customize Web Chat window"/>
-                           <item id="workgroup-text-settings"
-                                 name="Text"
-                                 url="workgroup-text-settings.jsp"
-                                 description="Click to customize Web Chat window"/>
-                           <item id="workgroup-properties" name="Settings"
-                                 url="workgroup-properties.jsp"
-                                 description="Click to view workgroup properties"/>
-                       </sidebar>
-                   </item>
-               </sidebar>
-               <sidebar id="reporting-sidebar" name="Reports">
-                   <item id="chat-summary" name="View Previous Chats"
-                         url="chat-summary.jsp"
-                         description="Click to view Chat Transcripts">
-                   </item>
-                   <item id="usage-summary" name="View Chat Usage"
-                         url="usage-summary.jsp"
-                         description="Click to view Usage Summary"/>
-               </sidebar>
+             url="workgroup-summary.jsp"
+             description="Click to manage FastPath.">
+            <sidebar id="workgroup-sidebar" name="Workgroups Manager">
+                <item id="workgroup-summary" name="View Workgroups"
+                      url="workgroup-summary.jsp"
+                      description="Click to view all Workgroups"/>
+                <item id="workgroup-settings" name="Manage Settings"
+                      url="workgroup-settings.jsp"
+                      description="Click to configure global settings"/>
+                <item id="workgroup-create" name="Create Workgroup"
+                      url="workgroup-create.jsp"
+                      description="Click to create a Workgroup">
+                    <sidebar id="workgroup-setting-options" name="Workgroup Settings">
+                        <item id="workgroup-queues" name="Manage Queues"
+                              url="workgroup-queues.jsp"
+                              description="Click to edit workgroup Queue(s)"/>
+                        <item id="workgroup-macros" name="Canned Responses"
+                              url="workgroup-macros.jsp"
+                              description="Click to edit the Workgroup Canned Responses"/>
+                        <item id="workgroup-monitors" name="Room Monitors"
+                              url="workgroup-monitors.jsp"
+                              description="Click to Manage Room Monitors"/>
+                        <item id="workgroup-offline" name="Offline Settings"
+                              url="workgroup-offline.jsp"
+                              description="Click to edit Offline instructions"/>
+                        <item id="workgroup-transcript-config" name="Transcripts"
+                              url="workgroup-transcript-config.jsp"
+                              description="Click to edit Transcript settings"/>
+                        <item id="workgroup-forms" name="Form UI"
+                              url="forms/workgroup-dataform.jsp"
+                              description="Click to create or edit the Form used for this workgroup"/>
+                        <item id="workgroup-variables" name="Form Variables"
+                              url="workgroup-variables.jsp"
+                              description="Click to create or edit the Variables to retrieve for this workgroup"/>
+                        <item id="workgroup-image-settings"
+                              name="Images"
+                              url="workgroup-image-settings.jsp"
+                              description="Click to customize Web Chat window"/>
+                        <item id="workgroup-text-settings"
+                              name="Text"
+                              url="workgroup-text-settings.jsp"
+                              description="Click to customize Web Chat window"/>
+                        <item id="workgroup-properties" name="Settings"
+                              url="workgroup-properties.jsp"
+                              description="Click to view workgroup properties"/>
+                    </sidebar>
+                </item>
+            </sidebar>
+            <sidebar id="reporting-sidebar" name="Reports">
+                <item id="chat-summary" name="View Previous Chats"
+                      url="chat-summary.jsp"
+                      description="Click to view Chat Transcripts">
+                </item>
+                <item id="usage-summary" name="View Chat Usage"
+                      url="usage-summary.jsp"
+                      description="Click to view Usage Summary"/>
+            </sidebar>
         </tab>
     </adminconsole>
 </plugin>

--- a/src/plugins/fastpath/plugin.xml
+++ b/src/plugins/fastpath/plugin.xml
@@ -5,7 +5,7 @@
     <name>Fastpath Service</name>
     <description>Support for managed queued chat requests, such as a support team might use.</description>
     <author>Jive Software</author>
-    <version>4.4.4-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.1.0</minServerVersion>
     <databaseKey>fastpath</databaseKey>

--- a/src/plugins/gojara/plugin.xml
+++ b/src/plugins/gojara/plugin.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin>
     <!-- Main plugin class -->
-    <class>org.jivesoftware.openfire.plugin.gojara.base.RemoteRosterPlugin
-    </class>
-
-
-    <name>GoJara</name>
-    <description>XEP-0321: Remote Roster Management support
-    </description>
+    <class>org.jivesoftware.openfire.plugin.gojara.base.RemoteRosterPlugin</class>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Holger Bergunde / Daniel Henninger / Axel-F. Brand</author>
     <version>${project.version}</version>
     <date>03/23/2018</date>
@@ -21,23 +17,25 @@
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">
                 <item id="remoteRoster" name="Gojara Settings" url="rr-main.jsp"
-                    description="Manage GoJara Settings" />
+                      description="Manage GoJara Settings"/>
             </sidebar>
         </tab>
         <tab id="tab-server">
             <sidebar id="sidebar-server-manager">
                 <item id="gojaraGatewayStatistics" name="Spectrum2 Stats"
-                    url="gojara-gatewayStatistics.jsp" description="Click to see Stats of Spectrum2 Components"></item>
+                      url="gojara-gatewayStatistics.jsp"
+                      description="Click to see Stats of Spectrum2 Components"/>
             </sidebar>
         </tab>
         <tab id="tab-session">
             <sidebar id="sidebar-session">
                 <item id="gojaraSessions" name="Gateway Sessions" url="gojara-activeSessions.jsp"
-                    description="Click to manage Gateway sessions"></item>
+                      description="Click to manage Gateway sessions"/>
             </sidebar>
             <sidebar id="sidebar-tools">
                 <item id="gojaraRegistrationAdministration" name="Gateway Registration Overview"
-                    url="gojara-RegistrationsOverview.jsp" description="Manage existing Spectrum2 registrations"></item>
+                      url="gojara-RegistrationsOverview.jsp"
+                      description="Manage existing Spectrum2 registrations"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/gojara/plugin.xml
+++ b/src/plugins/gojara/plugin.xml
@@ -9,7 +9,7 @@
     <description>XEP-0321: Remote Roster Management support
     </description>
     <author>Holger Bergunde / Daniel Henninger / Axel-F. Brand</author>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>03/23/2018</date>
     <databaseKey>gojara</databaseKey>
     <databaseVersion>1</databaseVersion>

--- a/src/plugins/hazelcast/plugin.xml
+++ b/src/plugins/hazelcast/plugin.xml
@@ -5,7 +5,7 @@
     <name>Hazelcast plugin</name>
     <description>Adds clustering support</description>
     <author>Tom Evans</author>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc</date>
     <minServerVersion>4.3.0</minServerVersion>
 </plugin>

--- a/src/plugins/hazelcast/plugin.xml
+++ b/src/plugins/hazelcast/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.HazelcastPlugin</class>
-    <name>Hazelcast plugin</name>
-    <description>Adds clustering support</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Tom Evans</author>
     <version>${project.version}</version>
     <date>tbc</date>

--- a/src/plugins/httpFileUpload/plugin.xml
+++ b/src/plugins/httpFileUpload/plugin.xml
@@ -4,7 +4,7 @@
     <name>HTTP File Upload</name>
     <description>Allows clients to share files, as described in the XEP-0363 'HTTP File Upload' specification.</description>
     <author>Guus der Kinderen</author>
-    <version>1.1.0</version>
+    <version>${project.version}</version>
     <date>02/19/2018</date>
     <minServerVersion>4.1.0</minServerVersion>
 </plugin>

--- a/src/plugins/httpFileUpload/plugin.xml
+++ b/src/plugins/httpFileUpload/plugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin>
     <class>org.igniterealtime.openfire.plugins.httpfileupload.HttpFileUploadPlugin</class>
-    <name>HTTP File Upload</name>
-    <description>Allows clients to share files, as described in the XEP-0363 'HTTP File Upload' specification.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
     <date>02/19/2018</date>

--- a/src/plugins/inverse/plugin.xml
+++ b/src/plugins/inverse/plugin.xml
@@ -4,7 +4,7 @@
     <name>inVerse</name>
     <description>Adds the (third-party) inVerse web client to Openfire.</description>
     <author>Guus der Kinderen</author>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc</date>
     <minServerVersion>4.1.5</minServerVersion>
     <adminconsole>

--- a/src/plugins/inverse/plugin.xml
+++ b/src/plugins/inverse/plugin.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin>
     <class>org.igniterealtime.openfire.plugin.inverse.InversePlugin</class>
-    <name>inVerse</name>
-    <description>Adds the (third-party) inVerse web client to Openfire.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
     <date>tbc</date>
     <minServerVersion>4.1.5</minServerVersion>
     <adminconsole>
-        <tab id="tab-webclients" name="${admin.sidebar.webclients.name}" description="${admin.sidebar.webclients.description}" url="inverse-config.jsp">
-            <sidebar id="tab-inverse" name="${admin.sidebar.webclients.item.inverse.name}" description="${admin.sidebar.webclients.item.inverse.description}">
-                <item id="inverse-config" name="${admin.sidebar.webclients.item.settings.name}" description="${admin.sidebar.webclients.item.settings.description}" url="inverse-config.jsp"/>
+        <tab id="tab-webclients" name="${admin.sidebar.webclients.name}"
+             description="${admin.sidebar.webclients.description}" url="inverse-config.jsp">
+            <sidebar id="tab-inverse" name="${admin.sidebar.webclients.item.inverse.name}"
+                     description="${admin.sidebar.webclients.item.inverse.description}">
+                <item id="inverse-config" name="${admin.sidebar.webclients.item.settings.name}"
+                      description="${admin.sidebar.webclients.item.settings.description}" url="inverse-config.jsp"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/jingleNodes/plugin.xml
+++ b/src/plugins/jingleNodes/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin>
     <class>org.jinglenodes.JingleNodesPlugin</class>
-    <name>Jingle Nodes Plugin</name>
-    <description>Provides support for Jingle Nodes</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Jingle Nodes (Rodrigo Martins)</author>
     <version>${project.version}</version>
     <date>10/12/2015</date>

--- a/src/plugins/jingleNodes/plugin.xml
+++ b/src/plugins/jingleNodes/plugin.xml
@@ -5,7 +5,7 @@
     <name>Jingle Nodes Plugin</name>
     <description>Provides support for Jingle Nodes</description>
     <author>Jingle Nodes (Rodrigo Martins)</author>
-    <version>0.2.0</version>
+    <version>${project.version}</version>
     <date>10/12/2015</date>
     <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/jmxweb/plugin.xml
+++ b/src/plugins/jmxweb/plugin.xml
@@ -4,7 +4,7 @@
     <class>com.ifsoft.jmxweb.plugin.JmxWebPlugin</class>
     <name>JmxWeb Plugin</name>
     <description>JmxWeb plugin is web based platform for managing and monitoring openfire via JMX.</description>
-    <version>0.0.9-SNAPSHOT</version>
+    <version>${project.version}</version>
     <licenseType>Apache 2.0</licenseType>    
     <date>05/09/2018</date>
     <minServerVersion>4.3.0</minServerVersion>

--- a/src/plugins/jmxweb/plugin.xml
+++ b/src/plugins/jmxweb/plugin.xml
@@ -2,11 +2,11 @@
 
 <plugin>
     <class>com.ifsoft.jmxweb.plugin.JmxWebPlugin</class>
-    <name>JmxWeb Plugin</name>
-    <description>JmxWeb plugin is web based platform for managing and monitoring openfire via JMX.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <version>${project.version}</version>
-    <licenseType>Apache 2.0</licenseType>    
+    <licenseType>Apache 2.0</licenseType>
     <date>05/09/2018</date>
     <minServerVersion>4.3.0</minServerVersion>
-    <author>igniterealtime.org</author>   
+    <author>igniterealtime.org</author>
 </plugin>

--- a/src/plugins/justmarried/plugin.xml
+++ b/src/plugins/justmarried/plugin.xml
@@ -5,7 +5,7 @@
    <name>Just married</name>
    <description>Allows admins to rename or copy users</description>
    <author>Holger Bergunde</author>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
    

--- a/src/plugins/justmarried/plugin.xml
+++ b/src/plugins/justmarried/plugin.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin>
-   <class>org.jivesoftware.openfire.plugin.married.JustMarriedPlugin</class>
-   <name>Just married</name>
-   <description>Allows admins to rename or copy users</description>
-   <author>Holger Bergunde</author>
+    <class>org.jivesoftware.openfire.plugin.married.JustMarriedPlugin</class>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
+    <author>Holger Bergunde</author>
     <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
-   
-   <adminconsole>
+
+    <adminconsole>
         <tab id="tab-users">
             <sidebar id="sidebar-users">
                 <item id="justmarried" name="Just married"
-                    url="married.jsp"
-                    description="Just married" />
+                      url="married.jsp"
+                      description="Just married"/>
             </sidebar>
-         </tab>
+        </tab>
     </adminconsole>
 </plugin>

--- a/src/plugins/kraken/plugin.xml
+++ b/src/plugins/kraken/plugin.xml
@@ -8,7 +8,7 @@
     <name>Kraken IM Gateway</name>
     <description>Adds transports to other IM networks.</description>
     <author>Daniel Henninger</author>
-    <version>1.3.2</version>
+    <version>${project.version}</version>
     <date>03/23/2018</date>
     <minServerVersion>4.2.0</minServerVersion>
     <databaseKey>gateway</databaseKey>

--- a/src/plugins/kraken/plugin.xml
+++ b/src/plugins/kraken/plugin.xml
@@ -3,10 +3,10 @@
 
     <!-- Main plugin class -->
     <class>net.sf.kraken.KrakenPlugin</class>
-    
+
     <!-- Plugin meta-data -->
-    <name>Kraken IM Gateway</name>
-    <description>Adds transports to other IM networks.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Daniel Henninger</author>
     <version>${project.version}</version>
     <date>03/23/2018</date>
@@ -14,13 +14,13 @@
     <databaseKey>gateway</databaseKey>
     <databaseVersion>12</databaseVersion>
     <licenseType>apache2</licenseType>
-    
+
     <!-- Admin console meta-data -->
-    <adminconsole>              
+    <adminconsole>
         <tab id="tab-server">
-        
+
             <sidebar id="gateways" name="${gateway.gateways}" description="${gateway.gateways.desc}">
-                <item id="kraken-settings" 
+                <item id="kraken-settings"
                       name="${gateway.settings}"
                       url="kraken-settings.jsp"
                       description="${gateway.settings.desc}"/>
@@ -28,12 +28,12 @@
                       name="${gateway.transports}"
                       url="kraken-transports.jsp"
                       description="${gateway.transports.desc}"/>
-                <item id="kraken-registrations" 
+                <item id="kraken-registrations"
                       name="${gateway.registrations}"
                       url="kraken-registrations.jsp"
                       description="${gateway.registrations.desc}"/>
             </sidebar>
-        
+
         </tab>
     </adminconsole>
 </plugin>

--- a/src/plugins/loadStats/plugin.xml
+++ b/src/plugins/loadStats/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.StatisticPlugin</class>
-    <name>Load Statistic</name>
-    <description>Logs load statistics to a file</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Jive Software</author>
     <version>${project.version}</version>
     <date>tbc.</date>

--- a/src/plugins/loadStats/plugin.xml
+++ b/src/plugins/loadStats/plugin.xml
@@ -5,7 +5,7 @@
     <name>Load Statistic</name>
     <description>Logs load statistics to a file</description>
     <author>Jive Software</author>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>3.9.0</minServerVersion>
 </plugin>

--- a/src/plugins/monitoring/plugin.xml
+++ b/src/plugins/monitoring/plugin.xml
@@ -5,7 +5,7 @@
     <name>Monitoring Service</name>
     <description>Monitors conversations and statistics of the server.</description>
     <author>IgniteRealtime // Jive Software</author>
-    <version>1.6.1</version>
+    <version>${project.version}</version>
     <date>06/28/2018</date>
     <minServerVersion>4.1.0</minServerVersion>
     <databaseKey>monitoring</databaseKey>

--- a/src/plugins/monitoring/plugin.xml
+++ b/src/plugins/monitoring/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.MonitoringPlugin</class>
-    <name>Monitoring Service</name>
-    <description>Monitors conversations and statistics of the server.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>IgniteRealtime // Jive Software</author>
     <version>${project.version}</version>
     <date>06/28/2018</date>
@@ -13,7 +13,8 @@
 
     <adminconsole>
         <tab id="tab-server">
-            <sidebar id="stats-dashboard" name="${admin.sidebar.statistics.name}" description="${admin.item.stats-dashboard.description}">
+            <sidebar id="stats-dashboard" name="${admin.sidebar.statistics.name}"
+                     description="${admin.item.stats-dashboard.description}">
                 <item id="statistics" name="${admin.sidebar.statistics.name}"
                       url="stats-dashboard.jsp"
                       description="${admin.sidebar.statistics.description}"/>
@@ -22,7 +23,8 @@
                       description="${admin.item.stats-reporter.description}"/>
             </sidebar>
 
-            <sidebar id="archiving" name="${admin.sidebar.archiving.name}" description="${admin.sidebar.archiving.description}">
+            <sidebar id="archiving" name="${admin.sidebar.archiving.name}"
+                     description="${admin.sidebar.archiving.description}">
                 <item id="archive-search" name="${admin.item.archive-search.name}"
                       url="archive-search.jsp"
                       description="${admin.item.archive-search.description}"/>

--- a/src/plugins/motd/plugin.xml
+++ b/src/plugins/motd/plugin.xml
@@ -5,7 +5,7 @@
    <name>MotD (Message of the Day)</name>
    <description>Allows admins to have a message sent to users each time they log in.</description>
    <author>Ryan Graham</author>
-   <version>1.2.2-SNAPSHOT</version>
+   <version>${project.version}</version>
    <date>tbc.</date>
    <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/motd/plugin.xml
+++ b/src/plugins/motd/plugin.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin>
-   <class>org.jivesoftware.openfire.plugin.MotDPlugin</class>
-   <name>MotD (Message of the Day)</name>
-   <description>Allows admins to have a message sent to users each time they log in.</description>
-   <author>Ryan Graham</author>
-   <version>${project.version}</version>
-   <date>tbc.</date>
-   <minServerVersion>4.0.0</minServerVersion>
+    <class>org.jivesoftware.openfire.plugin.MotDPlugin</class>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
+    <author>Ryan Graham</author>
+    <version>${project.version}</version>
+    <date>tbc.</date>
+    <minServerVersion>4.0.0</minServerVersion>
 
-   <adminconsole>
-      <tab id="tab-users">
-         <sidebar id="sidebar-users">
-            <item id="motd-form" name="MotD Properties" url="motd-form.jsp" description="Settings for MotD" />
-         </sidebar>
-      </tab>
-   </adminconsole>
+    <adminconsole>
+        <tab id="tab-users">
+            <sidebar id="sidebar-users">
+                <item id="motd-form" name="MotD Properties" url="motd-form.jsp" description="Settings for MotD"/>
+            </sidebar>
+        </tab>
+    </adminconsole>
 </plugin>

--- a/src/plugins/mucservice/plugin.xml
+++ b/src/plugins/mucservice/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.MUCServicePlugin</class>
-    <name>MUC Service</name>
-    <description>(Deprecated) Please use the REST API Plugin. MUC administration over REST Interface</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
     <date>tbc</date>

--- a/src/plugins/mucservice/plugin.xml
+++ b/src/plugins/mucservice/plugin.xml
@@ -5,7 +5,7 @@
     <name>MUC Service</name>
     <description>(Deprecated) Please use the REST API Plugin. MUC administration over REST Interface</description>
     <author>Roman Soldatow</author>
-    <version>0.2.4-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc</date>
     <minServerVersion>3.9.1</minServerVersion>
 </plugin>

--- a/src/plugins/nodejs/plugin.xml
+++ b/src/plugins/nodejs/plugin.xml
@@ -5,7 +5,7 @@
     <name>NodeJs</name>
     <description>Integrates NodeJs Applications with Openfire.</description>
     <licenseType>Apache 2.0</licenseType>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/nodejs/plugin.xml
+++ b/src/plugins/nodejs/plugin.xml
@@ -2,14 +2,14 @@
 <plugin>
     <author>igniterealtime.org</author>
     <class>org.ifsoft.nodejs.openfire.PluginImpl</class>
-    <name>NodeJs</name>
-    <description>Integrates NodeJs Applications with Openfire.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <licenseType>Apache 2.0</licenseType>
     <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
 
-   <adminconsole>
+    <adminconsole>
         <tab id="tab-server">
             <sidebar id="siderbar-nodejs"
                      name="${plugin.title}">
@@ -19,5 +19,5 @@
                       url="nodejs.jsp"/>
             </sidebar>
         </tab>
-    </adminconsole> 
+    </adminconsole>
 </plugin>

--- a/src/plugins/nonSaslAuthentication/plugin.xml
+++ b/src/plugins/nonSaslAuthentication/plugin.xml
@@ -5,7 +5,7 @@
     <name>Non-SASL Authentication</name>
     <description>This plugin implements a the (obsolete!) XEP-0078 specification for authentication using the jabber:iq:auth namespace.</description>
     <author>Guus der Kinderen</author>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.1.0 Alpha</minServerVersion>
 </plugin>

--- a/src/plugins/nonSaslAuthentication/plugin.xml
+++ b/src/plugins/nonSaslAuthentication/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.NonSaslAuthenticationPlugin</class>
-    <name>Non-SASL Authentication</name>
-    <description>This plugin implements a the (obsolete!) XEP-0078 specification for authentication using the jabber:iq:auth namespace.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
     <date>tbc.</date>

--- a/src/plugins/packetFilter/plugin.xml
+++ b/src/plugins/packetFilter/plugin.xml
@@ -2,10 +2,8 @@
 <plugin>
     <!-- Main plugin class -->
     <class>org.jivesoftware.openfire.plugin.PacketFilterPlugin</class>
-
-
-    <name>Packet Filter</name>
-    <description>Rules to enforce ethical communication</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Nate Putnam</author>
     <version>${project.version}</version>
     <date>tbc.</date>
@@ -19,9 +17,9 @@
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">
                 <item id="packetFilter" name="${pf.summary.title}"
-                    url="pf-main.jsp"
-                    description="${pf.summary.title}" />
+                      url="pf-main.jsp"
+                      description="${pf.summary.title}"/>
             </sidebar>
-         </tab>
+        </tab>
     </adminconsole>
 </plugin>

--- a/src/plugins/packetFilter/plugin.xml
+++ b/src/plugins/packetFilter/plugin.xml
@@ -7,7 +7,7 @@
     <name>Packet Filter</name>
     <description>Rules to enforce ethical communication</description>
     <author>Nate Putnam</author>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>packetfilter</databaseKey>

--- a/src/plugins/presence/plugin.xml
+++ b/src/plugins/presence/plugin.xml
@@ -2,18 +2,18 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.PresencePlugin</class>
-    <name>Presence Service</name>
-    <description>Exposes presence information through HTTP.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Jive Software</author>
     <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
-    
-    <adminconsole>		
+
+    <adminconsole>
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">
                 <item id="presence-service" name="Presence Service" url="presence-service.jsp"
-                     description="Click to manage the service that exposes presence information" />
+                      description="Click to manage the service that exposes presence information"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/presence/plugin.xml
+++ b/src/plugins/presence/plugin.xml
@@ -5,7 +5,7 @@
     <name>Presence Service</name>
     <description>Exposes presence information through HTTP.</description>
     <author>Jive Software</author>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     

--- a/src/plugins/rayo/plugin.xml
+++ b/src/plugins/rayo/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin>
     <class>org.ifsoft.rayo.RayoPlugin</class>
-    <name>Rayo Plugin</name>
-    <description>Provides support for XEP-0327</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Ignite Realtime Community</author>
     <version>${project.version}</version>
     <date>10/12/2015</date>
@@ -12,7 +12,8 @@
     <adminconsole>
         <tab id="tab-rayo" name="Rayo" url="rayo.jsp" description="${admin.item.rayo.description}">
             <sidebar id="siderbar-rayo" name="${admin.item.rayo.settings}">
-                <item id="rayo" name="${admin.item.rayo.settings.name}" description="${admin.item.rayo.settings.description}" url="rayo.jsp"/>
+                <item id="rayo" name="${admin.item.rayo.settings.name}"
+                      description="${admin.item.rayo.settings.description}" url="rayo.jsp"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/rayo/plugin.xml
+++ b/src/plugins/rayo/plugin.xml
@@ -5,7 +5,7 @@
     <name>Rayo Plugin</name>
     <description>Provides support for XEP-0327</description>
     <author>Ignite Realtime Community</author>
-    <version>0.1.0</version>
+    <version>${project.version}</version>
     <date>10/12/2015</date>
     <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/registration/plugin.xml
+++ b/src/plugins/registration/plugin.xml
@@ -5,7 +5,7 @@
     <name>Registration</name>
     <description>Performs various actions whenever a new user account is created.</description>
     <author>Ryan Graham</author>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     

--- a/src/plugins/registration/plugin.xml
+++ b/src/plugins/registration/plugin.xml
@@ -2,19 +2,19 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.RegistrationPlugin</class>
-    <name>Registration</name>
-    <description>Performs various actions whenever a new user account is created.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Ryan Graham</author>
     <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
-    
+
     <adminconsole>
         <tab id="tab-users">
             <sidebar id="sidebar-users">
                 <item id="registration-props-form" name="Registration Properties"
-                        url="registration-props-form.jsp"
-                        description="User Registration" />
+                      url="registration-props-form.jsp"
+                      description="User Registration"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/restAPI/plugin.xml
+++ b/src/plugins/restAPI/plugin.xml
@@ -2,8 +2,8 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.rest.RESTServicePlugin</class>
-    <name>REST API</name>
-    <description>Allows administration over a RESTful API.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
     <date>tbc.</date>
@@ -12,7 +12,7 @@
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">
                 <item id="rest-api" name="REST API" url="rest-api.jsp"
-                     description="Click to manage the service that allows to configure the Openfire over a RESTFul API" />
+                      description="Click to manage the service that allows to configure the Openfire over a RESTFul API"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/restAPI/plugin.xml
+++ b/src/plugins/restAPI/plugin.xml
@@ -5,7 +5,7 @@
     <name>REST API</name>
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
-    <version>1.3.4-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.1.0</minServerVersion>
     <adminconsole>

--- a/src/plugins/search/plugin.xml
+++ b/src/plugins/search/plugin.xml
@@ -5,7 +5,7 @@
     <name>Search</name>
     <description>Provides support for Jabber Search (XEP-0055)</description>
     <author>Ryan Graham</author>
-    <version>1.7.1</version>
+    <version>${project.version}</version>
     <date>07/24/2016</date>
     <minServerVersion>4.0.0</minServerVersion>
     

--- a/src/plugins/search/plugin.xml
+++ b/src/plugins/search/plugin.xml
@@ -2,26 +2,26 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.SearchPlugin</class>
-    <name>Search</name>
-    <description>Provides support for Jabber Search (XEP-0055)</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Ryan Graham</author>
     <version>${project.version}</version>
     <date>07/24/2016</date>
     <minServerVersion>4.0.0</minServerVersion>
-    
+
     <adminconsole>
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">
                 <item id="search-props-edit-form" name="${search.props.edit.form.title}"
-                    url="search-props-edit-form.jsp"
-                    description="${search.props.edit.form.description}" />
+                      url="search-props-edit-form.jsp"
+                      description="${search.props.edit.form.description}"/>
             </sidebar>
         </tab>
         <tab id="tab-users">
             <sidebar id="sidebar-users">
                 <item id="advance-user-search" name="${advance.user.search.title}"
-                    url="advance-user-search.jsp"
-                    description="${advance.user.search.description}" />
+                      url="advance-user-search.jsp"
+                      description="${advance.user.search.description}"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/sip/plugin.xml
+++ b/src/plugins/sip/plugin.xml
@@ -2,21 +2,24 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.sip.SipManager</class>
-    <name>SIP Phone Plugin</name>
-    <description>Provides support for SIP account management</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
     <date>10/12/2015</date>
     <databaseKey>sip</databaseKey>
     <databaseVersion>2</databaseVersion>
     <minServerVersion>4.0.0</minServerVersion>
-    
+
     <adminconsole>
         <tab id="tab-server">
             <sidebar id="siderbar-sip" name="${admin.item.sipark}">
-                <item id="sipark-user-summary" name="${admin.item.sipark.user.name}" description="${admin.item.sipark.user.description}" url="sipark-user-summary.jsp"/>
-                <item id="sipark-settings" name="${admin.item.sipark.settings.name}" description="${admin.item.sipark.settings.description}" url="sipark-settings.jsp"/>
-                <item id="sipark-log-summary" name="${admin.item.sipark.calls.name}" description="${admin.item.sipark.calls.description}" url="sipark-log-summary.jsp"/>
+                <item id="sipark-user-summary" name="${admin.item.sipark.user.name}"
+                      description="${admin.item.sipark.user.description}" url="sipark-user-summary.jsp"/>
+                <item id="sipark-settings" name="${admin.item.sipark.settings.name}"
+                      description="${admin.item.sipark.settings.description}" url="sipark-settings.jsp"/>
+                <item id="sipark-log-summary" name="${admin.item.sipark.calls.name}"
+                      description="${admin.item.sipark.calls.description}" url="sipark-log-summary.jsp"/>
             </sidebar>
 
         </tab>

--- a/src/plugins/sip/plugin.xml
+++ b/src/plugins/sip/plugin.xml
@@ -5,7 +5,7 @@
     <name>SIP Phone Plugin</name>
     <description>Provides support for SIP account management</description>
     <author>Ignite Realtime</author>
-    <version>1.2.0</version>
+    <version>${project.version}</version>
     <date>10/12/2015</date>
     <databaseKey>sip</databaseKey>
     <databaseVersion>2</databaseVersion>

--- a/src/plugins/stunserver/plugin.xml
+++ b/src/plugins/stunserver/plugin.xml
@@ -5,7 +5,7 @@
     <name>STUN server plugin</name>
     <description>Adds STUN functionality to Openfire</description>
     <author>Ignite Realtime</author>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     

--- a/src/plugins/stunserver/plugin.xml
+++ b/src/plugins/stunserver/plugin.xml
@@ -2,13 +2,13 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.stun.STUNService</class>
-    <name>STUN server plugin</name>
-    <description>Adds STUN functionality to Openfire</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
-    
+
     <adminconsole>
         <tab id="sidebar-media-services">
             <item id="stun-settings" name="${sidebar.stun}"

--- a/src/plugins/subscription/plugin.xml
+++ b/src/plugins/subscription/plugin.xml
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin>
-   <class>org.jivesoftware.openfire.plugin.SubscriptionPlugin</class>
+    <class>org.jivesoftware.openfire.plugin.SubscriptionPlugin</class>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
+    <author>Ryan Graham</author>
+    <version>${project.version}</version>
+    <date>tbc.</date>
+    <url>http://www.igniterealtime.org</url>
+    <minServerVersion>4.0.0</minServerVersion>
 
-   <name>Subscription</name>
-   <description>Automatically accepts or rejects subscription requests</description>
-   <author>Ryan Graham</author>
-   <version>${project.version}</version>
-   <date>tbc.</date>
-   <url>http://www.igniterealtime.org</url>
-   <minServerVersion>4.0.0</minServerVersion>
-
-   <adminconsole>
-      <tab id="tab-server">
-         <sidebar id="sidebar-server-settings">
-            <item id="subscription-plugin-properties" 
-                  name="Subscription Properties" 
-                  url="subscription-plugin-properties.jsp" 
-                  description="Edit subscription plugin properties" />
-         </sidebar>
-      </tab>
-   </adminconsole>
+    <adminconsole>
+        <tab id="tab-server">
+            <sidebar id="sidebar-server-settings">
+                <item id="subscription-plugin-properties"
+                      name="Subscription Properties"
+                      url="subscription-plugin-properties.jsp"
+                      description="Edit subscription plugin properties"/>
+            </sidebar>
+        </tab>
+    </adminconsole>
 </plugin>

--- a/src/plugins/subscription/plugin.xml
+++ b/src/plugins/subscription/plugin.xml
@@ -5,7 +5,7 @@
    <name>Subscription</name>
    <description>Automatically accepts or rejects subscription requests</description>
    <author>Ryan Graham</author>
-   <version>1.4.1-SNAPSHOT</version>
+   <version>${project.version}</version>
    <date>tbc.</date>
    <url>http://www.igniterealtime.org</url>
    <minServerVersion>4.0.0</minServerVersion>

--- a/src/plugins/tikitoken/plugin.xml
+++ b/src/plugins/tikitoken/plugin.xml
@@ -1,7 +1,7 @@
 <plugin>
     <class>org.tiki.tikitoken.TikiTokenPlugin</class>
-    <name>TikiToken</name>
-    <description>Allows users to authenticate with a Tiki token.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Tiki Wiki CMS Groupware</author>
     <version>${project.version}</version>
     <date>04/24/2017</date>

--- a/src/plugins/tikitoken/plugin.xml
+++ b/src/plugins/tikitoken/plugin.xml
@@ -3,7 +3,7 @@
     <name>TikiToken</name>
     <description>Allows users to authenticate with a Tiki token.</description>
     <author>Tiki Wiki CMS Groupware</author>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>04/24/2017</date>
     <url>https://dev.tiki.org/OpenFire</url>
     <minServerVersion>4.1.3</minServerVersion>

--- a/src/plugins/userCreation/plugin.xml
+++ b/src/plugins/userCreation/plugin.xml
@@ -8,7 +8,7 @@
     <name>User Creation</name>
     <description>Creates users and populates rosters.</description>
     <author>Jive Software</author>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <url>http://www.igniterealtime.org</url>
     <minServerVersion>4.3.0</minServerVersion>

--- a/src/plugins/userCreation/plugin.xml
+++ b/src/plugins/userCreation/plugin.xml
@@ -5,8 +5,8 @@
 -->
 <plugin>
     <class>org.jivesoftware.openfire.plugin.UserCreationPlugin</class>
-    <name>User Creation</name>
-    <description>Creates users and populates rosters.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Jive Software</author>
     <version>${project.version}</version>
     <date>tbc.</date>
@@ -17,8 +17,8 @@
         <tab id="tab-users">
             <sidebar id="sidebar-users">
                 <item id="users-creation" name="Users Creation"
-                    url="users-creation.jsp"
-                    description="Quickly create users and populate their rosters" />
+                      url="users-creation.jsp"
+                      description="Quickly create users and populate their rosters"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/userImportExport/plugin.xml
+++ b/src/plugins/userImportExport/plugin.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin>
-   <class>org.jivesoftware.openfire.plugin.ImportExportPlugin</class>
+    <class>org.jivesoftware.openfire.plugin.ImportExportPlugin</class>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
+    <author>Ryan Graham</author>
+    <version>${project.version}</version>
+    <date>tbc.</date>
+    <minServerVersion>4.0.0</minServerVersion>
 
-   <name>User Import Export</name>
-   <description>Enables import and export of user data</description>
-   <author>Ryan Graham</author>
-   <version>${project.version}</version>
-   <date>tbc.</date>
-   <minServerVersion>4.0.0</minServerVersion>
-
-   <adminconsole>
-      <tab id="tab-users">
-         <sidebar id="user-import-export" name="Import &amp; Export">
-            <item id="import-export-selection" name="User Import &amp; Export"
-                  url="import-export-selection.jsp"
-                  description="Allows the importing and exporting of Openfire user data." />
-         </sidebar>
-      </tab>
-   </adminconsole>
+    <adminconsole>
+        <tab id="tab-users">
+            <sidebar id="user-import-export" name="Import &amp; Export">
+                <item id="import-export-selection" name="User Import &amp; Export"
+                      url="import-export-selection.jsp"
+                      description="Allows the importing and exporting of Openfire user data."/>
+            </sidebar>
+        </tab>
+    </adminconsole>
 </plugin>

--- a/src/plugins/userImportExport/plugin.xml
+++ b/src/plugins/userImportExport/plugin.xml
@@ -6,7 +6,7 @@
    <name>User Import Export</name>
    <description>Enables import and export of user data</description>
    <author>Ryan Graham</author>
-   <version>2.6.3-SNAPSHOT</version>
+   <version>${project.version}</version>
    <date>tbc.</date>
    <minServerVersion>4.0.0</minServerVersion>
 

--- a/src/plugins/userStatus/plugin.xml
+++ b/src/plugins/userStatus/plugin.xml
@@ -8,7 +8,7 @@
     <name>User Status Plugin</name>
     <description>Openfire plugin to save the user status to the database.</description>
     <author>Stefan Reuter</author>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>tbc.</date>
     <minServerVersion>4.0.0</minServerVersion>
     <databaseKey>user-status</databaseKey>

--- a/src/plugins/userStatus/plugin.xml
+++ b/src/plugins/userStatus/plugin.xml
@@ -3,10 +3,10 @@
 
     <!-- Main plugin class -->
     <class>com.reucon.openfire.plugins.userstatus.UserStatusPlugin</class>
-    
+
     <!-- Plugin meta-data -->
-    <name>User Status Plugin</name>
-    <description>Openfire plugin to save the user status to the database.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Stefan Reuter</author>
     <version>${project.version}</version>
     <date>tbc.</date>
@@ -14,14 +14,14 @@
     <databaseKey>user-status</databaseKey>
     <databaseVersion>0</databaseVersion>
     <licenseType>gpl</licenseType>
-    
+
     <!-- Admin console meta-data -->
-    <adminconsole>              
+    <adminconsole>
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">
-               <item id="user-status-settings" name="${user-status.settings.title}"
-                   url="user-status-settings.jsp"
-                   description="${user-status.settings.description}" />
+                <item id="user-status-settings" name="${user-status.settings.title}"
+                      url="user-status-settings.jsp"
+                      description="${user-status.settings.description}"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/userservice/plugin.xml
+++ b/src/plugins/userservice/plugin.xml
@@ -2,18 +2,18 @@
 
 <plugin>
     <class>org.jivesoftware.openfire.plugin.UserServicePlugin</class>
-    <name>User Service</name>
-    <description>(Deprecated) Please use the REST API Plugin. Allows administration of users via HTTP requests.</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Roman Soldatow, Justin Hunt</author>
     <version>${project.version}</version>
     <date>10/12/2015</date>
     <minServerVersion>4.0.0</minServerVersion>
-    
-    <adminconsole>		
+
+    <adminconsole>
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">
                 <item id="user-service" name="User Service" url="user-service.jsp"
-                     description="Click to manage the service that allows remote admin of users" />
+                      description="Click to manage the service that allows remote admin of users"/>
             </sidebar>
         </tab>
     </adminconsole>

--- a/src/plugins/userservice/plugin.xml
+++ b/src/plugins/userservice/plugin.xml
@@ -5,7 +5,7 @@
     <name>User Service</name>
     <description>(Deprecated) Please use the REST API Plugin. Allows administration of users via HTTP requests.</description>
     <author>Roman Soldatow, Justin Hunt</author>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>${project.version}</version>
     <date>10/12/2015</date>
     <minServerVersion>4.0.0</minServerVersion>
     

--- a/src/plugins/xmldebugger/plugin.xml
+++ b/src/plugins/xmldebugger/plugin.xml
@@ -8,7 +8,7 @@
     <name>Debugger Plugin</name>
     <description>Prints XML traffic to the stdout (raw and interpreted XML)</description>
     <author>Jive Software</author>
-    <version>1.7.1</version>
+    <version>${project.version}</version>
     <date>07/11/2018</date>
     <minServerVersion>4.0.0</minServerVersion>
     <minJavaVersion>1.7</minJavaVersion>

--- a/src/plugins/xmldebugger/plugin.xml
+++ b/src/plugins/xmldebugger/plugin.xml
@@ -5,22 +5,22 @@
 -->
 <plugin>
     <class>org.jivesoftware.openfire.plugin.DebuggerPlugin</class>
-    <name>Debugger Plugin</name>
-    <description>Prints XML traffic to the stdout (raw and interpreted XML)</description>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
     <author>Jive Software</author>
     <version>${project.version}</version>
     <date>07/11/2018</date>
     <minServerVersion>4.0.0</minServerVersion>
     <minJavaVersion>1.7</minJavaVersion>
 
-   <adminconsole>
-      <tab id="tab-server">
-         <sidebar id="sidebar-server-settings">
-            <item id="debugger-conf"
-                  name="Debugger Properties"
-                  url="debugger-conf.jsp"
-                  description="Edit debugger plugin properties" />
-         </sidebar>
-      </tab>
-   </adminconsole>
+    <adminconsole>
+        <tab id="tab-server">
+            <sidebar id="sidebar-server-settings">
+                <item id="debugger-conf"
+                      name="Debugger Properties"
+                      url="debugger-conf.jsp"
+                      description="Edit debugger plugin properties"/>
+            </sidebar>
+        </tab>
+    </adminconsole>
 </plugin>


### PR DESCRIPTION
During recent changes to various plugin.xml files for the plugins, it became clear that the plugin versions in plugin.xml did not necessarily match the plugin version in the pom.xml

Maven to the rescue - we already had the hooks in place to edit the pom.xml when the .jar file was created, it was simply a case of editing the plugin.xml appropriately. Now the plugin.xml and pom.xml have identical versions.