### PR TITLE
Ensure that the resources folder is included in the distribution

### DIFF
--- a/plugins/openfire-plugin-assembly-descriptor/src/main/resources/assemblies/openfire-plugin-assembly.xml
+++ b/plugins/openfire-plugin-assembly-descriptor/src/main/resources/assemblies/openfire-plugin-assembly.xml
@@ -101,6 +101,13 @@
                 <exclude>**/*.properties</exclude>
             </excludes>
         </fileSet>
+
+        <!-- Include any resources folder -->
+        <fileSet>
+            <directory>src/resources</directory>
+            <outputDirectory>classes</outputDirectory>
+        </fileSet>
+
     </fileSets>
 
     <!-- Bundle the dependencies of this plugin -->


### PR DESCRIPTION
Note; this is required for https://github.com/igniterealtime/openfire-xmldebugger-plugin/issues/2 to ensure plugins can have their own log4j2 config. 

In an idea world, we would have a proper plugin repo structure

```
src/main/java
src/main/resources
src/main/webapp
src/test/java
src/test/resources 
```

etc. but that's something to tackle for another day ...