### PR TITLE
OF-1584 bis: Use the Jetty content type mappings instead of the JRE

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServlet.java
@@ -484,7 +484,7 @@ public class PluginServlet extends HttpServlet {
             return;
         }
 
-        String contentType = URLConnection.guessContentTypeFromName(pathInfo);
+        String contentType = getServletContext().getMimeType(pathInfo);
         if (contentType == null) {
             contentType = "text/plain";
         }


### PR DESCRIPTION
(The JRE doesn't contain a content type for CSS files, for example)