### PR TITLE
OF-1648: Add IV column to ofProperty before the ofPrivate migration

### DIFF
--- a/distribution/src/database/upgrade/27/openfire_db2.sql
+++ b/distribution/src/database/upgrade/27/openfire_db2.sql
@@ -1,3 +1,4 @@
--- The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java
--- Update version
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
 UPDATE ofVersion SET version = 27 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/27/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/27/openfire_hsqldb.sql
@@ -1,3 +1,4 @@
-// The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java
-// Update version
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
 UPDATE ofVersion SET version = 27 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/27/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/27/openfire_mysql.sql
@@ -1,3 +1,4 @@
-# The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java
-# Update version
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
 UPDATE ofVersion SET version = 27 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/27/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/27/openfire_oracle.sql
@@ -1,5 +1,4 @@
--- The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java
--- Update version
-UPDATE ofVersion SET version = 27 WHERE name = 'openfire';
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
 
-COMMIT;
+UPDATE ofVersion SET version = 27 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/27/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/27/openfire_postgresql.sql
@@ -1,3 +1,4 @@
--- The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java
--- Update version
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
 UPDATE ofVersion SET version = 27 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/27/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/27/openfire_sqlserver.sql
@@ -1,3 +1,4 @@
-/* The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java */
-/* Update version */
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
 UPDATE ofVersion SET version = 27 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/27/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/27/openfire_sybase.sql
@@ -1,3 +1,4 @@
-/* The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java */
-/* Update version */
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
 UPDATE ofVersion SET version = 27 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/28/openfire_db2.sql
+++ b/distribution/src/database/upgrade/28/openfire_db2.sql
@@ -1,5 +1,3 @@
--- Only when the update in 27 succeeded, drop the table that was used as its source.
-DROP TABLE ofPrivate;
-
+-- The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java
 -- Update version
 UPDATE ofVersion SET version = 28 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/28/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/28/openfire_hsqldb.sql
@@ -1,5 +1,3 @@
-// Only when the update in 27 succeeded, drop the table that was used as its source.
-DROP TABLE ofPrivate;
-
+// The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java
 // Update version
 UPDATE ofVersion SET version = 28 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/28/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/28/openfire_mysql.sql
@@ -1,5 +1,3 @@
-# Only when the update in 27 succeeded, drop the table that was used as its source.
-DROP TABLE ofPrivate;
-
+# The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java
 # Update version
 UPDATE ofVersion SET version = 28 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/28/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/28/openfire_oracle.sql
@@ -1,6 +1,4 @@
--- Only when the update in 27 succeeded, drop the table that was used as its source.
-DROP TABLE ofPrivate;
-
+-- The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java
 -- Update version
 UPDATE ofVersion SET version = 28 WHERE name = 'openfire';
 

--- a/distribution/src/database/upgrade/28/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/28/openfire_postgresql.sql
@@ -1,5 +1,3 @@
--- Only when the update in 27 succeeded, drop the table that was used as its source.
-DROP TABLE ofPrivate;
-
+-- The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java
 -- Update version
 UPDATE ofVersion SET version = 28 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/28/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/28/openfire_sqlserver.sql
@@ -1,5 +1,3 @@
-/* Only when the update in 27 succeeded, drop the table that was used as its source. */
-DROP TABLE ofPrivate;
-
+/* The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java */
 /* Update version */
 UPDATE ofVersion SET version = 28 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/28/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/28/openfire_sybase.sql
@@ -1,5 +1,3 @@
-/* Only when the update in 27 succeeded, drop the table that was used as its source. */
-DROP TABLE ofPrivate;
-
+/* The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java */
 /* Update version */
 UPDATE ofVersion SET version = 28 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/29/openfire_db2.sql
+++ b/distribution/src/database/upgrade/29/openfire_db2.sql
@@ -1,4 +1,5 @@
-ALTER TABLE ofProperty
-  ADD iv   CHAR(24);
+-- Only when the update in 28 succeeded, drop the table that was used as its source.
+DROP TABLE ofPrivate;
 
+-- Update version
 UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/29/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/29/openfire_hsqldb.sql
@@ -1,4 +1,5 @@
-ALTER TABLE ofProperty
-  ADD iv   CHAR(24);
+// Only when the update in 28 succeeded, drop the table that was used as its source.
+DROP TABLE ofPrivate;
 
+// Update version
 UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/29/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/29/openfire_mysql.sql
@@ -1,4 +1,5 @@
-ALTER TABLE ofProperty
-  ADD iv   CHAR(24);
+# Only when the update in 28 succeeded, drop the table that was used as its source.
+DROP TABLE ofPrivate;
 
+# Update version
 UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/29/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/29/openfire_oracle.sql
@@ -1,4 +1,7 @@
-ALTER TABLE ofProperty
-  ADD iv   CHAR(24);
+-- Only when the update in 28 succeeded, drop the table that was used as its source.
+DROP TABLE ofPrivate;
 
+-- Update version
 UPDATE ofVersion SET version = 29 WHERE name = 'openfire';
+
+COMMIT;

--- a/distribution/src/database/upgrade/29/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/29/openfire_postgresql.sql
@@ -1,4 +1,5 @@
-ALTER TABLE ofProperty
-  ADD iv   CHAR(24);
+-- Only when the update in 28 succeeded, drop the table that was used as its source.
+DROP TABLE ofPrivate;
 
+-- Update version
 UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/29/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/29/openfire_sqlserver.sql
@@ -1,4 +1,5 @@
-ALTER TABLE ofProperty
-  ADD iv   CHAR(24);
+/* Only when the update in 28 succeeded, drop the table that was used as its source. */
+DROP TABLE ofPrivate;
 
+/* Update version */
 UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/29/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/29/openfire_sybase.sql
@@ -1,4 +1,5 @@
-ALTER TABLE ofProperty
-  ADD iv   CHAR(24);
+/* Only when the update in 28 succeeded, drop the table that was used as its source. */
+DROP TABLE ofPrivate;
 
+/* Update version */
 UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
@@ -272,7 +272,7 @@ public class SchemaManager {
                         if (i == 21 && schemaKey.equals("openfire")) {
                             OF33.executeFix(con);
                         }
-                        if (i == 27 && schemaKey.equals("openfire")) {
+                        if (i == 28 && schemaKey.equals("openfire")) {
                             OF1515.executeFix();
                         }
                     } catch (Exception e) {


### PR DESCRIPTION
Before:
version 27 Did the `ofPrivate`->`ofPubSub` migration with `OF1515.java`. This class used `JiveGlobals`, which reads from `ofProperty`.
version 28 Dropped `ofPrivate`
version 29 Added the `iv` column to `ofProperty`

With this PR:
version 27 Adds the `iv` column to `ofProperty`
version 28 Does the `ofPrivate`->`ofPubSub` migration
version 29 Drops `ofPrivate`

Tested with a new install of Openfire 4.2.3 on PostgreSQL, creating some private storage entries, then running Openfire 4.3.0-beta with this PR applied. ofPrivate entries were migrated to ofPubSub - though OF-1390 is still an issue when viewing entries the first time.