### PR TITLE
OF-1689: Isolate broadcasts & log problems.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/BroadcastMessageRequest.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/BroadcastMessageRequest.java
@@ -20,6 +20,8 @@ import org.dom4j.Element;
 import org.dom4j.tree.DefaultElement;
 import org.jivesoftware.openfire.muc.spi.LocalMUCRoom;
 import org.jivesoftware.util.cache.ExternalizableUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmpp.packet.Message;
 
 import java.io.IOException;
@@ -34,6 +36,7 @@ import java.io.ObjectOutput;
  * @author Gaston Dombiak
  */
 public class BroadcastMessageRequest extends MUCRoomTask<Void> {
+    private static final Logger Log = LoggerFactory.getLogger( BroadcastMessageRequest.class );
     private int occupants;
     private Message message;
 
@@ -65,7 +68,14 @@ public class BroadcastMessageRequest extends MUCRoomTask<Void> {
         execute(new Runnable() {
             @Override
             public void run() {
-                getRoom().broadcast(BroadcastMessageRequest.this);
+                try
+                {
+                    getRoom().broadcast( BroadcastMessageRequest.this );
+                }
+                catch ( Exception e )
+                {
+                    Log.warn( "An unexpected exception occurred while trying to broadcast a message from {} in the room {}", message.getFrom(), getRoom().getJID() );
+                }
             }
         });
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/BroadcastPresenceRequest.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/BroadcastPresenceRequest.java
@@ -20,6 +20,8 @@ import org.dom4j.Element;
 import org.dom4j.tree.DefaultElement;
 import org.jivesoftware.openfire.muc.spi.LocalMUCRoom;
 import org.jivesoftware.util.cache.ExternalizableUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmpp.packet.Presence;
 
 import java.io.IOException;
@@ -35,6 +37,8 @@ import java.io.ObjectOutput;
  * @author Gaston Dombiak
  */
 public class BroadcastPresenceRequest extends MUCRoomTask<Void> {
+    private static final Logger Log = LoggerFactory.getLogger( BroadcastPresenceRequest.class );
+
     private Presence presence;
 
     private boolean isJoinPresence;
@@ -67,7 +71,14 @@ public class BroadcastPresenceRequest extends MUCRoomTask<Void> {
         execute(new Runnable() {
             @Override
             public void run() {
-                getRoom().broadcast(BroadcastPresenceRequest.this);
+                try
+                {
+                    getRoom().broadcast( BroadcastPresenceRequest.this );
+                }
+                catch ( Exception e )
+                {
+                    Log.warn( "An unexpected exception occurred while trying to broadcast a presence update from {} in the room {}", presence.getFrom(), getRoom().getJID() );
+                }
             }
         });
     }


### PR DESCRIPTION
Openfire has routines to broadcast message and presence stanzas to occupants in a room.

Up until this method, any exception that occurred would:
- not be logged;
- stop the broadcast to any pending intended recipients.

This commit adds logging, and makes sure that failure to deliver a stanza to one entity
does not prevent other entities from receiving it.