### PR TITLE
OF-1515: Add Bookmarks Conversion feature

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivateHandler.java
@@ -26,6 +26,7 @@ import org.jivesoftware.openfire.disco.ServerFeaturesProvider;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.PacketError;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 
@@ -113,6 +114,9 @@ public class IQPrivateHandler extends IQHandler implements ServerFeaturesProvide
 
     @Override
     public Iterator<String> getFeatures() {
-        return Collections.singleton("jabber:iq:private").iterator();
+        return Arrays.asList(
+            "jabber:iq:private",
+            "urn:xmpp:bookmarks-conversion:0"
+        ).iterator();
     }
 }


### PR DESCRIPTION
Through OF-1515, a PEP/Private XML Storage conversion was added that can be used to manage
bookmarks via both mechanisms.

There's a protoXEP that describes this functionality: https://xmpp.org/extensions/inbox/bookmarks-conversion.html

It defines a namespace to identify this feature, which can be used by clients, to prevent them
from merging data obtained from both mechanisms (Gajim reportedly does this).

This feature is added to Openfire by this commit.