### PR TITLE
use right search jar file for bundling into deb/rpm

### DIFF
--- a/build/debian/build_debs.sh
+++ b/build/debian/build_debs.sh
@@ -21,7 +21,7 @@ mkdir -p $WORKDIR
 
 cp -r distribution/target/distribution-base/. $WORKDIR/
 # Need to copy in plugins that are defaulted to distribute
-cp -f plugins/search/target/search.jar $WORKDIR/plugins/
+cp -f plugins/search/target/search-*.jar $WORKDIR/plugins/search.jar
 
 mkdir -p $WORKDIR/debian
 cp build/debian/* $WORKDIR/debian/

--- a/build/rpm/build_rpms.sh
+++ b/build/rpm/build_rpms.sh
@@ -47,7 +47,7 @@ else
 fi
 
 # Need to copy in plugins that are defaulted to distribute
-cp -f plugins/search/target/search.jar distribution/target/distribution-base/plugins/
+cp -f plugins/search/target/search-*.jar distribution/target/distribution-base/plugins/search.jar
 
 # generate our psuedo source tree, which is actually dist tree from maven
 cd distribution/target


### PR DESCRIPTION
This is a bandaid until we fully fix how plugin jars are included. 