### PR TITLE
OF-1700 OF-1701 OF-1705 OF-1706 OF-1707 OF-1729 OF-1732: Clustered state improvements

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceRouter.java
@@ -208,7 +208,7 @@ public class PresenceRouter extends BasicModule {
         presenceManager = server.getPresenceManager();
         multicastRouter = server.getMulticastRouter();
         sessionManager = server.getSessionManager();
-        entityCapsManager = EntityCapabilitiesManager.getInstance();
+        entityCapsManager = server.getEntityCapabilitiesManager();
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -419,9 +419,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
         localSessionManager.getComponentsSessions().add(session);
 
         // Keep track of the cluster node hosting the new external component
-        final HashSet<NodeID> nodeIDs = componentSessionsCache.getOrDefault(address.toString(), new HashSet<>());
-        nodeIDs.add( server.getNodeID() );
-        componentSessionsCache.put(address.toString(), nodeIDs); // Explicitly add it back for the change to propagate through Hazelcast.
+        CacheUtil.addValueToMultiValuedCache( componentSessionsCache, address.toString(), server.getNodeID(), HashSet::new );
 
         return session;
     }
@@ -1652,12 +1650,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
     private void restoreCacheContent() {
         // Add external component sessions hosted locally to the cache (using new nodeID)
         for (Session session : localSessionManager.getComponentsSessions()) {
-            HashSet<NodeID> nodeIDs = componentSessionsCache.get(session.getAddress().toString());
-            if (nodeIDs == null) {
-                nodeIDs = new HashSet<>();
-            }
-            nodeIDs.add( server.getNodeID() );
-            componentSessionsCache.put(session.getAddress().toString(), nodeIDs);
+            CacheUtil.addValueToMultiValuedCache( componentSessionsCache, session.getAddress().toString(), server.getNodeID(), HashSet::new );
         }
 
         // Add connection multiplexer sessions hosted locally to the cache (using new nodeID)

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -72,6 +72,8 @@ public class SessionManager extends BasicModule implements ClusterEventListener
     public static final String COMPONENT_SESSION_CACHE_NAME = "Components Sessions";
     public static final String CM_CACHE_NAME = "Connection Managers Sessions";
     public static final String ISS_CACHE_NAME = "Incoming Server Sessions";
+    public static final String HOSTNAME_SESSIONS_CACHE_NAME = "Sessions by Hostname";
+    public static final String VALIDATED_DOMAINS_CACHE_NAME = "Validated Domains";
     public static final String C2S_INFO_CACHE_NAME = "Client Session Info Cache";
 
     public static final int NEVER_KICK = -1;
@@ -1359,8 +1361,8 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         componentSessionsCache = CacheFactory.createCache(COMPONENT_SESSION_CACHE_NAME);
         multiplexerSessionsCache = CacheFactory.createCache(CM_CACHE_NAME);
         incomingServerSessionsCache = CacheFactory.createCache(ISS_CACHE_NAME);
-        hostnameSessionsCache = CacheFactory.createCache("Sessions by Hostname");
-        validatedDomainsCache = CacheFactory.createCache("Validated Domains");
+        hostnameSessionsCache = CacheFactory.createCache(HOSTNAME_SESSIONS_CACHE_NAME);
+        validatedDomainsCache = CacheFactory.createCache(VALIDATED_DOMAINS_CACHE_NAME);
         sessionInfoCache = CacheFactory.createCache(C2S_INFO_CACHE_NAME);
 
         // Listen to cluster events

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -29,7 +29,6 @@ import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.cluster.ClusterEventListener;
 import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.cluster.NodeID;
-import org.jivesoftware.openfire.component.InternalComponentManager;
 import org.jivesoftware.openfire.container.BasicModule;
 import org.jivesoftware.openfire.event.SessionEventDispatcher;
 import org.jivesoftware.openfire.http.HttpConnection;
@@ -60,8 +59,8 @@ import org.xmpp.packet.Presence;
  *
  * @author Derek DeMoro
  */
-public class SessionManager extends BasicModule implements ClusterEventListener/*, ServerItemsProvider, DiscoInfoProvider, DiscoItemsProvider */{
-
+public class SessionManager extends BasicModule implements ClusterEventListener
+{
     private static final Logger Log = LoggerFactory.getLogger(SessionManager.class);
     private static final SystemProperty<Integer> CONFLICT_LIMIT = SystemProperty.Builder.ofType(Integer.class)
         .setKey("xmpp.session.conflict-limit")
@@ -1238,51 +1237,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
         conflictLimit = limit;
         CONFLICT_LIMIT.setValue(limit);
     }
-    /*
-    @Override
-    public Iterator<DiscoServerItem> getItems() {
-        return Arrays.asList(new DiscoServerItem(serverAddress, null, null, null, this, this)).iterator();
-    }
 
-    @Override
-    public Iterator<Element> getIdentities(String name, String node, JID senderJID) {
-        return Collections.emptyIterator();
-    }
-
-    @Override
-    public Iterator<String> getFeatures(String name, String node, JID senderJID) {
-        return Collections.emptyIterator();
-    }
-
-    @Override
-    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
-    }
-
-    @Override
-    public boolean hasInfo(String name, String node, JID senderJID) {
-        return false;
-    }
-
-    @Override
-    public Iterator<DiscoItem> getItems(String name, String node, JID senderJID) {
-        try {
-            // If the requesting entity is the user itself or the requesting entity can probe the presence of the user.
-            if (name != null && senderJID != null &&
-                server.getUserManager().isRegisteredUser(senderJID) &&
-                (name.equals(senderJID.getNode()) || server.getPresenceManager().canProbePresence(senderJID, name))) {
-                Collection<DiscoItem> discoItems = new ArrayList<DiscoItem>();
-                for (ClientSession clientSession : getSessions(name)) {
-                    discoItems.add(new DiscoItem(clientSession.getAddress(), null, null, null));
-                }
-                return discoItems.iterator();
-            }
-            return Collections.emptyIterator();
-        } catch (UserNotFoundException e) {
-            return Collections.emptyIterator();
-        }
-    }
-    */
     private class ClientSessionListener implements ConnectionCloseListener {
         /**
          * Handle a session that just closed.
@@ -1407,9 +1362,9 @@ public class SessionManager extends BasicModule implements ClusterEventListener/
         hostnameSessionsCache = CacheFactory.createCache("Sessions by Hostname");
         validatedDomainsCache = CacheFactory.createCache("Validated Domains");
         sessionInfoCache = CacheFactory.createCache(C2S_INFO_CACHE_NAME);
+
         // Listen to cluster events
         ClusterManager.addListener(this);
-        //server.getIQDiscoItemsHandler().addServerItemsProvider(this);
     }
 
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -55,6 +55,7 @@ import org.jivesoftware.openfire.disco.ServerItemsProvider;
 import org.jivesoftware.openfire.disco.UserFeaturesProvider;
 import org.jivesoftware.openfire.disco.UserIdentitiesProvider;
 import org.jivesoftware.openfire.disco.UserItemsProvider;
+import org.jivesoftware.openfire.entitycaps.EntityCapabilitiesManager;
 import org.jivesoftware.openfire.filetransfer.DefaultFileTransferManager;
 import org.jivesoftware.openfire.filetransfer.FileTransferManager;
 import org.jivesoftware.openfire.filetransfer.proxy.FileTransferProxy;
@@ -772,6 +773,7 @@ public class XMPPServer {
         loadModule(MultiUserChatManager.class.getName());
         loadModule(IQMessageCarbonsHandler.class.getName());
         loadModule(CertificateStoreManager.class.getName());
+        loadModule(EntityCapabilitiesManager.class.getName());
 
         // Load this module always last since we don't want to start listening for clients
         // before the rest of the modules have been started
@@ -1498,6 +1500,17 @@ public class XMPPServer {
      */
     public AuditManager getAuditManager() {
         return (AuditManager) modules.get(AuditManagerImpl.class);
+    }
+
+    /**
+     * Returns the <code>EntityCapabilitiesManager</code> registered with this server. The
+     * <code>EntityCapabilitiesManager</code> was registered with the server as a module while starting up
+     * the server.
+     *
+     * @return the <code>EntityCapabilitiesManager</code> registered with this server.
+     */
+    public EntityCapabilitiesManager getEntityCapabilitiesManager() {
+        return (EntityCapabilitiesManager) modules.get(EntityCapabilitiesManager.class);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -29,17 +29,7 @@ import java.net.UnknownHostException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimerTask;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.dom4j.Document;
@@ -166,7 +156,7 @@ public class XMPPServer {
     private boolean initialized = false;
     private boolean started = false;
     private NodeID nodeID;
-    private static final NodeID DEFAULT_NODE_ID = NodeID.getInstance(new byte[0]);
+    private static final NodeID DEFAULT_NODE_ID = NodeID.getInstance( UUID.randomUUID().toString().getBytes() );
 
     public static final String EXIT = "exit";
     private final static Set<String> XML_ONLY_PROPERTIES;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
@@ -16,10 +16,7 @@
 
 package org.jivesoftware.openfire.component;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -117,6 +114,11 @@ public class InternalComponentManager extends BasicModule implements ComponentMa
     @Override
     public void stop() {
         super.stop();
+        synchronized ( routables ) {
+            // OF-1700: Shut down each connected component properly, which benefits other cluster nodes.
+            final Set<String> subdomains = routables.keySet();
+            subdomains.forEach( this::removeComponent );
+        }
         if (getAddress() != null) {
             // Remove the route to this service
             XMPPServer.getInstance().getRoutingTable().removeComponentRoute(getAddress());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
@@ -671,7 +671,7 @@ public class InternalComponentManager extends BasicModule implements ClusterEven
         final Map<Boolean, Map<JID, HashSet<NodeID>>> modified = CacheUtil.removeValueFromMultiValuedCache( componentCache, NodeID.getInstance( nodeID ) );
 
         modified.get( false ).keySet().forEach( removedDomain -> {
-            Log.debug( "Cluster node {} just left the cluster, and was the only node on which component '{}' was living. Invoking the 'component unregistered' event on all remaining cluster nodes.", nodeID, removedDomain );
+            Log.debug( "Cluster node {} just left the cluster, and was the only node on which component '{}' was living. Invoking the 'component unregistered' event on all remaining cluster nodes.", NodeID.getInstance( nodeID ), removedDomain );
             notifyComponentUnregistered( removedDomain );
 
             // As we have removed the disappeared components from the clustered cache, other nodes

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/RequestComponentInfoNotification.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/RequestComponentInfoNotification.java
@@ -1,0 +1,55 @@
+package org.jivesoftware.openfire.component;
+
+import org.jivesoftware.openfire.cluster.NodeID;
+import org.jivesoftware.util.cache.CacheFactory;
+import org.jivesoftware.util.cache.ClusterTask;
+import org.jivesoftware.util.cache.ExternalizableUtil;
+import org.xmpp.packet.IQ;
+import org.xmpp.packet.JID;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class RequestComponentInfoNotification implements ClusterTask<Void>
+{
+    private JID component;
+    private NodeID requestee;
+
+    public RequestComponentInfoNotification() {
+    }
+
+    public RequestComponentInfoNotification(final JID component, NodeID requestee)
+    {
+        this.component = component;
+        this.requestee = requestee;
+    }
+
+    @Override
+    public Void getResult() {
+        return null;
+    }
+
+    @Override
+    public void run() {
+        final InternalComponentManager manager = InternalComponentManager.getInstance();
+        final IQ componentInfo = manager.getComponentInfo( component );
+        if ( componentInfo != null )
+        {
+            CacheFactory.doClusterTask( new NotifyComponentInfo( componentInfo ), requestee.toByteArray() );
+        }
+    }
+
+    @Override
+    public void writeExternal( ObjectOutput out) throws IOException
+    {
+        ExternalizableUtil.getInstance().writeSerializable( out, component );
+        ExternalizableUtil.getInstance().writeSerializable( out, requestee );
+    }
+
+    @Override
+    public void readExternal( ObjectInput in) throws IOException, ClassNotFoundException {
+        component = (JID) ExternalizableUtil.getInstance().readSerializable( in );
+        requestee = (NodeID) ExternalizableUtil.getInstance().readSerializable( in );
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
@@ -102,12 +102,15 @@ public class ComponentStanzaHandler extends StanzaHandler {
                 else {
                     try {
                         // Get the requested subdomain
-                        String subdomain = extraDomain;
+                        final String subdomain;
                         int index = extraDomain.indexOf( XMPPServer.getInstance().getServerInfo().getXMPPDomain() );
                         if (index > -1) {
                             subdomain = extraDomain.substring(0, index -1);
+                        } else {
+                            subdomain = extraDomain;
                         }
                         InternalComponentManager.getInstance().addComponent(subdomain, component);
+                        session.getConnection().registerCloseListener( handback -> InternalComponentManager.getInstance().removeComponent( subdomain, (ComponentSession.ExternalComponent) handback ), component );
                         // Send confirmation that the new domain has been registered
                         connection.deliverRawText("<bind/>");
                     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -526,7 +526,7 @@ public class SocketConnection implements Connection {
                 
             closeConnection();
             notifyCloseListeners();
-            
+            listeners.clear();
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -198,6 +198,7 @@ public abstract class VirtualConnection implements Connection {
             // their session was closed. Effectively, the bug prevents the MUC room from getting a
             // presence update to notify it that the user logged off.
             notifyCloseListeners();
+            listeners.clear();
 
             try {
                 closeVirtualConnection();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -24,6 +24,7 @@ import org.jivesoftware.openfire.RoutableChannelHandler;
 import org.jivesoftware.openfire.RoutingTable;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.cluster.NodeID;
 import org.jivesoftware.openfire.interceptor.InterceptorManager;
 import org.jivesoftware.openfire.interceptor.PacketInterceptor;
 import org.jivesoftware.openfire.interceptor.PacketRejectedException;
@@ -79,7 +80,7 @@ public class OutgoingSessionPromise implements RoutableChannelHandler {
      * Cache (unlimited, never expire) that holds outgoing sessions to remote servers from this server.
      * Key: server domain, Value: nodeID
      */
-    private Cache<String, byte[]> serversCache;
+    private Cache<String, NodeID> serversCache;
     /**
      * Flag that indicates if the process that consumed the queued packets should stop.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
@@ -150,6 +150,8 @@ public class LocalComponentSession extends LocalSession implements ComponentSess
 
         // Create a ComponentSession for the external component
         LocalComponentSession session = SessionManager.getInstance().createComponentSession(componentJID, connection);
+        connection.registerCloseListener( handback -> SessionManager.getInstance().removeComponentSession( (LocalComponentSession) handback ), session );
+
         session.component = new LocalExternalComponent(session, connection);
 
         try {
@@ -241,6 +243,7 @@ public class LocalComponentSession extends LocalSession implements ComponentSess
             ExternalComponent component = getExternalComponent();
             try {
                 InternalComponentManager.getInstance().addComponent(defaultSubdomain, component);
+                conn.registerCloseListener( handback -> InternalComponentManager.getInstance().removeComponent( defaultSubdomain, (ExternalComponent) handback ), component );
                 Log.debug(
                         "LocalComponentSession: [ExComp] External component was registered SUCCESSFULLY with domain: " +
                                 defaultSubdomain);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
@@ -266,6 +266,7 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
             if (!addedToCache) {
                 return;
             }
+            Log.debug( "Recording 'last activity' for user '{}'.", username);
             lastActivityCache.put(username, offlinePresenceDate.getTime());
 
             writeToDatabase(username, offlinePresence, offlinePresenceDate);
@@ -502,6 +503,8 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
     public void userDeleting(User user, Map<String, Object> params) {
         // Delete user information
         deleteOfflinePresenceFromDB(user.getUsername());
+        offlinePresenceCache.remove(user.getUsername());
+        lastActivityCache.remove(user.getUsername());
     }
 
     @Override
@@ -509,7 +512,7 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
         // Do nothing
     }
 
-// #####################################################################
+    // #####################################################################
     // Module management
     // #####################################################################
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -34,6 +34,7 @@ import org.jivesoftware.openfire.session.*;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.cache.Cache;
 import org.jivesoftware.util.cache.CacheFactory;
+import org.jivesoftware.util.cache.CacheUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.*;
@@ -1034,6 +1035,16 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     public void stop() {
         super.stop();
         localRoutingTable.stop();
+
+        try
+        {
+            // Purge our own components from the cache for the benefit of other cluster nodes.
+            CacheUtil.removeValueFromMultiValuedCache( componentsCache, XMPPServer.getInstance().getNodeID() );
+        }
+        catch ( Exception e )
+        {
+            Log.warn( "An exception occurred while trying to remove locally connected external components from the clustered cache. Other cluster nodes might continue to see our external components, even though we this instance is stopping.", e );
+        }
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -949,8 +949,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
     @Override
     public boolean removeServerRoute(DomainPair route) {
-        String address = route.toString();
-        boolean removed = false;
+        boolean removed;
         Lock lock = CacheFactory.getLock(route, serversCache);
         try {
             lock.lock();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1043,9 +1043,8 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     }
 
     @Override
-    public void joinedCluster() {
-        restoreCacheContent();
-
+    public void joinedCluster()
+    {
         // Upon joining a cluster, the server gets a new ID. Here, all old IDs are replaced with the new identity.
         final NodeID defaultNodeID = server.getDefaultNodeID();
         final NodeID nodeID = server.getNodeID();
@@ -1074,9 +1073,6 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     @Override
     public void leftCluster() {
         if (!XMPPServer.getInstance().isShuttingDown()) {
-            // Add local sessions to caches
-            restoreCacheContent();
-
             // Upon leaving a cluster, the server uses its non-clustered/default ID again. Here, all clustered IDs are replaced with the new identity.
             final NodeID defaultNodeID = server.getDefaultNodeID();
             final NodeID nodeID = server.getNodeID();
@@ -1157,24 +1153,4 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     public void markedAsSeniorClusterMember() {
         // Do nothing
     }
-
-    private void restoreCacheContent() {
-        // Add outgoing server sessions hosted locally to the cache (using new nodeID)
-        for (LocalOutgoingServerSession session : localRoutingTable.getServerRoutes()) {
-            for (DomainPair pair : session.getOutgoingDomainPairs()) {
-                addServerRoute(pair, session);
-            }
-        }
-
-        // Add component sessions hosted locally to the cache (using new nodeID) and remove traces to old nodeID
-        for (RoutableChannelHandler route : localRoutingTable.getComponentRoute()) {
-            addComponentRoute(route.getAddress(), route);
-        }
-
-        // Add client sessions hosted locally to the cache (using new nodeID)
-        for (LocalClientSession session : localRoutingTable.getClientRoutes()) {
-            addClientRoute(session.getAddress(), session);
-        }
-    }
-
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1111,7 +1111,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             }
             Log.debug( "The local cluster node left the cluster. A total of {} client sessions were living on one (or more) other cluster nodes, and are no longer available.", remoteClientRoutes.size() );
             for (String route : remoteClientRoutes) {
-                removeClientRoute(new JID(route));
+                // This call takes responsibility for cleaning up the state in RoutingTableImpl as well as SessionManager.
+                // The detour is needed, as SessionManager does not keep track what client is associated to what cluster node.
+                SessionManager.getInstance().removeRemoteClientSession( new JID(route) );
             }
         }
     }
@@ -1140,7 +1142,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             }
             Log.debug( "Cluster node {} just left the cluster. A total of {} client sessions was living there, and are no longer available.", NodeID.getInstance( nodeID ), remoteClientRoutes.size() );
             for (String route : remoteClientRoutes) {
-                removeClientRoute(new JID(route));
+                // This call takes responsibility for cleaning up the state in RoutingTableImpl as well as SessionManager.
+                // The detour is needed, as SessionManager does not keep track what client is associated to what cluster node.
+                SessionManager.getInstance().removeRemoteClientSession( new JID(route) );
             }
         }
         finally {

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheUtil.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Utility methods for working with caches.
@@ -17,27 +18,47 @@ import java.util.Set;
 public class CacheUtil
 {
     /**
+     * Adds the specified element to a cache, in a collection that is mapped by the provided key.
+     *
+     * When the cache does not contain an entry for the provided key, a cache entry is added, which will have a new collection
+     * created using the provided Supplier, to which the specified element is added.
+     *
+     * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
+     *
+     * @param cache    The cache from which to remove the element (cannot be null).
+     * @param element  The element to be added (cannot be null, as Cache does not support null values).
+     * @param key      The cache entry identifier (cannot be null)
+     * @param supplier A provider of empty instances of the collection used as a value of the cache (in which elements are placed).
+     */
+    public static <K extends Serializable, V, C extends Collection<V> & Serializable> void addValueToMultiValuedCache( Cache<K, C> cache, K key, V element, Supplier<C> supplier )
+    {
+        final C elements = cache.getOrDefault( key, supplier.get() );
+        elements.add( element );
+        cache.put( key, elements ); // Explicitly adding the value is required for the change to propagate through Hazelcast.
+    }
+
+    /**
      * Removes all instances the specified element from every collection that is a value of the cache.
-     * <p>
+     *
      * When the element removed from the set leaves that set empty, the cache entry is removed completely.
-     * <p>
+     *
      * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
      *
      * @param cache   The cache from which to remove the element (cannot be null).
      * @param element The element to be removed (should not be null, as Cache does not support null values).
      */
-    public static <K extends Serializable, E, V extends Collection<E> & Serializable> void removeValueFromMultiValuedCache( Cache<K, V> cache, E element )
+    public static <K extends Serializable, V, C extends Collection<V> & Serializable> void removeValueFromMultiValuedCache( Cache<K, C> cache, V element )
     {
         // In some cache implementations, the entry-set is unmodifiable. To guard against potential
         // future changes of this implementation (that would make the implementation incompatible with
         // these cache implementations), the entry-set that's operated on in this implementation is
         // explicitly wrapped in an unmodifiable collection. That forces this implementation to be
         // compatible with the 'lowest common denominator'.
-        final Set<Map.Entry<K, V>> entries = Collections.unmodifiableSet( cache.entrySet() );
+        final Set<Map.Entry<K, C>> entries = Collections.unmodifiableSet( cache.entrySet() );
 
-        for ( final Map.Entry<K, V> entry : entries )
+        for ( final Map.Entry<K, C> entry : entries )
         {
-            final V elements = entry.getValue();
+            final C elements = entry.getValue();
 
             // Remove all instances of the element from the entry value.
             boolean changed = false;

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheUtil.java
@@ -1,0 +1,64 @@
+package org.jivesoftware.util.cache;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Utility methods for working with caches.
+ *
+ * Different implementations of {@link Cache} have idiosyncrasies, which this implementation takes into
+ * account.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class CacheUtil
+{
+    /**
+     * Removes all instances the specified element from every collection that is a value of the cache.
+     * <p>
+     * When the element removed from the set leaves that set empty, the cache entry is removed completely.
+     * <p>
+     * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
+     *
+     * @param cache   The cache from which to remove the element (cannot be null).
+     * @param element The element to be removed (should not be null, as Cache does not support null values).
+     */
+    public static <K extends Serializable, E, V extends Collection<E> & Serializable> void removeValueFromMultiValuedCache( Cache<K, V> cache, E element )
+    {
+        // In some cache implementations, the entry-set is unmodifiable. To guard against potential
+        // future changes of this implementation (that would make the implementation incompatible with
+        // these cache implementations), the entry-set that's operated on in this implementation is
+        // explicitly wrapped in an unmodifiable collection. That forces this implementation to be
+        // compatible with the 'lowest common denominator'.
+        final Set<Map.Entry<K, V>> entries = Collections.unmodifiableSet( cache.entrySet() );
+
+        for ( final Map.Entry<K, V> entry : entries )
+        {
+            final V elements = entry.getValue();
+
+            // Remove all instances of the element from the entry value.
+            boolean changed = false;
+            while ( elements.remove( element ) )
+            {
+                changed = true;
+            }
+
+            if ( changed )
+            {
+                if ( elements.isEmpty() )
+                {
+                    // When after removal, the value is empty, remove the cache entry completely.
+                    cache.remove( entry.getKey() );
+                }
+                else
+                {
+                    // The cluster-based cache needs an explicit 'put' to cause the change to propagate.
+                    cache.put( entry.getKey(), elements );
+                }
+            }
+        }
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultLocalCacheStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultLocalCacheStrategy.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.util.cache;
 
+import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.cluster.ClusterNodeInfo;
 
 import java.util.Collection;
@@ -89,7 +90,7 @@ public class DefaultLocalCacheStrategy implements CacheFactoryStrategy {
 
     @Override
     public byte[] getClusterMemberID() {
-        return new byte[0];
+        return XMPPServer.getInstance().getNodeID().toByteArray();
     }
 
     @Override


### PR DESCRIPTION
This PR contains a number of changes that aim to improve the shared state of Openfire instances that are part of a cluster.

This PR is not intended to be merged (just yet), as more reviewing is needed.

At the time of this PR, I'm particularly interested in finding out how performant the state-update is, when one node leaves a cluster (other nodes will try to do a clean-up, which involves acquiring cluster-wide locks on most entries of some high-volume caches).