### PR TITLE
slf4j to 1.8.0-beta2 (CVE-2018-8088)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <mina.version>2.0.7</mina.version>
         <bouncycastle.version>1.60</bouncycastle.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.8.0-beta2</slf4j.version>
         <log4j.version>2.11.1</log4j.version>
     </properties>
 


### PR DESCRIPTION
slf4j to 1.8.0-beta2 (CVE-2018-8088)
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8088