### PR TITLE
OF-1590 Validate h against resumed session

### DIFF
--- a/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/src/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -274,7 +274,7 @@ public class StreamManager {
             sendError(new PacketError(PacketError.Condition.unexpected_request));
             return;
         }
-        if (!validateClientAcknowledgement(h)) {
+        if (!otherSession.getStreamManager().validateClientAcknowledgement(h)) {
             Log.debug("Not allowing a client to resume a session, as it reports it received more stanzas from us than that we've send it." );
             sendError(new PacketError(PacketError.Condition.unexpected_request));
             return;


### PR DESCRIPTION
The `<resume/>` element sent by the client during a XEP-0198 session
resumption contains an `h` attribute which is validated to ensure it
has not acknowledged more stanzas than were actually sent.

However, we were validating that against the current session, whose
counters would be disabled, and therefore left at zero. This simply
checks them against the correct session instead - the `otherSession`
which is to be resumed.