### PR TITLE
Fix typo in the xmppserver pom.xml

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -84,7 +84,7 @@
         <profile>
             <id>post-1.8</id>
             <activation>
-                <jdk>(1.8,]</jdk>
+                <jdk>(1.8,)</jdk>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
Ref: https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html - seems to confuse IntelliJ from time to time.