### PR TITLE
Prevent the compilation of JSPs throwing stack traces.

### DIFF
--- a/src/plugins/pom.xml
+++ b/src/plugins/pom.xml
@@ -314,6 +314,7 @@
                                 <goal>jspc</goal>
                             </goals>
                             <configuration>
+                                <useProvidedScope>true</useProvidedScope>
                                 <jspc>
                                     <package>org.jivesoftware.openfire.plugin.${plugin.name}</package>
                                 </jspc>
@@ -322,18 +323,6 @@
                             </configuration>
                         </execution>
                     </executions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.igniterealtime.openfire</groupId>
-                            <artifactId>xmppserver</artifactId>
-                            <version>${openfire.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.igniterealtime.openfire</groupId>
-                            <artifactId>webadmintld</artifactId>
-                            <version>${openfire.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
a) Allow provided dependencies to be included on the CP when compiling
b) Remove xmppserver has a dependency of the maven plugin