### PR TITLE
OF-1681: Enabling debug logging no longer enables trace logging

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -401,7 +401,8 @@ public class XMPPServer {
 
         JiveGlobals.migrateProperty(Log.LOG_DEBUG_ENABLED);
         Log.setDebugEnabled(JiveGlobals.getBooleanProperty(Log.LOG_DEBUG_ENABLED, false));
-        
+        Log.setDebugEnabled(JiveGlobals.getBooleanProperty(Log.LOG_TRACE_ENABLED, false));
+
         // Update server info
         xmppServerInfo = new XMPPServerInfoImpl(new Date());
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/Log.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Log.java
@@ -101,7 +101,7 @@ public class Log {
         // SLF4J doesn't provide a hook into the logging implementation. We'll have to do this 'direct', bypassing slf4j.
         final org.apache.logging.log4j.Level newLevel;
         if (enabled) {
-            newLevel = org.apache.logging.log4j.Level.ALL;
+            newLevel = org.apache.logging.log4j.Level.DEBUG;
         } else {
             newLevel = org.apache.logging.log4j.Level.INFO;
         }


### PR DESCRIPTION
Two changes; 
1. Enabling debug logging no longer enables trace logging
2. A new property, log.trace.enabled, which if set to true will enable trace logging and above. Note; as this is really only for use in special circumstances, there is no trace.log file (output instead is in all.log) and no specific UI for changing. Instead, it's necessary to change the property via the System Properties screen.
