### PR TITLE
Improve concurrency and performance of conversation log history.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/database/SequenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SequenceManager.java
@@ -68,6 +68,7 @@ public class SequenceManager {
         new SequenceManager(JiveConstants.ROSTER, 5);
         new SequenceManager(JiveConstants.OFFLINE, 5);
         new SequenceManager(JiveConstants.MUC_ROOM, 5);
+        new SequenceManager(JiveConstants.MUC_MESSAGE_ID, 50);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -594,7 +594,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         @Override
         public void run() {
             try {
-                logConversation();
+                logConversationBatch();
             }
             catch (final Throwable e) {
                 Log.error(LocaleUtils.getLocalizedString("admin.error"), e);
@@ -602,16 +602,25 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         }
     }
 
-    private void logConversation() {
+    private void logConversationBatch() {
         ConversationLogEntry entry;
         boolean success;
+
+        final LinkedList<ConversationLogEntry> batchList = new LinkedList<>();
+
         for (int index = 0; index <= log_batch_size && !logQueue.isEmpty(); index++) {
             entry = logQueue.poll();
             if (entry != null) {
-                success = MUCPersistenceManager.saveConversationLogEntry(entry);
-                if (!success) {
-                    logQueue.add(entry);
-                }
+                batchList.add(entry);
+            }
+        }
+
+        success = MUCPersistenceManager.saveConversationLogBatch(batchList);
+
+        if (!success) {
+            // query failed, restore the entries to the logQueue
+            while (!batchList.isEmpty()) {
+                logQueue.add(batchList.poll());
             }
         }
     }
@@ -625,7 +634,15 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         while (!logQueue.isEmpty()) {
             entry = logQueue.poll();
             if (entry != null) {
-                MUCPersistenceManager.saveConversationLogEntry(entry);
+                final LinkedList<ConversationLogEntry> batchList = new LinkedList<>();
+
+                for (int index = 0; index <= log_batch_size && !logQueue.isEmpty(); index++) {
+                    entry = logQueue.poll();
+                    if (entry != null) {
+                        batchList.add(entry);
+                    }
+                }
+                MUCPersistenceManager.saveConversationLogBatch(batchList);
             }
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveConstants.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveConstants.java
@@ -27,6 +27,7 @@ public class JiveConstants {
     public static final int MUC_ROOM = 23;
     public static final int SECURITY_AUDIT = 25;
     public static final int MUC_SERVICE = 26;
+    public static final int MUC_MESSAGE_ID = 27;
 
     public static final long SECOND = 1000;
     public static final long MINUTE = 60 * SECOND;


### PR DESCRIPTION
1. Use SequenceManager to assign the next messageID in ofMucConversationLog, instead of using select count(*) as part of the insert query, to solve 2 issues:
- In a clustered environment, with concurrent transactions taking place and default tx isolation level repeatable read, it was the cause of continuous deadlocks.
- If a process to remove old conversation logs is set up, having count(*) as messageID would lead to duplicates.

2. Instead of inserting conversation logs message by message, they're stored in batches as part of a single db transaction, to improve performance.