### PR TITLE
Reduce the amount of noise being sent to stdout/stderr;

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -77,6 +77,16 @@
                 <extensions>true</extensions>
             </plugin>
 
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
+++ b/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
@@ -1,0 +1,26 @@
+package org.jivesoftware;
+
+import java.io.File;
+import java.net.URL;
+
+import org.jivesoftware.util.JiveGlobals;
+
+public final class Fixtures {
+
+    private Fixtures() {
+    }
+
+    /**
+     * Reconfigures the Openfire home directory to the blank test one. This allows JiveGlobals.getProperty() etc.
+     * to work in test classes without errors being displayed to stderr.
+     */
+    public static void reconfigureOpenfireHome() throws Exception {
+        final URL configFile = ClassLoader.getSystemResource("conf/openfire.xml");
+        if (configFile == null) {
+            throw new IllegalStateException("Unable to read openfire.xml file; does conf/openfire.xml exist in the test classpath, i.e. test/resources?");
+        }
+        final File openfireHome = new File(configFile.toURI()).getParentFile().getParentFile();
+        JiveGlobals.setHomeDirectory(openfireHome.toString());
+    }
+
+}

--- a/xmppserver/src/test/java/org/jivesoftware/admin/AuthCheckFilterTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/admin/AuthCheckFilterTest.java
@@ -1,5 +1,6 @@
 package org.jivesoftware.admin;
 
+import org.jivesoftware.Fixtures;
 import org.jivesoftware.openfire.admin.AdminManager;
 import org.jivesoftware.openfire.auth.AuthToken;
 import org.junit.Before;
@@ -40,6 +41,8 @@ public class AuthCheckFilterTest {
 
     @Before
     public void setUp() throws Exception {
+
+        Fixtures.reconfigureOpenfireHome();
 
         doReturn("/uri/to/page").when(request).getRequestURI();
         doReturn(httpSession).when(request).getSession();

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/handler/IQEntityTimeHandlerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/handler/IQEntityTimeHandlerTest.java
@@ -11,6 +11,9 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -55,13 +58,13 @@ public class IQEntityTimeHandlerTest {
 
             DatatypeConverter.printDateTime(calendar);
         }
-        System.out.println(System.currentTimeMillis() - start);
+        assertThat(System.currentTimeMillis() - start, is(lessThan(2000L)));
 
         start = System.currentTimeMillis();
         for (int i = 0; i < 1000000; i++) {
             XMPPDateTimeFormat.format(date);
         }
-        System.out.println(System.currentTimeMillis() - start);
+        assertThat(System.currentTimeMillis() - start, is(lessThan(4000L)));
     }
 
     @Test

--- a/xmppserver/src/test/resources/conf/openfire.xml
+++ b/xmppserver/src/test/resources/conf/openfire.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Minimal Openfire configuration to allow JiveGlobals.getProperty() to complete without complaining to stderr -->
+<jive/>

--- a/xmppserver/src/test/resources/log4j2-test-mvn.xml
+++ b/xmppserver/src/test/resources/log4j2-test-mvn.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- log4j2 config file used when running under Maven -->
+<Configuration>
+    <Appenders>
+        <File name="file" fileName="target/surefire-reports/test.log">
+            <PatternLayout>
+                <Pattern>%d %-5p %X [%c{1}] - %m%n</Pattern>
+            </PatternLayout>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="file"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
1. Introduce a mvn specific log4j2 config file that sends logging output to target/surefire-reports/test.log
2. Replace some System.out.println() statements with genuine assertions
3. Introduce a Fixture that re-configures openfire home to a folder containing a "blank" openfire.xml to prevent JiveGlobals.getProperty() from complaining to stderr in tests.