### PR TITLE
OF-1548: Store the FQDN in the local config file

### DIFF
--- a/src/java/org/jivesoftware/database/bugfix/OF1515.java
+++ b/src/java/org/jivesoftware/database/bugfix/OF1515.java
@@ -115,7 +115,7 @@ public class OF1515
         String domain;
         try
         {
-            domain = JiveGlobals.getProperty( "xmpp.domain", JiveGlobals.getProperty( "xmpp.fqdn", InetAddress.getLocalHost().getCanonicalHostName() ) ).toLowerCase();
+            domain = JiveGlobals.getProperty( "xmpp.domain", JiveGlobals.getXMLProperty( "fqdn", InetAddress.getLocalHost().getCanonicalHostName() ) ).toLowerCase();
         }
         catch ( UnknownHostException e )
         {

--- a/src/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/src/java/org/jivesoftware/openfire/XMPPServer.java
@@ -89,11 +89,15 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimerTask;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -138,6 +142,7 @@ public class XMPPServer {
     private static final NodeID DEFAULT_NODE_ID = NodeID.getInstance(new byte[0]);
 
     public static final String EXIT = "exit";
+    private static Set<String> XML_ONLY_PROPERTIES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("fqdn")));
 
     /**
      * All modules loaded by this server
@@ -492,10 +497,12 @@ public class XMPPServer {
 
     private void finalSetupSteps() {
         for (String propName : JiveGlobals.getXMLPropertyNames()) {
-            if (JiveGlobals.getProperty(propName) == null) {
-                JiveGlobals.setProperty(propName, JiveGlobals.getXMLProperty(propName));
+            if (!XML_ONLY_PROPERTIES.contains(propName)) {
+                if (JiveGlobals.getProperty(propName) == null) {
+                    JiveGlobals.setProperty(propName, JiveGlobals.getXMLProperty(propName));
+                }
+                JiveGlobals.setPropertyEncrypted(propName, JiveGlobals.isXMLPropertyEncrypted(propName));
             }
-            JiveGlobals.setPropertyEncrypted(propName, JiveGlobals.isXMLPropertyEncrypted(propName));
         }
         // Set default SASL SCRAM-SHA-1 iteration count
         JiveGlobals.setProperty("sasl.scram-sha-1.iteration-count", Integer.toString(ScramUtils.DEFAULT_ITERATION_COUNT));

--- a/src/java/org/jivesoftware/openfire/spi/XMPPServerInfoImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/XMPPServerInfoImpl.java
@@ -58,7 +58,7 @@ public class XMPPServerInfoImpl implements XMPPServerInfo {
     @Override
     public String getHostname()
     {
-        final String fqdn = JiveGlobals.getProperty( "xmpp.fqdn" );
+        final String fqdn = JiveGlobals.getXMLProperty( "fqdn" );
         if ( fqdn != null && !fqdn.trim().isEmpty() )
         {
             return fqdn.trim().toLowerCase();
@@ -80,11 +80,11 @@ public class XMPPServerInfoImpl implements XMPPServerInfo {
     {
         if ( fqdn == null || fqdn.isEmpty() )
         {
-            JiveGlobals.deleteProperty( "xmpp.fqdn" );
+            JiveGlobals.deleteXMLProperty( "fqdn" );
         }
         else
         {
-            JiveGlobals.setProperty( "xmpp.fqdn", fqdn.toLowerCase() );
+            JiveGlobals.setXMLProperty( "fqdn", fqdn.toLowerCase() );
         }
     }
 

--- a/src/web/setup/setup-host-settings.jsp
+++ b/src/web/setup/setup-host-settings.jsp
@@ -88,7 +88,6 @@
             Map<String, String> xmppSettings = new HashMap<String, String>();
 
             xmppSettings.put("xmpp.domain", domain);
-            xmppSettings.put("xmpp.fqdn", fqdn);
             xmppSettings.put("xmpp.socket.ssl.active", "" + sslEnabled);
             xmppSettings.put("xmpp.auth.anonymous", "" + anonymousAuthentication);
             session.setAttribute("xmppSettings", xmppSettings);
@@ -96,6 +95,7 @@
             Map<String, String> xmlSettings = new HashMap<String, String>();
             xmlSettings.put("adminConsole.port", Integer.toString(embeddedPort));
             xmlSettings.put("adminConsole.securePort", Integer.toString(securePort));
+            xmlSettings.put("fqdn", fqdn);
             session.setAttribute("xmlSettings", xmlSettings);
 
             session.setAttribute("encryptedSettings", new HashSet<String>());
@@ -112,7 +112,7 @@
     // Load the current values:
     if (!doContinue) {
         domain = JiveGlobals.getXMLProperty("xmpp.domain");
-        fqdn = JiveGlobals.getXMLProperty("xmpp.fqdn");
+        fqdn = JiveGlobals.getXMLProperty("fqdn");
         embeddedPort = JiveGlobals.getXMLProperty("adminConsole.port", 9090);
         securePort = JiveGlobals.getXMLProperty("adminConsole.securePort", 9091);
         sslEnabled = JiveGlobals.getXMLProperty("xmpp.socket.ssl.active", true);


### PR DESCRIPTION
As it's host specific, the FQDN should be stored in the local to the host config file, rather than shared across all config files. 

A couple of comments;
a) I've introduce a set (currently only one entry) of XML properties that should not be copied to the database.
b) I've deliberately changed the property name from `xmpp.fqdn` to `fqdn` because it makes more sense within the context of config file as well as making searching for legacy uses easier
c) When upgrading from the previous version, the database version is only used in non-clustered deployments, otherwise the local host name (the old mechanism) is used.