### PR TITLE
OF-1687: Introduce a new SystemProperty class

### DIFF
--- a/i18n/src/main/resources/openfire_i18n_en.properties
+++ b/i18n/src/main/resources/openfire_i18n_en.properties
@@ -1582,6 +1582,7 @@ system_property.provider.auth.className=The class to use to authenticate users
 system_property.hybridAuthProvider.primaryProvider.className=The first class the HybridAuthProvider should to use to authenticate users
 system_property.hybridAuthProvider.secondaryProvider.className=The second class the HybridAuthProvider should to use to authenticate users
 system_property.hybridAuthProvider.tertiaryProvider.className=The third class the HybridAuthProvider should to use to authenticate users
+system_property.admin.authorizedJIDs=The bare JID of every admin user for the DefaultAdminProvider
 
 # Server properties Page
 

--- a/i18n/src/main/resources/openfire_i18n_en.properties
+++ b/i18n/src/main/resources/openfire_i18n_en.properties
@@ -1562,6 +1562,27 @@ server.db_stats.time=Total Time
 server.db_stats.average_time=Avg. Time
 server.db_stats.no_queries=No queries
 
+
+#
+# System property descriptions
+#
+system_property.log.debug.enabled=Controls the output of DEBUG level logs
+system_property.log.trace.enabled=Controls the output of TRACE level logs
+system_property.passwordKey=Used by the DefaultAuthProvider to encrypt passwords. If this property is changed, it will \
+  not be possible to authenticate users until their passwords are reset.
+system_property.update.lastCheck=The last time a check was made for available updates
+system_property.update.frequency=How often to check for available updates
+system_property.update.service-enabled=Determines if the automatic check for updates is performed
+system_property.update.notify-admins=Determines if the administrators receive a message when an update is found
+system_property.update.proxy.host=The proxy to use, if any, when checking for updates
+system_property.update.proxy.port=The port on the proxy to use, or -1 if no proxy
+system_property.xmpp.session.conflict-limit=-1 to never kick off existing sessions when another session with the same \
+  full JID joins, otherwise the number of login attempts before the existing session is kicked
+system_property.provider.auth.className=The class to use to authenticate users
+system_property.hybridAuthProvider.primaryProvider.className=The first class the HybridAuthProvider should to use to authenticate users
+system_property.hybridAuthProvider.secondaryProvider.className=The second class the HybridAuthProvider should to use to authenticate users
+system_property.hybridAuthProvider.tertiaryProvider.className=The third class the HybridAuthProvider should to use to authenticate users
+
 # Server properties Page
 
 server.properties.title=System Properties
@@ -1577,7 +1598,25 @@ server.properties.error_deleting=Error deleting the property.
 server.properties.no_property=No properties set.
 server.properties.name=Property Name
 server.properties.value=Property Value
+server.properties.description=Description
+server.properties.default=Default Value
+server.properties.search_all=All
+server.properties.search_none=None
+server.properties.default.unknown=Unknown
+server.properties.default.search_unchanged=Unchanged
+server.properties.default.search_changed=Changed
+server.properties.plugin=Plugin
+server.properties.dynamic=Dynamic
+server.properties.dynamic.search.true=Yes
+server.properties.dynamic.search.false=No
+server.properties.dynamic.search.restart=Needed
+server.properties.total=Total number of properties
+server.properties.filtered=Filtered properties
+server.properties.per-page=Properties per page
 server.properties.edit=Edit
+server.properties.alt_dynamic=Dynamic
+server.properties.alt_static=A restart will be required if this property changes
+server.properties.alt_restart-required=This property has changed and a restart is required
 server.properties.alt_edit=Click to edit this property
 server.properties.alt_delete=Click to delete this property
 server.properties.edit_property_title=Edit property

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SystemPropertiesServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SystemPropertiesServlet.java
@@ -1,0 +1,350 @@
+package org.jivesoftware.admin.servlet;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.jivesoftware.util.CookieUtils;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.ListPager;
+import org.jivesoftware.util.ParamUtils;
+import org.jivesoftware.util.StringUtils;
+import org.jivesoftware.util.SystemProperty;
+import org.jivesoftware.util.WebManager;
+
+@SuppressWarnings("serial")
+public class SystemPropertiesServlet extends HttpServlet {
+
+    private static final String[] SEARCH_FIELDS = {"searchName", "searchValue", "searchDefaultValue", "searchPlugin", "searchDescription", "searchDynamic"};
+
+    @Override
+    protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+
+        final Collection<SystemProperty> systemProperties = SystemProperty.getProperties();
+        final Set<String> systemPropertyKeys = systemProperties.stream().map(SystemProperty::getKey).collect(Collectors.toSet());
+        // Get all the SystemProperties
+        final List<CompoundProperty> compoundProperties = systemProperties.stream().map(CompoundProperty::new).collect(Collectors.toList());
+        // Now add any missing JiveGlobals properties
+        JiveGlobals.getPropertyNames().stream().filter(key -> !systemPropertyKeys.contains(key)).forEach(key -> compoundProperties.add(new CompoundProperty(key)));
+        // And sort by key
+        compoundProperties.sort(Comparator.comparing(o -> o.key));
+
+        // Find what we're searching for
+        final Search search = new Search(request);
+
+        final Predicate<CompoundProperty> predicate = getSearchPredicate(search);
+
+        // Finally, create a list pager
+        final ListPager<CompoundProperty> listPager = new ListPager<>(request, response, compoundProperties, predicate, SEARCH_FIELDS);
+
+        final List<String> plugins = compoundProperties.stream()
+            .map(compoundProperty -> compoundProperty.plugin)
+            .distinct()
+            .filter(plugin -> !plugin.isEmpty())
+            // Ensure Openfire comes first in the list
+            .sorted((o1, o2) -> {
+                if (o1.equalsIgnoreCase("Openfire")) {
+                    return -1;
+                } else if (o2.equalsIgnoreCase("Openfire")) {
+                    return 1;
+                } else {
+                    return o1.compareTo(o2);
+                }
+            })
+            .collect(Collectors.toList());
+
+        addSessionFlashes(request, "errorMessage", "warningMessage", "successMessage");
+        final String csrf = StringUtils.randomString(16);
+        CookieUtils.setCookie(request, response, "csrf", csrf, -1);
+        request.setAttribute("csrf", csrf);
+        request.setAttribute("listPager", listPager);
+        request.setAttribute("search", search);
+        request.setAttribute("plugins", plugins);
+
+        request.getRequestDispatcher("system-properties.jsp").forward(request, response);
+    }
+
+    private static void addSessionFlashes(final HttpServletRequest request, final String... flashes) {
+        final HttpSession session = request.getSession();
+        for (final String flash : flashes) {
+            final Object flashValue = session.getAttribute(flash);
+            if (flashValue != null) {
+                request.setAttribute(flash, flashValue);
+                session.setAttribute(flash, null);
+            }
+        }
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+        final HttpSession session = request.getSession();
+        final Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+        if (csrfCookie == null || !csrfCookie.getValue().equals(request.getParameter("csrf"))) {
+            session.setAttribute("errorMessage", "CSRF Failure!");
+        } else {
+            final WebManager webManager = new WebManager();
+            webManager.init(request, response, session, session.getServletContext());
+            final String action = ParamUtils.getStringParameter(request, "action", "");
+            switch (action) {
+                case "save":
+                    saveProperty(request);
+                    break;
+                case "cancel":
+                    session.setAttribute("warningMessage", String.format("No changes were made to the property %s", request.getParameter("key")));
+                    break;
+                case "encrypt":
+                    encryptProperty(request, webManager);
+                    break;
+                case "delete":
+                    deleteProperty(request, webManager);
+                    break;
+                default:
+                    session.setAttribute("warningMessage", String.format("Unexpected request action '%s'", action));
+                    break;
+            }
+        }
+        response.sendRedirect(request.getRequestURI() + ListPager.getQueryString(request, '?', SEARCH_FIELDS));
+    }
+
+    private void saveProperty(final HttpServletRequest request) {
+        final String key = request.getParameter("key");
+        final String value = request.getParameter("value");
+        final boolean encrypt = ParamUtils.getBooleanAttribute(request, "encrypt");
+        final boolean alreadyExists = JiveGlobals.getProperty(key) != null;
+        JiveGlobals.setProperty(key, value, encrypt);
+        request.getSession().setAttribute("successMessage", String.format("The property %s was %s", key, alreadyExists ? "updated" : "created"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void encryptProperty(final HttpServletRequest request, final WebManager webManager) {
+        final String key = request.getParameter("key");
+        if (JiveGlobals.getProperty(key) == null) {
+            // We can't encrypt a property that doesn't yet exist
+            SystemProperty.getProperty(key).ifPresent(property -> property.setValue(property.getDefaultValue()));
+        }
+        JiveGlobals.setPropertyEncrypted(key, true);
+        webManager.logEvent("Encrypted server property " + key, null);
+        request.getSession().setAttribute("successMessage", String.format("The property %s was encrypted", key));
+    }
+
+    private void deleteProperty(final HttpServletRequest request, final WebManager webManager) {
+        final String key = request.getParameter("key");
+        JiveGlobals.deleteProperty(key);
+        webManager.logEvent("deleted server property " + key, null);
+        request.getSession().setAttribute("successMessage", String.format("The property %s was deleted", key));
+    }
+
+    private Predicate<CompoundProperty> getSearchPredicate(final Search search) {
+        Predicate<CompoundProperty> predicate = compoundProperty -> true;
+
+        if (!search.name.isEmpty()) {
+            predicate = predicate.and(compoundProperty -> StringUtils.containsIgnoringCase(compoundProperty.key, search.name));
+        }
+
+        if (!search.value.isEmpty()) {
+            predicate = predicate.and(compoundProperty -> !compoundProperty.isEncrypted() && (StringUtils.containsIgnoringCase(compoundProperty.valueAsSaved, search.value) || StringUtils.containsIgnoringCase(compoundProperty.displayValue, search.value)));
+        }
+
+        switch (search.defaultValue) {
+            case "changed":
+                predicate = predicate.and(compoundProperty -> !compoundProperty.hidden && compoundProperty.systemProperty && compoundProperty.valueChanged);
+                break;
+            case "unchanged":
+                predicate = predicate.and(compoundProperty -> !compoundProperty.hidden && compoundProperty.systemProperty && !compoundProperty.valueChanged);
+                break;
+            case "unknown":
+                predicate = predicate.and(compoundProperty -> compoundProperty.hidden || !compoundProperty.systemProperty);
+                break;
+            default:
+                // Do nothing
+        }
+
+        switch (search.plugin) {
+            case "":
+                // All plugins, no filter required
+                break;
+            case "none":
+                predicate = predicate.and(compoundProperty -> compoundProperty.plugin.isEmpty());
+                break;
+            default:
+                predicate = predicate.and(compoundProperty -> search.plugin.equals(compoundProperty.plugin));
+        }
+
+        if (!search.description.isEmpty()) {
+            predicate = predicate.and(compoundProperty -> StringUtils.containsIgnoringCase(compoundProperty.description, search.description));
+        }
+
+        switch (search.dynamic) {
+            case "true":
+                predicate = predicate.and(compoundProperty -> compoundProperty.dynamic);
+                break;
+            case "false":
+                predicate = predicate.and(compoundProperty -> compoundProperty.systemProperty && !compoundProperty.dynamic && !compoundProperty.restartRequired);
+                break;
+            case "restart":
+                predicate = predicate.and(compoundProperty -> compoundProperty.systemProperty && compoundProperty.restartRequired);
+                break;
+            case "unknown":
+                predicate = predicate.and(compoundProperty -> !compoundProperty.systemProperty);
+            default:
+                // Do nothing
+        }
+
+        return predicate;
+    }
+
+    /**
+     * Not every entry in the ofProperty table will have a matching {@link SystemProperty} - so this class exists so
+     * that the admin UI can display either
+     */
+    public static final class CompoundProperty {
+
+        private final boolean systemProperty;
+        private final String key;
+        private final Object value;
+        private final String valueAsSaved;
+        private final String displayValue;
+        private final String defaultDisplayValue;
+        private final boolean valueChanged;
+        private final String description;
+        private final String plugin;
+        private final boolean dynamic;
+        private final boolean restartRequired;
+        private final boolean encrypted;
+        private final boolean hidden;
+
+        private CompoundProperty(final String key) {
+            this.systemProperty = false;
+            this.key = key;
+            this.value = JiveGlobals.getProperty(key);
+            this.valueAsSaved = (String) value;
+            this.displayValue = valueAsSaved;
+            this.defaultDisplayValue = null;
+            this.valueChanged = false;
+            this.description = "";
+            this.plugin = "";
+            this.dynamic = false;
+            this.restartRequired = false;
+            this.encrypted = JiveGlobals.isPropertyEncrypted(key);
+            this.hidden = encrypted || JiveGlobals.isPropertySensitive(key);
+        }
+
+        private CompoundProperty(final SystemProperty<?> systemProperty) {
+            this.systemProperty = true;
+            this.key = systemProperty.getKey();
+            this.value = systemProperty.getValue();
+            this.valueAsSaved = systemProperty.getValueAsSaved();
+            this.displayValue = systemProperty.getDisplayValue();
+            this.defaultDisplayValue = systemProperty.getDefaultDisplayValue();
+            this.valueChanged = systemProperty.hasValueChanged();
+            this.description = systemProperty.getDescription();
+            this.plugin = systemProperty.getPlugin();
+            this.dynamic = systemProperty.isDynamic();
+            this.restartRequired = systemProperty.isRestartRequired();
+            this.encrypted = systemProperty.isEncrypted();
+            this.hidden = encrypted || JiveGlobals.isPropertySensitive(key);
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getValueAsSaved() {
+            return valueAsSaved;
+        }
+
+        public String getDisplayValue() {
+            return displayValue;
+        }
+
+        public String getDefaultDisplayValue() {
+            return defaultDisplayValue;
+        }
+
+        public boolean isSystemProperty() {
+            return systemProperty;
+        }
+
+        public String getPlugin() {
+            return plugin;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public boolean isDynamic() {
+            return dynamic;
+        }
+
+        public boolean isRestartRequired() {
+            return restartRequired;
+        }
+
+        public boolean isHidden() {
+            return hidden;
+        }
+
+        public boolean isEncrypted() {
+            return encrypted;
+        }
+    }
+
+    /**
+     * Represents the properties being searched for
+     */
+    public static final class Search {
+
+        private final String name;
+        private final String value;
+        private final String defaultValue;
+        private final String plugin;
+        private final String description;
+        private final String dynamic;
+
+        public Search(final HttpServletRequest request) {
+            this.name = ParamUtils.getStringParameter(request, "searchName", "").trim();
+            this.value = ParamUtils.getStringParameter(request, "searchValue", "").trim();
+            this.defaultValue = ParamUtils.getStringParameter(request, "searchDefaultValue", "").trim();
+            this.plugin = ParamUtils.getStringParameter(request, "searchPlugin", "").trim();
+            this.description = ParamUtils.getStringParameter(request, "searchDescription", "").trim();
+            this.dynamic = ParamUtils.getStringParameter(request, "searchDynamic", "").trim();
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public String getDefaultValue() {
+            return defaultValue;
+        }
+
+        public String getPlugin() {
+            return plugin;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public String getDynamic() {
+            return dynamic;
+        }
+
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -48,6 +48,7 @@ import org.jivesoftware.database.JNDIDataSourceProvider;
 import org.jivesoftware.openfire.admin.AdminManager;
 import org.jivesoftware.openfire.audit.AuditManager;
 import org.jivesoftware.openfire.audit.spi.AuditManagerImpl;
+import org.jivesoftware.openfire.auth.AuthFactory;
 import org.jivesoftware.openfire.auth.ScramUtils;
 import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.cluster.NodeID;
@@ -399,9 +400,9 @@ public class XMPPServer {
 
         JiveGlobals.migrateProperty("xmpp.domain");
 
-        JiveGlobals.migrateProperty(Log.LOG_DEBUG_ENABLED);
-        Log.setDebugEnabled(JiveGlobals.getBooleanProperty(Log.LOG_DEBUG_ENABLED, false));
-        Log.setTraceEnabled(JiveGlobals.getBooleanProperty(Log.LOG_TRACE_ENABLED, false));
+        JiveGlobals.migrateProperty(Log.DEBUG_ENABLED.getKey());
+        Log.setDebugEnabled(Log.DEBUG_ENABLED.getValue());
+        Log.setTraceEnabled(Log.TRACE_ENABLED.getValue());
 
         // Update server info
         xmppServerInfo = new XMPPServerInfoImpl(new Date());
@@ -505,7 +506,7 @@ public class XMPPServer {
             JiveGlobals.setXMLProperty("connectionProvider.className",
                 "org.jivesoftware.database.DefaultConnectionProvider");
 
-            JiveGlobals.setProperty("provider.auth.className", JiveGlobals.getXMLProperty("provider.auth.className",
+            JiveGlobals.setProperty(AuthFactory.AUTH_PROVIDER.getKey(), JiveGlobals.getXMLProperty(AuthFactory.AUTH_PROVIDER.getKey(),
                 org.jivesoftware.openfire.auth.DefaultAuthProvider.class.getName()));
             JiveGlobals.setProperty("provider.user.className", JiveGlobals.getXMLProperty("provider.user.className",
                 org.jivesoftware.openfire.user.DefaultUserProvider.class.getName()));

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/admin/DefaultAdminProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/admin/DefaultAdminProvider.java
@@ -36,14 +36,13 @@ import org.xmpp.packet.JID;
  */
 public class DefaultAdminProvider implements AdminProvider {
 
-    private static final SystemProperty<List> ADMIN_JIDS = SystemProperty.Builder.ofType(List.class)
-        .setCollectionType(String.class)
+    private static final SystemProperty<List<String>> ADMIN_JIDS = SystemProperty.Builder.ofType(List.class)
         .setKey("admin.authorizedJIDs")
         .setDefaultValue(Collections.emptyList())
         .setSorted(true)
         .setDynamic(true)
         .addListener(jids -> AdminManager.getInstance().refreshAdminAccounts())
-        .build();
+        .buildList(String.class);
     private static final Logger Log = LoggerFactory.getLogger(DefaultAdminProvider.class);
 
     /**
@@ -64,9 +63,7 @@ public class DefaultAdminProvider implements AdminProvider {
     @Override
     public List<JID> getAdmins() {
         // Add bare JIDs of users that are admins (may include remote users), primarily used to override/add to list of admin users
-        @SuppressWarnings("unchecked")
-        final List<String> jids = ADMIN_JIDS.getValue();
-        final List<JID> adminList = jids
+        final List<JID> adminList = ADMIN_JIDS.getValue()
             .stream()
             .map(jid -> {
                 try {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/admin/DefaultAdminProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/admin/DefaultAdminProvider.java
@@ -18,9 +18,7 @@ package org.jivesoftware.openfire.admin;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.StringTokenizer;
-import java.util.stream.Collectors;
 
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.util.JiveGlobals;
@@ -36,13 +34,13 @@ import org.xmpp.packet.JID;
  */
 public class DefaultAdminProvider implements AdminProvider {
 
-    private static final SystemProperty<List<String>> ADMIN_JIDS = SystemProperty.Builder.ofType(List.class)
+    private static final SystemProperty<List<JID>> ADMIN_JIDS = SystemProperty.Builder.ofType(List.class)
         .setKey("admin.authorizedJIDs")
         .setDefaultValue(Collections.emptyList())
         .setSorted(true)
         .setDynamic(true)
         .addListener(jids -> AdminManager.getInstance().refreshAdminAccounts())
-        .buildList(String.class);
+        .buildList(JID.class);
     private static final Logger Log = LoggerFactory.getLogger(DefaultAdminProvider.class);
 
     /**
@@ -63,18 +61,7 @@ public class DefaultAdminProvider implements AdminProvider {
     @Override
     public List<JID> getAdmins() {
         // Add bare JIDs of users that are admins (may include remote users), primarily used to override/add to list of admin users
-        final List<JID> adminList = ADMIN_JIDS.getValue()
-            .stream()
-            .map(jid -> {
-                try {
-                    return new JID(jid);
-                } catch( final Exception e) {
-                    Log.warn("Invalid JID found in {} system property: {}", ADMIN_JIDS.getKey(), jid, e);
-                    return null;
-                }
-            })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+        final List<JID> adminList = ADMIN_JIDS.getValue();
         if (adminList.isEmpty()) {
             // Add default admin account when none was specified
             return Collections.singletonList(new JID("admin", XMPPServer.getInstance().getServerInfo().getXMPPDomain(), null, true));
@@ -90,7 +77,7 @@ public class DefaultAdminProvider implements AdminProvider {
      */
     @Override
     public void setAdmins(final List<JID> admins) {
-        ADMIN_JIDS.setValue(admins.stream().map(JID::toBareJID).collect(Collectors.toList()));
+        ADMIN_JIDS.setValue(admins);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
@@ -20,8 +20,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.jivesoftware.openfire.user.UserNotFoundException;
-import org.jivesoftware.util.ClassUtils;
 import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.SystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,6 +79,22 @@ import org.slf4j.LoggerFactory;
 public class HybridAuthProvider implements AuthProvider {
 
     private static final Logger Log = LoggerFactory.getLogger(HybridAuthProvider.class);
+    private static final SystemProperty<Class> PRIMARY_PROVIDER = SystemProperty.Builder.ofType(Class.class)
+        .setKey("hybridAuthProvider.primaryProvider.className")
+        .setBaseClass(AuthProvider.class)
+        .setDefaultValue(DefaultAuthProvider.class)
+        .setDynamic(false)
+        .build();
+    private static final SystemProperty<Class> SECONDARY_PROVIDER = SystemProperty.Builder.ofType(Class.class)
+        .setKey("hybridAuthProvider.secondaryProvider.className")
+        .setBaseClass(AuthProvider.class)
+        .setDynamic(false)
+        .build();
+    private static final SystemProperty<Class> TERTIARY_PROVIDER = SystemProperty.Builder.ofType(Class.class)
+        .setKey("hybridAuthProvider.tertiaryProvider.className")
+        .setBaseClass(AuthProvider.class)
+        .setDynamic(false)
+        .build();
 
     private AuthProvider primaryProvider;
     private AuthProvider secondaryProvider;
@@ -90,54 +106,48 @@ public class HybridAuthProvider implements AuthProvider {
 
     public HybridAuthProvider() {
         // Convert XML based provider setup to Database based
-        JiveGlobals.migrateProperty("hybridAuthProvider.primaryProvider.className");
-        JiveGlobals.migrateProperty("hybridAuthProvider.secondaryProvider.className");
-        JiveGlobals.migrateProperty("hybridAuthProvider.tertiaryProvider.className");
+        JiveGlobals.migrateProperty(PRIMARY_PROVIDER.getKey());
+        JiveGlobals.migrateProperty(SECONDARY_PROVIDER.getKey());
+        JiveGlobals.migrateProperty(TERTIARY_PROVIDER.getKey());
         JiveGlobals.migrateProperty("hybridAuthProvider.primaryProvider.overrideList");
         JiveGlobals.migrateProperty("hybridAuthProvider.secondaryProvider.overrideList");
         JiveGlobals.migrateProperty("hybridAuthProvider.tertiaryProvider.overrideList");
 
         // Load primary, secondary, and tertiary auth providers.
-        String primaryClass = JiveGlobals.getProperty(
-                "hybridAuthProvider.primaryProvider.className");
+        final Class primaryClass = PRIMARY_PROVIDER.getValue();
         if (primaryClass == null) {
             Log.error("A primary AuthProvider must be specified. Authentication will be disabled.");
             return;
         }
         try {
-            Class c = ClassUtils.forName(primaryClass);
-            primaryProvider = (AuthProvider)c.newInstance();
-            Log.debug("Primary auth provider: " + primaryClass);
+            primaryProvider = (AuthProvider)primaryClass.newInstance();
+            Log.debug("Primary auth provider: " + primaryClass.getName());
         }
         catch (Exception e) {
-            Log.error("Unable to load primary auth provider: " + primaryClass +
+            Log.error("Unable to load primary auth provider: " + primaryClass.getName() +
                     ". Authentication will be disabled.", e);
             return;
         }
 
-        String secondaryClass = JiveGlobals.getProperty(
-                "hybridAuthProvider.secondaryProvider.className");
+        final Class secondaryClass = SECONDARY_PROVIDER.getValue();
         if (secondaryClass != null) {
             try {
-                Class c = ClassUtils.forName(secondaryClass);
-                secondaryProvider = (AuthProvider)c.newInstance();
-                Log.debug("Secondary auth provider: " + secondaryClass);
+                secondaryProvider = (AuthProvider)secondaryClass.newInstance();
+                Log.debug("Secondary auth provider: " + secondaryClass.getName());
             }
             catch (Exception e) {
-                Log.error("Unable to load secondary auth provider: " + secondaryClass, e);
+                Log.error("Unable to load secondary auth provider: " + secondaryClass.getName(), e);
             }
         }
 
-        String tertiaryClass = JiveGlobals.getProperty(
-                "hybridAuthProvider.tertiaryProvider.className");
+        final Class tertiaryClass = TERTIARY_PROVIDER.getValue();
         if (tertiaryClass != null) {
             try {
-                Class c = ClassUtils.forName(tertiaryClass);
-                tertiaryProvider = (AuthProvider)c.newInstance();
-                Log.debug("Tertiary auth provider: " + tertiaryClass);
+                tertiaryProvider = (AuthProvider)tertiaryClass.newInstance();
+                Log.debug("Tertiary auth provider: " + tertiaryClass.getName());
             }
             catch (Exception e) {
-                Log.error("Unable to load tertiary auth provider: " + tertiaryClass, e);
+                Log.error("Unable to load tertiary auth provider: " + tertiaryClass.getName(), e);
             }
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/PluginDownloadManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/PluginDownloadManager.java
@@ -16,6 +16,8 @@
 
 package org.jivesoftware.openfire.update;
 
+import java.time.Instant;
+
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
@@ -85,8 +87,7 @@ public class PluginDownloadManager {
             updateManager.checkForPluginsUpdates(true);
 
             // Keep track of the last time we checked for updates
-            JiveGlobals.setProperty("update.lastCheck",
-                    String.valueOf(System.currentTimeMillis()));
+            UpdateManager.LAST_UPDATE_CHECK.setValue(Instant.now());
 
             return true;
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
@@ -27,6 +27,9 @@ import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -35,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -58,9 +62,9 @@ import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.container.BasicModule;
 import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.openfire.container.PluginMetadata;
-import org.jivesoftware.util.JiveConstants;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.LocaleUtils;
+import org.jivesoftware.util.SystemProperty;
 import org.jivesoftware.util.Version;
 import org.jivesoftware.util.XMLWriter;
 import org.slf4j.Logger;
@@ -79,6 +83,39 @@ import org.xmpp.packet.Message;
  * @author Gaston Dombiak
  */
 public class UpdateManager extends BasicModule {
+
+    private static final SystemProperty<Boolean> ENABLED = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("update.service-enabled")
+        .setDynamic(true)
+        .setDefaultValue(true)
+        .build();
+    private static final SystemProperty<Boolean> NOTIFY_ADMINS = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("update.notify-admins")
+        .setDynamic(true)
+        .setDefaultValue(true)
+        .build();
+    static final SystemProperty<Instant> LAST_UPDATE_CHECK = SystemProperty.Builder.ofType(Instant.class)
+        .setKey("update.lastCheck")
+        .setDynamic(true)
+        .build();
+    private static final SystemProperty<Duration> UPDATE_FREQUENCY = SystemProperty.Builder.ofType(Duration.class)
+        .setKey("update.frequency")
+        .setDynamic(false)
+        .setChronoUnit(ChronoUnit.HOURS)
+        .setDefaultValue(Duration.ofHours(48))
+        .setMinValue(Duration.ofHours(12))
+        .build();
+    private static final SystemProperty<String> PROXY_HOST = SystemProperty.Builder.ofType(String.class)
+        .setKey("update.proxy.host")
+        .setDynamic(true)
+        .build();
+    private static final SystemProperty<Integer> PROXY_PORT = SystemProperty.Builder.ofType(Integer.class)
+        .setKey("update.proxy.port")
+        .setDynamic(true)
+        .setDefaultValue(-1)
+        .setMinValue(-1)
+        .setMaxValue(65535)
+        .build();
 
     private static final Logger Log = LoggerFactory.getLogger(UpdateManager.class);
 
@@ -110,7 +147,7 @@ public class UpdateManager extends BasicModule {
     private Thread thread;
 
     /**
-     * Router to use for sending notitication messages to admins.
+     * Router to use for sending notification messages to admins.
      */
     private MessageRouter router;
     private String serverName;
@@ -118,6 +155,7 @@ public class UpdateManager extends BasicModule {
 
     public UpdateManager() {
         super("Update manager");
+        ENABLED.addListener(this::enableService);
     }
 
     @Override
@@ -155,13 +193,13 @@ public class UpdateManager extends BasicModule {
                                 Log.error("Error checking for updates", e);
                             }
                             // Keep track of the last time we checked for updates.
-                            long now = System.currentTimeMillis();
-                            JiveGlobals.setProperty("update.lastCheck", String.valueOf(now));
+                            final Instant lastUpdate = Instant.now();
+                            LAST_UPDATE_CHECK.setValue(lastUpdate);
                             // As an extra precaution, make sure that that the value
                             // we just set is saved. If not, return to make sure that
                             // no additional update checks are performed until Openfire
                             // is restarted.
-                            if (now != JiveGlobals.getLongProperty("update.lastCheck", 0)) {
+                            if(!lastUpdate.equals(LAST_UPDATE_CHECK.getValue())) {
                                 Log.error("Error: update service check did not save correctly. " +
                                         "Stopping update service.");
                                 return;
@@ -179,20 +217,16 @@ public class UpdateManager extends BasicModule {
             }
 
             private void waitForNextCheck() throws InterruptedException {
-                long lastCheck = JiveGlobals.getLongProperty("update.lastCheck", 0);
-                if (lastCheck == 0) {
+                final Instant lastCheck = LAST_UPDATE_CHECK.getValue();
+                if (lastCheck == null) {
                     // This is the first time the server is used (since we added this feature)
                     Thread.sleep(30000);
                 }
                 else {
-                    long elapsed = System.currentTimeMillis() - lastCheck;
-                    long frequency = getCheckFrequency() * JiveConstants.HOUR;
-                    // Sleep until we've waited the appropriate amount of time.
-                    while (elapsed < frequency) {
-                        Thread.sleep(frequency - elapsed);
-                        // Update the elapsed time. This check is necessary just in case the
-                        // thread woke up early.
-                        elapsed = System.currentTimeMillis() - lastCheck;
+                    final Duration updateFrequency = UPDATE_FREQUENCY.getValue();
+                    // This check is necessary just in case the thread woke up early.
+                    while (lastCheck.plus(updateFrequency).isAfter(Instant.now())) {
+                        Thread.sleep(Duration.between(Instant.now(), lastCheck.plus(updateFrequency)).toMillis());
                     }
                 }
             }
@@ -201,14 +235,21 @@ public class UpdateManager extends BasicModule {
         thread.start();
     }
 
+    private void stopService() {
+        if (thread != null) {
+            thread.interrupt();
+            thread = null;
+        }
+    }
+
     @Override
     public void initialize(XMPPServer server) {
         super.initialize(server);
         router = server.getMessageRouter();
         serverName = server.getServerInfo().getXMPPDomain();
 
-        JiveGlobals.migrateProperty("update.service-enabled");
-        JiveGlobals.migrateProperty("update.notify-admins");
+        JiveGlobals.migrateProperty(ENABLED.getKey());
+        JiveGlobals.migrateProperty(NOTIFY_ADMINS.getKey());
     }
 
     /**
@@ -396,7 +437,7 @@ public class UpdateManager extends BasicModule {
      * @return true if the check for updates service is enabled.
      */
     public boolean isServiceEnabled() {
-        return JiveGlobals.getBooleanProperty("update.service-enabled", true);
+        return ENABLED.getValue();
     }
 
     /**
@@ -404,10 +445,15 @@ public class UpdateManager extends BasicModule {
      *
      * @param enabled true if the check for updates service is enabled.
      */
-    public void setServiceEnabled(boolean enabled) {
-        JiveGlobals.setProperty("update.service-enabled", enabled ? "true" : "false");
+    public void setServiceEnabled(final boolean enabled) {
+        ENABLED.setValue(enabled);
+    }
+
+    private void enableService(final boolean enabled) {
         if (enabled && thread == null) {
             startService();
+        } else if (!enabled && thread != null) {
+            stopService();
         }
     }
 
@@ -417,7 +463,7 @@ public class UpdateManager extends BasicModule {
      * @return true if admins should be notified by IM when new updates are available.
      */
     public boolean isNotificationEnabled() {
-        return JiveGlobals.getBooleanProperty("update.notify-admins", true);
+        return NOTIFY_ADMINS.getValue();
     }
 
     /**
@@ -425,33 +471,8 @@ public class UpdateManager extends BasicModule {
      *
      * @param enabled true if admins should be notified by IM when new updates are available.
      */
-    public void setNotificationEnabled(boolean enabled) {
-        JiveGlobals.setProperty("update.notify-admins", enabled ? "true" : "false");
-    }
-
-    /**
-     * Returns the frequency to check for updates. By default, this will happen every 48 hours.
-     * The frequency returned will never be less than 12 hours.
-     *
-     * @return the frequency to check for updates in hours.
-     */
-    public int getCheckFrequency() {
-        int frequency = JiveGlobals.getIntProperty("update.frequency", 48);
-        if (frequency < 12) {
-            return 12;
-        }
-        else {
-            return frequency;
-        }
-    }
-
-    /**
-     * Sets the frequency to check for updates. By default, this will happen every 48 hours.
-     *
-     * @param checkFrequency the frequency to check for updates.
-     */
-    public void setCheckFrequency(int checkFrequency) {
-        JiveGlobals.setProperty("update.frequency", Integer.toString(checkFrequency));
+    public void setNotificationEnabled(final boolean enabled) {
+        NOTIFY_ADMINS.setValue(enabled);
     }
 
     /**
@@ -461,7 +482,7 @@ public class UpdateManager extends BasicModule {
      * @return true if a proxy is being used to connect to igniterealtime.org.
      */
     public boolean isUsingProxy() {
-        return !getProxyHost().isEmpty() && getProxyPort() > 0;
+        return !StringUtils.isBlank(getProxyHost()) && getProxyPort() > 0;
     }
 
     /**
@@ -471,7 +492,7 @@ public class UpdateManager extends BasicModule {
      * @return the host of the proxy or null if no proxy is used.
      */
     public String getProxyHost() {
-        return JiveGlobals.getProperty("update.proxy.host", "");
+        return PROXY_HOST.getValue();
     }
 
     /**
@@ -481,14 +502,7 @@ public class UpdateManager extends BasicModule {
      * @param host the host of the proxy or null if no proxy is used.
      */
     public void setProxyHost(String host) {
-        if (host == null) {
-            // Remove the property
-            JiveGlobals.deleteProperty("update.proxy.host");
-        }
-        else {
-            // Create or update the property
-            JiveGlobals.setProperty("update.proxy.host", host);
-        }
+        PROXY_HOST.setValue(host);
     }
 
     /**
@@ -499,7 +513,7 @@ public class UpdateManager extends BasicModule {
      *         proxy is being used.
      */
     public int getProxyPort() {
-        return JiveGlobals.getIntProperty("update.proxy.port", -1);
+        return PROXY_PORT.getValue();
     }
 
     /**
@@ -510,7 +524,7 @@ public class UpdateManager extends BasicModule {
      *        proxy is being used.
      */
     public void setProxyPort(int port) {
-        JiveGlobals.setProperty("update.proxy.port", Integer.toString(port));
+        PROXY_PORT.setValue(port);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/util/Log.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Log.java
@@ -24,7 +24,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -48,44 +47,30 @@ import org.apache.logging.log4j.core.config.LoggerConfig;
 public final class Log {
 
     private static final org.slf4j.Logger Logger = org.slf4j.LoggerFactory.getLogger(Log.class);
-    public static final String LOG_DEBUG_ENABLED = "log.debug.enabled";
-    public static final String LOG_TRACE_ENABLED = "log.trace.enabled";
+    public static final SystemProperty<Boolean> DEBUG_ENABLED = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("log.debug.enabled")
+        .setDefaultValue(false)
+        .setDynamic(true)
+        .addListener(Log::setDebugEnabled)
+        .build();
+    /**
+     * @deprecated in favour of {@link #DEBUG_ENABLED}
+     */
+    @Deprecated
+    public static final String LOG_DEBUG_ENABLED = DEBUG_ENABLED.getKey();
+    public static final SystemProperty<Boolean> TRACE_ENABLED = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("log.trace.enabled")
+        .setDefaultValue(false)
+        .setDynamic(true)
+        .addListener(Log::setTraceEnabled)
+        .build();
+    /**
+     * @deprecated in favour of {@link #TRACE_ENABLED}
+     */
+    @Deprecated
+    public static final String LOG_TRACE_ENABLED = TRACE_ENABLED.getKey();
     private static boolean debugEnabled = false;
     private static boolean traceEnabled = false;
-
-    // listen for changes to the log.debug.enabled property
-    static {
-        PropertyEventDispatcher.addListener(new PropertyEventListener() {
-            
-            @Override
-            public void propertySet(String property, Map<String, Object> params) {
-                enableLog(property, Boolean.parseBoolean(params.get("value").toString()));
-            }
-            
-            @Override
-            public void propertyDeleted(String property, Map<String, Object> params) {
-                enableLog(property, false);
-            }
-            
-            // ignore these events
-            @Override
-            public void xmlPropertySet(String property, Map<String, Object> params) { }
-            @Override
-            public void xmlPropertyDeleted(String property, Map<String, Object> params) { }
-            
-            private void enableLog(String property, boolean enabled) {
-                switch (property) {
-                    case LOG_TRACE_ENABLED:
-                        setTraceEnabled(enabled);
-                        break;
-                    case LOG_DEBUG_ENABLED:
-                        setDebugEnabled(enabled);
-                        break;
-                }
-            }
-        });
-    }
-    
 
     /**
      * @deprecated replaced by {@link org.slf4j.Logger#isErrorEnabled()}.

--- a/xmppserver/src/main/java/org/jivesoftware/util/StringUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/StringUtils.java
@@ -38,6 +38,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1176,6 +1177,28 @@ public final class StringUtils {
             return nullableString.toLowerCase().contains(value.toLowerCase());
         } else {
             return false;
+        }
+    }
+
+    public static Optional<Integer> parseInteger(final String value) {
+        if (value == null || value.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Integer.valueOf(value));
+        } catch (final NumberFormatException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<Long> parseLong(final String value) {
+        if (value == null || value.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Long.valueOf(value));
+        } catch (final NumberFormatException ignored) {
+            return Optional.empty();
         }
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
@@ -447,6 +447,7 @@ public final class SystemProperty<T> {
          * <li>{@link Boolean} - for which a default value must be supplied</li>
          * <li>{@link Duration} - for which a {@link ChronoUnit} must be specified, to indicate how the value will be saved, using {@link #setChronoUnit(ChronoUnit)}</li>
          * <li>{@link Instant}</li>
+         * <li>{@link JID}</li>
          * <li>{@link Class} - for which a base class must be specified from which values must inherit, using {@link #setBaseClass(Class)}</li>
          * <li>any {@link Enum} - for which a default value must be supplied</li>
          * <li>{@link List} - for which a collection type must be specified, using {@link #buildList(Class)}</li>

--- a/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -17,6 +18,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -32,90 +35,114 @@ public final class SystemProperty<T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SystemProperty.class);
     private static final Map<String, SystemProperty> PROPERTIES = new ConcurrentHashMap<>();
-    private static final Map<ChronoUnit, Function<Duration, Long>> DURATION_TO_LONG;
-    private static final Map<ChronoUnit, Function<Long, Duration>> LONG_TO_DURATION;
-    private static final Map<Class, BiFunction<SystemProperty, Object, String>> SAVE_FORMATTERS;
-    private static final Map<Class, BiFunction<SystemProperty, Object, String>> DISPLAY_FORMATTERS;
-    private static final Map<Class, Function> GETTERS;
+    private static final Map<ChronoUnit, Function<Duration, Long>> DURATION_TO_LONG = new HashMap<>();
+    private static final Map<ChronoUnit, Function<Long, Duration>> LONG_TO_DURATION = new HashMap<>();
+    private static final Map<Class, BiFunction<String, SystemProperty, Object>> FROM_STRING = new HashMap<>();
+    private static final Map<Class, BiFunction<Object, SystemProperty, String>> TO_STRING = new HashMap<>();
+    private static final Map<Class, BiFunction<Object, SystemProperty, String>> TO_DISPLAY_STRING = new HashMap<>();
     private static final Set<Class> NULLABLE_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(String.class, Class.class, Duration.class, Instant.class)));
 
     static {
         // Populate the map that turns a Duration to a Long based on the ChronoUnit a property should be saved in
-        final Map<ChronoUnit, Function<Duration, Long>> durationToLong = new HashMap<>();
-        durationToLong.put(ChronoUnit.MILLIS, Duration::toMillis);
-        durationToLong.put(ChronoUnit.SECONDS, Duration::getSeconds);
-        durationToLong.put(ChronoUnit.MINUTES, Duration::toMinutes);
-        durationToLong.put(ChronoUnit.HOURS, Duration::toHours);
-        durationToLong.put(ChronoUnit.DAYS, Duration::toDays);
-        DURATION_TO_LONG = Collections.unmodifiableMap(durationToLong);
+        DURATION_TO_LONG.put(ChronoUnit.MILLIS, Duration::toMillis);
+        DURATION_TO_LONG.put(ChronoUnit.SECONDS, Duration::getSeconds);
+        DURATION_TO_LONG.put(ChronoUnit.MINUTES, Duration::toMinutes);
+        DURATION_TO_LONG.put(ChronoUnit.HOURS, Duration::toHours);
+        DURATION_TO_LONG.put(ChronoUnit.DAYS, Duration::toDays);
     }
 
     static {
         // Populate the map that turns a Long to a Duration based on the ChronoUnit a property should be saved in
-        final Map<ChronoUnit, Function<Long, Duration>> longToDuration = new HashMap<>();
-        longToDuration.put(ChronoUnit.MILLIS, Duration::ofMillis);
-        longToDuration.put(ChronoUnit.SECONDS, Duration::ofSeconds);
-        longToDuration.put(ChronoUnit.MINUTES, Duration::ofMinutes);
-        longToDuration.put(ChronoUnit.HOURS, Duration::ofHours);
-        longToDuration.put(ChronoUnit.DAYS, Duration::ofDays);
-        LONG_TO_DURATION = Collections.unmodifiableMap(longToDuration);
+        LONG_TO_DURATION.put(ChronoUnit.MILLIS, Duration::ofMillis);
+        LONG_TO_DURATION.put(ChronoUnit.SECONDS, Duration::ofSeconds);
+        LONG_TO_DURATION.put(ChronoUnit.MINUTES, Duration::ofMinutes);
+        LONG_TO_DURATION.put(ChronoUnit.HOURS, Duration::ofHours);
+        LONG_TO_DURATION.put(ChronoUnit.DAYS, Duration::ofDays);
     }
 
     static {
-        // Populate the map that converts a property to the String value that it's saved as
-        final Map<Class, BiFunction<SystemProperty, Object, String>> formatters = new HashMap<>();
-        formatters.put(String.class, (systemProperty, value) -> (String) value);
-        formatters.put(Integer.class, (systemProperty, value) -> value.toString());
-        formatters.put(Long.class, (systemProperty, value) -> value.toString());
-        formatters.put(Boolean.class, (systemProperty, value) -> value.toString());
-        formatters.put(Duration.class, (systemProperty, value) -> value == null ? null : String.valueOf(DURATION_TO_LONG.get(systemProperty.chronoUnit).apply((Duration) value)));
-        formatters.put(Instant.class, (systemProperty, value) -> value == null ? null : String.valueOf(((Instant)value).toEpochMilli()));
-        formatters.put(Class.class, (systemProperty, value) -> value == null ? null : ((Class) value).getName());
-        SAVE_FORMATTERS = Collections.unmodifiableMap(formatters);
-    }
-
-    static {
-        // Populate the map that retrieves the property value of a given type from JiveGlobals
-        final Map<Class, Function> getters = new HashMap<>();
-        getters.put(String.class, (Function<SystemProperty<String>, String>) property -> JiveGlobals.getProperty(property.key, property.defaultValue));
-        getters.put(Integer.class, (Function<SystemProperty<Integer>, Integer>) property -> JiveGlobals.getIntProperty(property.key, property.defaultValue));
-        getters.put(Long.class, (Function<SystemProperty<Long>, Long>) property -> JiveGlobals.getLongProperty(property.key, property.defaultValue));
-        getters.put(Boolean.class, (Function<SystemProperty<Boolean>, Boolean>) property -> JiveGlobals.getBooleanProperty(property.key, property.defaultValue));
-        getters.put(Duration.class, (Function<SystemProperty<Duration>, Duration>) property -> longValueExists(property.key) ? LONG_TO_DURATION.get(property.chronoUnit).apply(JiveGlobals.getLongProperty(property.key, 0)) : property.defaultValue);
-        getters.put(Instant.class, (Function<SystemProperty<Instant>, Instant>) property -> longValueExists(property.key) ? Instant.ofEpochMilli(JiveGlobals.getLongProperty(property.key, 0)) : property.defaultValue);
-        getters.put(Class.class, (Function<SystemProperty<Class>, Class>) property -> {
-            final String className = JiveGlobals.getProperty(property.key, property.defaultValue == null ? null : property.defaultValue.getName());
-            if (StringUtils.isBlank(className)) {
-                // No configured value and no default either
+        // Given a String value and a system property, converts the String to the object of appropriate type or null
+        FROM_STRING.put(String.class, (value, systemProperty) -> value);
+        FROM_STRING.put(Integer.class, (value, systemProperty) -> org.jivesoftware.util.StringUtils.parseInteger(value).orElse(null));
+        FROM_STRING.put(Long.class, (value, systemProperty) -> org.jivesoftware.util.StringUtils.parseLong(value).orElse(null));
+        FROM_STRING.put(Boolean.class, (value, systemProperty) -> Boolean.valueOf(value));
+        FROM_STRING.put(Duration.class, (value, systemProperty) -> org.jivesoftware.util.StringUtils.parseLong(value).map(longValue -> LONG_TO_DURATION.get(systemProperty.chronoUnit).apply(longValue)).orElse(null));
+        FROM_STRING.put(Instant.class, (value, systemProperty) -> org.jivesoftware.util.StringUtils.parseLong(value).map(Instant::ofEpochMilli).orElse(null));
+        FROM_STRING.put(Class.class, (value, systemProperty) -> {
+            if(StringUtils.isBlank(value)) {
                 return null;
             }
             try {
-                final Class<?> clazz = Class.forName(className);
-                if (property.baseClass.isAssignableFrom(clazz)) {
+                final Class clazz = Class.forName(value);
+                //noinspection unchecked
+                if (systemProperty.baseClass.isAssignableFrom(clazz)) {
                     return clazz;
                 } else {
-                    LOGGER.warn("Configured property {} is not an instance of {}, using default value {} instead", className, property.baseClass.getName(), SAVE_FORMATTERS.get(Class.class).apply(property, property.defaultValue));
-                    return property.defaultValue;
+                    LOGGER.warn("Configured property {} is not an instance of {}, using default value instead", value, systemProperty.baseClass.getName());
+                    return null;
                 }
             } catch (final ClassNotFoundException e) {
-                LOGGER.warn("Class {} was not found, using default value {} instead", className, SAVE_FORMATTERS.get(Class.class).apply(property, property.defaultValue), e);
-                return property.defaultValue;
+                LOGGER.warn("Class {} was not found, using default value instead", value, e);
+                return null;
             }
         });
-        GETTERS = Collections.unmodifiableMap(getters);
+        FROM_STRING.put(List.class, (value, systemProperty) -> {
+            if(StringUtils.isEmpty(value)) {
+                return null;
+            }
+            final List<String> strings = Arrays.asList(value.split(","));
+            Stream<Object> stream = strings.stream()
+                .map(singleValue -> FROM_STRING.get(systemProperty.collectionType).apply(singleValue, systemProperty));
+            if(systemProperty.sorted) {
+                stream = stream.sorted();
+            }
+            return stream.collect(Collectors.toList());
+        });
     }
 
     static {
-        // Populate the map that converts a property to the String value that it's saved as
-        final Map<Class, BiFunction<SystemProperty, Object, String>> formatters = new HashMap<>();
-        formatters.put(String.class, (systemProperty, value) -> (String) value);
-        formatters.put(Integer.class, (systemProperty, value) -> value.toString());
-        formatters.put(Long.class, (systemProperty, value) -> value.toString());
-        formatters.put(Boolean.class, (systemProperty, value) -> value.toString());
-        formatters.put(Duration.class, (systemProperty, value) -> value == null ? null : org.jivesoftware.util.StringUtils.getFullElapsedTime((Duration)value));
-        formatters.put(Instant.class, (systemProperty, value) -> value == null ? null : Date.from((Instant) value).toString());
-        formatters.put(Class.class, (systemProperty, value) -> value == null ? null : ((Class)value).getName());
-        DISPLAY_FORMATTERS = Collections.unmodifiableMap(formatters);
+        // Given a value and a system property, converts the value to a String with the appropriate value or null
+        TO_STRING.put(String.class, (value, systemProperty) -> (String)value);
+        TO_STRING.put(Integer.class, (value, systemProperty) -> value.toString());
+        TO_STRING.put(Long.class, (value, systemProperty) -> value.toString());
+        TO_STRING.put(Boolean.class, (value, systemProperty) -> value.toString());
+        TO_STRING.put(Duration.class, (value, systemProperty) -> value == null ? null : DURATION_TO_LONG.get(systemProperty.chronoUnit).apply((Duration) value).toString());
+        TO_STRING.put(Instant.class, (value, systemProperty) -> value == null ? null : String.valueOf(((Instant)value).toEpochMilli()));
+        TO_STRING.put(Class.class, (value, systemProperty) -> value == null ? null : ((Class)value).getName());
+        TO_STRING.put(List.class, (value, systemProperty) -> {
+            final List listValue = (List) value;
+            if (listValue == null || listValue.isEmpty()) {
+                return null;
+            }
+            // noinspection unchecked
+            Stream<String> stream = listValue.stream()
+                .map(singleValue -> TO_STRING.get(systemProperty.collectionType).apply(singleValue, systemProperty));
+            if(systemProperty.sorted) {
+                stream = stream.sorted();
+            }
+            return stream.collect(Collectors.joining(","));
+        });
+    }
+
+    static {
+        // Given a value and a system property, converts the value to a display String of the appropriate value or null
+        TO_DISPLAY_STRING.put(String.class, (value, systemProperty) -> (String) value);
+        TO_DISPLAY_STRING.put(Integer.class, (value, systemProperty) -> value.toString());
+        TO_DISPLAY_STRING.put(Long.class, (value, systemProperty) -> value.toString());
+        TO_DISPLAY_STRING.put(Boolean.class, (value, systemProperty) -> value.toString());
+        TO_DISPLAY_STRING.put(Duration.class, (value, systemProperty) -> value == null ? null : org.jivesoftware.util.StringUtils.getFullElapsedTime((Duration)value));
+        TO_DISPLAY_STRING.put(Instant.class, (value, systemProperty) -> value == null ? null : Date.from((Instant) value).toString());
+        TO_DISPLAY_STRING.put(Class.class, (value, systemProperty) -> value == null ? null : ((Class)value).getName());
+        TO_DISPLAY_STRING.put(List.class, (value, systemProperty) -> {
+            final List listValue = (List) value;
+            if (listValue == null || listValue.isEmpty()) {
+                return null;
+            }
+            // noinspection unchecked
+            return ((Stream<String>) listValue.stream()
+                .map(singleValue -> TO_DISPLAY_STRING.get(systemProperty.collectionType).apply(singleValue, systemProperty)))
+                .collect(Collectors.joining(","));
+        });
     }
 
     static {
@@ -153,14 +180,16 @@ public final class SystemProperty<T> {
     private final String description;
     private final String plugin;
     private final T defaultValue;
-    private final Class<?> baseClass;
     private final T minValue;
     private final T maxValue;
     private final boolean dynamic;
-    private final ChronoUnit chronoUnit;
     private final Set<Consumer<T>> listeners = ConcurrentHashMap.newKeySet();
     private final T initialValue;
     private final boolean encrypted;
+    private final ChronoUnit chronoUnit;
+    private final Class baseClass;
+    private final Class collectionType;
+    private final boolean sorted;
 
     private SystemProperty(final Builder<T> builder) {
         this.clazz = builder.clazz;
@@ -168,31 +197,20 @@ public final class SystemProperty<T> {
         this.description = LocaleUtils.getLocalizedString("system_property." + key);
         this.plugin = builder.plugin;
         this.defaultValue = builder.defaultValue;
-        this.baseClass = builder.baseClass;
         this.minValue = builder.minValue;
         this.maxValue = builder.maxValue;
         this.dynamic = builder.dynamic;
         this.encrypted = builder.encrypted;
-        this.chronoUnit = builder.chronoUnit;
-        this.listeners.addAll(builder.listeners);
-        this.initialValue = getValue();
         if (encrypted) {
             // Ensure a pre-existing JiveGlobal is encrypted - a null-operation if it doesn't exist/is already encrypted
             JiveGlobals.setPropertyEncrypted(key, true);
         }
-    }
-
-    private static boolean longValueExists(final String key) {
-        final String stringValue = JiveGlobals.getProperty(key);
-        if (stringValue != null) {
-            try {
-                Long.parseLong(stringValue);
-                return true;
-            } catch (final NumberFormatException ignored) {
-                // Do nothing - will return false
-            }
-        }
-        return false;
+        this.chronoUnit = builder.chronoUnit;
+        this.baseClass = builder.baseClass;
+        this.collectionType = builder.collectionType;
+        this.sorted = builder.sorted;
+        this.listeners.addAll(builder.listeners);
+        this.initialValue = getValue();
     }
 
     /**
@@ -230,7 +248,7 @@ public final class SystemProperty<T> {
      */
     @SuppressWarnings("unchecked")
     public T getValue() {
-        final T value = (T) GETTERS.get(clazz).apply(this);
+        final T value = (T) Optional.ofNullable(FROM_STRING.get(clazz).apply(JiveGlobals.getProperty(key), this)).orElse(defaultValue);
         if (minValue != null && value != null && ((Comparable) minValue).compareTo(value) > 0) {
             LOGGER.warn("Configured value of {} is less than the minimum value of {} for the SystemProperty {} - will use default value of {} instead",
                 value, minValue, key, defaultValue);
@@ -248,14 +266,14 @@ public final class SystemProperty<T> {
      * @return the value of this property as saved in the ofProperty table. {@code null} if there is no current value and the default is not set.
      */
     public String getValueAsSaved() {
-        return SAVE_FORMATTERS.get(clazz).apply(this, getValue());
+        return TO_STRING.get(clazz).apply(getValue(), this);
     }
 
     /**
      * @return the value a human readable value of this property. {@code null} if there is no current value and the default is not set.
      */
     public String getDisplayValue() {
-        return DISPLAY_FORMATTERS.get(clazz).apply(this, getValue());
+        return TO_DISPLAY_STRING.get(clazz).apply(getValue(), this);
     }
 
     /**
@@ -269,7 +287,7 @@ public final class SystemProperty<T> {
      * @return the value a human readable value of this property. {@code null} if the default value is not configured.
      */
     public String getDefaultDisplayValue() {
-        return DISPLAY_FORMATTERS.get(clazz).apply(this, defaultValue);
+        return TO_DISPLAY_STRING.get(clazz).apply(defaultValue, this);
     }
 
     /**
@@ -279,7 +297,7 @@ public final class SystemProperty<T> {
      * @param value the new value for the SystemProperty
      */
     public void setValue(final T value) {
-        JiveGlobals.setProperty(key, SAVE_FORMATTERS.get(clazz).apply(this, value), isEncrypted());
+        JiveGlobals.setProperty(key, TO_STRING.get(clazz).apply(value, this), isEncrypted());
     }
 
     /**
@@ -363,6 +381,8 @@ public final class SystemProperty<T> {
         private Boolean dynamic;
         private boolean encrypted = false;
         private Class<?> baseClass;
+        private Class collectionType;
+        private boolean sorted;
 
         private Builder(final Class<T> clazz) {
             this.clazz = clazz;
@@ -378,6 +398,7 @@ public final class SystemProperty<T> {
          * <li>{@link Duration} - for which a {@link ChronoUnit} must be specified, to indicate how the value will be saved, using {@link #setChronoUnit(ChronoUnit)}</li>
          * <li>{@link Instant}</li>
          * <li>{@link Class} - for which a base class must be specified from which values must be assignable to, using {@link #setBaseClass(Class)}</li>
+         * <li>{@link List} - for which a collection type must be specified, using {@link #setCollectionType(Class)}</li>
          * </ul>
          *
          * @param <T>   the type of SystemProperty
@@ -385,7 +406,7 @@ public final class SystemProperty<T> {
          * @return A SystemProperty builder
          */
         public static <T> Builder<T> ofType(final Class<T> clazz) {
-            if (!GETTERS.containsKey(clazz) || !SAVE_FORMATTERS.containsKey(clazz) || !DISPLAY_FORMATTERS.containsKey(clazz)) {
+            if (!FROM_STRING.containsKey(clazz) || !TO_STRING.containsKey(clazz) || !TO_DISPLAY_STRING.containsKey(clazz)) {
                 throw new IllegalArgumentException("Cannot create a SystemProperty of type " + clazz.getName());
             }
             return new Builder<>(clazz);
@@ -426,7 +447,6 @@ public final class SystemProperty<T> {
         public Builder<T> setBaseClass(final Class<?> baseClass) {
             if(clazz != Class.class) {
                 throw new IllegalArgumentException("Only properties of type Class can have a base class set");
-
             }
             this.baseClass = baseClass;
             return this;
@@ -442,9 +462,6 @@ public final class SystemProperty<T> {
          * @return The current SystemProperty builder
          */
         public Builder<T> setMinValue(final T minValue) {
-            if (!Comparable.class.isAssignableFrom(clazz)) {
-                throw new IllegalArgumentException("A minimum value can only be applied to properties that implement Comparable");
-            }
             this.minValue = minValue;
             return this;
         }
@@ -459,9 +476,6 @@ public final class SystemProperty<T> {
          * @return The current SystemProperty builder
          */
         public Builder<T> setMaxValue(final T maxValue) {
-            if (!Comparable.class.isAssignableFrom(clazz)) {
-                throw new IllegalArgumentException("A maximum value can only be applied to properties that implement Comparable");
-            }
             this.maxValue = maxValue;
             return this;
         }
@@ -476,9 +490,6 @@ public final class SystemProperty<T> {
          * @return The current SystemProperty builder
          */
         public Builder<T> setChronoUnit(final ChronoUnit chronoUnit) {
-            if(clazz != Duration.class) {
-                throw new IllegalArgumentException("Only properties of type Duration can have a ChronoUnit set");
-            }
             this.chronoUnit = chronoUnit;
             return this;
         }
@@ -513,6 +524,15 @@ public final class SystemProperty<T> {
         }
 
         /**
+         * @param sorted {@code true} if this property is a list and should be sorted, {@code false} otherwise.
+         * @return The current SystemProperty builder
+         */
+        public Builder<T> setSorted(final boolean sorted) {
+            this.sorted = sorted;
+            return this;
+        }
+
+        /**
          * Sets the name of the plugin that is associated with this property. This is used on the Openfire System
          * Properties admin interface to provide filtering capabilities. This will default to Openfire if not set.
          *
@@ -521,6 +541,24 @@ public final class SystemProperty<T> {
          */
         public Builder<T> setPlugin(final String plugin) {
             this.plugin = plugin;
+            return this;
+        }
+
+        /**
+         * Sets the type of object that the list contains. This can be any of the non-Collection objects supported
+         * by {@link #ofType(Class)}.
+         *
+         * @param collectionType the type of object that the collection contains
+         * @return The current SystemProperty builder
+         */
+        public Builder<T> setCollectionType(final Class collectionType) {
+            if (!Collection.class.isAssignableFrom(clazz)) {
+                throw new IllegalArgumentException("The collection type can only set set for Collection properties");
+            }
+            if (Collections.class.isAssignableFrom(collectionType)) {
+                throw new IllegalArgumentException("A collection cannot contain a collection");
+            }
+            this.collectionType = collectionType;
             return this;
         }
 
@@ -538,23 +576,54 @@ public final class SystemProperty<T> {
             if (!NULLABLE_TYPES.contains(clazz)) {
                 checkNotNull(defaultValue, "The properties default value has not been set");
             }
+            final Class classToCheck;
+            if (Collection.class.isAssignableFrom(clazz)) {
+                checkNotNull(collectionType, "The collection type must be set for collection properties");
+                classToCheck = collectionType;
+            } else {
+                classToCheck = clazz;
+            }
+
+            if (sorted) {
+                if (!List.class.isAssignableFrom(clazz)) {
+                    throw new IllegalArgumentException("Only List properties can be sorted");
+                }
+                if (!Comparable.class.isAssignableFrom(classToCheck)) {
+                    throw new IllegalArgumentException("Only List properties containing Comparable elements can be sorted");
+                }
+            }
+
             checkNotNull(plugin, "The property plugin has not been set");
             checkNotNull(dynamic, "The property dynamism has not been set");
-            if (clazz == Duration.class) {
+            if (classToCheck == Duration.class) {
                 checkNotNull(chronoUnit, "The ChronoUnit for the Duration property has not been set");
                 if (!DURATION_TO_LONG.containsKey(chronoUnit) || !LONG_TO_DURATION.containsKey(chronoUnit)) {
                     throw new IllegalArgumentException("A Duration property cannot be saved with a ChronoUnit of " + chronoUnit);
                 }
+            } else if (chronoUnit != null) {
+                throw new IllegalArgumentException("Only properties of type Duration can have a ChronoUnit set");
             }
-            //noinspection unchecked
-            if (minValue != null && defaultValue != null && ((Comparable<T>) minValue).compareTo(defaultValue) > 0) {
-                throw new IllegalArgumentException("The minimum value cannot be more than the default value");
+            if (minValue != null) {
+                if (!Comparable.class.isAssignableFrom(clazz)) {
+                    throw new IllegalArgumentException("A minimum value can only be applied to properties that implement Comparable");
+                }
+
+                //noinspection unchecked
+                if (defaultValue != null && ((Comparable<T>) minValue).compareTo(defaultValue) > 0) {
+                    throw new IllegalArgumentException("The minimum value cannot be more than the default value");
+                }
             }
-            //noinspection unchecked
-            if (maxValue != null && defaultValue != null && ((Comparable<T>) maxValue).compareTo(defaultValue) < 0) {
-                throw new IllegalArgumentException("The maximum value cannot be less than the default value");
+            if (maxValue != null) {
+                if (!Comparable.class.isAssignableFrom(clazz)) {
+                    throw new IllegalArgumentException("A maximum value can only be applied to properties that implement Comparable");
+                }
+
+                //noinspection unchecked
+                if (defaultValue != null && ((Comparable<T>) maxValue).compareTo(defaultValue) < 0) {
+                    throw new IllegalArgumentException("The maximum value cannot be less than the default value");
+                }
             }
-            if (clazz == Class.class) {
+            if (classToCheck == Class.class) {
                 checkNotNull(baseClass, "The base class must be set for properties of type class");
             }
             final SystemProperty<T> property = new SystemProperty<>(this);

--- a/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
@@ -1,0 +1,571 @@
+package org.jivesoftware.util;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents a system property - also accessible via {@link JiveGlobals}. The only way to create a SystemProperty object
+ * is to use a {@link Builder}.
+ *
+ * @param <T> The type of system property. Can be a {@link String}, {@link Integer}, {@link Long}, {@link Boolean} or {@link Duration}.
+ */
+public final class SystemProperty<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SystemProperty.class);
+    private static final Map<String, SystemProperty> PROPERTIES = new ConcurrentHashMap<>();
+    private static final Map<ChronoUnit, Function<Duration, Long>> DURATION_TO_LONG;
+    private static final Map<ChronoUnit, Function<Long, Duration>> LONG_TO_DURATION;
+    private static final Map<Class, BiFunction<SystemProperty, Object, String>> SAVE_FORMATTERS;
+    private static final Map<Class, BiFunction<SystemProperty, Object, String>> DISPLAY_FORMATTERS;
+    private static final Map<Class, Function> GETTERS;
+    private static final Set<Class> NULLABLE_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(String.class, Class.class, Duration.class, Instant.class)));
+
+    static {
+        // Populate the map that turns a Duration to a Long based on the ChronoUnit a property should be saved in
+        final Map<ChronoUnit, Function<Duration, Long>> durationToLong = new HashMap<>();
+        durationToLong.put(ChronoUnit.MILLIS, Duration::toMillis);
+        durationToLong.put(ChronoUnit.SECONDS, Duration::getSeconds);
+        durationToLong.put(ChronoUnit.MINUTES, Duration::toMinutes);
+        durationToLong.put(ChronoUnit.HOURS, Duration::toHours);
+        durationToLong.put(ChronoUnit.DAYS, Duration::toDays);
+        DURATION_TO_LONG = Collections.unmodifiableMap(durationToLong);
+    }
+
+    static {
+        // Populate the map that turns a Long to a Duration based on the ChronoUnit a property should be saved in
+        final Map<ChronoUnit, Function<Long, Duration>> longToDuration = new HashMap<>();
+        longToDuration.put(ChronoUnit.MILLIS, Duration::ofMillis);
+        longToDuration.put(ChronoUnit.SECONDS, Duration::ofSeconds);
+        longToDuration.put(ChronoUnit.MINUTES, Duration::ofMinutes);
+        longToDuration.put(ChronoUnit.HOURS, Duration::ofHours);
+        longToDuration.put(ChronoUnit.DAYS, Duration::ofDays);
+        LONG_TO_DURATION = Collections.unmodifiableMap(longToDuration);
+    }
+
+    static {
+        // Populate the map that converts a property to the String value that it's saved as
+        final Map<Class, BiFunction<SystemProperty, Object, String>> formatters = new HashMap<>();
+        formatters.put(String.class, (systemProperty, value) -> (String) value);
+        formatters.put(Integer.class, (systemProperty, value) -> value.toString());
+        formatters.put(Long.class, (systemProperty, value) -> value.toString());
+        formatters.put(Boolean.class, (systemProperty, value) -> value.toString());
+        formatters.put(Duration.class, (systemProperty, value) -> value == null ? null : String.valueOf(DURATION_TO_LONG.get(systemProperty.chronoUnit).apply((Duration) value)));
+        formatters.put(Instant.class, (systemProperty, value) -> value == null ? null : String.valueOf(((Instant)value).toEpochMilli()));
+        formatters.put(Class.class, (systemProperty, value) -> value == null ? null : ((Class) value).getName());
+        SAVE_FORMATTERS = Collections.unmodifiableMap(formatters);
+    }
+
+    static {
+        // Populate the map that retrieves the property value of a given type from JiveGlobals
+        final Map<Class, Function> getters = new HashMap<>();
+        getters.put(String.class, (Function<SystemProperty<String>, String>) property -> JiveGlobals.getProperty(property.key, property.defaultValue));
+        getters.put(Integer.class, (Function<SystemProperty<Integer>, Integer>) property -> JiveGlobals.getIntProperty(property.key, property.defaultValue));
+        getters.put(Long.class, (Function<SystemProperty<Long>, Long>) property -> JiveGlobals.getLongProperty(property.key, property.defaultValue));
+        getters.put(Boolean.class, (Function<SystemProperty<Boolean>, Boolean>) property -> JiveGlobals.getBooleanProperty(property.key, property.defaultValue));
+        getters.put(Duration.class, (Function<SystemProperty<Duration>, Duration>) property -> longValueExists(property.key) ? LONG_TO_DURATION.get(property.chronoUnit).apply(JiveGlobals.getLongProperty(property.key, 0)) : property.defaultValue);
+        getters.put(Instant.class, (Function<SystemProperty<Instant>, Instant>) property -> longValueExists(property.key) ? Instant.ofEpochMilli(JiveGlobals.getLongProperty(property.key, 0)) : property.defaultValue);
+        getters.put(Class.class, (Function<SystemProperty<Class>, Class>) property -> {
+            final String className = JiveGlobals.getProperty(property.key, property.defaultValue == null ? null : property.defaultValue.getName());
+            if (StringUtils.isBlank(className)) {
+                // No configured value and no default either
+                return null;
+            }
+            try {
+                final Class<?> clazz = Class.forName(className);
+                if (property.baseClass.isAssignableFrom(clazz)) {
+                    return clazz;
+                } else {
+                    LOGGER.warn("Configured property {} is not an instance of {}, using default value {} instead", className, property.baseClass.getName(), SAVE_FORMATTERS.get(Class.class).apply(property, property.defaultValue));
+                    return property.defaultValue;
+                }
+            } catch (final ClassNotFoundException e) {
+                LOGGER.warn("Class {} was not found, using default value {} instead", className, SAVE_FORMATTERS.get(Class.class).apply(property, property.defaultValue), e);
+                return property.defaultValue;
+            }
+        });
+        GETTERS = Collections.unmodifiableMap(getters);
+    }
+
+    static {
+        // Populate the map that converts a property to the String value that it's saved as
+        final Map<Class, BiFunction<SystemProperty, Object, String>> formatters = new HashMap<>();
+        formatters.put(String.class, (systemProperty, value) -> (String) value);
+        formatters.put(Integer.class, (systemProperty, value) -> value.toString());
+        formatters.put(Long.class, (systemProperty, value) -> value.toString());
+        formatters.put(Boolean.class, (systemProperty, value) -> value.toString());
+        formatters.put(Duration.class, (systemProperty, value) -> value == null ? null : org.jivesoftware.util.StringUtils.getFullElapsedTime((Duration)value));
+        formatters.put(Instant.class, (systemProperty, value) -> value == null ? null : Date.from((Instant) value).toString());
+        formatters.put(Class.class, (systemProperty, value) -> value == null ? null : ((Class)value).getName());
+        DISPLAY_FORMATTERS = Collections.unmodifiableMap(formatters);
+    }
+
+    static {
+        // Add a (single) listener that will call the listeners of each given property
+        PropertyEventDispatcher.addListener(new PropertyEventListener() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public void propertySet(final String property, final Map<String, Object> params) {
+                final SystemProperty systemProperty = PROPERTIES.get(property);
+                if (systemProperty != null) {
+                    final Object newValue = systemProperty.getValue();
+                    systemProperty.listeners.forEach(consumer -> ((Consumer) consumer).accept(newValue));
+                }
+            }
+
+            @Override
+            public void propertyDeleted(final String property, final Map<String, Object> params) {
+                propertySet(property, params);
+            }
+
+            @Override
+            public void xmlPropertySet(final String property, final Map<String, Object> params) {
+                // Ignored - we're only covering database properties
+            }
+
+            @Override
+            public void xmlPropertyDeleted(final String property, final Map<String, Object> params) {
+                // Ignored - we're only covering database properties
+            }
+        });
+    }
+
+    private final Class<T> clazz;
+    private final String key;
+    private final String description;
+    private final String plugin;
+    private final T defaultValue;
+    private final Class<?> baseClass;
+    private final T minValue;
+    private final T maxValue;
+    private final boolean dynamic;
+    private final ChronoUnit chronoUnit;
+    private final Set<Consumer<T>> listeners = ConcurrentHashMap.newKeySet();
+    private final T initialValue;
+    private final boolean encrypted;
+
+    private SystemProperty(final Builder<T> builder) {
+        this.clazz = builder.clazz;
+        this.key = builder.key;
+        this.description = LocaleUtils.getLocalizedString("system_property." + key);
+        this.plugin = builder.plugin;
+        this.defaultValue = builder.defaultValue;
+        this.baseClass = builder.baseClass;
+        this.minValue = builder.minValue;
+        this.maxValue = builder.maxValue;
+        this.dynamic = builder.dynamic;
+        this.encrypted = builder.encrypted;
+        this.chronoUnit = builder.chronoUnit;
+        this.listeners.addAll(builder.listeners);
+        this.initialValue = getValue();
+        if (encrypted) {
+            // Ensure a pre-existing JiveGlobal is encrypted - a null-operation if it doesn't exist/is already encrypted
+            JiveGlobals.setPropertyEncrypted(key, true);
+        }
+    }
+
+    private static boolean longValueExists(final String key) {
+        final String stringValue = JiveGlobals.getProperty(key);
+        if (stringValue != null) {
+            try {
+                Long.parseLong(stringValue);
+                return true;
+            } catch (final NumberFormatException ignored) {
+                // Do nothing - will return false
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return an unmodifiable collection of all the current SystemProperties
+     */
+    public static Collection<SystemProperty> getProperties() {
+        return Collections.unmodifiableCollection(PROPERTIES.values());
+    }
+
+    /**
+     * Removes all the properties for a specific plugin. This should be called by a plugin when it is unloaded to
+     * allow it to be added again without a server restart
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static void removePropertiesForPlugin(final String plugin) {
+        getProperties().stream()
+            .filter(systemProperty -> systemProperty.plugin.equals(plugin))
+            .map(systemProperty -> systemProperty.key)
+            .forEach(PROPERTIES::remove);
+    }
+
+    /**
+     * Returns the SystemProperty for the specified key
+     *
+     * @param key the key for the property to fetch
+     * @return The SystemProperty for that key, if any
+     */
+    public static Optional<SystemProperty> getProperty(final String key) {
+        return Optional.ofNullable(PROPERTIES.get(key));
+    }
+
+    /**
+     * @return the current value of the SystemProperty, or the default value if it is not currently set to within the
+     * configured constraints. {@code null} if the property has not been set and there is no default value.
+     */
+    @SuppressWarnings("unchecked")
+    public T getValue() {
+        final T value = (T) GETTERS.get(clazz).apply(this);
+        if (minValue != null && value != null && ((Comparable) minValue).compareTo(value) > 0) {
+            LOGGER.warn("Configured value of {} is less than the minimum value of {} for the SystemProperty {} - will use default value of {} instead",
+                value, minValue, key, defaultValue);
+            return defaultValue;
+        }
+        if (maxValue != null && value != null && ((Comparable) maxValue).compareTo(value) < 0) {
+            LOGGER.warn("Configured value of {} is more than the maximum value of {} for the SystemProperty {} - will use default value of {} instead",
+                value, maxValue, key, defaultValue);
+            return defaultValue;
+        }
+        return value;
+    }
+
+    /**
+     * @return the value of this property as saved in the ofProperty table. {@code null} if there is no current value and the default is not set.
+     */
+    public String getValueAsSaved() {
+        return SAVE_FORMATTERS.get(clazz).apply(this, getValue());
+    }
+
+    /**
+     * @return the value a human readable value of this property. {@code null} if there is no current value and the default is not set.
+     */
+    public String getDisplayValue() {
+        return DISPLAY_FORMATTERS.get(clazz).apply(this, getValue());
+    }
+
+    /**
+     * @return {@code false} if the property has been changed from it's default value, otherwise {@code true}
+     */
+    public boolean hasValueChanged() {
+        return !Objects.equals(getValue(), defaultValue);
+    }
+
+    /**
+     * @return the value a human readable value of this property. {@code null} if the default value is not configured.
+     */
+    public String getDefaultDisplayValue() {
+        return DISPLAY_FORMATTERS.get(clazz).apply(this, defaultValue);
+    }
+
+    /**
+     * Sets the value of the SystemProperty. Note that the new value can be outside any minimum/maximum for the property,
+     * and will be saved to the database as such, however subsequent attempts to retrieve it's value will return the default.
+     *
+     * @param value the new value for the SystemProperty
+     */
+    public void setValue(final T value) {
+        JiveGlobals.setProperty(key, SAVE_FORMATTERS.get(clazz).apply(this, value), isEncrypted());
+    }
+
+    /**
+     * @return the plugin that created this property - or simply {@code "Openfire"}
+     */
+    public String getPlugin() {
+        return plugin;
+    }
+
+    /**
+     * @return {@code false} if Openfire or the plugin needs to be restarted for changes to this property to take effect, otherwise {@code true}
+     */
+    public boolean isDynamic() {
+        return dynamic;
+    }
+
+    /**
+     * @return {@code true} if the property was initially setup to be encrypted, or was encrypted subsequently, otherwise {@code false}
+     */
+    public boolean isEncrypted() {
+        return encrypted || JiveGlobals.isPropertyEncrypted(key);
+    }
+
+    /**
+     * @return {@code true} if this property has changed and an Openfire or plugin restart is required, otherwise {@code false}
+     */
+    public boolean isRestartRequired() {
+        return !(dynamic || Objects.equals(getValue(), initialValue));
+    }
+
+    /***
+     * @param listener a listener to add to the property, that will be called whenever the property value changes
+     */
+    public void addListener(final Consumer<T> listener) {
+        this.listeners.add(listener);
+    }
+
+    /***
+     * @param listener the listener that is no longer required
+     */
+    public void removeListener(final Consumer<T> listener) {
+        this.listeners.remove(listener);
+    }
+
+    /**
+     * @return the {@link JiveGlobals} key for this property.
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @return the description of this property. This is set in the resource bundle for the current locale, using the
+     * key {@code system_property.}<b><i>property-key</i></b>.
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @return the default value of this property. {@code null} if there is no default value configured.
+     */
+    public T getDefaultValue() {
+        return defaultValue;
+    }
+
+    /**
+     * Used to build a {@link SystemProperty}
+     *
+     * @param <T> the type of system property to build
+     */
+    public static final class Builder<T> {
+        private final Class<T> clazz;
+        private final Set<Consumer<T>> listeners = new HashSet<>();
+        private String key;
+        private String plugin = "Openfire";
+        private T defaultValue;
+        private T minValue;
+        private T maxValue;
+        private ChronoUnit chronoUnit;
+        private Boolean dynamic;
+        private boolean encrypted = false;
+        private Class<?> baseClass;
+
+        private Builder(final Class<T> clazz) {
+            this.clazz = clazz;
+        }
+
+        /**
+         * Start a new SystemProperty builder. The following types of SystemProperty are supported:
+         * <ul>
+         * <li>{@link String}</li>
+         * <li>{@link Integer} - for which a default value must be supplied using {@link #setDefaultValue(Object)}</li>
+         * <li>{@link Long} - for which a default value must be supplied</li>
+         * <li>{@link Boolean} - for which a default value must be supplied</li>
+         * <li>{@link Duration} - for which a {@link ChronoUnit} must be specified, to indicate how the value will be saved, using {@link #setChronoUnit(ChronoUnit)}</li>
+         * <li>{@link Instant}</li>
+         * <li>{@link Class} - for which a base class must be specified from which values must be assignable to, using {@link #setBaseClass(Class)}</li>
+         * </ul>
+         *
+         * @param <T>   the type of SystemProperty
+         * @param clazz The class of property being built
+         * @return A SystemProperty builder
+         */
+        public static <T> Builder<T> ofType(final Class<T> clazz) {
+            if (!GETTERS.containsKey(clazz) || !SAVE_FORMATTERS.containsKey(clazz) || !DISPLAY_FORMATTERS.containsKey(clazz)) {
+                throw new IllegalArgumentException("Cannot create a SystemProperty of type " + clazz.getName());
+            }
+            return new Builder<>(clazz);
+        }
+
+        /**
+         * Sets the key for the SystemProperty. Must be unique
+         *
+         * @param key the property key
+         * @return The current SystemProperty builder
+         */
+        public Builder<T> setKey(final String key) {
+            this.key = key;
+            return this;
+        }
+
+        /**
+         * Sets the default value for the SystemProperty. This value will be used if the property is not set, or
+         * falls outside the minimum/maximum values configured.
+         *
+         * @param defaultValue the default value for the property
+         * @return The current SystemProperty builder
+         * @see #setMinValue(Object)
+         * @see #setMaxValue(Object)
+         */
+        public Builder<T> setDefaultValue(final T defaultValue) {
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        /**
+         * This indicates which class configured values must inherit from. It must be set (and can only be set) if the default
+         * value is a class.
+         *
+         * @param baseClass - the base class from which all configured values must inherit
+         * @return The current SystemProperty builder
+         */
+        public Builder<T> setBaseClass(final Class<?> baseClass) {
+            if(clazz != Class.class) {
+                throw new IllegalArgumentException("Only properties of type Class can have a base class set");
+
+            }
+            this.baseClass = baseClass;
+            return this;
+        }
+
+        /**
+         * Sets the minimum value for the SystemProperty. If the configured value is less than minimum value, the
+         * default value will be used instead.
+         * <p><strong>Important:</strong> If a minimum value is configured, the type of property being built must
+         * implement {@link Comparable}.</p>
+         *
+         * @param minValue the minimum value for the property
+         * @return The current SystemProperty builder
+         */
+        public Builder<T> setMinValue(final T minValue) {
+            if (!Comparable.class.isAssignableFrom(clazz)) {
+                throw new IllegalArgumentException("A minimum value can only be applied to properties that implement Comparable");
+            }
+            this.minValue = minValue;
+            return this;
+        }
+
+        /**
+         * Sets the maximum value for the SystemProperty. If the configured value is more than maximum value, the
+         * default value will be used instead.
+         * <p><strong>Important:</strong> If a maximum value is configured, the type of property being built must
+         * implement {@link Comparable}.</p>
+         *
+         * @param maxValue the maximum value for the property
+         * @return The current SystemProperty builder
+         */
+        public Builder<T> setMaxValue(final T maxValue) {
+            if (!Comparable.class.isAssignableFrom(clazz)) {
+                throw new IllegalArgumentException("A maximum value can only be applied to properties that implement Comparable");
+            }
+            this.maxValue = maxValue;
+            return this;
+        }
+
+        /**
+         * If the type of the property is a {@link Duration} this is used to indicate how the value is saved in the
+         * database. For an example a Duration of one hour will be saved as "60" if the ChronoUnit is {@link ChronoUnit#MINUTES}, or
+         * saved as "3600" if the ChronoUnit is {@link ChronoUnit#SECONDS}.
+         * <p><strong>Important:</strong> The ChronoUnit is required, and must be set, if the type of property is a Duration.
+         *
+         * @param chronoUnit the unit of time the Duration is saved to the database in
+         * @return The current SystemProperty builder
+         */
+        public Builder<T> setChronoUnit(final ChronoUnit chronoUnit) {
+            if(clazz != Duration.class) {
+                throw new IllegalArgumentException("Only properties of type Duration can have a ChronoUnit set");
+            }
+            this.chronoUnit = chronoUnit;
+            return this;
+        }
+
+        /**
+         * @param listener the listener that will be called when the value of the property changes
+         * @return The current SystemProperty builder
+         */
+        public Builder<T> addListener(final Consumer<T> listener) {
+            this.listeners.add(listener);
+            return this;
+        }
+
+        /**
+         * @param dynamic {@code true} if changes to this property take effect immediately, {@code false} if a restart
+         *                is required.
+         * @return The current SystemProperty builder
+         */
+        public Builder<T> setDynamic(final boolean dynamic) {
+            this.dynamic = dynamic;
+            return this;
+        }
+
+        /**
+         * @param encrypted {@code true} if this property should be encrypted, {@code false} if can be stored in
+         *                  plain text. Defaults to plain text if not otherwise specified.
+         * @return The current SystemProperty builder
+         */
+        public Builder<T> setEncrypted(final boolean encrypted) {
+            this.encrypted = encrypted;
+            return this;
+        }
+
+        /**
+         * Sets the name of the plugin that is associated with this property. This is used on the Openfire System
+         * Properties admin interface to provide filtering capabilities. This will default to Openfire if not set.
+         *
+         * @param plugin the name of the plugin creating this property.
+         * @return The current SystemProperty builder
+         */
+        public Builder<T> setPlugin(final String plugin) {
+            this.plugin = plugin;
+            return this;
+        }
+
+        /**
+         * Validates the details of the SystemProperty, and generates one if it's valid.
+         *
+         * @return A SystemProperty object
+         * @throws IllegalArgumentException if incorrect arguments have been supplied to the builder
+         */
+        public SystemProperty<T> build() throws IllegalArgumentException {
+            checkNotNull(key, "The property key has not been set");
+            if (PROPERTIES.containsKey(key)) {
+                throw new IllegalArgumentException("A SystemProperty already exists with a key of " + key);
+            }
+            if (!NULLABLE_TYPES.contains(clazz)) {
+                checkNotNull(defaultValue, "The properties default value has not been set");
+            }
+            checkNotNull(plugin, "The property plugin has not been set");
+            checkNotNull(dynamic, "The property dynamism has not been set");
+            if (clazz == Duration.class) {
+                checkNotNull(chronoUnit, "The ChronoUnit for the Duration property has not been set");
+                if (!DURATION_TO_LONG.containsKey(chronoUnit) || !LONG_TO_DURATION.containsKey(chronoUnit)) {
+                    throw new IllegalArgumentException("A Duration property cannot be saved with a ChronoUnit of " + chronoUnit);
+                }
+            }
+            //noinspection unchecked
+            if (minValue != null && defaultValue != null && ((Comparable<T>) minValue).compareTo(defaultValue) > 0) {
+                throw new IllegalArgumentException("The minimum value cannot be more than the default value");
+            }
+            //noinspection unchecked
+            if (maxValue != null && defaultValue != null && ((Comparable<T>) maxValue).compareTo(defaultValue) < 0) {
+                throw new IllegalArgumentException("The maximum value cannot be less than the default value");
+            }
+            if (clazz == Class.class) {
+                checkNotNull(baseClass, "The base class must be set for properties of type class");
+            }
+            final SystemProperty<T> property = new SystemProperty<>(this);
+            PROPERTIES.put(key, property);
+            return property;
+        }
+
+        private void checkNotNull(final Object value, final String s) {
+            if (value == null) {
+                throw new IllegalArgumentException(s);
+            }
+        }
+    }
+}

--- a/xmppserver/src/main/resources/admin-sidebar.xml
+++ b/xmppserver/src/main/resources/admin-sidebar.xml
@@ -20,7 +20,7 @@
 
             <!-- System Properties -->
             <item id="server-props" name="${sidebar.system-props}"
-                  url="server-properties.jsp"
+                  url="SystemProperties.jsp"
                   description="${sidebar.system-props.descr}"/>
 
             <!-- System Locale -->

--- a/xmppserver/src/main/webapp/WEB-INF/web.xml
+++ b/xmppserver/src/main/webapp/WEB-INF/web.xml
@@ -57,7 +57,7 @@
 
     <filter>
         <filter-name>sitemesh</filter-name>
-        <filter-class>com.opensymphony.module.sitemesh.filter.PageFilter</filter-class>
+        <filter-class>com.opensymphony.sitemesh.webapp.SiteMeshFilter</filter-class>
     </filter>
 
     <filter-mapping>
@@ -127,11 +127,10 @@
         <servlet-class>org.jivesoftware.openfire.container.PluginIconServlet</servlet-class>
     </servlet>
 
-    <!--<servlet>
-        <servlet-name>WebDAVLiteServlet</servlet-name>
-        <servlet-class>org.jivesoftware.openfire.webdav.WebDAVLiteServlet</servlet-class>
-    </servlet>-->
-
+    <servlet>
+        <servlet-name>SystemPropertiesServlet</servlet-name>
+        <servlet-class>org.jivesoftware.admin.servlet.SystemPropertiesServlet</servlet-class>
+    </servlet>
 
     <!--@@JSPC-SERVLETS@@-->
 
@@ -150,10 +149,11 @@
         <url-pattern>/geticon</url-pattern>
     </servlet-mapping>
 
-    <!--<servlet-mapping>
-        <servlet-name>WebDAVLiteServlet</servlet-name>
-        <url-pattern>/webdav/*</url-pattern>
-    </servlet-mapping>-->
+    <servlet-mapping>
+        <servlet-name>SystemPropertiesServlet</servlet-name>
+        <!-- NB. .jsp extension is only required so filters are applied -->
+        <url-pattern>/SystemProperties.jsp</url-pattern>
+    </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>dwr-invoker</servlet-name>

--- a/xmppserver/src/main/webapp/logviewer.jsp
+++ b/xmppserver/src/main/webapp/logviewer.jsp
@@ -136,7 +136,7 @@
     // Enable/disable debugging
     if (request.getParameter("debugEnabled") != null && debugEnabled != Log.isDebugEnabled()) {
         if (!(csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam))) {
-            JiveGlobals.setProperty(Log.LOG_DEBUG_ENABLED, String.valueOf(debugEnabled));
+            Log.DEBUG_ENABLED.setValue(debugEnabled);
             // Log the event
             admin.logEvent((debugEnabled ? "enabled" : "disabled")+" debug logging", null);
             response.sendRedirect("logviewer.jsp?log=debug");

--- a/xmppserver/src/main/webapp/system-properties.jsp
+++ b/xmppserver/src/main/webapp/system-properties.jsp
@@ -1,0 +1,406 @@
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ page contentType="text/html; charset=UTF-8" %>
+<jsp:useBean scope="request" id="errorMessage" class="java.lang.String"/>
+<jsp:useBean scope="request" id="warningMessage" class="java.lang.String"/>
+<jsp:useBean scope="request" id="successMessage" class="java.lang.String"/>
+<jsp:useBean scope="request" id="csrf" type="java.lang.String"/>
+<jsp:useBean scope="request" id="listPager" type="org.jivesoftware.util.ListPager"/>
+<jsp:useBean scope="request" id="search" type="org.jivesoftware.admin.servlet.SystemPropertiesServlet.Search"/>
+<jsp:useBean scope="request" id="plugins" type="java.util.List"/>
+
+<html>
+<head>
+    <title><fmt:message key="server.properties.title"/></title>
+    <meta name="pageID" content="server-props"/>
+    <meta name="helpPage" content="manage_system_properties.html"/>
+    <style type="text/css">
+        .nameColumn {
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+            max-width: 200px;
+        }
+
+        .valueColumn {
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+            max-width: 250px;
+        }
+
+        .hidden {
+            color: #999;
+            font-style: italic;
+        }
+
+        img.clickable {
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+
+<c:if test="${not empty errorMessage}">
+    <div class="error">${errorMessage}</div>
+</c:if>
+
+<c:if test="${not empty warningMessage}">
+    <div class="warning">${warningMessage}</div>
+</c:if>
+
+<c:if test="${not empty successMessage}">
+    <div class="success">${successMessage}</div>
+</c:if>
+
+<p><fmt:message key="server.properties.info"/></p>
+
+<p><b><fmt:message key="server.properties.system"/></b></p>
+
+<p>
+    <fmt:message key="server.properties.total"/>: <c:out value="${listPager.totalItemCount}"/>
+    <c:if test="${listPager.filtered}">
+        <fmt:message key="server.properties.filtered"/>: <c:out value="${listPager.filteredItemCount}"/>
+    </c:if>
+
+    <c:if test="${listPager.totalPages > 1}">
+        <fmt:message key="global.showing"/> <c:out value="${listPager.firstItemNumberOnPage}"/>-<c:out
+        value="${listPager.lastItemNumberOnPage}"/>
+    </c:if>
+    -- <fmt:message key="server.properties.per-page"/>: ${listPager.pageSizeSelection}
+
+</p>
+
+<p><fmt:message key="global.pages"/>: [ ${listPager.pageLinks} ]</p>
+<div class="jive-table">
+    <table cellpadding="0" cellspacing="0" border="0" width="100%">
+        <thead>
+        <tr>
+            <th nowrap><label for="searchName"><fmt:message key="server.properties.name"/></label></th>
+            <th nowrap><label for="searchValue"><fmt:message key="server.properties.value"/></label></th>
+            <th nowrap><label for="searchDefaultValue"><fmt:message key="server.properties.default"/></label></th>
+            <th nowrap><label for="searchPlugin"><fmt:message key="server.properties.plugin"/></label></th>
+            <th nowrap><label for="searchDescription"><fmt:message key="server.properties.description"/></label></th>
+            <th nowrap><label for="searchDynamic"><fmt:message key="server.properties.dynamic"/></label></th>
+            <th style="text-align:center;"><fmt:message key="server.properties.edit"/></th>
+            <th style="text-align:center;"><fmt:message key="server.properties.encrypt"/></th>
+            <th style="text-align:center;"><fmt:message key="global.delete"/></th>
+        </tr>
+        <tr>
+            <td nowrap>
+                <input type="search"
+                       id="searchName"
+                       size="40"
+                       value="<c:out value="${search.name}"/>"/>
+                <img src="images/search-16x16.png"
+                     width="16" height="16"
+                     class="clickable"
+                     alt="Search" title="Search"
+                     style="vertical-align: middle;"
+                     onclick="submitForm();"
+                >
+            </td>
+            <td nowrap>
+                <input type="search"
+                       id="searchValue"
+                       size="40"
+                       value="<c:out value="${search.value}"/>"/>
+                <img src="images/search-16x16.png"
+                     width="16" height="16"
+                     class="clickable"
+                     alt="Search" title="Search"
+                     style="vertical-align: middle;"
+                     onclick="submitForm();"
+                >
+            </td>
+            <td nowrap>
+                <select id="searchDefaultValue" onchange="submitForm();">
+                    <option value="" <c:if test="${search.defaultValue == ''}">selected</c:if>><fmt:message key="server.properties.search_all"/></option>
+                    <option value="unchanged" <c:if test="${search.defaultValue == 'unchanged'}">selected</c:if>><fmt:message key="server.properties.default.search_unchanged"/></option>
+                    <option value="changed" <c:if test="${search.defaultValue == 'changed'}">selected</c:if>><fmt:message key="server.properties.default.search_changed"/></option>
+                    <option value="unknown" <c:if test="${search.defaultValue == 'unknown'}">selected</c:if>><fmt:message key="server.properties.default.unknown"/></option>
+                </select>
+            </td>
+            <td nowrap>
+                <select id="searchPlugin" onchange="submitForm();">
+                    <option value="" <c:if test="${search.plugin == ''}">selected</c:if>><fmt:message key="server.properties.search_all"/></option>
+                    <option value="none" <c:if test="${search.plugin == 'none'}">selected</c:if>><fmt:message key="server.properties.search_none"/></option>
+                    <c:forEach var="plugin" items="${plugins}">
+                        <option value="<c:out value="${plugin}"/>" <c:if test="${search.plugin == plugin}">selected</c:if>><c:out value="${plugin}"/></option>
+                    </c:forEach>
+                </select>
+            </td>
+            <td nowrap>
+                <input type="search"
+                       id="searchDescription"
+                       size="20"
+                       value="<c:out value="${search.description}"/>"/>
+                <img src="images/search-16x16.png"
+                     width="16" height="16"
+                     class="clickable"
+                     alt="Search" title="Search"
+                     style="vertical-align: middle;"
+                     onclick="submitForm();"
+                >
+            </td>
+            <td nowrap style="text-align: center">
+                <select id="searchDynamic" onchange="submitForm();">
+                    <option value="" <c:if test="${search.dynamic == ''}">selected</c:if>><fmt:message key="server.properties.search_all"/></option>
+                    <option value="true" <c:if test="${search.dynamic == 'true'}">selected</c:if>><fmt:message key="server.properties.dynamic.search.true"/></option>
+                    <option value="false" <c:if test="${search.dynamic == 'false'}">selected</c:if>><fmt:message key="server.properties.dynamic.search.false"/></option>
+                    <option value="restart" <c:if test="${search.dynamic == 'restart'}">selected</c:if>><fmt:message key="server.properties.dynamic.search.restart"/></option>
+                    <option value="unknown" <c:if test="${search.dynamic == 'unknown'}">selected</c:if>><fmt:message key="server.properties.default.unknown"/></option>
+                </select>
+            </td>
+            <td nowrap>
+
+            </td>
+            <td nowrap>
+
+            </td>
+            <td nowrap>
+
+            </td>
+        </tr>
+        </thead>
+        <tbody>
+        <c:set var="rowClass" value="jive-even"/>
+        <c:forEach var="property" items="${listPager.itemsOnCurrentPage}">
+            <%--@elvariable id="property" type="org.jivesoftware.admin.servlet.SystemPropertiesServlet.CompoundProperty"--%>
+            <c:choose>
+                <c:when test="${rowClass == 'jive-even'}"><c:set var="rowClass" value="jive-odd"/></c:when>
+                <c:otherwise><c:set var="rowClass" value="jive-even"/></c:otherwise>
+            </c:choose>
+            <tr class="${rowClass}">
+                <td class="nameColumn">
+                        <%--
+                        Note; wrap the property key (and value) in a span so it's easy to extract it in JavaScript
+                        without any extra whitespace
+                        --%>
+                    <span><c:out value="${property.key}"/></span>
+                </td>
+                <td class="valueColumn">
+                    <c:choose>
+                        <c:when test="${property.hidden}">
+                            <span class="hidden">hidden</span>
+                        </c:when>
+                        <c:when test="${property.valueAsSaved == null}">
+                            <span class="hidden">none</span>
+                        </c:when>
+                        <c:otherwise>
+                            <span><c:out value="${property.valueAsSaved}"/></span>
+                            <c:if test="${property.valueAsSaved != property.displayValue}">
+                                (<c:out value="${property.displayValue}"/>)
+                            </c:if>
+                        </c:otherwise>
+                    </c:choose>
+                </td>
+                <td class="valueColumn">
+                    <c:choose>
+                        <c:when test="${!property.systemProperty}">
+                            <span class="hidden">unknown</span>
+                        </c:when>
+                        <c:when test="${property.defaultDisplayValue == null}">
+                            <span class="hidden">none</span>
+                        </c:when>
+                        <c:otherwise>
+                            <c:out value="${property.defaultDisplayValue}"/>
+                        </c:otherwise>
+                    </c:choose>
+                </td>
+                <td><c:out value="${property.plugin}"/></td>
+                <td><c:out value="${property.description}"/></td>
+                <td style="text-align:center">
+                    <c:if test="${property.systemProperty}">
+                        <c:choose>
+                            <c:when test="${property.dynamic}">
+                                <img src="images/check-16x16.gif" width="16" height="16" alt="<fmt:message key="server.properties.alt_dynamic"/>">
+                            </c:when>
+                            <c:when test="${!property.dynamic}">
+                                <img src="images/delete-16x16.gif" width="16" height="16" alt="<fmt:message key="server.properties.alt_static"/>">
+                                <c:if test="${property.restartRequired}">
+                                    <img src="images/icon_warning-small.gif" width="16" height="16" alt="<fmt:message key="server.properties.alt_restart-required"/>">
+                                </c:if>
+                            </c:when>
+                        </c:choose>
+                    </c:if>
+                </td>
+                <td style="text-align:center">
+                    <img class="clickable"
+                        src="images/edit-16x16.gif"
+                        width="16" height="16"
+                        onclick="doEdit(this, <c:out value='${property.hidden}'/>, <c:out value='${property.encrypted}'/>, <c:out value='${property.displayValue == null}'/>)"
+                        alt="<fmt:message key="server.properties.alt_edit"/>">
+                </td>
+                <td style="text-align:center">
+                    <c:choose>
+                        <c:when test="${property.encrypted}">
+                            <img src="images/lock.gif" width="16" height="16"
+                                 alt="<fmt:message key="server.properties.alt_encrypted"/>" border="0">
+                        </c:when>
+                        <c:otherwise>
+                            <img class="clickable"
+                                src="images/add-16x16.gif"
+                                width="16" height="16"
+                                onclick="doEncrypt(this);"
+                                alt="<fmt:message key="server.properties.alt_encrypt"/>">
+                        </c:otherwise>
+                    </c:choose>
+                </td>
+                <td style="text-align:center">
+                    <img class="clickable"
+                        src="images/delete-16x16.gif"
+                        width="16" height="16"
+                        onclick="doDelete(this);"
+                        alt="<fmt:message key="server.properties.alt_delete"/>">
+                </td>
+            </tr>
+        </c:forEach>
+        </tbody>
+    </table>
+</div>
+<p><fmt:message key="global.pages"/>: [ ${listPager.pageLinks} ]</p>
+${listPager.jumpToPageForm}
+
+<div class="jive-table">
+    <table cellpadding="0" cellspacing="0" border="0" width="100%">
+        <thead>
+        <tr>
+            <th colspan="2">
+                <span id="editPropertyTitle" style="display:none"><fmt:message key="server.properties.edit_property_title"/></span>
+                <span id="newPropertyTitle"><fmt:message key="server.properties.new_property"/></span>
+            </th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr valign="top">
+            <td>
+                <label for="editPropertyName">
+                    <fmt:message key="server.properties.name"/>:
+                </label>
+            </td>
+            <td>
+                <input type="text" id="editPropertyName" name="propName" size="40" maxlength="100">
+            </td>
+        </tr>
+        <tr valign="top">
+            <td>
+                <label for="editPropertyValue">
+                    <fmt:message key="server.properties.value"/>:
+                </label>
+            </td>
+            <td>
+                <textarea id="editPropertyValue" cols="45" rows="5" name="propValue" wrap="soft"></textarea>
+            </td>
+        </tr>
+        <tr valign="top">
+            <td>
+                <fmt:message key="server.properties.encryption"/>:
+            </td>
+            <td>
+                <input type="radio"
+                       name="encrypt"
+                       id="editPropertyEncryptTrue"
+                       value="true"/>
+                <label for="editPropertyEncryptTrue"><fmt:message key="server.properties.encrypt_property_true"/></label>
+                <br/>
+                <input type="radio"
+                       name="encrypt"
+                       id="editPropertyEncryptFalse"
+                       value="false"
+                       checked/>
+                <label for="editPropertyEncryptFalse"><fmt:message key="server.properties.encrypt_property_false"/></label>
+            </td>
+        </tr>
+        </tbody>
+        <tfoot>
+        <tr>
+            <td colspan="2">
+                <input type="button" value="<fmt:message key="global.save_property" />" onclick="submitEditForm(true);">
+                <input type="button" value="<fmt:message key="global.cancel" />" onclick="submitEditForm(false);">
+            </td>
+        </tr>
+        </tfoot>
+    </table>
+</div>
+
+
+<form method="post" id="actionForm">
+    <%=listPager.getHiddenFields()%>
+    <input type="hidden" name="csrf" value="<c:out value='${csrf}'/>">
+    <input type="hidden" name="action">
+    <input type="hidden" name="key">
+    <input type="hidden" name="value">
+    <input type="hidden" name="encrypt">
+</form>
+
+<script type="text/javascript">
+    ${listPager.pageFunctions}
+
+    function getKey(imgObject) {
+        return imgObject.parentNode.parentNode.childNodes[1].childNodes[1].textContent;
+    }
+
+    function doEdit(imgObject, hidden, encrypted, nullValue) {
+        document.getElementById("editPropertyName").value = getKey(imgObject);
+        var valueField = document.getElementById("editPropertyValue");
+        if (encrypted || hidden || nullValue) {
+            valueField.value = "";
+        } else {
+            valueField.value = imgObject.parentNode.parentNode.childNodes[3].childNodes[1].textContent;
+        }
+        document.getElementById(encrypted ? "editPropertyEncryptTrue" : "editPropertyEncryptFalse").checked = true;
+        document.getElementById("newPropertyTitle").style.display = "none";
+        document.getElementById("editPropertyTitle").style.display = "";
+        valueField.focus();
+        valueField.selectionEnd = 0;
+        window.scrollTo(0, document.body.scrollHeight);
+    }
+
+    function doEncrypt(imgObject) {
+        if (confirm('<fmt:message key="server.properties.encrypt_confirm"/>')) {
+            submitActionForm("encrypt", getKey(imgObject));
+        }
+    }
+
+    function doDelete(imgObject) {
+        if (confirm('<fmt:message key="server.properties.delete_confirm"/>')) {
+            submitActionForm("delete", getKey(imgObject));
+        }
+    }
+
+    function submitEditForm(save) {
+        var action = save ? "save" : "cancel";
+        var key = document.getElementById("editPropertyName").value;
+        if (key.trim() === "") {
+            <%-- There's no need to submit the form --%>
+            return;
+        }
+        if (save) {
+            var value = document.getElementById("editPropertyValue").value;
+            var encrypt = document.getElementById("editPropertyEncryptTrue").checked;
+            submitActionForm(action, key, value, encrypt);
+        } else {
+            submitActionForm(action, key);
+        }
+    }
+
+    function submitActionForm(action, key, value, encrypt) {
+        var form = document.getElementById("actionForm");
+        form["action"].value = action;
+        form["key"].value = key;
+        if(typeof value !== "undefined") {
+            form["value"].value = value;
+        } else {
+            form["value"].disabled = true;
+        }
+        if(typeof encrypt !== "undefined") {
+            form["encrypt"].value = encrypt;
+        } else {
+            form["encrypt"].disabled = true;
+        }
+        form.submit();
+    }
+</script>
+</body>
+</html>

--- a/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
@@ -10,8 +10,11 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.jivesoftware.Fixtures;
@@ -497,4 +500,27 @@ public class SystemPropertyTest {
         assertThat(property.getDisplayValue(), is("1 hour,0 ms"));
         assertThat(JiveGlobals.getProperty(key), is("1,0"));
     }
+
+    @Test
+    public void willCreateASetOfStringProperties() {
+        final String key = "a set property";
+
+        final SystemProperty<Set> property = SystemProperty.Builder.ofType(Set.class)
+            .setCollectionType(String.class)
+            .setKey(key)
+            .setSorted(true)
+            .setDefaultValue(Collections.emptySet())
+            .setDynamic(true)
+            .build();
+
+        assertThat(property.getValue(), is(Collections.emptySet()));
+        property.setValue(new HashSet<>(Arrays.asList("3", "2", "1", "2")));
+        assertThat(property.getValue(), is(new LinkedHashSet<>(Arrays.asList("1", "2", "3"))));
+        assertThat(property.getDisplayValue(), is("1,2,3"));
+        assertThat(JiveGlobals.getProperty(key), is("1,2,3"));
+        JiveGlobals.setProperty(key, "3,2,1,3");
+        assertThat(property.getValue(), is(new LinkedHashSet<>(Arrays.asList("1", "2", "3"))));
+        assertThat(property.getDisplayValue(), is("1,2,3"));
+    }
+
 }

--- a/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
@@ -25,6 +25,7 @@ import org.jivesoftware.openfire.ldap.LdapAuthProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.xmpp.packet.JID;
 
 public class SystemPropertyTest {
 
@@ -519,4 +520,38 @@ public class SystemPropertyTest {
         assertThat(property.getDisplayValue(), is("1,2,3"));
     }
 
+    @Test
+    public void willBuildAJIDProperty() {
+
+        final String jidString = "test-user@test-domain/test-resource";
+        final JID jid = new JID(jidString);
+        final String key = "a jid property";
+
+        final SystemProperty<JID> property = SystemProperty.Builder.ofType(JID.class)
+            .setKey(key)
+            .setDynamic(true)
+            .build();
+
+        assertThat(property.getValue(),is(nullValue()));
+        property.setValue(jid);
+        assertThat(property.getValue(),is(jid));
+        assertThat(property.getDisplayValue(), is(jidString));
+        assertThat(JiveGlobals.getProperty(key), is(jidString));
+    }
+
+    @Test
+    public void willReturnNullForInvalidJID() {
+
+        final String jidString = "@test-domain";
+        final String key = "an invalid jid property";
+
+        final SystemProperty<JID> property = SystemProperty.Builder.ofType(JID.class)
+            .setKey(key)
+            .setDynamic(true)
+            .build();
+
+        assertThat(property.getValue(),is(nullValue()));
+        JiveGlobals.setProperty(key, jidString);
+        assertThat(property.getValue(),is(nullValue()));
+    }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
@@ -1,0 +1,438 @@
+package org.jivesoftware.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.auth.AuthProvider;
+import org.jivesoftware.openfire.auth.DefaultAuthProvider;
+import org.jivesoftware.openfire.auth.HybridAuthProvider;
+import org.jivesoftware.openfire.ldap.LdapAuthProvider;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SystemPropertyTest {
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Fixtures.reconfigureOpenfireHome();
+        // The following allows JiveGlobals to persist
+        JiveGlobals.setXMLProperty("setup", "true");
+        // The following speeds up tests by avoiding DB retries
+        JiveGlobals.setXMLProperty("database.maxRetries", "0");
+        JiveGlobals.setXMLProperty("database.retryDelay", "0");
+    }
+
+    @Before
+    public void setUp() {
+        JiveGlobals.getPropertyNames().forEach(JiveGlobals::deleteProperty);
+    }
+
+    @Test
+    public void willBuildAStringProperty() {
+
+        final SystemProperty<String> stringProperty = SystemProperty.Builder.ofType(String.class)
+            .setKey("a-test-string-property")
+            .setDefaultValue("this-is-a-default")
+            .setDynamic(true)
+            .build();
+
+        assertThat(stringProperty.getValue(), is("this-is-a-default"));
+        assertThat(stringProperty.getValueAsSaved(), is("this-is-a-default"));
+        stringProperty.setValue("this-is-not-a-default");
+        assertThat(stringProperty.getValue(), is("this-is-not-a-default"));
+        assertThat(stringProperty.getValueAsSaved(), is("this-is-not-a-default"));
+    }
+
+    @Test
+    public void willBuildALongProperty() {
+
+        final SystemProperty<Long> longProperty = SystemProperty.Builder.ofType(Long.class)
+            .setKey("a-test-long-property")
+            .setDefaultValue(42L)
+            .setDynamic(true)
+            .build();
+
+        assertThat(longProperty.getValue(), is(42L));
+        assertThat(longProperty.getValueAsSaved(), is("42"));
+        longProperty.setValue(84L);
+        assertThat(longProperty.getValue(), is(84L));
+        assertThat(longProperty.getValueAsSaved(), is("84"));
+    }
+
+    @Test
+    public void willBuildADurationProperty() {
+
+        final SystemProperty<Duration> longProperty = SystemProperty.Builder.ofType(Duration.class)
+            .setKey("a-test-duration-property")
+            .setDefaultValue(Duration.ofHours(1))
+            .setChronoUnit(ChronoUnit.MINUTES)
+            .setDynamic(true)
+            .build();
+
+        assertThat(longProperty.getValue(), is(Duration.ofHours(1)));
+        assertThat(longProperty.getValueAsSaved(), is("60"));
+        longProperty.setValue(Duration.ofDays(1));
+        assertThat(longProperty.getValue(), is(Duration.ofDays(1)));
+        assertThat(JiveGlobals.getProperty("a-test-duration-property"), is("1440"));
+        assertThat(longProperty.getValueAsSaved(), is("1440"));
+    }
+
+    @Test
+    public void willBuildABooleanProperty() {
+
+        final SystemProperty<Boolean> booleanProperty = SystemProperty.Builder.ofType(Boolean.class)
+            .setKey("a-test-boolean-property")
+            .setDefaultValue(false)
+            .setDynamic(true)
+            .build();
+
+        assertThat(booleanProperty.getValue(), is(false));
+        assertThat(booleanProperty.getValueAsSaved(), is("false"));
+        booleanProperty.setValue(true);
+        assertThat(booleanProperty.getValue(), is(true));
+        assertThat(booleanProperty.getValueAsSaved(), is("true"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void willNotBuildAPropertyWithoutAKey() {
+        SystemProperty.Builder.ofType(String.class)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void willNotBuildAPropertyWithoutADefaultValue() {
+        SystemProperty.Builder.ofType(String.class)
+            .setKey("a-test-property-without-a-default-value")
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void willNotBuildAPropertyWithoutADynamicIndicator() {
+        SystemProperty.Builder.ofType(String.class)
+            .setKey("a-test-property-without-dynamic-set")
+            .setDefaultValue("default value")
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void willNotBuildAPropertyForAnUnsupportedClass() {
+        SystemProperty.Builder.ofType(JavaSpecVersion.class)
+            .setKey("a-property-for-an-unsupported-class")
+            .setDefaultValue(new JavaSpecVersion("1.8"))
+            .setDynamic(true)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void willNotBuildTheSamePropertyTwice() {
+        SystemProperty.Builder.ofType(String.class)
+            .setKey("a-duplicate-property")
+            .setDefaultValue("")
+            .setDynamic(true)
+            .build();
+        SystemProperty.Builder.ofType(Boolean.class)
+            .setKey("a-duplicate-property")
+            .setDefaultValue(false)
+            .setDynamic(true)
+            .build();
+    }
+
+    @Test
+    public void willPreventAValueBeingTooLow() {
+        final SystemProperty<Long> property = SystemProperty.Builder.ofType(Long.class)
+            .setKey("this-is-a-constrained-long-key")
+            .setDefaultValue(42L)
+            .setMinValue(0L)
+            .setMaxValue(42L)
+            .setDynamic(true)
+            .build();
+
+        property.setValue(-1L);
+
+        assertThat(property.getValue(), is(42L));
+        assertThat(property.getValueAsSaved(), is("42"));
+    }
+
+    @Test
+    public void willPreventAValueBeingTooHigh() {
+        final SystemProperty<Long> property = SystemProperty.Builder.ofType(Long.class)
+            .setKey("this-is-another-constrained-long-key")
+            .setDefaultValue(42L)
+            .setMinValue(0L)
+            .setMaxValue(42L)
+            .setDynamic(true)
+            .build();
+
+        property.setValue(500L);
+
+        assertThat(property.getValue(), is(42L));
+        assertThat(property.getValueAsSaved(), is("42"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void willNotBuildADurationPropertyWithoutAChronoUnit() {
+        SystemProperty.Builder.ofType(Duration.class)
+            .setKey("this-will-not-work")
+            .setDefaultValue(Duration.ZERO)
+            .setDynamic(true)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void willNotBuildADurationPropertyWithAnInvalidChronoUnit() {
+        SystemProperty.Builder.ofType(Duration.class)
+            .setKey("this-will-not-work")
+            .setDefaultValue(Duration.ZERO)
+            .setChronoUnit(ChronoUnit.CENTURIES)
+            .setDynamic(true)
+            .build();
+    }
+
+    @Test
+    public void willNotifyListenersOfChanges() {
+
+        final AtomicReference<Duration> notifiedValue = new AtomicReference<>();
+
+        final SystemProperty<Duration> property = SystemProperty.Builder.ofType(Duration.class)
+            .setKey("property-notifier")
+            .setDefaultValue(Duration.ZERO)
+            .setChronoUnit(ChronoUnit.SECONDS)
+            .setDynamic(true)
+            .addListener(notifiedValue::set)
+            .build();
+
+        property.setValue(Duration.ofMinutes(60));
+
+        assertThat(notifiedValue.get(), is(Duration.ofHours(1)));
+    }
+
+    @Test
+    public void willIndicateDynamicPropertyDoesNotNeedRestarting() {
+
+        final SystemProperty<Long> longProperty = SystemProperty.Builder.ofType(Long.class)
+            .setKey("a-test-dynamic-property")
+            .setDefaultValue(42L)
+            .setDynamic(true)
+            .build();
+
+        assertThat(longProperty.isDynamic(), is(true));
+        assertThat(longProperty.isRestartRequired(), is(false));
+        longProperty.setValue(84L);
+        assertThat(longProperty.isRestartRequired(), is(false));
+    }
+
+    @Test
+    public void willIndicateNonDynamicPropertyNeedsRestarting() {
+
+        final SystemProperty<Long> longProperty = SystemProperty.Builder.ofType(Long.class)
+            .setKey("a-test-non-dynamic-property")
+            .setDefaultValue(42L)
+            .setDynamic(false)
+            .build();
+
+        assertThat(longProperty.isDynamic(), is(false));
+        assertThat(longProperty.isRestartRequired(), is(false));
+        longProperty.setValue(84L);
+        assertThat(longProperty.isRestartRequired(), is(true));
+    }
+
+    @Test
+    public void theDefaultPluginIsOpenfire() {
+
+        final SystemProperty<Long> longProperty = SystemProperty.Builder.ofType(Long.class)
+            .setKey("an-openfire-property")
+            .setDefaultValue(42L)
+            .setDynamic(false)
+            .build();
+
+        assertThat(longProperty.getPlugin(), is("Openfire"));
+    }
+
+    @Test
+    public void thePluginCanBeChanged() {
+
+        final SystemProperty<Long> longProperty = SystemProperty.Builder.ofType(Long.class)
+            .setKey("a-plugin-property")
+            .setDefaultValue(42L)
+            .setPlugin("TestPluginName")
+            .setDynamic(false)
+            .build();
+
+        assertThat(longProperty.getPlugin(), is("TestPluginName"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void aPluginIsRequired() {
+
+        SystemProperty.Builder.ofType(Long.class)
+            .setKey("a-null-plugin-property")
+            .setDefaultValue(42L)
+            .setPlugin(null)
+            .setDynamic(false)
+            .build();
+    }
+
+    @Test
+    public void willReturnAClass() {
+
+        final SystemProperty<Class> classProperty = SystemProperty.Builder.ofType(Class.class)
+            .setKey("a-class-property")
+            .setDefaultValue(DefaultAuthProvider.class)
+            .setBaseClass(AuthProvider.class)
+            .setDynamic(false)
+            .build();
+
+        assertThat(classProperty.getValue(), is(equalTo(DefaultAuthProvider.class)));
+        assertThat(classProperty.getValueAsSaved(), is("org.jivesoftware.openfire.auth.DefaultAuthProvider"));
+        JiveGlobals.setProperty("a-class-property", "org.jivesoftware.openfire.auth.HybridAuthProvider");
+        assertThat(classProperty.getValue(), is(equalTo(HybridAuthProvider.class)));
+        assertThat(classProperty.getValueAsSaved(), is("org.jivesoftware.openfire.auth.HybridAuthProvider"));
+        classProperty.setValue(LdapAuthProvider.class);
+        assertThat(classProperty.getValue(), is(equalTo(LdapAuthProvider.class)));
+        assertThat(classProperty.getValueAsSaved(), is("org.jivesoftware.openfire.ldap.LdapAuthProvider"));
+    }
+
+    @Test
+    public void willNotReturnAnotherClass() {
+
+        final SystemProperty<Class> classProperty = SystemProperty.Builder.ofType(Class.class)
+            .setKey("another-subclass-property")
+            .setDefaultValue(DefaultAuthProvider.class)
+            .setBaseClass(AuthProvider.class)
+            .setDynamic(false)
+            .build();
+
+        JiveGlobals.setProperty("another-subclass-property", "java.lang.Object");
+
+        assertThat(classProperty.getValue(), is(equalTo(DefaultAuthProvider.class)));
+    }
+
+    @Test
+    public void willNotReturnAMissingClass() {
+
+        final SystemProperty<Class> classProperty = SystemProperty.Builder.ofType(Class.class)
+            .setKey("a-missing-subclass-property")
+            .setDefaultValue(DefaultAuthProvider.class)
+            .setBaseClass(AuthProvider.class)
+            .setDynamic(false)
+            .build();
+
+        JiveGlobals.setProperty("a-missing-subclass-property", "this.class.is.missing");
+
+        assertThat(classProperty.getValue(), is(equalTo(DefaultAuthProvider.class)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void willNotBuildAClassPropertyWithoutABaseClass() {
+
+        SystemProperty.Builder.ofType(Class.class)
+            .setKey("a-broken-class-property")
+            .setDefaultValue(DefaultAuthProvider.class)
+            .setDynamic(false)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void willNotBuildARegularPropertyWithABaseClass() {
+
+        SystemProperty.Builder.ofType(Long.class)
+            .setKey("a-broken-long-property")
+            .setDefaultValue(42L)
+            .setBaseClass(java.lang.Long.class)
+            .setDynamic(false)
+            .build();
+    }
+
+    @Test
+    public void shouldEncryptAProperty() {
+        final SystemProperty<Long> longProperty = SystemProperty.Builder.ofType(Long.class)
+            .setKey("an-encrypted-property")
+            .setDefaultValue(42L)
+            .setDynamic(false)
+            .setEncrypted(true)
+            .build();
+
+        longProperty.setValue(84L);
+
+        assertThat(JiveGlobals.isPropertyEncrypted("an-encrypted-property"), is(true));
+    }
+
+    @Test
+    public void willAllowNullDefaultsForAStringProperty() {
+
+        final SystemProperty<String> stringProperty = SystemProperty.Builder.ofType(String.class)
+            .setKey("a-null-string-property")
+            .setDynamic(true)
+            .build();
+
+        assertThat(stringProperty.getDefaultValue(), is(nullValue()));
+    }
+
+    @Test
+    public void willAllowNullDefaultsForAClassProperty() {
+
+        final SystemProperty<Class> classProperty = SystemProperty.Builder.ofType(Class.class)
+            .setKey("a-null-class-property")
+            .setBaseClass(AuthProvider.class)
+            .setDynamic(false)
+            .build();
+
+        assertThat(classProperty.getDefaultValue(), is(nullValue()));
+    }
+
+    @Test
+    public void willRemovePluginSpecificProperties() {
+
+        final String key = "a-class-property-to-remove";
+        final SystemProperty<Class> property = SystemProperty.Builder.ofType(Class.class)
+            .setKey(key)
+            .setBaseClass(AuthProvider.class)
+            .setPlugin("TestPluginName")
+            .setDynamic(false)
+            .build();
+
+        assertThat(SystemProperty.getProperty(key), is(Optional.of(property)));
+        SystemProperty.removePropertiesForPlugin("TestPluginName");
+        assertThat(SystemProperty.getProperty(key), is(Optional.empty()));
+    }
+
+    @Test
+    public void willCreateAnInstantProperty() {
+
+        final String key = "test.instant.property";
+        final SystemProperty<Instant> property = SystemProperty.Builder.ofType(Instant.class)
+            .setKey(key)
+            .setDynamic(true)
+            .build();
+
+        assertThat(property.getValue(), is(nullValue()));
+        final Instant value = Instant.now();
+        property.setValue(value);
+        assertThat(property.getValue(), is(value));
+    }
+
+    @Test
+    public void willCreateAnInstantPropertyWithADefaultValue() {
+
+        final String key = "test.instant.property.with.default";
+        final Instant defaultValue = Instant.now();
+
+        final SystemProperty<Instant> property = SystemProperty.Builder.ofType(Instant.class)
+            .setKey(key)
+            .setDefaultValue(defaultValue)
+            .setDynamic(true)
+            .build();
+
+        assertThat(property.getValue(), is(defaultValue));
+    }
+}

--- a/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
@@ -8,6 +8,9 @@ import static org.junit.Assert.assertThat;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -434,5 +437,64 @@ public class SystemPropertyTest {
             .build();
 
         assertThat(property.getValue(), is(defaultValue));
+    }
+
+    @Test
+    public void willCreateAListOfStringProperties() {
+        final String key = "a list property";
+
+        final SystemProperty<List> property = SystemProperty.Builder.ofType(List.class)
+            .setCollectionType(String.class)
+            .setKey(key)
+            .setDefaultValue(Collections.emptyList())
+            .setDynamic(true)
+            .build();
+
+        assertThat(property.getValue(), is(Collections.emptyList()));
+        property.setValue(Arrays.asList("3", "2", "1"));
+        assertThat(property.getValue(), is(Arrays.asList("3", "2", "1")));
+        assertThat(property.getDisplayValue(), is("3,2,1"));
+        assertThat(JiveGlobals.getProperty(key), is("3,2,1"));
+    }
+
+    @Test
+    public void willCreateAListOfLongProperties() {
+        final String key = "a list of longs property";
+
+        final SystemProperty<List> property = SystemProperty.Builder.ofType(List.class)
+            .setCollectionType(Long.class)
+            .setKey(key)
+            .setSorted(true)
+            .setDefaultValue(Collections.emptyList())
+            .setDynamic(true)
+            .build();
+
+        assertThat(property.getValue(), is(Collections.emptyList()));
+        property.setValue(Arrays.asList(3, 2, 1));
+        assertThat(property.getValue(), is(Arrays.asList(1L, 2L, 3L)));
+        assertThat(property.getDisplayValue(), is("1,2,3"));
+        assertThat(JiveGlobals.getProperty(key), is("1,2,3"));
+        JiveGlobals.setProperty(key, "3,2,1");
+        assertThat(property.getValue(), is(Arrays.asList(1L, 2L, 3L)));
+        assertThat(property.getDisplayValue(), is("1,2,3"));
+    }
+
+    @Test
+    public void willCreateAListOfDurationProperties() {
+        final String key = "a list of durations property";
+
+        final SystemProperty<List> property = SystemProperty.Builder.ofType(List.class)
+            .setCollectionType(Duration.class)
+            .setChronoUnit(ChronoUnit.HOURS)
+            .setKey(key)
+            .setDefaultValue(Collections.singletonList(Duration.ZERO))
+            .setDynamic(true)
+            .build();
+
+        assertThat(property.getValue(), is(Collections.singletonList(Duration.ZERO)));
+        property.setValue(Arrays.asList(Duration.ofHours(1), Duration.ZERO));
+        assertThat(property.getValue(), is(Arrays.asList(Duration.ofHours(1), Duration.ZERO)));
+        assertThat(property.getDisplayValue(), is("1 hour,0 ms"));
+        assertThat(JiveGlobals.getProperty(key), is("1,0"));
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
@@ -446,12 +446,11 @@ public class SystemPropertyTest {
     public void willCreateAListOfStringProperties() {
         final String key = "a list property";
 
-        final SystemProperty<List> property = SystemProperty.Builder.ofType(List.class)
-            .setCollectionType(String.class)
+        final SystemProperty<List<String>> property = SystemProperty.Builder.ofType(List.class)
             .setKey(key)
             .setDefaultValue(Collections.emptyList())
             .setDynamic(true)
-            .build();
+            .buildList(String.class);
 
         assertThat(property.getValue(), is(Collections.emptyList()));
         property.setValue(Arrays.asList("3", "2", "1"));
@@ -464,16 +463,15 @@ public class SystemPropertyTest {
     public void willCreateAListOfLongProperties() {
         final String key = "a list of longs property";
 
-        final SystemProperty<List> property = SystemProperty.Builder.ofType(List.class)
-            .setCollectionType(Long.class)
+        final SystemProperty<List<Long>> property = SystemProperty.Builder.ofType(List.class)
             .setKey(key)
             .setSorted(true)
             .setDefaultValue(Collections.emptyList())
             .setDynamic(true)
-            .build();
+            .buildList(Long.class);
 
         assertThat(property.getValue(), is(Collections.emptyList()));
-        property.setValue(Arrays.asList(3, 2, 1));
+        property.setValue(Arrays.asList(3L, 2L, 1L));
         assertThat(property.getValue(), is(Arrays.asList(1L, 2L, 3L)));
         assertThat(property.getDisplayValue(), is("1,2,3"));
         assertThat(JiveGlobals.getProperty(key), is("1,2,3"));
@@ -486,13 +484,12 @@ public class SystemPropertyTest {
     public void willCreateAListOfDurationProperties() {
         final String key = "a list of durations property";
 
-        final SystemProperty<List> property = SystemProperty.Builder.ofType(List.class)
-            .setCollectionType(Duration.class)
+        final SystemProperty<List<Duration>> property = SystemProperty.Builder.ofType(List.class)
             .setChronoUnit(ChronoUnit.HOURS)
             .setKey(key)
             .setDefaultValue(Collections.singletonList(Duration.ZERO))
             .setDynamic(true)
-            .build();
+            .buildList(Duration.class);
 
         assertThat(property.getValue(), is(Collections.singletonList(Duration.ZERO)));
         property.setValue(Arrays.asList(Duration.ofHours(1), Duration.ZERO));
@@ -505,13 +502,12 @@ public class SystemPropertyTest {
     public void willCreateASetOfStringProperties() {
         final String key = "a set property";
 
-        final SystemProperty<Set> property = SystemProperty.Builder.ofType(Set.class)
-            .setCollectionType(String.class)
+        final SystemProperty<Set<String>> property = SystemProperty.Builder.ofType(Set.class)
             .setKey(key)
             .setSorted(true)
             .setDefaultValue(Collections.emptySet())
             .setDynamic(true)
-            .build();
+            .buildSet(String.class);
 
         assertThat(property.getValue(), is(Collections.emptySet()));
         property.setValue(new HashSet<>(Arrays.asList("3", "2", "1", "2")));

--- a/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
@@ -554,4 +554,29 @@ public class SystemPropertyTest {
         JiveGlobals.setProperty(key, jidString);
         assertThat(property.getValue(),is(nullValue()));
     }
+
+    private enum TestEnum {
+        TEST_1,
+        TEST_2
+    }
+
+    @Test
+    public void willBuildAnEnumProperty() {
+
+        final String key = "an enum property";
+
+        final SystemProperty<TestEnum> property = SystemProperty.Builder.ofType(TestEnum.class)
+            .setKey(key)
+            .setDefaultValue(TestEnum.TEST_1)
+            .setDynamic(true)
+            .build();
+
+        assertThat(property.getValue(),is(TestEnum.TEST_1));
+        property.setValue(TestEnum.TEST_2);
+        assertThat(property.getValue(),is(TestEnum.TEST_2));
+        assertThat(property.getDisplayValue(), is("TEST_2"));
+        assertThat(JiveGlobals.getProperty(key), is("TEST_2"));
+    }
+
+
 }


### PR DESCRIPTION
~~This is still a work in progress, but though I'd see if there was general support for this idea before I progressed further.~~

The idea is that a `SystemProperty` can represent the system properties currently accessed via `JiveGlobals`, stored in `ofProperty`. By providing a single place where they are referenced (the static method `SystemProperty.getProperties()`) it should be possible to incorporate their current/default values and description on the existing System Properties page. 

I'm not proposing to replace every access of JiveGlobals with this class, instead gradually migrate over time, and as more properties are migrated the System Properties page becomes more complete. 

Creating a sysprop can be done so;
```
        final SystemProperty<Long> property = SystemProperty.Builder.ofType(Long.class)
            .setKey("this-is-a-constrained-long-key")
            .setDefaultValue(42L)
            .setMinValue(0L)
            .setMaxValue(100L)
            .build();

        assertThat(longProperty.getValue(), is(42L));
        longProperty.setValue(84L);
        assertThat(longProperty.getValue(), is(84L));
```

See the tests for examples of how to use, but as it stands the properties can be a String, Integer, Long or Duration, with a default value, description, and optional min/max values. A listener can also be supplied, which will be called whenever the property changes.
