### PR TITLE
Keep jsp source

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -7,7 +7,7 @@
     <packaging>pom</packaging>
     <name>Openfire Plugins</name>
 
-    <description>Aggregate project for Openfire plugins.</description>
+    <description>Parent POM for Openfire plugins.</description>
     <url>http://www.igniterealtime.org/projects/openfire/</url>
 
     <inceptionYear>2003</inceptionYear>
@@ -274,6 +274,15 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <excludes>
+                            <exclude>**/*_jsp.java</exclude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>2.6</version>
                     <dependencies>
@@ -324,6 +333,7 @@
                                 </jspc>
                                 <sourceVersion>1.8</sourceVersion>
                                 <targetVersion>1.8</targetVersion>
+                                <keepSources>true</keepSources>
                             </configuration>
                         </execution>
                     </executions>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -24,6 +24,9 @@
                             <addClasspath>true</addClasspath>
                         </manifest>
                     </archive>
+                    <excludes>
+                        <exclude>**/*_jsp.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
 
@@ -63,6 +66,7 @@
                             </jspc>
                             <sourceVersion>1.8</sourceVersion>
                             <targetVersion>1.8</targetVersion>
+                            <keepSources>true</keepSources>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
The thread at https://discourse.igniterealtime.org/t/where-is-the-admin-jsp-source-java-files-in-openfire-4-3-0/83971 reminded me just how useful it can be to have the .java files that .jsp files generate. This PR makes these files available (in `target/classes/org/jivesoftware/openfire/admin` or `target/classes/org/jivesoftware/openfire/[plugin]` - but doesn't not inflate the resulting JAR file by specifically excluding them.