### PR TITLE
OF-1687: Retain mutability in returned list of admin JIDs.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/admin/DefaultAdminProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/admin/DefaultAdminProvider.java
@@ -62,12 +62,18 @@ public class DefaultAdminProvider implements AdminProvider {
     public List<JID> getAdmins() {
         // Add bare JIDs of users that are admins (may include remote users), primarily used to override/add to list of admin users
         final List<JID> adminList = ADMIN_JIDS.getValue();
+
+        // Prior to 4.4.0, the return value was mutable. To prevent issues, we'll keep that characteristic.
+        final List<JID> returnValue = new ArrayList<>();
+
         if (adminList.isEmpty()) {
             // Add default admin account when none was specified
-            return Collections.singletonList(new JID("admin", XMPPServer.getInstance().getServerInfo().getXMPPDomain(), null, true));
+            returnValue.add( new JID("admin", XMPPServer.getInstance().getServerInfo().getXMPPDomain(), null, true));
         } else {
-            return adminList;
+            returnValue.addAll( adminList );
         }
+
+        return returnValue;
     }
 
     /**


### PR DESCRIPTION
Prior to the OF-1687 changes, the list returned by `org.jivesoftware.openfire.admin.DefaultAdminProvider#getAdmins` was mutable. This commit restores that characteristic, which is depended on in other parts of the code.