### PR TITLE
The encrypted properties cannot be decrypted correctly if your run multiple setups

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -440,6 +440,10 @@ public class XMPPServer {
     }
 
     void runAutoSetup() {
+        // Setup property encryptor as early as possible so that database related properties can use it
+        JiveGlobals.setupPropertyEncryptionAlgorithm(JiveGlobals.getXMLProperty("autosetup.encryption.algorithm", "Blowfish")); // or AES
+        JiveGlobals.setupPropertyEncryptionKey(JiveGlobals.getXMLProperty("autosetup.encryption.key", null));
+
         // steps from setup-datasource-standard.jsp
         // do this first so that other changes persist
         if ("standard".equals(JiveGlobals.getXMLProperty("autosetup.database.mode"))) {
@@ -454,21 +458,21 @@ public class XMPPServer {
 
             try {
                 minConnections = Integer.parseInt(
-                    JiveGlobals.getXMLProperty("database.defaultProvider.minConnections"));
+                    JiveGlobals.getXMLProperty("autosetup.database.defaultProvider.minConnections"));
             }
             catch (Exception e) {
                 minConnections = 5;
             }
             try {
                 maxConnections = Integer.parseInt(
-                    JiveGlobals.getXMLProperty("database.defaultProvider.maxConnections"));
+                    JiveGlobals.getXMLProperty("autosetup.database.defaultProvider.maxConnections"));
             }
             catch (Exception e) {
                 maxConnections = 25;
             }
             try {
                 connectionTimeout = Double.parseDouble(
-                    JiveGlobals.getXMLProperty("database.defaultProvider.connectionTimeout"));
+                    JiveGlobals.getXMLProperty("autosetup.database.defaultProvider.connectionTimeout"));
             }
             catch (Exception e) {
                 connectionTimeout = 1.0;
@@ -497,9 +501,6 @@ public class XMPPServer {
 
         ConnectionSettings.Client.ENABLE_OLD_SSLPORT_PROPERTY.setValue(Boolean.valueOf(JiveGlobals.getXMLProperty("autosetup." + ConnectionSettings.Client.ENABLE_OLD_SSLPORT_PROPERTY.getKey(), "true")));
         AnonymousSaslServer.ENABLED.setValue(Boolean.valueOf(JiveGlobals.getXMLProperty("autosetup." + AnonymousSaslServer.ENABLED.getKey(), "false")));
-
-        JiveGlobals.setupPropertyEncryptionAlgorithm(JiveGlobals.getXMLProperty("autosetup.encryption.algorithm", "Blowfish")); // or AES
-        JiveGlobals.setupPropertyEncryptionKey(JiveGlobals.getXMLProperty("autosetup.encryption.key", null));
 
 
         // steps from setup-profile-settings.jsp

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1063,18 +1063,16 @@ public class JiveGlobals {
     public static void setupPropertyEncryptionAlgorithm(String alg) {
         // Get the old secret key and encryption type
         String oldAlg = securityProperties.getProperty(ENCRYPTION_ALGORITHM);
-        if (oldAlg.equals(alg)) {
-          return;
-        }
         String oldKey = securityProperties.getProperty(ENCRYPTION_KEY_CURRENT);
-        if(StringUtils.isNotEmpty(alg) && StringUtils.isNotEmpty(oldKey)){
+        if(StringUtils.isNotEmpty(alg) && !oldAlg.equals(alg) && StringUtils.isNotEmpty(oldKey)){
+            oldKey = new AesEncryptor().decrypt(oldKey);
             // update encrypted properties
             updateEncryptionProperties(alg, oldKey);
-        }
-        if (ENCRYPTION_ALGORITHM_AES.equalsIgnoreCase(alg)) {
-            securityProperties.setProperty(ENCRYPTION_ALGORITHM, ENCRYPTION_ALGORITHM_AES);
-        } else {
-            securityProperties.setProperty(ENCRYPTION_ALGORITHM, ENCRYPTION_ALGORITHM_BLOWFISH);
+            if (ENCRYPTION_ALGORITHM_AES.equalsIgnoreCase(alg)) {
+                securityProperties.setProperty(ENCRYPTION_ALGORITHM, ENCRYPTION_ALGORITHM_AES);
+            } else {
+                securityProperties.setProperty(ENCRYPTION_ALGORITHM, ENCRYPTION_ALGORITHM_BLOWFISH);
+            }
         }
     }
     
@@ -1083,16 +1081,16 @@ public class JiveGlobals {
      * set a custom key for encrypting property values 
      */
     public static void setupPropertyEncryptionKey(String key) {
+        if (key == null) {
+            key = "";
+        }
         // Get the old secret key and encryption type
+        String oldAlg = securityProperties.getProperty(ENCRYPTION_ALGORITHM);
         String oldKey = securityProperties.getProperty(ENCRYPTION_KEY_CURRENT);
         if (StringUtils.isNotEmpty(oldKey)) {
-          oldKey = new AesEncryptor().decrypt(oldKey);
+            oldKey = new AesEncryptor().decrypt(oldKey);
         }
-        if (oldKey.equals(key)) {
-          return;
-        }
-        String oldAlg = securityProperties.getProperty(ENCRYPTION_ALGORITHM);
-        if(StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(oldAlg)) {
+        if(!key.equals(oldKey) && StringUtils.isNotEmpty(oldAlg)) {
             // update encrypted properties
             updateEncryptionProperties(oldAlg, key);
             securityProperties.setProperty(ENCRYPTION_KEY_CURRENT, new AesEncryptor().encrypt(currentKey));

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1092,13 +1092,13 @@ public class JiveGlobals {
         // Get the old secret key and encryption type
         String oldAlg = securityProperties.getProperty(ENCRYPTION_ALGORITHM);
         String oldKey = getCurrentKey();
-        if (!key.equals(oldKey) && StringUtils.isNotEmpty(oldAlg)) {
+        if (StringUtils.isNotEmpty(key) && !key.equals(oldKey) && StringUtils.isNotEmpty(oldAlg)) {
             // update encrypted properties
             updateEncryptionProperties(oldAlg, key);
         }
         // Set the new key
         securityProperties.setProperty(ENCRYPTION_KEY_CURRENT, new AesEncryptor().encrypt(key));
-        currentKey = key;
+        currentKey = key == "" ? null : key;
         propertyEncryptorNew = getEncryptor(oldAlg, key);
         propertyEncryptor = propertyEncryptorNew;
     }

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1072,7 +1072,7 @@ public class JiveGlobals {
         // Get the old secret key and encryption type
         String oldAlg = securityProperties.getProperty(ENCRYPTION_ALGORITHM);
         String oldKey = getCurrentKey();
-        if (StringUtils.isNotEmpty(alg) && !oldAlg.equals(alg)) {
+        if (StringUtils.isNotEmpty(alg) && !oldAlg.equals(alg) && StringUtils.isNotEmpty(oldKey)) {
             // update encrypted properties
             updateEncryptionProperties(alg, oldKey);
         }
@@ -1092,7 +1092,7 @@ public class JiveGlobals {
         // Get the old secret key and encryption type
         String oldAlg = securityProperties.getProperty(ENCRYPTION_ALGORITHM);
         String oldKey = getCurrentKey();
-        if (StringUtils.isNotEmpty(key) && !key.equals(oldKey) && StringUtils.isNotEmpty(oldAlg)) {
+        if (StringUtils.isNotEmpty(oldKey) && StringUtils.isNotEmpty(key) && !key.equals(oldKey) && StringUtils.isNotEmpty(oldAlg)) {
             // update encrypted properties
             updateEncryptionProperties(oldAlg, key);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1092,12 +1092,11 @@ public class JiveGlobals {
           return;
         }
         String oldAlg = securityProperties.getProperty(ENCRYPTION_ALGORITHM);
-        if(StringUtils.isNotEmpty(oldKey) && StringUtils.isNotEmpty(oldAlg)) {
+        if(StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(oldAlg)) {
             // update encrypted properties
             updateEncryptionProperties(oldAlg, key);
+            securityProperties.setProperty(ENCRYPTION_KEY_CURRENT, new AesEncryptor().encrypt(currentKey));
         }
-        securityProperties.setProperty(ENCRYPTION_KEY_CURRENT, new AesEncryptor().encrypt(key));
-        currentKey = key;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1072,7 +1072,7 @@ public class JiveGlobals {
         // Get the old secret key and encryption type
         String oldAlg = securityProperties.getProperty(ENCRYPTION_ALGORITHM);
         String oldKey = getCurrentKey();
-        if (StringUtils.isNotEmpty(alg) && !oldAlg.equals(alg) && StringUtils.isNotEmpty(oldKey)) {
+        if (StringUtils.isNotEmpty(alg) && !oldAlg.equals(alg) && (StringUtils.isNotEmpty(oldKey) || propertyEncryptor != null)) {
             // update encrypted properties
             updateEncryptionProperties(alg, oldKey);
         }
@@ -1092,7 +1092,7 @@ public class JiveGlobals {
         // Get the old secret key and encryption type
         String oldAlg = securityProperties.getProperty(ENCRYPTION_ALGORITHM);
         String oldKey = getCurrentKey();
-        if (StringUtils.isNotEmpty(oldKey) && StringUtils.isNotEmpty(key) && !key.equals(oldKey) && StringUtils.isNotEmpty(oldAlg)) {
+        if ((StringUtils.isNotEmpty(oldKey) || propertyEncryptor != null) && StringUtils.isNotEmpty(key) && !key.equals(oldKey) && StringUtils.isNotEmpty(oldAlg)) {
             // update encrypted properties
             updateEncryptionProperties(oldAlg, key);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveProperties.java
@@ -349,7 +349,7 @@ public class JiveProperties implements Map<String, String> {
     }
 
     private void insertProperty(String name, String value, boolean isEncrypted) {
-        Encryptor encryptor = getEncryptor();
+        Encryptor encryptor = getEncryptor(true);
         Connection con = null;
         PreparedStatement pstmt = null;
         try {
@@ -381,7 +381,7 @@ public class JiveProperties implements Map<String, String> {
     }
 
     private void updateProperty(String name, String value, boolean isEncrypted) {
-        Encryptor encryptor = getEncryptor();
+        Encryptor encryptor = getEncryptor(true);
         Connection con = null;
         PreparedStatement pstmt = null;
         try {
@@ -478,7 +478,11 @@ public class JiveProperties implements Map<String, String> {
         }
     }
     
+    private Encryptor getEncryptor(boolean useNewEncryptor) {
+        return JiveGlobals.getPropertyEncryptor(useNewEncryptor);
+    }
+    
     private Encryptor getEncryptor() {
-        return JiveGlobals.getPropertyEncryptor();
+        return getEncryptor(false);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
@@ -646,7 +646,7 @@ public class XMLProperties {
             String propValue = StringEscapeUtils.escapeXml10(value);
             // check to see if the property is marked as encrypted
             if (JiveGlobals.isXMLPropertyEncrypted(name)) {
-                propValue = JiveGlobals.getPropertyEncryptor().encrypt(value);
+                propValue = JiveGlobals.getPropertyEncryptor(true).encrypt(value);
                 element.addAttribute(ENCRYPTED_ATTRIBUTE, "true");
             }
             element.setText(propValue);


### PR DESCRIPTION
Symptom:
(1) Run setup;
(2) Change the setup property in the openfire.xml to false and run set up again;
(3) Set a different key;
Result:
In the setup-datasource-standard.jsp page, the db username is displayed as gibberish.
You can also see some error messages in the log file, something like "[ERROR] LWCrypto encryp or descrypt failed".

Root cause:
The original logic for encryption key update is unfinished.

Solution:
Keep an old key in JiveGlobals, so that when updating the encryption key both the new key (for updating) and the old key (for retrieving) are available.

For example, the method JiveProperties.put() has both updating (updateProperty(key, value, isEncrypted);) and retrieval (JiveGlobals.clearXMLPropertyEncryptionEntry(key) -> openfireProperties.getProperty(name)) operation.
In this case, if it is during the process of updating the property encryption key, both the new key and the old key will be required.