### PR TITLE
OF-1606: Properly restart Admin Console's Jetty when requested.

### DIFF
--- a/src/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/src/java/org/jivesoftware/openfire/XMPPServer.java
@@ -531,8 +531,6 @@ public class XMPPServer {
                             // render properly!
                             Thread.sleep(1000);
                             ((AdminConsolePlugin) pluginManager.getPlugin("admin")).restart();
-//                            ((AdminConsolePlugin) pluginManager.getPlugin("admin")).shutdown();
-//                            ((AdminConsolePlugin) pluginManager.getPlugin("admin")).startup();
                         }
 
                         verifyDataSource();
@@ -778,8 +776,7 @@ public class XMPPServer {
                     // Otherwise, this page won't render properly!
                     try {
                         Thread.sleep(1000);
-                        ((AdminConsolePlugin) pluginManager.getPlugin("admin")).shutdown();
-                        ((AdminConsolePlugin) pluginManager.getPlugin("admin")).startup();
+                        ((AdminConsolePlugin) pluginManager.getPlugin("admin")).restart();
                     } catch (Exception e) {
                         e.printStackTrace();
                     }


### PR DESCRIPTION
This commit fixes the restart of the admin console (needed after installing new certs). It now no longer causes
nullpointer exceptions to be thrown after the restart.

Additionally, the restart that occurs after initial setup was improved. Now, the certificates generated at startup
are immediately loaded (preventing the "http server needs restart") message in the TLS config page, directly after
installation.