### PR TITLE
Add MUC invitation endpoint to restAPI

### DIFF
--- a/plugins/restAPI/plugin.xml
+++ b/plugins/restAPI/plugin.xml
@@ -6,7 +6,7 @@
     <description>Allows administration over a RESTful API.</description>
     <author>Roman Soldatow</author>
     <version>${project.version}</version>
-    <date>08/30/2018</date>
+    <date>11/28/2018</date>
     <minServerVersion>4.1.1</minServerVersion>
     <adminconsole>
         <tab id="tab-server">

--- a/plugins/restAPI/pom.xml
+++ b/plugins/restAPI/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>restAPI</artifactId>
-    <version>1.3.7</version>
+    <version>1.3.8</version>
     <name>Rest API Plugin</name>
     <description>Allows administration over a RESTful API.</description>
     

--- a/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
+++ b/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/controller/MUCRoomController.java
@@ -13,25 +13,13 @@ import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.openfire.group.ConcurrentGroupList;
 import org.jivesoftware.openfire.group.Group;
-import org.jivesoftware.openfire.muc.ConflictException;
-import org.jivesoftware.openfire.muc.ForbiddenException;
-import org.jivesoftware.openfire.muc.MUCRole;
-import org.jivesoftware.openfire.muc.MUCRoom;
-import org.jivesoftware.openfire.muc.NotAllowedException;
+import org.jivesoftware.openfire.muc.*;
 import org.jivesoftware.openfire.muc.cluster.RoomAvailableEvent;
 import org.jivesoftware.openfire.muc.cluster.RoomUpdatedEvent;
 import org.jivesoftware.openfire.muc.cluster.RoomRemovedEvent;
 import org.jivesoftware.openfire.muc.spi.LocalMUCRoom;
 import org.jivesoftware.openfire.plugin.rest.RESTServicePlugin;
-import org.jivesoftware.openfire.plugin.rest.entity.MUCChannelType;
-import org.jivesoftware.openfire.plugin.rest.entity.MUCRoomEntities;
-import org.jivesoftware.openfire.plugin.rest.entity.MUCRoomEntity;
-import org.jivesoftware.openfire.plugin.rest.entity.OccupantEntities;
-import org.jivesoftware.openfire.plugin.rest.entity.OccupantEntity;
-import org.jivesoftware.openfire.plugin.rest.entity.ParticipantEntities;
-import org.jivesoftware.openfire.plugin.rest.entity.ParticipantEntity;
-import org.jivesoftware.openfire.plugin.rest.entity.MUCRoomMessageEntities;
-import org.jivesoftware.openfire.plugin.rest.entity.MUCRoomMessageEntity;
+import org.jivesoftware.openfire.plugin.rest.entity.*;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ExceptionType;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 import org.jivesoftware.openfire.plugin.rest.utils.MUCRoomUtils;
@@ -42,8 +30,6 @@ import org.xmpp.packet.JID;
 import org.xmpp.packet.Presence;
 
 import org.xmpp.packet.Message;
-import org.jivesoftware.openfire.muc.MultiUserChatService;
-import org.jivesoftware.openfire.muc.MUCRoomHistory;
 import org.dom4j.Element;
 
 import org.slf4j.Logger;
@@ -423,6 +409,30 @@ public class MUCRoomController {
         }
         mucRoomMessageEntities.setMessages(listMessages);
         return mucRoomMessageEntities;
+    }
+
+    /**
+     * Invites the user to the MUC room.
+     *
+     * @param serviceName
+     *            the service name
+     * @param roomName
+     *            the room name
+     * @param jid
+     *            the jid to invite
+     * @throws ServiceException
+     *             the service exception
+     */
+    public void inviteUser(String serviceName, String roomName, String jid, MUCInvitationEntity mucInvitationEntity)
+            throws ServiceException {
+        MUCRoom room = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(serviceName)
+            .getChatRoom(roomName.toLowerCase());
+
+        try {
+            room.sendInvitation(UserUtils.checkAndGetJID(jid), mucInvitationEntity.getReason(), room.getRole(), null);
+        } catch (ForbiddenException | CannotBeInvitedException e) {
+            throw new ServiceException("Could not invite user", jid, ExceptionType.NOT_ALLOWED, Response.Status.FORBIDDEN, e);
+        }
     }
 
 

--- a/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/entity/MUCInvitationEntity.java
+++ b/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/entity/MUCInvitationEntity.java
@@ -1,0 +1,23 @@
+package org.jivesoftware.openfire.plugin.rest.entity;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "mucInvitation")
+public class MUCInvitationEntity {
+
+    String reason;
+
+    public MUCInvitationEntity() {
+    }
+
+    @XmlElement
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+}

--- a/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomService.java
+++ b/plugins/restAPI/src/java/org/jivesoftware/openfire/plugin/rest/service/MUCRoomService.java
@@ -13,12 +13,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import org.jivesoftware.openfire.plugin.rest.entity.MUCChannelType;
-import org.jivesoftware.openfire.plugin.rest.entity.MUCRoomEntities;
-import org.jivesoftware.openfire.plugin.rest.entity.MUCRoomEntity;
-import org.jivesoftware.openfire.plugin.rest.entity.OccupantEntities;
-import org.jivesoftware.openfire.plugin.rest.entity.ParticipantEntities;
-import org.jivesoftware.openfire.plugin.rest.entity.MUCRoomMessageEntities;
+import org.jivesoftware.openfire.plugin.rest.entity.*;
 import org.jivesoftware.openfire.plugin.rest.exceptions.ServiceException;
 import org.jivesoftware.openfire.plugin.rest.controller.MUCRoomController;
 
@@ -33,7 +28,7 @@ public class MUCRoomService {
             @DefaultValue("false") @QueryParam("expandGroups") Boolean expand) {
         return MUCRoomController.getInstance().getChatRooms(serviceName, channelType, roomSearch, expand);
     }
-    
+
     @GET
     @Path("/{roomName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
@@ -75,7 +70,7 @@ public class MUCRoomService {
             @DefaultValue("conference") @QueryParam("servicename") String serviceName) {
         return MUCRoomController.getInstance().getRoomParticipants(roomName, serviceName);
     }
-    
+
     @GET
     @Path("/{roomName}/occupants")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
@@ -90,6 +85,15 @@ public class MUCRoomService {
     public MUCRoomMessageEntities getMUCRoomHistory(@PathParam("roomName") String roomName,
                                                     @DefaultValue("conference") @QueryParam("servicename") String serviceName) throws ServiceException {
         return MUCRoomController.getInstance().getRoomHistory(roomName, serviceName);
+    }
+
+    @POST
+    @Path("/{roomName}/invite/{jid}")
+    public Response inviteUserToMUCRoom(@PathParam("roomName") String roomName, @PathParam("jid") String jid,
+            @DefaultValue("conference") @QueryParam("servicename") String serviceName,
+            MUCInvitationEntity mucInvitationEntity) throws ServiceException {
+        MUCRoomController.getInstance().inviteUser(serviceName, roomName, jid, mucInvitationEntity);
+        return Response.status(Status.OK).build();
     }
 
 }


### PR DESCRIPTION
This endpoint for the restAPI plugin allows to send MUC invitations on behalf of the chatroom.
An optional reason may be provided. It does _not_ change any memberships or room affiliations.

Tested (and works) on Psi+.
