### PR TITLE
OF-1713 Unit tests shouldn't break because of non English system locale

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -88,6 +88,7 @@
                     <systemPropertyVariables>
                         <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
                     </systemPropertyVariables>
+                    <argLine>-Duser.language=us -Duser.country=US</argLine>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Openfire xmppserver unit test fails if the system locale isn't English. We can configure surefire plugin to start the JVM with a specific locale via the <argLine> option, so it only impact the unit tests.

[Forum thread](https://discourse.igniterealtime.org/t/openfire-xmppserver-unitary-tests-failing-because-of-locale/84549/2)
[JIRA](https://issues.igniterealtime.org/browse/OF-1713)