### PR TITLE
OF-1563 (4.2.x): Ensure that stream management settings are not enabled on a new install

### DIFF
--- a/src/conf/openfire.xml
+++ b/src/conf/openfire.xml
@@ -44,15 +44,4 @@
     </spdy>
     -->
 
-    <!-- XEP-0198 properties -->
-    <stream>
-        <management>
-            <!-- Whether stream management is offered to clients by server. -->
-            <active>true</active>
-            <!-- Number of stanzas sent to client before a stream management
-                 acknowledgement request is made. -->
-            <requestFrequency>5</requestFrequency>
-        </management>
-    </stream>
-
 </jive>


### PR DESCRIPTION
I recently noticed that whilst the "enabled if no property is present" is correct set to false, on new installs the property is set to true.

I also removed the requestFrequency (which defaults to 5 anyway).