### PR TITLE
Revert "OF-1542: Apply filtering to the user summary page"

### DIFF
--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -2640,7 +2640,6 @@ user.search.search=Search
 user.summary.title=User Summary
 user.summary.deleted=User deleted successfully.
 user.summary.total_user=Total Users
-user.summary.filtered_user_count=Filtered Users
 user.summary.sorted=Sorted by Username
 user.summary.users_per_page=Users per page
 user.summary.created=Created


### PR DESCRIPTION
This reverts (most of) commit e1ee7a3c75b8110f921ae23b038d32cdd086d757.

The changes in the original commit caused all users to be obtained from
the user provider when looking at the user-summary page. For instances
with many users, this requires to much resources and takes to long to
complete.