### PR TITLE
Update PresenceUpdateHandler.java

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -459,8 +459,8 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
     }
 
     /**
-     * Sends an unavailable presence to the entities that received a directed (available) presence
-     * by the user that is now going offline.
+     * Sends an unavailable presence to the entities that send a directed (available) presence
+     * to other entities.
      *
      * @param update the unavailable presence sent by the user.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -459,7 +459,7 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
     }
 
     /**
-     * Sends an unavailable presence to the entities that send a directed (available) presence
+     * Sends an unavailable presence to the entities that sent a directed (available) presence
      * to other entities.
      *
      * @param update the unavailable presence sent by the user.


### PR DESCRIPTION
i thought directedPresencesCache is a map for saving directed presence sender. and this module send the presence to entities who is belong in directedPresenceCache. so i think this description has little wrong information.