### PR TITLE
OF-1592: Be less verbose when VCard updates fail expectedly.

### DIFF
--- a/i18n/src/main/resources/openfire_i18n_en.properties
+++ b/i18n/src/main/resources/openfire_i18n_en.properties
@@ -3473,3 +3473,6 @@ system.dns.srv.check.label.priority=Priority
 system.dns.srv.check.label.weight=Weight
 system.dns.srv.check.recordbox.title=DNS SRV records
 system.dns.srv.check.recordbox.description=The table below lists all DNS SRV records for the XMPP domain that is services by this instance of Openfire. The first table contains all client-to-server records, the last table all server-to-server records.
+
+# vcard settings.
+vcard.read_only=The VCard provider is read-only.

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -2463,3 +2463,6 @@ connection-type.unspecified=unspecified
 connection-mode.plain=plain text (with STARTSSL)
 connection-mode.legacy=encrypted (legacy-mode)
 connection-mode.unspecified=unspecified
+
+# vcard settings.
+vcard.read_only=Het VCard beheer-systeem is in 'alleen-lezen' modus.

--- a/src/java/org/jivesoftware/openfire/handler/IQvCardHandler.java
+++ b/src/java/org/jivesoftware/openfire/handler/IQvCardHandler.java
@@ -96,7 +96,9 @@ public class IQvCardHandler extends IQHandler {
                         VCardManager.getInstance().setVCard( user.getUsername(), vcard );
                     } catch ( UnsupportedOperationException e ) {
                         Log.debug( "Entity '{}' tried to set VCard, but the configured VCard provider is read-only. An IQ error will be returned to sender.", packet.getFrom() );
-                        result.setChildElement( packet.getChildElement().createCopy() );
+                        // VCards can include binary data. Let's not echo that back in the error.
+                        // result.setChildElement( packet.getChildElement().createCopy() );
+
                         result.setError( PacketError.Condition.not_allowed );
 
                         Locale locale = JiveGlobals.getLocale(); // default to server locale.
@@ -109,7 +111,9 @@ public class IQvCardHandler extends IQHandler {
                 }
             }
             catch (UserNotFoundException e) {
-                result.setChildElement(packet.getChildElement().createCopy());
+                // VCards can include binary data. Let's not echo that back in the error.
+                // result.setChildElement( packet.getChildElement().createCopy() );
+
                 result.setError(PacketError.Condition.item_not_found);
             }
             catch (Exception e) {


### PR DESCRIPTION
When the VCard provider is read-only, there's no need to log a VCard update attempt
to the 'error' level. This commit reduces the log verbosity, and improves the error
sent back to the client.