### PR TITLE
Fix marked as senior event is not triggered

### DIFF
--- a/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
+++ b/src/plugins/hazelcast/src/java/org/jivesoftware/openfire/plugin/util/cache/ClusteredCacheFactory.java
@@ -276,9 +276,7 @@ public class ClusteredCacheFactory implements CacheFactoryStrategy {
         if (clusterListener == null || !clusterListener.isClusterMember()) {
             return false;
         }
-        // first cluster member is the oldest
-        Iterator<Member> members = cluster.getMembers().iterator();
-        return members.next().getUuid().equals(cluster.getLocalMember().getUuid());
+        return clusterListener.isSeniorClusterMember();
     }
 
     @Override


### PR DESCRIPTION
On startup the ClusteredCacheFactory calls the constructor of the ClusterListener, which calls the CacheFactory.isSeniorClusterMember(). This method checks if the clusterListerner object is null. This is always the case because the object is not set at this moment.

This pull request ensures, that that the markedAsSeniorClusterMember will be fired on startup on a single node (or the first) too.
