### PR TITLE
OF-1671: Ensure Openfire can copy with a non-snapshot four digit version (4.3 backport)

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/Version.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Version.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 public final class Version implements Comparable<Version> {
 
     private static final Pattern PATTERN = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(?:\\s+(\\w+))?(?:\\s+(\\d+))?");
+    private static final Pattern FOUR_DOT_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)");
     private static final Pattern SNAPSHOT_PATTERN = Pattern.compile("(?i)(\\d+)\\.(\\d+)\\.(\\d+)(?:\\.(\\d+))?-SNAPSHOT");
 
     /**
@@ -122,6 +123,15 @@ public final class Version implements Comparable<Version> {
                 status = ReleaseStatus.Snapshot;
                 final String statusVersionString = snapshotMatcher.group(4);
                 statusVersion = statusVersionString == null ? -1 : Integer.parseInt(statusVersionString);
+                return;
+            }
+            final Matcher fourDotMatcher = FOUR_DOT_PATTERN.matcher(source);
+            if (fourDotMatcher.matches()) {
+                major = Integer.parseInt(fourDotMatcher.group(1));
+                minor = Integer.parseInt(fourDotMatcher.group(2));
+                micro = Integer.parseInt(fourDotMatcher.group(3));
+                statusVersion = Integer.parseInt(fourDotMatcher.group(4));
+                status = ReleaseStatus.Release;
                 return;
             }
         }

--- a/xmppserver/src/test/java/org/jivesoftware/util/VersionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/VersionTest.java
@@ -140,4 +140,18 @@ public class VersionTest {
         assertThat(releaseVersion.isNewerThan(alphaVersion), is(true));
         assertThat(releaseVersion.isNewerThan(alphaVersion.ignoringReleaseStatus()), is(false));
     }
+
+    @Test
+    public void willVersionAFourDigitRelease() {
+
+        final String versionString = "1.2.3.4";
+        final Version test = new Version(versionString);
+
+        assertThat(test.getMajor(), is(1));
+        assertThat(test.getMinor(), is(2));
+        assertThat(test.getMicro(), is(3));
+        assertThat(test.getStatusVersion(), is(4));
+        assertThat(test.getStatus(), is(ReleaseStatus.Release));
+        assertThat(test.getVersionString(),is("1.2.3 Release 4"));
+    }
 }


### PR DESCRIPTION
(e.g. 1.2.3.4)