### PR TITLE
OF-1686: Clear the group cache when deleting/adding groups

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -318,6 +318,8 @@ public class GroupManager {
                 // The group doesn't already exist so we can create a new group
                 newGroup = provider.createGroup(name);
                 // Update caches.
+                clearGroupNameCache();
+                clearGroupCountCache();
                 groupCache.put(name, newGroup);
 
                 // Fire event.
@@ -394,6 +396,8 @@ public class GroupManager {
 
         // Expire cache.
         groupCache.remove(group.getName());
+        clearGroupNameCache();
+        clearGroupCountCache();
     }
 
     /**


### PR DESCRIPTION
NB. This is largely causes by excessive optimisation. 