### PR TITLE
OF-1547: Avoid ConcurrentModificationExceptions with PluginMetadata

### DIFF
--- a/src/java/org/jivesoftware/database/SchemaManager.java
+++ b/src/java/org/jivesoftware/database/SchemaManager.java
@@ -35,6 +35,7 @@ import org.jivesoftware.database.bugfix.OF33;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
+import org.jivesoftware.openfire.container.PluginMetadataHelper;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.LocaleUtils;
 import org.slf4j.Logger;
@@ -115,8 +116,8 @@ public class SchemaManager {
      */
     public boolean checkPluginSchema(final Plugin plugin) {
         final PluginManager pluginManager = XMPPServer.getInstance().getPluginManager();
-        String schemaKey = pluginManager.getDatabaseKey(plugin);
-        int schemaVersion = pluginManager.getDatabaseVersion(plugin);
+        String schemaKey = PluginMetadataHelper.getDatabaseKey(plugin);
+        int schemaVersion = PluginMetadataHelper.getDatabaseVersion(plugin);
         // If the schema key or database version aren't defined, then the plugin doesn't
         // need database tables.
         if (schemaKey == null || schemaVersion == -1) {
@@ -128,7 +129,7 @@ public class SchemaManager {
             return checkSchema(con, schemaKey, schemaVersion, new ResourceLoader() {
                 @Override
                 public InputStream loadResource(String resourceName) {
-                    File file = new File(pluginManager.getPluginDirectory(plugin) +
+                    File file = new File(pluginManager.getPluginPath(plugin) +
                             File.separator + "database", resourceName);
                     try {
                         return new FileInputStream(file);

--- a/src/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/src/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -92,7 +92,7 @@ public class PluginManager
     /**
      * Plugin metadata for all extracted plugins, mapped by canonical name.
      */
-    private final Map<String, PluginMetadata> pluginMetadata = new TreeMap<>( String.CASE_INSENSITIVE_ORDER );
+    private final Map<String, PluginMetadata> pluginMetadata = Collections.synchronizedMap(new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
 
     private final Map<Plugin, PluginDevEnvironment> pluginDevelopment = new HashMap<>();
     private final Map<Plugin, List<String>> parentPluginMap = new HashMap<>();
@@ -296,7 +296,12 @@ public class PluginManager
      */
     public Map<String, PluginMetadata> getMetadataExtractedPlugins()
     {
-        return Collections.unmodifiableMap( this.pluginMetadata );
+        // Create a copy of the TreeMap to avoid ConcurrentModificationExceptions
+        // Note; needs to be synchronized as creating the copy iterates over the elements
+        // See https://docs.oracle.com/javase/8/docs/api/java/util/Collections.html#synchronizedMap-java.util.Map-
+        synchronized (this.pluginMetadata) {
+            return Collections.unmodifiableMap(new TreeMap<>(this.pluginMetadata));
+        }
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/src/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -195,11 +195,11 @@ public class PluginManager
             Files.copy( in, partFile, StandardCopyOption.REPLACE_EXISTING );
 
             // Check if zip file, else ZipException caught below.
-            try (JarFile file = new JarFile(partFile.toFile())) {
+            try (JarFile ignored = new JarFile(partFile.toFile())) {
             } catch (ZipException e) {
                 Files.deleteIfExists(partFile);
                 throw e;
-            };
+            }
 
             // Rename temp file to .jar
             Files.move( partFile, absolutePath, StandardCopyOption.REPLACE_EXISTING );
@@ -230,8 +230,7 @@ public class PluginManager
         final DirectoryStream.Filter<Path> filter = new DirectoryStream.Filter<Path>()
         {
             @Override
-            public boolean accept( Path entry ) throws IOException
-            {
+            public boolean accept( Path entry ) {
                 final String name = entry.getFileName().toString();
                 return Files.exists( entry ) && !Files.isDirectory( entry ) &&
                         ( name.equalsIgnoreCase( canonicalName + ".jar" ) || name.equalsIgnoreCase( canonicalName + ".war" ) );
@@ -327,7 +326,7 @@ public class PluginManager
      */
     public Collection<Plugin> getPlugins()
     {
-        return Collections.unmodifiableCollection( Arrays.asList( pluginsLoaded.values().toArray( new Plugin[ pluginsLoaded.size() ] ) ) );
+        return Collections.unmodifiableCollection( Arrays.asList( pluginsLoaded.values().toArray(new Plugin[0]) ) );
     }
 
     /**
@@ -732,8 +731,7 @@ public class PluginManager
         try ( final DirectoryStream<Path> ds = Files.newDirectoryStream( getPluginsDirectory(), new DirectoryStream.Filter<Path>()
         {
             @Override
-            public boolean accept( final Path path ) throws IOException
-            {
+            public boolean accept( final Path path ) {
                 if ( Files.isDirectory( path ) )
                 {
                     return false;
@@ -824,7 +822,7 @@ public class PluginManager
             // See if any child plugins are defined.
             if ( parentPluginMap.containsKey( plugin ) )
             {
-                String[] childPlugins = parentPluginMap.get( plugin ).toArray( new String[ parentPluginMap.get( plugin ).size() ] );
+                String[] childPlugins = parentPluginMap.get( plugin ).toArray(new String[0]);
                 for ( String childPlugin : childPlugins )
                 {
                     Log.debug( "Unloading child plugin: '{}'.", childPlugin );
@@ -953,12 +951,8 @@ public class PluginManager
      * @param className the name of the class to load.
      * @return the class.
      * @throws ClassNotFoundException if the class was not found.
-     * @throws IllegalAccessException if not allowed to access the class.
-     * @throws InstantiationException if the class could not be created.
      */
-    public Class loadClass( Plugin plugin, String className ) throws ClassNotFoundException,
-            IllegalAccessException, InstantiationException
-    {
+    public Class loadClass( Plugin plugin, String className ) throws ClassNotFoundException {
         PluginClassLoader loader = classloaders.get( plugin );
         return loader.loadClass( className );
     }

--- a/src/java/org/jivesoftware/openfire/container/PluginServlet.java
+++ b/src/java/org/jivesoftware/openfire/container/PluginServlet.java
@@ -331,7 +331,7 @@ public class PluginServlet extends HttpServlet {
             Plugin plugin, GenericServlet servlet, String relativeUrl)
             throws ServletException {
 
-        String pluginName = pluginManager.getPluginDirectory(plugin).getName();
+        String pluginName = pluginManager.getPluginPath(plugin).getFileName().toString();
         PluginServlet.pluginManager = pluginManager;
         if (servlet == null) {
             throw new ServletException("Servlet is missing");
@@ -352,7 +352,7 @@ public class PluginServlet extends HttpServlet {
      */
     public static GenericServlet unregisterServlet(Plugin plugin, String url)
             throws ServletException {
-        String pluginName = pluginManager.getPluginDirectory(plugin).getName();
+        String pluginName = pluginManager.getPluginPath(plugin).getFileName().toString();
         if (url == null) {
             throw new ServletException("Servlet URL is missing");
         }
@@ -542,7 +542,7 @@ public class PluginServlet extends HttpServlet {
                 return false;
             }
 
-            File pluginDirectory = pluginManager.getPluginDirectory(plugin);
+            File pluginDirectory = pluginManager.getPluginPath(plugin).toFile();
 
             File compilationDir = new File(pluginDirectory, "classes");
             compilationDir.mkdirs();
@@ -604,7 +604,7 @@ public class PluginServlet extends HttpServlet {
     private static String getClasspathForPlugin(Plugin plugin) {
         final StringBuilder classpath = new StringBuilder();
 
-        File pluginDirectory = pluginManager.getPluginDirectory(plugin);
+        File pluginDirectory = pluginManager.getPluginPath(plugin).toFile();
 
         PluginDevEnvironment pluginEnv = pluginManager.getDevEnvironment(plugin);
 

--- a/src/java/org/jivesoftware/openfire/container/PluginServletContext.java
+++ b/src/java/org/jivesoftware/openfire/container/PluginServletContext.java
@@ -108,7 +108,7 @@ public class PluginServletContext implements ServletContext
     @Override
     public Set<String> getResourcePaths( String s )
     {
-        final String pluginPath = "/plugins/" + pluginManager.getName( plugin ) + "/";
+        final String pluginPath = "/plugins/" + PluginMetadataHelper.getName(plugin) + "/";
         final Set<String> proxyResults = proxy.getResourcePaths( pluginPath + s );
         final Set<String> results = new HashSet<>();
         for ( final String proxyResult : proxyResults )

--- a/src/plugins/broadcast/plugin.xml
+++ b/src/plugins/broadcast/plugin.xml
@@ -11,5 +11,5 @@
     <version>${project.version}</version>
     <date>tbc.</date>
     <url>http://www.igniterealtime.org</url>
-    <minServerVersion>4.0.0</minServerVersion>
+    <minServerVersion>4.1.1</minServerVersion>
 </plugin>

--- a/src/plugins/broadcast/src/java/org/jivesoftware/openfire/plugin/BroadcastPlugin.java
+++ b/src/plugins/broadcast/src/java/org/jivesoftware/openfire/plugin/BroadcastPlugin.java
@@ -29,6 +29,7 @@ import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
+import org.jivesoftware.openfire.container.PluginMetadataHelper;
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.group.GroupManager;
 import org.jivesoftware.openfire.group.GroupNotFoundException;
@@ -140,12 +141,12 @@ public class BroadcastPlugin implements Plugin, Component, PropertyEventListener
 
     public String getName() {
         // Get the name from the plugin.xml file.
-        return pluginManager.getName(this);
+        return PluginMetadataHelper.getName(this);
     }
 
     public String getDescription() {
         // Get the description from the plugin.xml file.
-        return pluginManager.getDescription(this);
+        return PluginMetadataHelper.getDescription(this);
     }
 
     public void processPacket(Packet packet) {

--- a/src/plugins/fastpath/plugin.xml
+++ b/src/plugins/fastpath/plugin.xml
@@ -7,7 +7,7 @@
     <author>Jive Software</author>
     <version>${project.version}</version>
     <date>tbc.</date>
-    <minServerVersion>4.1.0</minServerVersion>
+    <minServerVersion>4.1.1</minServerVersion>
     <databaseKey>fastpath</databaseKey>
     <databaseVersion>0</databaseVersion>
     

--- a/src/plugins/fastpath/src/java/org/jivesoftware/openfire/fastpath/settings/chat/ChatSettingsCreator.java
+++ b/src/plugins/fastpath/src/java/org/jivesoftware/openfire/fastpath/settings/chat/ChatSettingsCreator.java
@@ -227,7 +227,7 @@ public class ChatSettingsCreator {
     private void createImageSettings(JID workgroupJID) {
         PluginManager pluginManager = XMPPServer.getInstance().getPluginManager();
         Plugin fastpathPlugin = pluginManager.getPlugin("fastpath");
-        File fastpathPluginDirectory = pluginManager.getPluginDirectory(fastpathPlugin);
+        File fastpathPluginDirectory = pluginManager.getPluginPath(fastpathPlugin).toFile();
 
         File imagesDir = new File(fastpathPluginDirectory, "web/images");
 

--- a/src/plugins/presence/plugin.xml
+++ b/src/plugins/presence/plugin.xml
@@ -7,7 +7,7 @@
     <author>Jive Software</author>
     <version>${project.version}</version>
     <date>tbc.</date>
-    <minServerVersion>4.0.0</minServerVersion>
+    <minServerVersion>4.1.1</minServerVersion>
     
     <adminconsole>		
         <tab id="tab-server">

--- a/src/plugins/presence/src/java/org/jivesoftware/openfire/plugin/PresencePlugin.java
+++ b/src/plugins/presence/src/java/org/jivesoftware/openfire/plugin/PresencePlugin.java
@@ -24,6 +24,7 @@ import org.jivesoftware.openfire.PresenceManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
+import org.jivesoftware.openfire.container.PluginMetadataHelper;
 import org.jivesoftware.openfire.user.User;
 import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.openfire.user.UserNotFoundException;
@@ -101,11 +102,11 @@ public class PresencePlugin implements Plugin, Component {
     }
 
     public String getName() {
-        return pluginManager.getName(this);
+        return PluginMetadataHelper.getName(this);
     }
 
     public String getDescription() {
-        return pluginManager.getDescription(this);
+        return PluginMetadataHelper.getDescription(this);
     }
 
     public void initialize(JID jid, ComponentManager componentManager) {

--- a/src/plugins/restAPI/plugin.xml
+++ b/src/plugins/restAPI/plugin.xml
@@ -7,7 +7,7 @@
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
     <date>tbc.</date>
-    <minServerVersion>4.1.0</minServerVersion>
+    <minServerVersion>4.1.1</minServerVersion>
     <adminconsole>
         <tab id="tab-server">
             <sidebar id="sidebar-server-settings">

--- a/src/plugins/restAPI/src/web/rest-api.jsp
+++ b/src/plugins/restAPI/src/web/rest-api.jsp
@@ -5,6 +5,7 @@
                 org.jivesoftware.openfire.container.Plugin,
                 org.jivesoftware.openfire.container.PluginManager"
     errorPage="error.jsp"%>
+<%@ page import="org.jivesoftware.openfire.container.PluginMetadataHelper" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
@@ -53,8 +54,8 @@
             plugin.setCustomAuthFiIterClassName(customAuthFilterClassName);
             
             if(is2Reload) {
-                String pluginName  = pluginManager.getName(plugin);
-                String pluginDir = pluginManager.getPluginDirectory(plugin).getName();
+                String pluginName  = PluginMetadataHelper.getName(plugin);
+                String pluginDir = pluginManager.getPluginPath(plugin).getFileName().toString();
                 pluginManager.reloadPlugin(pluginDir);
             
                 // Log the event

--- a/src/plugins/search/plugin.xml
+++ b/src/plugins/search/plugin.xml
@@ -7,7 +7,7 @@
     <author>Ryan Graham</author>
     <version>${project.version}</version>
     <date>07/24/2016</date>
-    <minServerVersion>4.0.0</minServerVersion>
+    <minServerVersion>4.1.1</minServerVersion>
     
     <adminconsole>
         <tab id="tab-server">

--- a/src/plugins/search/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
+++ b/src/plugins/search/src/java/org/jivesoftware/openfire/plugin/SearchPlugin.java
@@ -37,6 +37,7 @@ import org.dom4j.QName;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
+import org.jivesoftware.openfire.container.PluginMetadataHelper;
 import org.jivesoftware.openfire.disco.IQDiscoInfoHandler;
 import org.jivesoftware.openfire.disco.IQDiscoItemsHandler;
 import org.jivesoftware.openfire.group.Group;
@@ -142,7 +143,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * @see org.xmpp.component.Component#getName()
      */
     public String getName() {
-        return pluginManager.getName(this);
+        return PluginMetadataHelper.getName(this);
     }
 
     /*
@@ -151,7 +152,7 @@ public class SearchPlugin implements Component, Plugin, PropertyEventListener {
      * @see org.xmpp.component.Component#getDescription()
      */
     public String getDescription() {
-        return pluginManager.getDescription(this);
+        return PluginMetadataHelper.getDescription(this);
     }
 
     /*


### PR DESCRIPTION
I started by simply ensuring that access to PluginMetaData was properly synchronised (https://github.com/igniterealtime/Openfire/commit/98534aaaf1ddaef5640139f2f8a92a9e3bb67202) to fix OF-1547.

I then took some of the IntelliJ suggested improvements (https://github.com/igniterealtime/Openfire/commit/fe8d2095c30501538af97e24283ce450964e4072)

Finally, I replaced the use of the deprecated methods in PluginManager with their replacements - this also required setting MinServerVersion=4.1.1 in the respective pom.xml files (https://github.com/igniterealtime/Openfire/commit/ebdb44eb27388fe7f57f6db78db7706466b9041d) as that was when the replacements were introduced.