### PR TITLE
OF-1453: Protect against exceptions during plugin initialisation

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadataHelper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadataHelper.java
@@ -147,8 +147,9 @@ public class PluginMetadataHelper
         if ( name != null ) {
             try {
                 return AdminConsole.getAdminText(name, pluginName);
-            } catch(final Exception ignored) {
-                // Silently fail - default to non-internationalised name
+            } catch (final Exception e) {
+                Log.warn("Unexpected exception attempting to retrieve admin text", e);
+                // Default to non-internationalised name
                 return name;
             }
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadataHelper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadataHelper.java
@@ -144,14 +144,15 @@ public class PluginMetadataHelper
     {
         final String name = getElementValue( pluginDir, "/plugin/name" );
         final String pluginName = getCanonicalName( pluginDir );
-        if ( name != null )
-        {
-            return AdminConsole.getAdminText( name, pluginName );
+        if ( name != null ) {
+            try {
+                return AdminConsole.getAdminText(name, pluginName);
+            } catch(final Exception ignored) {
+                // Silently fail - default to non-internationalised name
+                return name;
+            }
         }
-        else
-        {
-            return pluginName;
-        }
+        return pluginName;
     }
 
     /**


### PR DESCRIPTION
The initial bug report was against a long-retired plugin, but that's not to say it couldn't happen elsewhere so this PR protects against exceptions of this sort. 