### PR TITLE
Remove an orphan component cache entry before adding a new one.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -255,6 +255,16 @@ public class XMPPServer {
     }
 
     /**
+     * Returns the default node ID used by this server before clustering is
+     * initialized.
+     *
+     * @return The default node ID.
+     */
+    public NodeID getDefaultNodeID() {
+        return DEFAULT_NODE_ID;
+    }
+
+    /**
      * Returns true if the given address matches a component service JID.
      *
      * @param jid the JID to check.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -139,6 +139,11 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             if (nodes == null) {
                 nodes = new HashSet<>();
             }
+            // Remove an orphan entry (if any) in the routing table; mainly for clustering
+            if (nodes.remove(server.getDefaultNodeID())) {
+                Log.debug("Replacing DEFAULT_NODE_ID with \"{}\" for component {}",
+                    server.getNodeID(), route);
+            }
             nodes.add(server.getNodeID());
             componentsCache.put(address, nodes);
         } finally {


### PR DESCRIPTION
The orphan component cache entry had a DEFAULT_NODE_ID as node ID
which was added before Hazelcast was initialized with a real node ID.
When the real node ID was ready and it was added to component cache
without removing the old entry.  So the component cache always had two
entries for a component.  When the component was disconnected, the
Component Manager believed that the component existed and prevented the
component to reconnect.