### PR TITLE
OF-1479: Show the number of cache culls in the last three hours

### DIFF
--- a/i18n/src/main/resources/openfire_i18n_en.properties
+++ b/i18n/src/main/resources/openfire_i18n_en.properties
@@ -2985,6 +2985,7 @@ system.cache.head.effectiveness=Effectiveness*
 system.cache.desc.effectiveness=* Effectiveness measures how well your cache is working. If the \
     effectiveness is low, that usually means that the cache is too small. Caches for which this \
     may be the case are specially flagged.
+system.cache.head.culls=Cache culls in last
 system.cache.total=Total:
 system.cache.clear-selected=Clear Selected
 

--- a/src/java/org/jivesoftware/util/StringUtils.java
+++ b/src/java/org/jivesoftware/util/StringUtils.java
@@ -30,6 +30,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.text.BreakIterator;
 import java.text.MessageFormat;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -893,6 +894,16 @@ public final class StringUtils {
      * Returns a textual representation for the time that has elapsed.
      *
      * @param delta the elapsed time.
+     * @return textual representation for the time that has elapsed.
+     */
+    public static String getFullElapsedTime(final Duration delta) {
+        return getFullElapsedTime(delta.toMillis());
+    }
+
+    /**
+     * Returns a textual representation for the time that has elapsed.
+     *
+     * @param delta the elapsed time in milliseconds.
      * @return textual representation for the time that has elapsed.
      */
     public static String getElapsedTime(long delta) {


### PR DESCRIPTION
This shows the number of cache culls in the last 3/6/12 hours on the cache summary screen. Note that no cull counts are shown for clustered caches as the culling is done behind the scenes.

![image](https://user-images.githubusercontent.com/435813/45038515-44581000-b059-11e8-8003-89edb5a9b9df.png)
