### PR TITLE
OF-1692: Broadcast original 'unavailable' stanza when leaving MUC.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
@@ -541,6 +541,7 @@ public class LocalMUCUser implements MUCUser {
                     if (Presence.Type.unavailable == packet.getType()) {
                         try {
                             // TODO Consider that different nodes can be creating and processing this presence at the same time (when remote node went down)
+                            role.setPresence(packet);
                             removeRole(group);
                             role.getChatRoom().leaveRoom(role);
                         }


### PR DESCRIPTION
When a client sends a presence 'unavailable' stanza to leave a multi-user chat room, Openfire broadcasts not that stanza, but one that was received earlier (and is modified to include 'unavailable').

This appears to be an oversight, combined with a better-safe-than-sorry override of the presence type.

Openfire should broadcast the original stanza (modified to add some metadata where needed). This will, for instance, keep intact the reflected stanza ID.