### PR TITLE
OF-1682: Don't double escape XML entities

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
@@ -485,7 +485,7 @@ public class XMLProperties {
                 childElement.addCDATA(value.substring(9, value.length()-3));
             }
             else {
-                String propValue = StringEscapeUtils.escapeXml10(value);
+                String propValue = value;
                 // check to see if the property is marked as encrypted
                 if (JiveGlobals.isPropertyEncrypted(name)) {
                     propValue = JiveGlobals.getPropertyEncryptor().encrypt(value);
@@ -643,7 +643,7 @@ public class XMLProperties {
             }
             element.addCDATA(value.substring(9, value.length() - 3));
         } else {
-            String propValue = StringEscapeUtils.escapeXml10(value);
+            String propValue = value;
             // check to see if the property is marked as encrypted
             if (JiveGlobals.isXMLPropertyEncrypted(name)) {
                 propValue = JiveGlobals.getPropertyEncryptor().encrypt(value);

--- a/xmppserver/src/main/webapp/setup/setup-datasource-standard.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-datasource-standard.jsp
@@ -238,21 +238,23 @@
 
 
 <%  // DB preset data
-    List<String[]> presets = new ArrayList<String []>();
-    presets.add(new String[]{"MySQL","com.mysql.jdbc.Driver","jdbc:mysql://HOSTNAME:3306/DATABASENAME?rewriteBatchedStatements=true"});
+    final List<String[]> presets = new ArrayList<String []>();
+    presets.add(new String[]{"MySQL","com.mysql.cj.jdbc.Driver","jdbc:mysql://HOSTNAME:3306/DATABASENAME?rewriteBatchedStatements=true&characterEncoding=UTF-8&characterSetResults=UTF-8"});
     presets.add(new String[]{"Oracle","oracle.jdbc.driver.OracleDriver","jdbc:oracle:thin:@HOSTNAME:1521:SID"});
     presets.add(new String[]{"Microsoft SQL Server (legacy)","net.sourceforge.jtds.jdbc.Driver","jdbc:jtds:sqlserver://HOSTNAME/DATABASENAME;appName=Openfire"});
     presets.add(new String[]{"PostgreSQL","org.postgresql.Driver","jdbc:postgresql://HOSTNAME:5432/DATABASENAME"});
     presets.add(new String[]{"IBM DB2","com.ibm.db2.jcc.DB2Driver","jdbc:db2://HOSTNAME:50000/DATABASENAME"});
     presets.add(new String[]{"Microsoft SQL Server","com.microsoft.sqlserver.jdbc.SQLServerDriver","jdbc:sqlserver://HOSTNAME:1433;databaseName=DATABASENAME;applicationName=Openfire"});
+    pageContext.setAttribute("presets", presets );
 %>
 <script language="JavaScript" type="text/javascript">
-var data = new Array();
-<%  for (int i=0; i<presets.size(); i++) {
-        String[] data = presets.get(i);
-%>
-    data[<%= i %>] = new Array('<%= data[0] %>','<%= data[1] %>','<%= data[2] %>');
-<%  } %>
+var data = [];
+<c:set var="i" value="0"/>
+<c:forEach items="${presets}" var="preset">
+data[${i}] = ['${preset[0]}','${preset[1]}','${preset[2]}'];
+<c:set var="i" value="${i+1}"/>
+</c:forEach>
+
 function populate(i) {
     document.dbform.driver.value=data[i][1];
     document.dbform.serverURL.value=data[i][2];


### PR DESCRIPTION
It turns out the code has double escaped XML entities in `openfire.xml` for a long time. This PR fixes that, and also tidies up the code where the preset values are translated in to JavaScript (which is where I first thought the issue lay, incorrectly as it turns out).

Note; This also updates the preset MySQL JDBC driver name (the previous one was complaining about being deprecated in the console), and sets UTF-8 as the preset charset.

