### PR TITLE
The old password always fails validation if the admin password is not the default one "admin"

### DIFF
--- a/xmppserver/src/main/webapp/setup/setup-admin-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-admin-settings.jsp
@@ -71,7 +71,7 @@
             errors.put("password", "password");
         }
         try {
-            AuthFactory.authenticate("admin", "admin");
+            AuthFactory.authenticate("admin", password);
         } catch (UnauthorizedException e) {
             errors.put("password", "password");
         }


### PR DESCRIPTION
Symptom:
(1) Complete a setup;
(2) Change the setup property in the openfire.xml to false and run set up again;
Result:
In the page to set admin password, the old password always fails validation.

Root cause:
When validating the old password, the hardcoded default password is used.
AuthFactory.authenticate("admin", "admin");

Solution:
Use real password to authenticate