### PR TITLE
OF-1581: Use latest presence info when syncing MUC join status

### DIFF
--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -680,6 +680,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             } else {
                 // Grab the existing one.
                 joinRole = (LocalMUCRole) occupantsByFullJID.get(user.getAddress());
+                joinRole.setPresence( presence ); // OF-1581: Use latest presence information.
            }
         }
         finally {


### PR DESCRIPTION
When a participant joins a MUC that it already is in (eg: a client state sync issue), Openfire should use the presence information from the latest join, not the original one.