### PR TITLE
OF-1563: Ensure that stream management settings are not enabled on a new install

### DIFF
--- a/src/conf/openfire.xml
+++ b/src/conf/openfire.xml
@@ -34,25 +34,4 @@
     </network>
     -->
 
-    <!-- SPDY  Protocol is npn.
-        (note: npn does not work with Java 8)
-        add -Xbootclasspath/p:/OPENFIRE_HOME/lib/npn-boot.jar to .vmoptions file    -->
-
-    <!--
-    <spdy>
-        <protocol>npn</protocol>
-    </spdy>
-    -->
-
-    <!-- XEP-0198 properties -->
-    <stream>
-        <management>
-            <!-- Whether stream management is offered to clients by server. -->
-            <active>true</active>
-            <!-- Number of stanzas sent to client before a stream management
-                 acknowledgement request is made. -->
-            <requestFrequency>5</requestFrequency>
-        </management>
-    </stream>
-
 </jive>


### PR DESCRIPTION
I recently noticed that whilst the "enabled if no property is present" is correct set to false, on new installs the property is set to true.

I also removed the requestFrequency (which defaults to 5 anyway) and the now redundant, commented out SPDY settings.