### PR TITLE
OF-1641: Ensure all JSP pages have the correct contentType

### DIFF
--- a/plugins/bookmarks/src/web/confirm-bookmark-delete.jsp
+++ b/plugins/bookmarks/src/web/confirm-bookmark-delete.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="/error.jsp" %>
 <%@ page import="org.jivesoftware.openfire.plugin.spark.Bookmark" %>
 <%@ page import="org.jivesoftware.openfire.plugin.spark.BookmarkManager" %>

--- a/plugins/bookmarks/src/web/create-bookmark.jsp
+++ b/plugins/bookmarks/src/web/create-bookmark.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.plugin.spark.Bookmark" %>
 <%@ page import="org.jivesoftware.util.Log" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>

--- a/plugins/bookmarks/src/web/groupchat-bookmarks.jsp
+++ b/plugins/bookmarks/src/web/groupchat-bookmarks.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.plugin.spark.Bookmark" %>
 <%@ page import="org.jivesoftware.openfire.plugin.spark.BookmarkManager" %>
 <%@ page import="org.jivesoftware.util.LocaleUtils" %>

--- a/plugins/bookmarks/src/web/url-bookmarks.jsp
+++ b/plugins/bookmarks/src/web/url-bookmarks.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.plugin.spark.Bookmark" %>
 <%@ page import="org.jivesoftware.openfire.plugin.spark.BookmarkManager" %>
 <%@ page import="java.util.Collection" %>

--- a/plugins/candy/src/web/candy-config.jsp
+++ b/plugins/candy/src/web/candy-config.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <!--
   - Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
   -

--- a/plugins/certificateManager/src/web/certificate-management.jsp
+++ b/plugins/certificateManager/src/web/certificate-management.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <!--
   - Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
   -

--- a/plugins/clientControl/src/web/client-features.jsp
+++ b/plugins/clientControl/src/web/client-features.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.plugin.spark.manager.FileTransferFilterManager" %>
 <%@ page import="org.jivesoftware.util.JiveGlobals"%>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>

--- a/plugins/clientControl/src/web/permitted-clients.jsp
+++ b/plugins/clientControl/src/web/permitted-clients.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="/error.jsp" import="org.jivesoftware.util.JiveGlobals" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.List" %>

--- a/plugins/clientControl/src/web/spark-download.jsp
+++ b/plugins/clientControl/src/web/spark-download.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.util.JiveGlobals" %>
 <%@ page import="java.io.File" %>

--- a/plugins/clientControl/src/web/spark-form.jsp
+++ b/plugins/clientControl/src/web/spark-form.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp" import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.util.JiveGlobals" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>

--- a/plugins/contentFilter/src/web/contentfilter-props-edit-form.jsp
+++ b/plugins/contentFilter/src/web/contentfilter-props-edit-form.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.*,
                  org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.openfire.user.*,

--- a/plugins/dbaccess/src/web/db-access.jsp
+++ b/plugins/dbaccess/src/web/db-access.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.database.DbConnectionManager" %>
 <%@ page import="java.sql.*" %>
 <%@ page import="org.jivesoftware.util.StringUtils" %>

--- a/plugins/emailListener/src/web/email-listener.jsp
+++ b/plugins/emailListener/src/web/email-listener.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.
   -

--- a/plugins/externalservicediscovery/src/web/external-service-discovery-config.jsp
+++ b/plugins/externalservicediscovery/src/web/external-service-discovery-config.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <!--
   - Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
   -

--- a/plugins/fastpath/src/web/agent-group-browser.jsp
+++ b/plugins/fastpath/src/web/agent-group-browser.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 

--- a/plugins/fastpath/src/web/agent-selectors.jsp
+++ b/plugins/fastpath/src/web/agent-selectors.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/plugins/fastpath/src/web/chat-conversation.jsp
+++ b/plugins/fastpath/src/web/chat-conversation.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 <%@ page

--- a/plugins/fastpath/src/web/chat-summary.jsp
+++ b/plugins/fastpath/src/web/chat-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 <%@ page

--- a/plugins/fastpath/src/web/forms/create-element.jsp
+++ b/plugins/fastpath/src/web/forms/create-element.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.ParamUtils,
                  org.jivesoftware.xmpp.workgroup.WorkgroupManager,
                  org.jivesoftware.xmpp.workgroup.Workgroup,

--- a/plugins/fastpath/src/web/forms/workgroup-dataform.jsp
+++ b/plugins/fastpath/src/web/forms/workgroup-dataform.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.ParamUtils,
                  org.jivesoftware.xmpp.workgroup.WorkgroupManager,
                  org.jivesoftware.xmpp.workgroup.Workgroup,

--- a/plugins/fastpath/src/web/global-workgroup.jsp
+++ b/plugins/fastpath/src/web/global-workgroup.jsp
@@ -1,1 +1,2 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 

--- a/plugins/fastpath/src/web/interceptors.jsp
+++ b/plugins/fastpath/src/web/interceptors.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/plugins/fastpath/src/web/upload.jsp
+++ b/plugins/fastpath/src/web/upload.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.Log,
                  org.jivesoftware.xmpp.workgroup.Workgroup,
                  org.jivesoftware.xmpp.workgroup.WorkgroupManager,

--- a/plugins/fastpath/src/web/uploadSounds.jsp
+++ b/plugins/fastpath/src/web/uploadSounds.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.xmpp.workgroup.Workgroup,
                  org.jivesoftware.xmpp.workgroup.WorkgroupManager,
                  org.jivesoftware.xmpp.workgroup.utils.ModelUtil,

--- a/plugins/fastpath/src/web/usage-summary.jsp
+++ b/plugins/fastpath/src/web/usage-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 

--- a/plugins/fastpath/src/web/user-browser.jsp
+++ b/plugins/fastpath/src/web/user-browser.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 

--- a/plugins/fastpath/src/web/workgroup-add-category.jsp
+++ b/plugins/fastpath/src/web/workgroup-add-category.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 
 <%--
 --%>

--- a/plugins/fastpath/src/web/workgroup-add-response.jsp
+++ b/plugins/fastpath/src/web/workgroup-add-response.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 
 <%--
 --%>

--- a/plugins/fastpath/src/web/workgroup-agent-chats.jsp
+++ b/plugins/fastpath/src/web/workgroup-agent-chats.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 
 

--- a/plugins/fastpath/src/web/workgroup-agents-status.jsp
+++ b/plugins/fastpath/src/web/workgroup-agents-status.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 
 

--- a/plugins/fastpath/src/web/workgroup-chatbot.jsp
+++ b/plugins/fastpath/src/web/workgroup-chatbot.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 <%@ page import="org.jivesoftware.util.*,

--- a/plugins/fastpath/src/web/workgroup-create-success.jsp
+++ b/plugins/fastpath/src/web/workgroup-create-success.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 <%@ page import="org.jivesoftware.util.*"

--- a/plugins/fastpath/src/web/workgroup-create.jsp
+++ b/plugins/fastpath/src/web/workgroup-create.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 
 

--- a/plugins/fastpath/src/web/workgroup-delete-success.jsp
+++ b/plugins/fastpath/src/web/workgroup-delete-success.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%--
 --%>

--- a/plugins/fastpath/src/web/workgroup-delete.jsp
+++ b/plugins/fastpath/src/web/workgroup-delete.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%--
 --%>

--- a/plugins/fastpath/src/web/workgroup-error.jsp
+++ b/plugins/fastpath/src/web/workgroup-error.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 

--- a/plugins/fastpath/src/web/workgroup-image-settings.jsp
+++ b/plugins/fastpath/src/web/workgroup-image-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 <%@ page import="org.jivesoftware.util.*,

--- a/plugins/fastpath/src/web/workgroup-macros.jsp
+++ b/plugins/fastpath/src/web/workgroup-macros.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%--
 --%>

--- a/plugins/fastpath/src/web/workgroup-monitors.jsp
+++ b/plugins/fastpath/src/web/workgroup-monitors.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.List,
         org.xmpp.packet.JID, java.util.StringTokenizer,
         org.jivesoftware.xmpp.workgroup.WorkgroupManager,

--- a/plugins/fastpath/src/web/workgroup-offline.jsp
+++ b/plugins/fastpath/src/web/workgroup-offline.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <% try { %>
 <%@ page import=" org.jivesoftware.xmpp.workgroup.utils.ModelUtil,

--- a/plugins/fastpath/src/web/workgroup-properties.jsp
+++ b/plugins/fastpath/src/web/workgroup-properties.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%--
 --%>

--- a/plugins/fastpath/src/web/workgroup-queue-agents.jsp
+++ b/plugins/fastpath/src/web/workgroup-queue-agents.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%--
 --%>

--- a/plugins/fastpath/src/web/workgroup-queue-create.jsp
+++ b/plugins/fastpath/src/web/workgroup-queue-create.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%--
 --%>

--- a/plugins/fastpath/src/web/workgroup-queue-manage.jsp
+++ b/plugins/fastpath/src/web/workgroup-queue-manage.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%--
 --%>

--- a/plugins/fastpath/src/web/workgroup-queue-rules.jsp
+++ b/plugins/fastpath/src/web/workgroup-queue-rules.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%--
 --%>

--- a/plugins/fastpath/src/web/workgroup-queues.jsp
+++ b/plugins/fastpath/src/web/workgroup-queues.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>

--- a/plugins/fastpath/src/web/workgroup-repos-settings.jsp
+++ b/plugins/fastpath/src/web/workgroup-repos-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page
     import="org.jivesoftware.xmpp.workgroup.WorkgroupManager,
                  org.jivesoftware.xmpp.workgroup.Workgroup,

--- a/plugins/fastpath/src/web/workgroup-settings.jsp
+++ b/plugins/fastpath/src/web/workgroup-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>

--- a/plugins/fastpath/src/web/workgroup-sound-settings.jsp
+++ b/plugins/fastpath/src/web/workgroup-sound-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 <%@ page import="org.jivesoftware.xmpp.workgroup.Workgroup,

--- a/plugins/fastpath/src/web/workgroup-summary.jsp
+++ b/plugins/fastpath/src/web/workgroup-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 
 

--- a/plugins/fastpath/src/web/workgroup-text-settings.jsp
+++ b/plugins/fastpath/src/web/workgroup-text-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 <%@ page import="org.jivesoftware.util.*,

--- a/plugins/fastpath/src/web/workgroup-transcript-config.jsp
+++ b/plugins/fastpath/src/web/workgroup-transcript-config.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <% try { %>
 <%@ page import="org.jivesoftware.xmpp.workgroup.utils.ModelUtil,

--- a/plugins/fastpath/src/web/workgroup-variables.jsp
+++ b/plugins/fastpath/src/web/workgroup-variables.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.ParamUtils,
                  org.jivesoftware.xmpp.workgroup.WorkgroupManager,
                  org.jivesoftware.xmpp.workgroup.Workgroup,

--- a/plugins/fastpath/src/web/workgroup-view-responses.jsp
+++ b/plugins/fastpath/src/web/workgroup-view-responses.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 
 <%--
 --%>

--- a/plugins/gojara/src/web/gojara-RegistrationsOverview.jsp
+++ b/plugins/gojara/src/web/gojara-RegistrationsOverview.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page
     import="org.jivesoftware.openfire.plugin.gojara.sessions.TransportSessionManager"%>
 <%@ page

--- a/plugins/gojara/src/web/gojara-activeSessions.jsp
+++ b/plugins/gojara/src/web/gojara-activeSessions.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page
     import="org.jivesoftware.openfire.plugin.gojara.sessions.TransportSessionManager"%>
 <%@ page

--- a/plugins/gojara/src/web/gojara-gatewayStatistics.jsp
+++ b/plugins/gojara/src/web/gojara-gatewayStatistics.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@page
     import="org.jivesoftware.openfire.plugin.gojara.sessions.TransportSessionManager"%>
 <%@ page

--- a/plugins/gojara/src/web/gojara-sessionDetails.jsp
+++ b/plugins/gojara/src/web/gojara-sessionDetails.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@page
     import="org.jivesoftware.openfire.plugin.gojara.sessions.GatewaySession"%>
 <%@ page

--- a/plugins/gojara/src/web/liveStats.jsp
+++ b/plugins/gojara/src/web/liveStats.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.plugin.gojara.permissions.PermissionManager"%>
 <%@ page import="org.jivesoftware.openfire.plugin.gojara.database.DatabaseManager"%>
 <%@ page import="org.dom4j.tree.DefaultElement"%>

--- a/plugins/gojara/src/web/rr-main.jsp
+++ b/plugins/gojara/src/web/rr-main.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.plugin.gojara.database.DatabaseManager"%>
 <%@ page import="org.jivesoftware.openfire.plugin.gojara.permissions.PermissionManager"%>
 <%@ page import="org.dom4j.tree.DefaultElement"%>

--- a/plugins/hazelcast/src/web/system-clustering-node.jsp
+++ b/plugins/hazelcast/src/web/system-clustering-node.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.plugin.util.cluster.NodeRuntimeStats,
                  org.jivesoftware.util.cache.CacheFactory,
                  com.hazelcast.core.Hazelcast,

--- a/plugins/inverse/src/web/inverse-config.jsp
+++ b/plugins/inverse/src/web/inverse-config.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <!--
   - Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
   -

--- a/plugins/justmarried/src/web/married.jsp
+++ b/plugins/justmarried/src/web/married.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page
     import="org.jivesoftware.openfire.plugin.married.JustMarriedPlugin"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>

--- a/plugins/monitoring/src/web/archive-conversation-participants.jsp
+++ b/plugins/monitoring/src/web/archive-conversation-participants.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.plugin.MonitoringPlugin" %>
 <%@ page import="org.jivesoftware.openfire.archive.Conversation" %>
 <%@ page import="org.jivesoftware.openfire.archive.ConversationManager" %>

--- a/plugins/monitoring/src/web/archive-search.jsp
+++ b/plugins/monitoring/src/web/archive-search.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="/error.jsp" import="org.jivesoftware.openfire.plugin.MonitoringPlugin"%>
 <%@ page import="org.jivesoftware.openfire.archive.ArchiveSearch" %>
 <%@ page import="org.jivesoftware.openfire.archive.ArchiveSearcher" %>

--- a/plugins/monitoring/src/web/archiving-settings.jsp
+++ b/plugins/monitoring/src/web/archiving-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="/error.jsp" import="org.jivesoftware.openfire.plugin.MonitoringPlugin"
     %>
 <%@ page import="org.jivesoftware.openfire.archive.ArchiveIndexer" %>

--- a/plugins/monitoring/src/web/conversation-viewer.jsp
+++ b/plugins/monitoring/src/web/conversation-viewer.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.plugin.MonitoringPlugin" %>
 <%@ page import="org.jivesoftware.openfire.archive.ArchivedMessage" %>
 <%@ page import="org.jivesoftware.openfire.archive.Conversation" %>

--- a/plugins/monitoring/src/web/conversations.jsp
+++ b/plugins/monitoring/src/web/conversations.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.*,
                  org.jivesoftware.openfire.XMPPServer"
 %>

--- a/plugins/monitoring/src/web/graph-viewer.jsp
+++ b/plugins/monitoring/src/web/graph-viewer.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <html>
 <title><meta name="decorator" content="none"/></title>
 <body>

--- a/plugins/monitoring/src/web/stats-dashboard.jsp
+++ b/plugins/monitoring/src/web/stats-dashboard.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.archive.Conversation" %>
 <%@ page import="org.jivesoftware.openfire.archive.ConversationManager" %>
 <%@ page import="org.jivesoftware.openfire.reporting.graph.GraphEngine" %>

--- a/plugins/monitoring/src/web/stats-reporter.jsp
+++ b/plugins/monitoring/src/web/stats-reporter.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.reporting.stats.StatsViewer" %>
 <%@ page import="org.jivesoftware.util.CookieUtils" %>
 <%@ page import="org.jivesoftware.util.JiveGlobals"%>

--- a/plugins/motd/src/web/motd-form.jsp
+++ b/plugins/motd/src/web/motd-form.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page
    import="org.jivesoftware.openfire.XMPPServer,
            org.jivesoftware.openfire.plugin.MotDPlugin,

--- a/plugins/packetFilter/src/web/delete-rule.jsp
+++ b/plugins/packetFilter/src/web/delete-rule.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 
 <%@page import="org.jivesoftware.openfire.plugin.PacketFilterUtil"%>
 <%@ page import="org.jivesoftware.util.*"%>

--- a/plugins/packetFilter/src/web/pf-main.jsp
+++ b/plugins/packetFilter/src/web/pf-main.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="org.jivesoftware.openfire.plugin.PacketFilterUtil"%>
 <%@ page import="org.jivesoftware.openfire.component.InternalComponentManager,
                  org.jivesoftware.openfire.plugin.component.ComponentList,

--- a/plugins/packetFilter/src/web/rule-edit-form.jsp
+++ b/plugins/packetFilter/src/web/rule-edit-form.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="org.jivesoftware.openfire.plugin.PacketFilterConstants"%>
 <%@ page import="org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.openfire.component.InternalComponentManager,

--- a/plugins/packetFilter/src/web/rule-form.jsp
+++ b/plugins/packetFilter/src/web/rule-form.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="org.jivesoftware.openfire.plugin.PacketFilterConstants"%>
 <%@ page import="org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.openfire.group.Group"

--- a/plugins/packetFilter/src/web/testform.jsp
+++ b/plugins/packetFilter/src/web/testform.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <script type="text/javascript"
     src="/plugins/packetfilter/dwr2/interface/RuleManagerProxy.js"> </script>
 <script type="text/javascript"

--- a/plugins/presence/src/web/presence-service.jsp
+++ b/plugins/presence/src/web/presence-service.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.*,
                  org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.util.*,

--- a/plugins/registration/src/web/registration-props-form.jsp
+++ b/plugins/registration/src/web/registration-props-form.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.
   -

--- a/plugins/registration/src/web/sign-up.jsp
+++ b/plugins/registration/src/web/sign-up.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.
   -

--- a/plugins/restAPI/src/web/rest-api.jsp
+++ b/plugins/restAPI/src/web/rest-api.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page
     import="java.util.*,
                 org.jivesoftware.openfire.XMPPServer,

--- a/plugins/search/src/web/advance-user-search.jsp
+++ b/plugins/search/src/web/advance-user-search.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.*,
                  java.net.URLEncoder,
                  org.jivesoftware.util.*,

--- a/plugins/search/src/web/search-props-edit-form.jsp
+++ b/plugins/search/src/web/search-props-edit-form.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.*,
                  org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.openfire.plugin.SearchPlugin,

--- a/plugins/sip/src/web/create-sipark-mapping.jsp
+++ b/plugins/sip/src/web/create-sipark-mapping.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.sip.sipaccount.SipAccount" %>
 <%@ page import="org.jivesoftware.openfire.sip.sipaccount.SipAccountDAO" %>
 <%@ page import="org.jivesoftware.util.JiveGlobals" %>

--- a/plugins/sip/src/web/sipark-log-summary.jsp
+++ b/plugins/sip/src/web/sipark-log-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.sip.calllog.CallLog,
                  org.jivesoftware.openfire.sip.calllog.CallLogDAO"
         %>

--- a/plugins/sip/src/web/sipark-settings.jsp
+++ b/plugins/sip/src/web/sipark-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="org.jivesoftware.util.JiveGlobals" %>

--- a/plugins/sip/src/web/sipark-user-delete.jsp
+++ b/plugins/sip/src/web/sipark-user-delete.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/plugins/sip/src/web/sipark-user-summary.jsp
+++ b/plugins/sip/src/web/sipark-user-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/plugins/subscription/src/web/subscription-plugin-properties.jsp
+++ b/plugins/subscription/src/web/subscription-plugin-properties.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.
   -

--- a/plugins/userCreation/src/web/users-creation.jsp
+++ b/plugins/userCreation/src/web/users-creation.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="org.jivesoftware.util.JiveGlobals"%>
 <%@ page import="org.jivesoftware.util.ParamUtils,
                  org.jivesoftware.util.TaskEngine,

--- a/plugins/userImportExport/src/web/export-user-data.jsp
+++ b/plugins/userImportExport/src/web/export-user-data.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.io.IOException,
                  java.util.*,
                  org.jivesoftware.openfire.plugin.ImportExportPlugin,

--- a/plugins/userImportExport/src/web/import-export-selection.jsp
+++ b/plugins/userImportExport/src/web/import-export-selection.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.plugin.ImportExportPlugin,
                  org.jivesoftware.openfire.XMPPServer"
 %>

--- a/plugins/userImportExport/src/web/import-user-data.jsp
+++ b/plugins/userImportExport/src/web/import-user-data.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.net.MalformedURLException,
                  java.util.*,
                  org.dom4j.DocumentException,

--- a/plugins/userStatus/src/web/user-status-settings.jsp
+++ b/plugins/userStatus/src/web/user-status-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jstl/core_rt" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jstl/fmt_rt" prefix="fmt" %>
 <%@ page import="com.reucon.openfire.plugins.userstatus.UserStatusPlugin" %>

--- a/plugins/userservice/src/web/user-service.jsp
+++ b/plugins/userservice/src/web/user-service.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.*,
                  org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.util.*,org.jivesoftware.openfire.plugin.UserServicePlugin"

--- a/plugins/xmldebugger/src/web/debugger-conf.jsp
+++ b/plugins/xmldebugger/src/web/debugger-conf.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.ParamUtils"
 %>
 <%@ page import="org.jivesoftware.openfire.plugin.DebuggerPlugin" %>

--- a/xmppserver/src/main/webapp/audit-policy.jsp
+++ b/xmppserver/src/main/webapp/audit-policy.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Licensed under the Apache License, Version 2.0 (the "License");

--- a/xmppserver/src/main/webapp/available-plugins.jsp
+++ b/xmppserver/src/main/webapp/available-plugins.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/chatroom-history-settings.jsp
+++ b/xmppserver/src/main/webapp/chatroom-history-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/component-session-details.jsp
+++ b/xmppserver/src/main/webapp/component-session-details.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/component-session-summary.jsp
+++ b/xmppserver/src/main/webapp/component-session-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/compression-settings.jsp
+++ b/xmppserver/src/main/webapp/compression-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/connection-managers-settings.jsp
+++ b/xmppserver/src/main/webapp/connection-managers-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/connection-settings-advanced.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-advanced.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
 <%@ page import="org.jivesoftware.util.CookieUtils" %>

--- a/xmppserver/src/main/webapp/connection-settings-external-components.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-external-components.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.Connection" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.component.ExternalComponentConfiguration" %>

--- a/xmppserver/src/main/webapp/connection-settings-socket-c2s.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-socket-c2s.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionConfiguration" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>

--- a/xmppserver/src/main/webapp/connection-settings-socket-s2s.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-socket-s2s.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionConfiguration" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>

--- a/xmppserver/src/main/webapp/decorators/main.jsp
+++ b/xmppserver/src/main/webapp/decorators/main.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/dns-check.jsp
+++ b/xmppserver/src/main/webapp/dns-check.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.*"
          errorPage="error.jsp"
 %>

--- a/xmppserver/src/main/webapp/error-serverdown.jsp
+++ b/xmppserver/src/main/webapp/error-serverdown.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
  <%--
 --%>
 <%@ page import="org.jivesoftware.admin.AdminConsole,

--- a/xmppserver/src/main/webapp/error.jsp
+++ b/xmppserver/src/main/webapp/error.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 

--- a/xmppserver/src/main/webapp/file-transfer-proxy.jsp
+++ b/xmppserver/src/main/webapp/file-transfer-proxy.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/group-create.jsp
+++ b/xmppserver/src/main/webapp/group-create.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/group-delete.jsp
+++ b/xmppserver/src/main/webapp/group-delete.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/group-edit.jsp
+++ b/xmppserver/src/main/webapp/group-edit.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/group-summary.jsp
+++ b/xmppserver/src/main/webapp/group-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/import-keystore-certificate.jsp
+++ b/xmppserver/src/main/webapp/import-keystore-certificate.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.keystore.IdentityStore" %>

--- a/xmppserver/src/main/webapp/import-truststore-certificate.jsp
+++ b/xmppserver/src/main/webapp/import-truststore-certificate.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
 <%@ page import="org.jivesoftware.openfire.keystore.TrustStore"%>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType"%>

--- a/xmppserver/src/main/webapp/index.jsp
+++ b/xmppserver/src/main/webapp/index.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 <%--
   -

--- a/xmppserver/src/main/webapp/js/jscalendar/i18n.jsp
+++ b/xmppserver/src/main/webapp/js/jscalendar/i18n.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.Calendar,java.text.DateFormat,java.text.SimpleDateFormat,org.jivesoftware.util.JiveGlobals"%>
 <%@ page import="org.jivesoftware.util.LocaleUtils"%>
 <%

--- a/xmppserver/src/main/webapp/ldap-group.jsp
+++ b/xmppserver/src/main/webapp/ldap-group.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.HashMap" %>
 <%

--- a/xmppserver/src/main/webapp/ldap-server.jsp
+++ b/xmppserver/src/main/webapp/ldap-server.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%
     String serverType = null;
     boolean initialSetup = false;

--- a/xmppserver/src/main/webapp/ldap-user.jsp
+++ b/xmppserver/src/main/webapp/ldap-user.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.HashMap" %>
 <%

--- a/xmppserver/src/main/webapp/log.jsp
+++ b/xmppserver/src/main/webapp/log.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/login.jsp
+++ b/xmppserver/src/main/webapp/login.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.admin.AdminConsole,
                  org.jivesoftware.openfire.admin.AdminManager"
     errorPage="error.jsp"

--- a/xmppserver/src/main/webapp/logviewer.jsp
+++ b/xmppserver/src/main/webapp/logviewer.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/manage-updates.jsp
+++ b/xmppserver/src/main/webapp/manage-updates.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-create-permission.jsp
+++ b/xmppserver/src/main/webapp/muc-create-permission.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-default-settings.jsp
+++ b/xmppserver/src/main/webapp/muc-default-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2010 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-history-settings.jsp
+++ b/xmppserver/src/main/webapp/muc-history-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-room-affiliations.jsp
+++ b/xmppserver/src/main/webapp/muc-room-affiliations.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-room-create.jsp
+++ b/xmppserver/src/main/webapp/muc-room-create.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-room-delete.jsp
+++ b/xmppserver/src/main/webapp/muc-room-delete.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-room-occupants.jsp
+++ b/xmppserver/src/main/webapp/muc-room-occupants.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-room-summary.jsp
+++ b/xmppserver/src/main/webapp/muc-room-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-service-create.jsp
+++ b/xmppserver/src/main/webapp/muc-service-create.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-service-delete.jsp
+++ b/xmppserver/src/main/webapp/muc-service-delete.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-service-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-service-edit-form.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-service-summary.jsp
+++ b/xmppserver/src/main/webapp/muc-service-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-sysadmins.jsp
+++ b/xmppserver/src/main/webapp/muc-sysadmins.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/muc-tasks.jsp
+++ b/xmppserver/src/main/webapp/muc-tasks.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/offline-messages.jsp
+++ b/xmppserver/src/main/webapp/offline-messages.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/plugin-admin.jsp
+++ b/xmppserver/src/main/webapp/plugin-admin.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.
   -

--- a/xmppserver/src/main/webapp/plugin-showfile.jsp
+++ b/xmppserver/src/main/webapp/plugin-showfile.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
 <%@ page import="org.jivesoftware.openfire.container.Plugin" %>
 <%@ page import="org.jivesoftware.openfire.container.PluginManager" %>

--- a/xmppserver/src/main/webapp/private-data-settings.jsp
+++ b/xmppserver/src/main/webapp/private-data-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/profile-settings.jsp
+++ b/xmppserver/src/main/webapp/profile-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.JiveGlobals" %>
 <%@ page import="org.jivesoftware.openfire.ldap.LdapManager" %>
 <%@ page import="org.jivesoftware.openfire.auth.AuthFactory" %>

--- a/xmppserver/src/main/webapp/pubsub-form-table.jsp
+++ b/xmppserver/src/main/webapp/pubsub-form-table.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>

--- a/xmppserver/src/main/webapp/pubsub-node-affiliates-delete.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-affiliates-delete.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
                 org.jivesoftware.openfire.pubsub.NodeAffiliate,
                 org.jivesoftware.openfire.pubsub.NodeSubscription,

--- a/xmppserver/src/main/webapp/pubsub-node-affiliates-edit.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-affiliates-edit.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
                 org.jivesoftware.openfire.pubsub.NodeAffiliate,
                 org.jivesoftware.openfire.pubsub.NodeAffiliate.Affiliation,

--- a/xmppserver/src/main/webapp/pubsub-node-affiliates.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-affiliates.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
                  org.jivesoftware.openfire.pubsub.Node,
                  org.jivesoftware.openfire.pubsub.NodeAffiliate,

--- a/xmppserver/src/main/webapp/pubsub-node-delete.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-delete.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
                  org.jivesoftware.openfire.pubsub.Node,
                  org.jivesoftware.openfire.pubsub.PubSubServiceInfo,

--- a/xmppserver/src/main/webapp/pubsub-node-edit.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-edit.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.*,
                  org.jivesoftware.openfire.group.Group,
                  org.jivesoftware.openfire.pubsub.Node,

--- a/xmppserver/src/main/webapp/pubsub-node-items.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-items.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
                  org.jivesoftware.openfire.pubsub.LeafNode,
                  org.jivesoftware.openfire.pubsub.Node,

--- a/xmppserver/src/main/webapp/pubsub-node-subscribers.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-subscribers.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
                  org.jivesoftware.openfire.pubsub.Node,
                  org.jivesoftware.openfire.pubsub.NodeSubscription,

--- a/xmppserver/src/main/webapp/pubsub-node-summary.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.openfire.pep.PEPServiceInfo,
                  org.jivesoftware.openfire.pep.PEPServiceManager,

--- a/xmppserver/src/main/webapp/pubsub-service-summary.jsp
+++ b/xmppserver/src/main/webapp/pubsub-service-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.*,
                  org.jivesoftware.openfire.pubsub.Node,
                  org.jivesoftware.openfire.pubsub.PubSubServiceInfo,

--- a/xmppserver/src/main/webapp/reg-settings.jsp
+++ b/xmppserver/src/main/webapp/reg-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/security-audit-viewer.jsp
+++ b/xmppserver/src/main/webapp/security-audit-viewer.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/security-certificate-details.jsp
+++ b/xmppserver/src/main/webapp/security-certificate-details.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
 
 <%@ page import="org.jivesoftware.openfire.keystore.CertificateStore"%>

--- a/xmppserver/src/main/webapp/security-certificate-store-backup.jsp
+++ b/xmppserver/src/main/webapp/security-certificate-store-backup.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.keystore.CertificateStoreManager" %>

--- a/xmppserver/src/main/webapp/security-certificate-store-management.jsp
+++ b/xmppserver/src/main/webapp/security-certificate-store-management.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>

--- a/xmppserver/src/main/webapp/security-keystore-signing-request.jsp
+++ b/xmppserver/src/main/webapp/security-keystore-signing-request.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="java.util.Enumeration"%>
 <%@page import="org.jivesoftware.openfire.XMPPServer"%>
 <%@page import="java.security.PublicKey"%>

--- a/xmppserver/src/main/webapp/security-keystore.jsp
+++ b/xmppserver/src/main/webapp/security-keystore.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="org.jivesoftware.util.StringUtils"%>
 <%@page import="java.security.PrivateKey"%>
 <%@page import="org.jivesoftware.util.CertificateManager"%>

--- a/xmppserver/src/main/webapp/security-truststore.jsp
+++ b/xmppserver/src/main/webapp/security-truststore.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
 <%@ page import="org.jivesoftware.openfire.keystore.TrustStore"%>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType"%>

--- a/xmppserver/src/main/webapp/server-connectiontest.jsp
+++ b/xmppserver/src/main/webapp/server-connectiontest.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   ~ Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
   ~

--- a/xmppserver/src/main/webapp/server-db-stats.jsp
+++ b/xmppserver/src/main/webapp/server-db-stats.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/server-db.jsp
+++ b/xmppserver/src/main/webapp/server-db.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/server-properties.jsp
+++ b/xmppserver/src/main/webapp/server-properties.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/server-props.jsp
+++ b/xmppserver/src/main/webapp/server-props.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/server-restart.jsp
+++ b/xmppserver/src/main/webapp/server-restart.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 

--- a/xmppserver/src/main/webapp/server-session-details.jsp
+++ b/xmppserver/src/main/webapp/server-session-details.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/server-session-summary.jsp
+++ b/xmppserver/src/main/webapp/server-session-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/session-conflict.jsp
+++ b/xmppserver/src/main/webapp/session-conflict.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/session-details.jsp
+++ b/xmppserver/src/main/webapp/session-details.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/session-summary.jsp
+++ b/xmppserver/src/main/webapp/session-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/setup/index.jsp
+++ b/xmppserver/src/main/webapp/setup/index.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>

--- a/xmppserver/src/main/webapp/setup/setup-admin-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-admin-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 

--- a/xmppserver/src/main/webapp/setup/setup-admin-settings_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-admin-settings_test.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.LocaleUtils" %>
 <%@ page import="org.jivesoftware.util.ParamUtils, org.jivesoftware.openfire.ldap.LdapManager, org.jivesoftware.openfire.user.UserNotFoundException, org.xmpp.packet.JID" %>
 <%@ page import="java.net.URLEncoder" %>

--- a/xmppserver/src/main/webapp/setup/setup-completed.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-completed.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 

--- a/xmppserver/src/main/webapp/setup/setup-datasource-jndi.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-datasource-jndi.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%--

--- a/xmppserver/src/main/webapp/setup/setup-datasource-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-datasource-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%--

--- a/xmppserver/src/main/webapp/setup/setup-datasource-standard.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-datasource-standard.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%--
 --%>

--- a/xmppserver/src/main/webapp/setup/setup-finished.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-finished.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 

--- a/xmppserver/src/main/webapp/setup/setup-host-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-host-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 

--- a/xmppserver/src/main/webapp/setup/setup-ldap-group.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-group.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer"%>
 
 <%

--- a/xmppserver/src/main/webapp/setup/setup-ldap-group_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-group_test.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.admin.LdapGroupTester" %>
 <%@ page import="org.jivesoftware.util.LocaleUtils" %>
 <%@ page import="org.jivesoftware.util.Log" %>

--- a/xmppserver/src/main/webapp/setup/setup-ldap-server.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-server.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%
     // Redirect if we've already run setup:

--- a/xmppserver/src/main/webapp/setup/setup-ldap-server_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-server_test.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.LocaleUtils" %>
 <%@ page import="org.jivesoftware.openfire.ldap.LdapManager, javax.naming.*, javax.naming.ldap.LdapContext, java.net.UnknownHostException" %>
 <%@ page import="java.util.Map" %>

--- a/xmppserver/src/main/webapp/setup/setup-ldap-user.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-user.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 
 <%

--- a/xmppserver/src/main/webapp/setup/setup-ldap-user_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-user_test.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.admin.LdapUserProfile" %>
 <%@ page import="org.jivesoftware.admin.LdapUserTester" %>
 <%@ page import="org.jivesoftware.util.LocaleUtils" %>

--- a/xmppserver/src/main/webapp/setup/setup-profile-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-profile-settings.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 

--- a/xmppserver/src/main/webapp/system-cache.jsp
+++ b/xmppserver/src/main/webapp/system-cache.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.CookieUtils"%>
 <%@ page import="org.jivesoftware.util.ParamUtils"%>
 <%@ page import="org.jivesoftware.util.StringUtils"%>

--- a/xmppserver/src/main/webapp/system-clustering.jsp
+++ b/xmppserver/src/main/webapp/system-clustering.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/system-email.jsp
+++ b/xmppserver/src/main/webapp/system-email.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.
   -

--- a/xmppserver/src/main/webapp/system-emailtest.jsp
+++ b/xmppserver/src/main/webapp/system-emailtest.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.
   -

--- a/xmppserver/src/main/webapp/system-sms.jsp
+++ b/xmppserver/src/main/webapp/system-sms.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.*,
                  org.jivesoftware.util.*"
     errorPage="error.jsp"

--- a/xmppserver/src/main/webapp/system-smstest.jsp
+++ b/xmppserver/src/main/webapp/system-smstest.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.
   -

--- a/xmppserver/src/main/webapp/user-create.jsp
+++ b/xmppserver/src/main/webapp/user-create.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-delete.jsp
+++ b/xmppserver/src/main/webapp/user-delete.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-edit-form.jsp
+++ b/xmppserver/src/main/webapp/user-edit-form.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-groups.jsp
+++ b/xmppserver/src/main/webapp/user-groups.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-lockout.jsp
+++ b/xmppserver/src/main/webapp/user-lockout.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-message.jsp
+++ b/xmppserver/src/main/webapp/user-message.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 
 <%--
   -

--- a/xmppserver/src/main/webapp/user-password.jsp
+++ b/xmppserver/src/main/webapp/user-password.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-properties.jsp
+++ b/xmppserver/src/main/webapp/user-properties.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-roster-add.jsp
+++ b/xmppserver/src/main/webapp/user-roster-add.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-roster-delete.jsp
+++ b/xmppserver/src/main/webapp/user-roster-delete.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-roster-edit.jsp
+++ b/xmppserver/src/main/webapp/user-roster-edit.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-roster-view.jsp
+++ b/xmppserver/src/main/webapp/user-roster-view.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-roster.jsp
+++ b/xmppserver/src/main/webapp/user-roster.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2005-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-search.jsp
+++ b/xmppserver/src/main/webapp/user-search.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>
 

--- a/xmppserver/src/main/webapp/user-summary.jsp
+++ b/xmppserver/src/main/webapp/user-summary.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
   - Copyright (C) 2004-2008 Jive Software. All rights reserved.

--- a/xmppserver/src/main/webapp/user-tabs.jsp
+++ b/xmppserver/src/main/webapp/user-tabs.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%--
 --%>


### PR DESCRIPTION
With possibly reckless use of `grep` and `sed`, I've added a `<%@ page contentType="text/html; charset=UTF-8" %>` to the top of every JSP page that didn't already have a contentType. 

This may be a bit of a sledgehammer/nut situation, but I think in this case it may be worthwhile.