### PR TITLE
Genericize the calling of cluster tasks.

### DIFF
--- a/src/java/org/jivesoftware/openfire/SessionManager.java
+++ b/src/java/org/jivesoftware/openfire/SessionManager.java
@@ -943,13 +943,13 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
     public int getConnectionsCount(boolean onlyLocal) {
         int total = connectionsCounter.get();
         if (!onlyLocal) {
-            Collection<Object> results =
+            Collection<Integer> results =
                     CacheFactory.doSynchronousClusterTask(new GetSessionsCountTask(false), false);
-            for (Object result : results) {
+            for (Integer result : results) {
                 if (result == null) {
                     continue;
                 }
-                total = total + (Integer) result;
+                total = total + result;
             }
         }
         return total;
@@ -965,13 +965,13 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
     public int getUserSessionsCount(boolean onlyLocal) {
         int total = routingTable.getClientsRoutes(true).size();
         if (!onlyLocal) {
-            Collection<Object> results =
+            Collection<Integer> results =
                     CacheFactory.doSynchronousClusterTask(new GetSessionsCountTask(true), false);
-            for (Object result : results) {
+            for (Integer result : results) {
                 if (result == null) {
                     continue;
                 }
-                total = total + (Integer) result;
+                total = total + result;
             }
         }
         return total;

--- a/src/java/org/jivesoftware/openfire/container/PluginCacheRegistry.java
+++ b/src/java/org/jivesoftware/openfire/container/PluginCacheRegistry.java
@@ -81,10 +81,10 @@ public class PluginCacheRegistry {
             for (CacheInfo info : caches) {
                 extraCacheMappings.remove(info.getCacheName());
                 // Check if other cluster nodes have this plugin installed
-                Collection<Object> answers =
+                Collection<Boolean> answers =
                         CacheFactory.doSynchronousClusterTask(new IsPluginInstalledTask(pluginName), false);
-                for (Object installed : answers) {
-                    if ((Boolean) installed) {
+                for (Boolean installed : answers) {
+                    if (installed) {
                         return;
                     }
                 }

--- a/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1395,13 +1395,13 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         }
         // Add users from remote cluster nodes
         if (!onlyLocal) {
-            Collection<Object> results =
+            Collection<Integer> results =
                     CacheFactory.doSynchronousClusterTask(new GetNumberConnectedUsers(), false);
-            for (Object result : results) {
+            for (Integer result : results) {
                 if (result == null) {
                     continue;
                 }
-                total = total + (Integer) result;
+                total = total + result;
             }
         }
         return total;

--- a/src/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/src/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -662,7 +662,7 @@ public class CacheFactory {
      * @param includeLocalMember true to run the task on the local member, false otherwise
      * @return collection with the result of the execution.
      */
-    public static Collection<Object> doSynchronousClusterTask(ClusterTask<?> task, boolean includeLocalMember) {
+    public static <T> Collection<T> doSynchronousClusterTask(ClusterTask<T> task, boolean includeLocalMember) {
         return cacheFactoryStrategy.doSynchronousClusterTask(task, includeLocalMember);
     }
 
@@ -675,7 +675,7 @@ public class CacheFactory {
      * @return result of remote operation or null if operation failed or operation returned null.
      * @throws IllegalStateException if requested node was not found or not running in a cluster.
      */
-    public static Object doSynchronousClusterTask(ClusterTask<?> task, byte[] nodeID) {
+    public static <T> T doSynchronousClusterTask(ClusterTask<T> task, byte[] nodeID) {
         return cacheFactoryStrategy.doSynchronousClusterTask(task, nodeID);
     }
 

--- a/src/java/org/jivesoftware/util/cache/CacheFactoryStrategy.java
+++ b/src/java/org/jivesoftware/util/cache/CacheFactoryStrategy.java
@@ -142,7 +142,7 @@ public interface CacheFactoryStrategy {
      * @param includeLocalMember true to run the task on the local member, false otherwise
      * @return collection with the result of the execution.
      */
-    Collection<Object> doSynchronousClusterTask(ClusterTask<?> task, boolean includeLocalMember);
+    <T> Collection<T> doSynchronousClusterTask(ClusterTask<T> task, boolean includeLocalMember);
 
     /**
      * Invokes a task on a given cluster member synchronously and returns the result of
@@ -153,7 +153,7 @@ public interface CacheFactoryStrategy {
      * @return result of remote operation or null if operation failed or operation returned null.
      * @throws IllegalStateException if requested node was not found.
      */
-    Object doSynchronousClusterTask(ClusterTask<?> task, byte[] nodeID);
+    <T> T doSynchronousClusterTask(ClusterTask<T> task, byte[] nodeID);
 
     /**
      * Updates the statistics of the specified caches and publishes them into

--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cluster/NodeRuntimeStats.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cluster/NodeRuntimeStats.java
@@ -51,10 +51,9 @@ public class NodeRuntimeStats {
     public static Map<NodeID, NodeInfo> getNodeInfo() {
 
         // Run cluster-wide stats query
-        Collection<Object> taskResult = CacheFactory.doSynchronousClusterTask(new NodeInfoTask(), true);
-        Map<NodeID, NodeInfo> result = new HashMap<NodeID, NodeInfo>();
-        for (Object tr : taskResult) {
-            NodeInfo nodeInfo = (NodeInfo) tr;
+        Collection<NodeInfo> taskResult = CacheFactory.doSynchronousClusterTask(new NodeInfoTask(), true);
+        Map<NodeID, NodeInfo> result = new HashMap<>();
+        for (NodeInfo nodeInfo : taskResult) {
             NodeID nodeId = NodeID.getInstance(nodeInfo.getNodeId());
             result.put(nodeId, nodeInfo);
         }
@@ -86,10 +85,10 @@ public class NodeRuntimeStats {
         }
 
         public void writeExternal(ObjectOutput out) throws IOException {
-            ExternalizableUtil.getInstance().writeSerializable(out, (NodeInfo) result);
+            ExternalizableUtil.getInstance().writeSerializable(out, result);
         }
         
-        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        public void readExternal(ObjectInput in) throws IOException {
             result = (NodeInfo) ExternalizableUtil.getInstance().readSerializable(in);
         }
 

--- a/src/web/system-clustering.jsp
+++ b/src/web/system-clustering.jsp
@@ -160,14 +160,13 @@
     Collection<ClusterNodeInfo> clusterNodesInfo = ClusterManager.getNodesInfo();
     // Get some basic statistics from the cluster nodes
     // TODO Set a timeout so the page can load fast even if a node is taking too long to answer
-    Collection<Object> statistics =
+    Collection<Map<String, Object>> statistics =
             CacheFactory.doSynchronousClusterTask(new GetBasicStatistics(), true);
     // Calculate percentages
     int clients = 0;
     int incoming = 0;
     int outgoing = 0;
-    for (Object stat : statistics) {
-        Map<String, Object> statsMap = (Map<String, Object>) stat;
+    for (Map<String, Object> statsMap : statistics) {
         if (statsMap == null) {
             continue;
         }
@@ -175,8 +174,7 @@
         incoming += (Integer) statsMap.get(GetBasicStatistics.INCOMING);
         outgoing += (Integer) statsMap.get(GetBasicStatistics.OUTGOING);
     }
-    for (Object stat : statistics) {
-        Map<String, Object> statsMap = (Map<String, Object>) stat;
+    for (Map<String, Object> statsMap : statistics) {
         if (statsMap == null) {
             continue;
         }


### PR DESCRIPTION
This PR adds Java generics to the two `CacheFactory.doSynchronousClusterTask(...)` methods - and also updates the calls to those methods to reflect this change.

Note; I've not raised a JIRA for this as it's really an internal change - but happy to do so if it's thought necessary,