### PR TITLE
OF-1699: Add additional clustering information

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1591,6 +1591,7 @@ system_property.sasl.scram-sha-1.iteration-count=The number of iterations when s
 system_property.xmpp.auth.anonymous=Set to true to allow anonymous login, otherwise false
 system_property.xmpp.client.idle=How long, in milliseconds, before idle sessions are dropped. Set to -1 to never drop idle sessions.
 system_property.xmpp.client.idle.ping=Set to true to ping idle clients, otherwise false
+system_property.cluster-monitor.service-enabled=Set to true to send messages to admins on cluster events, otherwise false
 
 # Server properties Page
 

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -727,6 +727,7 @@ admin.logged_in_as=Logged in as {0}
 admin.clustering.status=Clustering status
 admin.clustering.starting=Starting up
 admin.clustering.senior=Senior member
+admin.clustering.only=SENIOR AND ONLY MEMBER
 admin.clustering.junior=Junior member
 admin.clustering.disabled=Disabled
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterManager.java
@@ -19,6 +19,7 @@ package org.jivesoftware.openfire.cluster;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -403,6 +404,30 @@ public class ClusterManager {
      */
     public static Collection<ClusterNodeInfo> getNodesInfo() {
         return CacheFactory.getClusterNodesInfo();
+    }
+
+    /**
+     * Returns basic information about a specific member of the cluster.
+     *
+     * @since Openfire 4.4
+     * @param nodeID the node whose information is required
+     * @return the node specific information, or {@link Optional#empty()} if the node could not be identified
+     */
+    public static Optional<ClusterNodeInfo> getNodeInfo(final byte[] nodeID) {
+        return getNodeInfo(NodeID.getInstance(nodeID));
+    }
+
+    /**
+     * Returns basic information about a specific member of the cluster.
+     *
+     * @since Openfire 4.4
+     * @param nodeID the node whose information is required
+     * @return the node specific information, or {@link Optional#empty()} if the node could not be identified
+     */
+    public static Optional<ClusterNodeInfo> getNodeInfo(final NodeID nodeID) {
+        return CacheFactory.getClusterNodesInfo().stream()
+            .filter(nodeInfo -> nodeInfo.getNodeID().equals(nodeID))
+            .findAny();
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterMonitor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterMonitor.java
@@ -1,0 +1,111 @@
+package org.jivesoftware.openfire.cluster;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.container.Module;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Monitors the state of the cluster, and warns admins when nodes leave or rejoin the cluster
+ */
+public class ClusterMonitor implements Module, ClusterEventListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterMonitor.class);
+    private static final String MODULE_NAME = "Cluster monitor";
+    private static final String UNKNOWN_NODE_NAME = "<unknown>";
+    private final Map<NodeID, String> nodeNames = new ConcurrentHashMap<>();
+    private boolean nodeHasLeftCluster = false;
+    private XMPPServer xmppServer;
+
+    @SuppressWarnings("WeakerAccess")
+    public ClusterMonitor() {
+        LOGGER.debug("{} has been instantiated", MODULE_NAME);
+    }
+
+    @Override
+    public String getName() {
+        return MODULE_NAME;
+    }
+
+    @Override
+    public void initialize(final XMPPServer xmppServer) {
+        this.xmppServer = xmppServer;
+        LOGGER.debug("{} has been initialized", MODULE_NAME);
+    }
+
+    @Override
+    public void start() {
+        ClusterManager.addListener(this);
+        LOGGER.debug("{} has been started", MODULE_NAME);
+    }
+
+    @Override
+    public void stop() {
+        ClusterManager.removeListener(this);
+        LOGGER.debug("{} has been stopped", MODULE_NAME);
+    }
+
+    @Override
+    public void destroy() {
+        LOGGER.debug("{} has been destroyed", MODULE_NAME);
+    }
+
+    @Override
+    public void joinedCluster() {
+        LOGGER.info("This node ({}/{}) has joined the cluster", xmppServer.getNodeID(), xmppServer.getServerInfo().getHostname());
+    }
+
+    @Override
+    public void joinedCluster(final byte[] nodeIdBytes) {
+        final String nodeName = getNodeName(nodeIdBytes);
+        final NodeID nodeId = NodeID.getInstance(nodeIdBytes);
+        nodeNames.put(nodeId, nodeName);
+        LOGGER.info("Another node ({}/{}) has joined the cluster", nodeId, nodeName);
+        if (ClusterManager.isSeniorClusterMember() && nodeHasLeftCluster) {
+            xmppServer.sendMessageToAdmins(nodeName + " has joined the cluster - resilience is restored");
+        }
+    }
+
+    @Override
+    public void leftCluster() {
+        final String nodeName = xmppServer.getServerInfo().getHostname();
+        LOGGER.info("This node ({}/{}) has left the cluster", xmppServer.getNodeID(), nodeName);
+        xmppServer.sendMessageToAdmins("The local node ('" + nodeName + "') has left the cluster - this node no longer has any resilience");
+    }
+
+    @Override
+    public void leftCluster(final byte[] nodeIdBytes) {
+        nodeHasLeftCluster = true;
+        final NodeID nodeID = NodeID.getInstance(nodeIdBytes);
+        final String nodeName = Optional.ofNullable(nodeNames.remove(nodeID)).orElse(UNKNOWN_NODE_NAME);
+        LOGGER.info("Another node ({}/{}) has left the cluster", nodeID, nodeName);
+        if (ClusterManager.isSeniorClusterMember()) {
+            final int clusterSize = ClusterManager.getNodesInfo().size();
+            final String conjunction;
+            final String plural;
+            if (clusterSize == 1) {
+                conjunction = "is";
+                plural = "";
+            } else {
+                conjunction = "are";
+                plural = "s";
+            }
+            xmppServer.sendMessageToAdmins(nodeName + " has left the cluster - there " + conjunction + " now only " + clusterSize + " node" + plural + " in the cluster");
+        }
+    }
+
+    @Override
+    public void markedAsSeniorClusterMember() {
+        LOGGER.info("This node ({}/{}) is now the senior member", xmppServer.getNodeID(), xmppServer.getServerInfo().getHostname());
+    }
+
+    private String getNodeName(final byte[] nodeID) {
+        final Optional<ClusterNodeInfo> nodeInfo = ClusterManager.getNodeInfo(nodeID);
+        return nodeInfo.map(ClusterNodeInfo::getHostName).orElse(UNKNOWN_NODE_NAME);
+    }
+
+}

--- a/xmppserver/src/main/webapp/decorators/main.jsp
+++ b/xmppserver/src/main/webapp/decorators/main.jsp
@@ -16,10 +16,10 @@
   - limitations under the License.
 --%>
 
-<%@ page import="org.jivesoftware.util.StringUtils,
-                 org.jivesoftware.admin.AdminConsole,
+<%@ page import="org.jivesoftware.admin.AdminConsole,
+                 org.jivesoftware.openfire.cluster.ClusterManager,
                  org.jivesoftware.util.LocaleUtils,
-                 org.jivesoftware.openfire.cluster.ClusterManager"
+                 org.jivesoftware.util.StringUtils"
     errorPage="../error.jsp"
 %><%@ page import="org.xmpp.packet.JID"%>
 
@@ -101,7 +101,11 @@
                 <% if (ClusterManager.isClusteringEnabled()) { %>
                     <% if (ClusterManager.isClusteringStarted()) { %>
                         <% if (ClusterManager.isSeniorClusterMember()) { %>
+                                <% if(ClusterManager.getNodesInfo().size() == 1) { %>
+                                <fmt:message key="admin.clustering.only"/>
+                                <% } else { %>
                                 <fmt:message key="admin.clustering.senior"/>
+                                <% }%>
                         <% } else { %>
                                 <fmt:message key="admin.clustering.junior"/>
                         <% }  %>

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/cluster/ClusterMonitorTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/cluster/ClusterMonitorTest.java
@@ -1,0 +1,82 @@
+package org.jivesoftware.openfire.cluster;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.XMPPServerInfo;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterMonitorTest {
+
+    private static final String THIS_HOST_NAME = "test-host-name";
+    private static final byte[] OTHER_NODE_ID = new byte[]{0, 1, 2, 3};
+    private ClusterMonitor clusterMonitor;
+    @Mock private XMPPServer xmppServer;
+    @Mock private XMPPServerInfo xmppServerInfo;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        Fixtures.reconfigureOpenfireHome();
+    }
+
+    @Before
+    public void setUp() {
+
+        doReturn(xmppServerInfo).when(xmppServer).getServerInfo();
+
+        doReturn(THIS_HOST_NAME).when(xmppServerInfo).getHostname();
+
+        clusterMonitor = new ClusterMonitor();
+        clusterMonitor.initialize(xmppServer);
+        clusterMonitor.start();
+    }
+
+    @Test
+    public void whenAnotherNodeJoinsTheClusterNothingWillBeSent() {
+
+        clusterMonitor.joinedCluster(OTHER_NODE_ID);
+
+        verify(xmppServer, never()).sendMessageToAdmins(any());
+    }
+
+    @Test
+    public void whenAnotherNodeLeavesTheClusterAMessageWillBeSent() {
+
+        clusterMonitor.joinedCluster(OTHER_NODE_ID);
+        clusterMonitor.leftCluster(OTHER_NODE_ID);
+
+        verify(xmppServer).sendMessageToAdmins(any());
+    }
+
+    @Test
+    public void whenAnotherNodeJoinsTheClusterAfterANodeHasLeftTheClusterAMessageWillBeSent() {
+
+        clusterMonitor.joinedCluster(OTHER_NODE_ID);
+        clusterMonitor.leftCluster(OTHER_NODE_ID);
+        reset(xmppServer);
+
+        clusterMonitor.joinedCluster(OTHER_NODE_ID);
+
+        verify(xmppServer).sendMessageToAdmins(any());
+    }
+
+    @Test
+    public void whenThisNodeLeavesTheClusterAMessageWillBeSent() {
+
+        clusterMonitor.leftCluster();
+
+        verify(xmppServer).sendMessageToAdmins(any());
+    }
+}


### PR DESCRIPTION
a) Admin Console now highlights when it is the only member
![image](https://user-images.githubusercontent.com/435813/54939573-d275e400-4f20-11e9-98e1-a7953e3bd44c.png)

b) Message now sent when a node leaves the cluster, e.g.
`<node> has left the cluster - there is now only 1 node in the cluster`

c) Message is sent when a multi-node cluster is reformed
`<node> has joined the cluster - resilience is restored`

d) Message is sent when this node leaves the cluster (e.g. if clustering is disabled)
`The local node ('<node>') has left the cluster - this node no longer has any resilience`
