### PR TITLE
OF-1712: Introduce a new API to provide locking of Cache entries.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/Cache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/Cache.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
 
 /**
  * General purpose cache. It stores objects associated with unique keys in
@@ -166,5 +167,23 @@ public interface Cache<K extends Serializable, V extends Serializable> extends j
      */
     @Override
     Set<K> keySet();
+
+    /**
+     * Returns an existing {@link Lock} on the specified key or creates a new one
+     * if none was found. This operation is thread safe. Successive calls with the same key may or may not
+     * return the same {@link Lock}. However, different threads asking for the
+     * same Lock at the same time will get the same Lock object.
+     *
+     * <p>The supplied cache may or may not be used depending whether the server is running on cluster mode
+     * or not. When not running as part of a cluster then the lock will be unrelated to the cache and will
+     * only be visible in this JVM.
+     *
+     * @param key the object that defines the visibility or scope of the lock.
+     * @return an existing lock on the specified key or creates a new one if none was found.
+     */
+    @SuppressWarnings("deprecation")
+    default Lock getLock(final K key) {
+        return CacheFactory.getLock(key, this);
+    }
 
 }

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -478,7 +478,9 @@ public class CacheFactory {
     }
 
     /**
-     * Returns an existing {@link java.util.concurrent.locks.Lock} on the specified key or creates a new one
+     * @deprecated in favour of {@link Cache#getLock(K)}. Will be removed in Openfire 5.0.0.
+     *
+     * <p>Returns an existing {@link java.util.concurrent.locks.Lock} on the specified key or creates a new one
      * if none was found. This operation is thread safe. Successive calls with the same key may or may not
      * return the same {@link java.util.concurrent.locks.Lock}. However, different threads asking for the
      * same Lock at the same time will get the same Lock object.<p>
@@ -491,6 +493,7 @@ public class CacheFactory {
      * @param cache the cache used for holding the lock.
      * @return an existing lock on the specified key or creates a new one if none was found.
      */
+    @Deprecated
     public static synchronized Lock getLock(Object key, Cache cache) {
         if (localOnly.contains(cache.getName())) {
             return localCacheFactoryStrategy.getLock(key, cache);


### PR DESCRIPTION
Why? The single responsibility principle. It makes more sense (to me)
to ask the Cache to lock a key rather than the CacheFactory, which should
concentrate on creating cache's.

Note that only the API changes; the implementation still resides in
CacheFactory. Easiest to leave it there until the deprecated method is
removed.