### PR TITLE
OF-1670: Allow MUC sysadmins to join a password protected room (4.2 backport)

### DIFF
--- a/src/i18n/openfire_i18n_en.properties
+++ b/src/i18n/openfire_i18n_en.properties
@@ -906,6 +906,7 @@ groupchat.admins.introduction=Below is the list of system administrators of the 
 groupchat.admins.user_added=User/Group added to the list successfully.
 groupchat.admins.error_adding=Error adding the user/group. Please verify the JID is correct.
 groupchat.admins.user_removed=User/Group removed from the list successfully.
+groupchat.admins.settings.saved_successfully=Settings updated successfully.
 groupchat.admins.legend=Administrators
 groupchat.admins.label_add_admin=Add Administrator (JID):
 groupchat.admins.column_user=User/Group
@@ -917,6 +918,9 @@ groupchat.admins.dialog.text=Are you sure you want to remove this user/group fro
 groupchat.admins.add_group=Select Group (one or more):
 groupchat.admins.group=Group
 groupchat.admins.user=User
+groupchat.admins.passwordpolicy.legend=Password Policy
+groupchat.admins.passwordpolicy.join-without-password.legend=Administrators can join rooms without providing a password.
+groupchat.admins.passwordpolicy.join-requires-password.legend=Without providing the password, system administrators cannot join password-protected rooms.
 
 # Audit policy Page
 

--- a/src/i18n/openfire_i18n_nl.properties
+++ b/src/i18n/openfire_i18n_nl.properties
@@ -364,6 +364,7 @@ groupchat.admins.introduction=Hieronder staat een lijst van systeembeheerders va
 groupchat.admins.user_added=Gebruiker toevoegen aan de lijst is geslaagd.
 groupchat.admins.error_adding=Fout bij het toevoegen van de gebruiker. Controleer het adres.
 groupchat.admins.user_removed=Gebruiker verwijderen van de lijst is geslaagd.
+groupchat.admins.settings.saved_successfully=Instellingen wijzigen is geslaagd.
 groupchat.admins.legend=Beheerders
 groupchat.admins.label_add_admin=Beheerder toevoegen (adres):
 groupchat.admins.column_user=Gebruiker
@@ -372,6 +373,9 @@ groupchat.admins.add=Toevoegen
 groupchat.admins.no_admins=Er zijn geen beheerders. Gebruik het bovenstaande formulier om een beheerder toe te voegen.
 groupchat.admins.dialog.title=Klik om te verwijderen...
 groupchat.admins.dialog.text=Bent u zeker dat u deze gebruiker wil verwijderen van de lijst?
+groupchat.admins.passwordpolicy.legend=Wachtwoordbeleid
+groupchat.admins.passwordpolicy.join-without-password.legend=Systeembeheerders kunnen gespreksruimtes betreden, zonder een wachtwoord op te geven.
+groupchat.admins.passwordpolicy.join-requires-password.legend=Zonder een wachtwoord op te gegeven kunnen systeembeheerders gespreksruimtes die beveiligd zijn met een wachtwoord niet betreden.
 
 # Audit policy Page
 

--- a/src/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
+++ b/src/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.openfire.muc;
 
 import org.jivesoftware.openfire.handler.IQHandler;
+import org.jivesoftware.openfire.muc.spi.MUCPersistenceManager;
 import org.xmpp.component.Component;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
@@ -90,6 +91,26 @@ public interface MultiUserChatService extends Component {
      * @param userJID the bare JID of the user/group to remove from the list.
      */
     void removeSysadmin(JID userJID);
+
+    /**
+     * Returns true when a system administrator of the MUC service can join a
+     * password-protected room, without supplying the password.
+     *
+     * @return false if a sysadmin can join a password-protected room without a password, otherwise true.
+     */
+    default boolean isPasswordRequiredForSysadminsToJoinRoom() {
+        return MUCPersistenceManager.getBooleanProperty( getServiceName(), "sysadmin.requires.room.passwords", false );
+    }
+
+    /**
+     * Sets if a system administrator of the MUC service can join a
+     * password-protected room, without supplying the password.
+     *
+     * @param isRequired false if a sysadmin is allowed to join a password-protected room without a password, otherwise true.
+     */
+    default void setPasswordRequiredForSysadminsToJoinRoom(boolean isRequired) {
+        MUCPersistenceManager.setProperty( getServiceName(), "sysadmin.requires.room.passwords", Boolean.toString(isRequired) );
+    }
 
     /**
      * Returns false if anyone can create rooms or true if only the returned JIDs in

--- a/src/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
+++ b/src/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
@@ -98,9 +98,7 @@ public interface MultiUserChatService extends Component {
      *
      * @return false if a sysadmin can join a password-protected room without a password, otherwise true.
      */
-    default boolean isPasswordRequiredForSysadminsToJoinRoom() {
-        return MUCPersistenceManager.getBooleanProperty( getServiceName(), "sysadmin.requires.room.passwords", false );
-    }
+    boolean isPasswordRequiredForSysadminsToJoinRoom();
 
     /**
      * Sets if a system administrator of the MUC service can join a
@@ -108,9 +106,7 @@ public interface MultiUserChatService extends Component {
      *
      * @param isRequired false if a sysadmin is allowed to join a password-protected room without a password, otherwise true.
      */
-    default void setPasswordRequiredForSysadminsToJoinRoom(boolean isRequired) {
-        MUCPersistenceManager.setProperty( getServiceName(), "sysadmin.requires.room.passwords", Boolean.toString(isRequired) );
-    }
+    void setPasswordRequiredForSysadminsToJoinRoom(boolean isRequired);
 
     /**
      * Returns false if anyone can create rooms or true if only the returned JIDs in

--- a/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -594,9 +594,12 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
                 }
             }
             // If the room is password protected and the provided password is incorrect raise a
-            // Unauthorized exception
+            // Unauthorized exception - unless the JID that is joining is a system admin.
             if (isPasswordProtected()) {
-                if (password == null || !password.equals(getPassword())) {
+                final boolean isCorrectPassword = (password != null && password.equals(getPassword()));
+                final boolean isSysadmin = mucService.isSysadmin(bareJID);
+                final boolean requirePassword = isSysadmin ? mucService.isPasswordRequiredForSysadminsToJoinRoom() : true;
+                if (!isCorrectPassword && requirePassword ) {
                     throw new UnauthorizedException();
                 }
             }

--- a/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/src/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1034,6 +1034,26 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     }
 
     /**
+     * Returns true when a system administrator of the MUC service can join a
+     * password-protected room, without supplying the password.
+     *
+     * @return false if a sysadmin can join a password-protected room without a password, otherwise true.
+     */
+    public boolean isPasswordRequiredForSysadminsToJoinRoom() {
+        return MUCPersistenceManager.getBooleanProperty( getServiceName(), "sysadmin.requires.room.passwords", false );
+    }
+
+    /**
+     * Sets if a system administrator of the MUC service can join a
+     * password-protected room, without supplying the password.
+     *
+     * @param isRequired false if a sysadmin is allowed to join a password-protected room without a password, otherwise true.
+     */
+    public void setPasswordRequiredForSysadminsToJoinRoom(boolean isRequired) {
+        MUCPersistenceManager.setProperty( getServiceName(), "sysadmin.requires.room.passwords", Boolean.toString(isRequired) );
+    }
+
+    /**
      * Returns the flag that indicates if the service should provide information about non-public
      * members-only rooms when handling service discovery requests.
      *

--- a/src/web/muc-sysadmins.jsp
+++ b/src/web/muc-sysadmins.jsp
@@ -36,7 +36,9 @@
     String userJID = ParamUtils.getParameter(request,"userJID");
     String[] groupNames = ParamUtils.getParameters(request, "groupNames");
     boolean add = request.getParameter("add") != null;
+    boolean passwordPolicy = request.getParameter("passwordPolicy") != null;
     boolean delete = ParamUtils.getBooleanParameter(request,"delete");
+    boolean requirePassword = ParamUtils.getBooleanParameter(request,"requirePassword");
     String mucname = ParamUtils.getParameter(request,"mucname");
 
     if (!webManager.getMultiUserChatManager().isServiceRegistered(mucname)) {
@@ -53,10 +55,11 @@
     Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
     String csrfParam = ParamUtils.getParameter(request, "csrf");
 
-    if (add || delete) {
+    if (add || delete || passwordPolicy) {
         if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
             add = false;
             delete = false;
+            passwordPolicy = false;
             errors.put("csrf", "CSRF Failure!");
         }
     }
@@ -109,6 +112,15 @@
             response.sendRedirect("muc-sysadmins.jsp?deletesuccess=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
             return;
         }
+
+        if (passwordPolicy) {
+            mucService.setPasswordRequiredForSysadminsToJoinRoom(requirePassword);
+            // Log the event
+            webManager.logEvent("muc sysadmins for service "+mucname + "now " + (requirePassword ? "cannot" : "can") + " join a password-protected room, without supplying the password.", null);
+            // done, return
+            response.sendRedirect("muc-sysadmins.jsp?success=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+            return;
+        }
     }
 %>
 
@@ -150,6 +162,19 @@
         </td></tr>
     </tbody>
     </table>
+    </div><br>
+
+<%  } else if ("true".equals(request.getParameter("success"))) { %>
+
+    <div class="jive-success">
+        <table cellpadding="0" cellspacing="0" border="0">
+            <tbody>
+            <tr><td class="jive-icon"><img src="images/success-16x16.gif" width="16" height="16" border="0" alt=""></td>
+                <td class="jive-icon-label">
+                    <fmt:message key="groupchat.admins.settings.saved_successfully"/>
+                </td></tr>
+            </tbody>
+        </table>
     </div><br>
 
 <%  } else if (errors.size() > 0) {  
@@ -246,6 +271,41 @@
 </form>
 <!-- END 'Administrators' -->
 
+<br>
+<!-- BEGIN 'Permission Policy' -->
+<form action="muc-sysadmins.jsp?passwordPolicy" method="post">
+    <input type="hidden" name="csrf" value="${csrf}">
+    <input type="hidden" name="mucname" value="<%= StringUtils.escapeForXML(mucname) %>" />
+    <div class="jive-contentBoxHeader">
+        <fmt:message key="groupchat.admins.passwordpolicy.legend" />
+    </div>
+    <div class="jive-contentBox">
+        <table cellpadding="3" cellspacing="0" border="0">
+            <tbody>
+            <tr>
+                <td width="1%">
+                    <input type="radio" name="requirePassword" value="false" id="pp01"
+                        <%= ((!mucService.isPasswordRequiredForSysadminsToJoinRoom()) ? "checked" : "") %>>
+                </td>
+                <td width="99%">
+                    <label for="pp01"><fmt:message key="groupchat.admins.passwordpolicy.join-without-password.legend" /></label>
+                </td>
+            </tr>
+            <tr>
+                <td width="1%">
+                    <input type="radio" name="requirePassword" value="true" id="pp02"
+                        <%= ((mucService.isPasswordRequiredForSysadminsToJoinRoom()) ? "checked" : "") %>>
+                </td>
+                <td width="99%">
+                    <label for="pp02"><fmt:message key="groupchat.admins.passwordpolicy.join-requires-password.legend" /></label>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <input type="submit" value="<fmt:message key="global.save_settings" />">
+</form>
+<!-- END 'Permission Policy' -->
 
 </body>
 </html>


### PR DESCRIPTION
When a MUC room is configured to require a password upon entry, a sysadmin should be able
to join the room (without providing the password).

The above will now be the default configuration. It can be configured, through the admin
console, on a per conference service basis (which is the same context in which sysadmins
are defined).