### PR TITLE
Fix Copy&Paste comment error

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
@@ -144,7 +144,7 @@ public class DefaultVCardProvider implements VCardProvider {
     @Override
     public Element updateVCard(String username, Element vCardElement) throws NotFoundException {
         if (loadVCard(username) == null) {
-            // The user already has a vCard
+            // The user does not have a vCard
             throw new NotFoundException("Username " + username + " does not have a vCard");
         }
 


### PR DESCRIPTION
Fixed a confusing comment in ```DefaultVCardProvider``` that was probably just copy&pasted from the method above.