### PR TITLE
OF-1709: Make it clearer that the ldap.override.avatar setting is dynamic

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1590,6 +1590,7 @@ system_property.sasl.scram-sha-1.iteration-count=The number of iterations when s
 system_property.xmpp.auth.anonymous=Set to true to allow anonymous login, otherwise false
 system_property.xmpp.client.idle=How long, in milliseconds, before idle sessions are dropped. Set to -1 to never drop idle sessions.
 system_property.xmpp.client.idle.ping=Set to true to ping idle clients, otherwise false
+system_property.ldap.override.avatar=Set to true to save avatars in the local database, otherwise false
 
 # Server properties Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/admin/LdapUserProfile.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/LdapUserProfile.java
@@ -515,7 +515,7 @@ public class LdapUserProfile {
         LdapManager.getInstance().setEmailField(email.replaceAll("(\\{)([\\d\\D&&[^}]]+)(})", "$2"));
 
         // Store the DB storage variable in the actual database.
-        JiveGlobals.setProperty("ldap.override.avatar", avatarStoredInDB.toString());
+        LdapVCardProvider.STORE_AVATAR_IN_DB.setValue(avatarStoredInDB);
     }
 
     /**
@@ -641,7 +641,7 @@ public class LdapUserProfile {
                     businessDepartment = element.elementTextTrim("ORGUNIT");
                 }
             }
-            avatarStoredInDB = JiveGlobals.getBooleanProperty("ldap.override.avatar", false);
+            avatarStoredInDB = LdapVCardProvider.STORE_AVATAR_IN_DB.getValue();
         }
         catch (DocumentException e) {
             Log.error("Error loading vcard mappings from property", e);


### PR DESCRIPTION
Now shown on the System Properties screen:

![image](https://user-images.githubusercontent.com/435813/54914353-ab052400-4eec-11e9-8df6-9c9567fbdbdb.png)
