### PR TITLE
Allow plugins to have their own log4j2.xml file

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -16,6 +16,8 @@
 
 package org.jivesoftware.openfire.container;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.spi.LoggerContext;
 import org.dom4j.Attribute;
 import org.dom4j.Document;
 import org.dom4j.Element;
@@ -522,6 +524,13 @@ public class PluginManager
             if ( dev != null && dev.getClassesDir() != null )
             {
                 pluginLoader.addURLFile( dev.getClassesDir().toURI().toURL() );
+            }
+
+            // Initialise a logging context, if necessary
+            final Path path = pluginDir.resolve("classes/log4j2.xml");
+            if (Files.isRegularFile(path)) {
+                final LoggerContext loggerContext = LogManager.getContext(pluginLoader, false, path.toUri());
+                loggerContext.getLogger("To avoid LOG4J2-1094");
             }
 
             // Instantiate the plugin!


### PR DESCRIPTION
(and thus their own logging context)
With Openfire 4.2 this happened automatically as 4.2 used Log4J1, and plugins using Log4J2 automatically got their own context.
With Openfire 4.3+, it's necessary to explicitly initialise a new context.