### PR TITLE
Avoid using Map keySet().removeIf when evict cache

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -156,6 +156,7 @@ public class GroupManager {
 
                                 if ("everybody".equals(originalValue) || "everybody".equals(newValue)) {
                                     evictCachedUserSharedGroups();
+                                    evictCachedPaginatedGroupNames();
                                 }
                             }
                         } else if ("sharedRoster.groupList".equals(key)) {
@@ -717,6 +718,7 @@ public class GroupManager {
             {
                 case "everybody":
                     evictCachedUserSharedGroups();
+                    evictCachedPaginatedGroupNames();
                     break;
 
                 case "onlygroup":
@@ -756,16 +758,19 @@ public class GroupManager {
     }
 
     private void evictCachedPaginatedGroupNames() {
-        groupMetaCache.keySet()
-            .removeIf( key -> key.startsWith( GROUP_NAMES_KEY ) );
+        synchronized(GROUP_NAMES_KEY) {
+            for (Map.Entry<String, Serializable> entry : groupMetaCache.entrySet()) {
+                if (entry.getKey().startsWith(GROUP_NAMES_KEY)) {
+                    groupMetaCache.remove(entry.getKey());
+                }
+            }
+        }
     }
 
     private void evictCachedUserSharedGroups() {
         synchronized (USER_SHARED_GROUPS_KEY) {
-            groupMetaCache.keySet()
-                .removeIf( key -> key.startsWith( USER_SHARED_GROUPS_KEY ) );
             for (Map.Entry<String, Serializable> entry : groupMetaCache.entrySet()) {
-                if (entry.getKey().startsWith(GROUP_NAMES_KEY)) {
+                if (entry.getKey().startsWith(USER_SHARED_GROUPS_KEY)) {
                     groupMetaCache.remove(entry.getKey());
                 }
             }


### PR DESCRIPTION
The DefaultCache class returns a copy of internal map.keySet() when the keySet() method is called https://github.com/igniterealtime/Openfire/blob/57bcd0f8fa7cb44dead637c79a027cf7bd07aedf/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultCache.java#L465

So, the use of keySet().removeIf does not remove the entry of the internal map of DefaultCache.

The simple solution would be to return the actual *map.keySet()* instead of *new HashSet<>(map.keySet());*, but it could cause some unpredictable side effects in other caches.
