### PR TITLE
OF-1670: Allow MUC sysadmins to join a password protected room

### DIFF
--- a/i18n/src/main/resources/openfire_i18n_en.properties
+++ b/i18n/src/main/resources/openfire_i18n_en.properties
@@ -908,6 +908,7 @@ groupchat.admins.introduction=Below is the list of system administrators of the 
 groupchat.admins.user_added=User/Group added to the list successfully.
 groupchat.admins.error_adding=Error adding the user/group. Please verify the JID is correct.
 groupchat.admins.user_removed=User/Group removed from the list successfully.
+groupchat.admins.settings.saved_successfully=Settings updated successfully.
 groupchat.admins.legend=Administrators
 groupchat.admins.label_add_admin=Add Administrator (JID):
 groupchat.admins.column_user=User/Group
@@ -919,6 +920,9 @@ groupchat.admins.dialog.text=Are you sure you want to remove this user/group fro
 groupchat.admins.add_group=Select Group (one or more):
 groupchat.admins.group=Group
 groupchat.admins.user=User
+groupchat.admins.passwordpolicy.legend=Password Policy
+groupchat.admins.passwordpolicy.join-without-password.legend=Administrators can join rooms without providing a password.
+groupchat.admins.passwordpolicy.join-requires-password.legend=Without providing the password, system administrators cannot join password-protected rooms.
 
 # Audit policy Page
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -368,6 +368,7 @@ groupchat.admins.introduction=Hieronder staat een lijst van systeembeheerders va
 groupchat.admins.user_added=Gebruiker toevoegen aan de lijst is geslaagd.
 groupchat.admins.error_adding=Fout bij het toevoegen van de gebruiker. Controleer het adres.
 groupchat.admins.user_removed=Gebruiker verwijderen van de lijst is geslaagd.
+groupchat.admins.settings.saved_successfully=Instellingen wijzigen is geslaagd.
 groupchat.admins.legend=Beheerders
 groupchat.admins.label_add_admin=Beheerder toevoegen (adres):
 groupchat.admins.column_user=Gebruiker
@@ -376,6 +377,9 @@ groupchat.admins.add=Toevoegen
 groupchat.admins.no_admins=Er zijn geen beheerders. Gebruik het bovenstaande formulier om een beheerder toe te voegen.
 groupchat.admins.dialog.title=Klik om te verwijderen...
 groupchat.admins.dialog.text=Bent u zeker dat u deze gebruiker wil verwijderen van de lijst?
+groupchat.admins.passwordpolicy.legend=Wachtwoordbeleid
+groupchat.admins.passwordpolicy.join-without-password.legend=Systeembeheerders kunnen gespreksruimtes betreden, zonder een wachtwoord op te geven.
+groupchat.admins.passwordpolicy.join-requires-password.legend=Zonder een wachtwoord op te gegeven kunnen systeembeheerders gespreksruimtes die beveiligd zijn met een wachtwoord niet betreden.
 
 # Audit policy Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.openfire.muc;
 
 import org.jivesoftware.openfire.handler.IQHandler;
+import org.jivesoftware.openfire.muc.spi.MUCPersistenceManager;
 import org.xmpp.component.Component;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
@@ -90,6 +91,26 @@ public interface MultiUserChatService extends Component {
      * @param userJID the bare JID of the user/group to remove from the list.
      */
     void removeSysadmin(JID userJID);
+
+    /**
+     * Returns true when a system administrator of the MUC service can join a
+     * password-protected room, without supplying the password.
+     *
+     * @return false if a sysadmin can join a password-protected room without a password, otherwise true.
+     */
+    default boolean isPasswordRequiredForSysadminsToJoinRoom() {
+        return MUCPersistenceManager.getBooleanProperty( getServiceName(), "sysadmin.requires.room.passwords", false );
+    }
+
+    /**
+     * Sets if a system administrator of the MUC service can join a
+     * password-protected room, without supplying the password.
+     *
+     * @param isRequired false if a sysadmin is allowed to join a password-protected room without a password, otherwise true.
+     */
+    default void setPasswordRequiredForSysadminsToJoinRoom(boolean isRequired) {
+        MUCPersistenceManager.setProperty( getServiceName(), "sysadmin.requires.room.passwords", Boolean.toString(isRequired) );
+    }
 
     /**
      * Returns false if anyone can create rooms or true if only the returned JIDs in

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -594,9 +594,12 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
                 }
             }
             // If the room is password protected and the provided password is incorrect raise a
-            // Unauthorized exception
+            // Unauthorized exception - unless the JID that is joining is a system admin.
             if (isPasswordProtected()) {
-                if (password == null || !password.equals(getPassword())) {
+                final boolean isCorrectPassword = (password != null && password.equals(getPassword()));
+                final boolean isSysadmin = mucService.isSysadmin(bareJID);
+                final boolean requirePassword = isSysadmin ? mucService.isPasswordRequiredForSysadminsToJoinRoom() : true;
+                if (!isCorrectPassword && requirePassword ) {
                     throw new UnauthorizedException();
                 }
             }


### PR DESCRIPTION
When a MUC room is configured to require a password upon entry, a sysadmin should be able
to join the room (without providing the password).

The above will now be the default configuration. It can be configured, through the admin
console, on a per conference service basis (which is the same context in which sysadmins
are defined).