### PR TITLE
OF-1528: Allow Java 8 to be used when compiling JSP pages

### DIFF
--- a/src/plugins/jingleNodes/pom.xml
+++ b/src/plugins/jingleNodes/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>jingleNodes</artifactId>

--- a/src/plugins/kraken/pom.xml
+++ b/src/plugins/kraken/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>kraken</artifactId>

--- a/src/plugins/pom.xml
+++ b/src/plugins/pom.xml
@@ -317,6 +317,8 @@
                                 <jspc>
                                     <package>org.jivesoftware.openfire.plugin.${plugin.name}</package>
                                 </jspc>
+                                <sourceVersion>1.8</sourceVersion>
+                                <targetVersion>1.8</targetVersion>
                             </configuration>
                         </execution>
                     </executions>

--- a/src/plugins/rayo/pom.xml
+++ b/src/plugins/rayo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>rayo</artifactId>

--- a/src/plugins/sip/pom.xml
+++ b/src/plugins/sip/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>sip</artifactId>

--- a/src/plugins/userImportExport/plugin.xml
+++ b/src/plugins/userImportExport/plugin.xml
@@ -8,7 +8,7 @@
    <author>Ryan Graham</author>
    <version>${project.version}</version>
    <date>tbc.</date>
-   <minServerVersion>4.0.0</minServerVersion>
+   <minServerVersion>4.3.0</minServerVersion>
 
    <adminconsole>
       <tab id="tab-users">

--- a/src/web/pubsub-node-summary.jsp
+++ b/src/web/pubsub-node-summary.jsp
@@ -59,54 +59,29 @@
     if ( pubSubServiceInfo != null )
     {
         nodes = pubSubServiceInfo.getLeafNodes();
+        nodes.sort(Comparator.comparing(node -> node.getNodeID().toLowerCase()));
     }
     else
     {
         nodes = Collections.emptyList();
     }
 
-    Collections.sort(nodes, new Comparator<Node>() {
-        public int compare(Node node1, Node node2) {
-            return node1.getNodeID().toLowerCase().compareTo(node2.getNodeID().toLowerCase());
-        }
-    });
-
     // By default, display all nodes
-    Predicate<Node> filter = new Predicate<Node>() {
-        @Override
-        public boolean test(final Node node) {
-            return true;
-        }
-    };
+    Predicate<Node> filter = node -> true;
     final String searchNodeId = ParamUtils.getStringParameter(request, "searchNodeId", "");
     if(!searchNodeId.trim().isEmpty()) {
         final String searchCriteria = searchNodeId.trim().toLowerCase();
-        filter = filter.and(new Predicate<Node>() {
-            @Override
-            public boolean test(final Node node) {
-                return node.getNodeID().toLowerCase().contains(searchCriteria);
-            }
-        });
+        filter = filter.and(node -> node.getNodeID().toLowerCase().contains(searchCriteria));
     }
     final String searchNodeName = ParamUtils.getStringParameter(request, "searchNodeName", "");
     if(!searchNodeName.trim().isEmpty()) {
         final String searchCriteria = searchNodeName.trim().toLowerCase();
-        filter = filter.and(new Predicate<Node>() {
-            @Override
-            public boolean test(final Node node) {
-                return node.getName().toLowerCase().contains(searchCriteria);
-            }
-        });
+        filter = filter.and(node -> node.getName().toLowerCase().contains(searchCriteria));
     }
     final String searchNodeDescription = ParamUtils.getStringParameter(request, "searchNodeDescription", "");
     if(!searchNodeDescription.trim().isEmpty()) {
         final String searchCriteria = searchNodeDescription.trim().toLowerCase();
-        filter = filter.and(new Predicate<Node>() {
-            @Override
-            public boolean test(final Node node) {
-                return node.getDescription().toLowerCase().contains(searchCriteria);
-            }
-        });
+        filter = filter.and(node -> node.getDescription().toLowerCase().contains(searchCriteria));
     }
 
     final ListPager<Node> listPager = new ListPager<>(request, response, nodes, filter, "searchNodeId", "searchNodeName", "searchNodeDescription");

--- a/webadmin/pom.xml
+++ b/webadmin/pom.xml
@@ -48,6 +48,8 @@
                             <jspc>
                                 <package>org.jivesoftware.openfire.admin</package>
                             </jspc>
+                            <sourceVersion>1.8</sourceVersion>
+                            <targetVersion>1.8</targetVersion>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This is a re-work of https://github.com/igniterealtime/Openfire/pull/1080

My poor git skills, coupled with a fairly significant amount of change in master, meant it was easier for me to do this in  a a new branch.

Note; where possible, I'm made sure that plugins depend on the 4.2.0 parent - where they depend on 4.3.0-SNAPSHOT, I've made sure that they also specify a minServerVersion of 4.3.0 as changes in the Jetty compiler mean that a plugin compiled against 4.3.0 will not work with 4.2.x (though a plugin compiled against 4.2.0 will work on 4.3.0 unless there are 4.3.0 specifics in play).