### PR TITLE
OF-1665: Fix issue when adding "missing" remote users to a group

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1597,6 +1597,7 @@ system_property.provider.lockout.className=The class to use to lock-out Openfire
 system_property.provider.securityAudit.className=The class to use to audit actions performed by administrators
 system_property.provider.user.className=The class to use to provide the Openfire users
 system_property.provider.vcard.className=The class to use to provide vCard handling
+system_property.usermanager.remote-disco-info-timeout-seconds=The maximum time the UserManager should wait, in seconds, for the a remote server to respond to a disco#info request to confirm the presence of a user
 
 # Server properties Page
 

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1598,6 +1598,7 @@ system_property.provider.securityAudit.className=The class to use to audit actio
 system_property.provider.user.className=The class to use to provide the Openfire users
 system_property.provider.vcard.className=The class to use to provide vCard handling
 system_property.usermanager.remote-disco-info-timeout-seconds=The maximum time the UserManager should wait, in seconds, for the a remote server to respond to a disco#info request to confirm the presence of a user
+system_property.provider.userproperty.className=The class to use to provide user properties
 
 # Server properties Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -52,7 +52,7 @@ import gnu.inet.encoding.StringprepException;
  * @author Matt Tucker
  * @see User
  */
-@SuppressWarnings({"WeakerAccess", "unused", "JavadocReference"})
+@SuppressWarnings({"WeakerAccess", "unused"})
 public final class UserManager {
 
     public static final SystemProperty<Class> USER_PROVIDER = SystemProperty.Builder.ofType(Class.class)
@@ -446,6 +446,7 @@ public final class UserManager {
                     final Semaphore completionSemaphore = new Semaphore(0);
                     // Send the disco#info request to the remote server.
                     final IQRouter iqRouter = xmppServer.getIQRouter();
+                    final long timeoutInMillis = REMOTE_DISCO_INFO_TIMEOUT.getValue().toMillis();
                     iqRouter.addIQResultListener(iq.getID(), new IQResultListener() {
                         @Override
                         public void receivedAnswer(final IQ packet) {
@@ -476,12 +477,12 @@ public final class UserManager {
                             Log.warn("The result from the disco#info request was never received. request: {}", iq);
                             completionSemaphore.release();
                         }
-                    });
+                    }, timeoutInMillis);
                     // Send the request
                     iqRouter.route(iq);
                     // Wait for the response
                     try {
-                        completionSemaphore.tryAcquire(REMOTE_DISCO_INFO_TIMEOUT.getValue().toMillis(), TimeUnit.MILLISECONDS);
+                        completionSemaphore.tryAcquire(timeoutInMillis, TimeUnit.MILLISECONDS);
                     } catch (final InterruptedException e) {
                         Thread.currentThread().interrupt();
                         Log.warn("Interrupted whilst waiting for response from remote server", e);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -16,6 +16,8 @@
 
 package org.jivesoftware.openfire.user;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -29,7 +31,6 @@ import org.jivesoftware.openfire.event.UserEventListener;
 import org.jivesoftware.openfire.user.property.DefaultUserPropertyProvider;
 import org.jivesoftware.openfire.user.property.UserPropertyProvider;
 import org.jivesoftware.util.ClassUtils;
-import org.jivesoftware.util.JiveConstants;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.PropertyEventDispatcher;
 import org.jivesoftware.util.PropertyEventListener;
@@ -60,6 +61,12 @@ public final class UserManager implements IQResultListener {
         .setBaseClass(UserProvider.class)
         .setDefaultValue(DefaultUserProvider.class)
         .addListener(UserManager::initProvider)
+        .setDynamic(true)
+        .build();
+    private static final SystemProperty<Duration> REMOTE_DISCO_INFO_TIMEOUT = SystemProperty.Builder.ofType(Duration.class)
+        .setKey("usermanager.remote-disco-info-timeout-seconds")
+        .setDefaultValue(Duration.ofMinutes(1))
+        .setChronoUnit(ChronoUnit.SECONDS)
         .setDynamic(true)
         .build();
 
@@ -459,7 +466,7 @@ public final class UserManager implements IQResultListener {
                         server.getIQRouter().route(iq);
                         // Wait for the reply to be processed. Time out in 1 minute by default
                         try {
-                            user.toBareJID().intern().wait(JiveGlobals.getLongProperty("usermanager.remote-disco-info-timeout-seconds", 60) * JiveConstants.SECOND);
+                            user.toBareJID().intern().wait(REMOTE_DISCO_INFO_TIMEOUT.getValue().toMillis());
                         }
                         catch (final InterruptedException e) {
                             // Do nothing

--- a/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
@@ -231,6 +231,8 @@ public final class SystemProperty<T> {
     private final boolean sorted;
 
     private SystemProperty(final Builder<T> builder) {
+        // Before we do anything, convert XML based provider setup to Database based
+        JiveGlobals.migrateProperty(builder.key);
         this.clazz = builder.clazz;
         this.key = builder.key;
         this.description = LocaleUtils.getLocalizedString("system_property." + key);

--- a/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
+++ b/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
@@ -1,11 +1,40 @@
 package org.jivesoftware;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.io.SAXReader;
+import org.jivesoftware.openfire.IQRouter;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.XMPPServerInfo;
+import org.jivesoftware.openfire.user.User;
+import org.jivesoftware.openfire.user.UserAlreadyExistsException;
+import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.jivesoftware.openfire.user.UserProvider;
 import org.jivesoftware.util.JiveGlobals;
+import org.xmpp.packet.IQ;
+import org.xmpp.packet.JID;
 
+@SuppressWarnings({"ResultOfMethodCallIgnored", "WeakerAccess"})
 public final class Fixtures {
+
+    public static final String XMPP_DOMAIN = "test.xmpp.domain";
 
     private Fixtures() {
     }
@@ -21,6 +50,147 @@ public final class Fixtures {
         }
         final File openfireHome = new File(configFile.toURI()).getParentFile().getParentFile();
         JiveGlobals.setHomeDirectory(openfireHome.toString());
+        // The following allows JiveGlobals to persist
+        JiveGlobals.setXMLProperty("setup", "true");
+        // The following speeds up tests by avoiding DB retries
+        JiveGlobals.setXMLProperty("database.maxRetries", "0");
+        JiveGlobals.setXMLProperty("database.retryDelay", "0");
+    }
+
+    public static XMPPServer mockXMPPServer() {
+        final XMPPServer xmppServer = mock(XMPPServer.class, withSettings().lenient());
+        doAnswer(invocationOnMock -> {
+            final JID jid = invocationOnMock.getArgument(0);
+            return jid.getDomain().equals(XMPP_DOMAIN);
+        }).when(xmppServer).isLocal(any(JID.class));
+
+        doReturn(mockXMPPServerInfo()).when(xmppServer).getServerInfo();
+        doReturn(mockIQRouter()).when(xmppServer).getIQRouter();
+
+        return xmppServer;
+    }
+
+    public static XMPPServerInfo mockXMPPServerInfo() {
+        final XMPPServerInfo xmppServerInfo = mock(XMPPServerInfo.class, withSettings().lenient());
+        doReturn(XMPP_DOMAIN).when(xmppServerInfo).getXMPPDomain();
+        return xmppServerInfo;
+    }
+
+    public static IQRouter mockIQRouter() {
+        final IQRouter iqRouter = mock(IQRouter.class, withSettings().lenient());
+        return iqRouter;
+    }
+
+    public static class StubUserProvider implements UserProvider {
+        final Map<String, User> users = new HashMap<>();
+
+        @Override
+        public User loadUser(final String username) throws UserNotFoundException {
+            return Optional.ofNullable(users.get(username)).orElseThrow(UserNotFoundException::new);
+        }
+
+        @Override
+        public User createUser(final String username, final String password, final String name, final String email) throws UserAlreadyExistsException {
+            if (users.containsKey(username)) {
+                throw new UserAlreadyExistsException();
+            }
+            final User user = mock(User.class, withSettings().lenient());
+            doReturn(username).when(user).getUsername();
+            doReturn(name).when(user).getName();
+            doReturn(email).when(user).getEmail();
+            doReturn(new Date()).when(user).getCreationDate();
+            doReturn(new Date()).when(user).getModificationDate();
+            return user;
+        }
+
+        @Override
+        public void deleteUser(final String username) {
+            users.remove(username);
+        }
+
+        @Override
+        public int getUserCount() {
+            return users.size();
+        }
+
+        @Override
+        public Collection<User> getUsers() {
+            return users.values();
+        }
+
+        @Override
+        public Collection<String> getUsernames() {
+            return users.keySet();
+        }
+
+        @Override
+        public Collection<User> getUsers(final int startIndex, final int numResults) {
+            return null;
+        }
+
+        @Override
+        public void setName(final String username, final String name) throws UserNotFoundException {
+            final User user = loadUser(username);
+            doReturn(name).when(user).getName();
+        }
+
+        @Override
+        public void setEmail(final String username, final String email) throws UserNotFoundException {
+            final User user = loadUser(username);
+            doReturn(email).when(user).getEmail();
+        }
+
+        @Override
+        public void setCreationDate(final String username, final Date creationDate) throws UserNotFoundException {
+            final User user = loadUser(username);
+            doReturn(new Date()).when(user).getCreationDate();
+        }
+
+        @Override
+        public void setModificationDate(final String username, final Date modificationDate) throws UserNotFoundException {
+            final User user = loadUser(username);
+            doReturn(new Date()).when(user).getModificationDate();
+        }
+
+        @Override
+        public Set<String> getSearchFields() throws UnsupportedOperationException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Collection<User> findUsers(final Set<String> fields, final String query) throws UnsupportedOperationException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Collection<User> findUsers(final Set<String> fields, final String query, final int startIndex, final int numResults) throws UnsupportedOperationException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return false;
+        }
+
+        @Override
+        public boolean isNameRequired() {
+            return false;
+        }
+
+        @Override
+        public boolean isEmailRequired() {
+            return false;
+        }
+    }
+
+    public static IQ iqFrom(final String stanza) {
+        try {
+            final SAXReader reader = new SAXReader();
+            final Document document = reader.read(new ByteArrayInputStream(stanza.getBytes(StandardCharsets.UTF_8)));
+            return new IQ(document.getRootElement());
+        } catch (final DocumentException e) {
+            throw new IllegalArgumentException("The supplied input did not contain a well-formed XML document", e);
+        }
     }
 
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/user/UserManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/user/UserManagerTest.java
@@ -4,6 +4,7 @@ package org.jivesoftware.openfire.user;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 
@@ -90,7 +91,7 @@ public class UserManagerTest {
             final IQResultListener listener = invocationOnMock.getArgument(1);
             iqListener.set(listener);
             return null;
-        }).when(iqRouter).addIQResultListener(any(), any());
+        }).when(iqRouter).addIQResultListener(any(), any(), anyLong());
 
         doAnswer(invocationOnMock -> {
             iqListener.get().receivedAnswer(Fixtures.iqFrom(USER_FOUND_RESULT));
@@ -111,7 +112,7 @@ public class UserManagerTest {
             final IQResultListener listener = invocationOnMock.getArgument(1);
             iqListener.set(listener);
             return null;
-        }).when(iqRouter).addIQResultListener(any(), any());
+        }).when(iqRouter).addIQResultListener(any(), any(), anyLong());
 
         doAnswer(invocationOnMock -> {
             final IQ iq = invocationOnMock.getArgument(0);
@@ -137,7 +138,7 @@ public class UserManagerTest {
             final IQResultListener listener = invocationOnMock.getArgument(1);
             iqListener.set(listener);
             return null;
-        }).when(iqRouter).addIQResultListener(any(), any());
+        }).when(iqRouter).addIQResultListener(any(), any(), anyLong());
 
         doAnswer(invocationOnMock -> {
             final IQ iq = invocationOnMock.getArgument(0);

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/user/UserManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/user/UserManagerTest.java
@@ -1,0 +1,163 @@
+package org.jivesoftware.openfire.user;
+
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.dom4j.Element;
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.IQRouter;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.cache.CacheFactory;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.xmpp.component.IQResultListener;
+import org.xmpp.packet.IQ;
+import org.xmpp.packet.JID;
+import org.xmpp.packet.PacketError;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserManagerTest {
+
+    private static final String REMOTE_XMPP_DOMAIN = "remote.xmpp.domain";
+    private static final String USER_ID = "test-user-id";
+    private static final JID REMOTE_USER_JID = new JID(USER_ID, REMOTE_XMPP_DOMAIN, null);
+
+    private static final String USER_FOUND_RESULT = "<iq type='result' from='" + REMOTE_USER_JID + "' to='"  + Fixtures.XMPP_DOMAIN + "' id='info1'>\n" +
+        "  <query xmlns='http://jabber.org/protocol/disco#info'>\n" +
+        "    <identity\n" +
+        "        category='account'\n" +
+        "        type='registered'/>\n" +
+        "  </query>\n" +
+        "</iq>";
+
+    private UserManager userManager;
+    private IQRouter iqRouter;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Fixtures.reconfigureOpenfireHome();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+
+        // Ensure the cache's are cleared
+        CacheFactory.createCache("User").clear();
+        CacheFactory.createCache("Remote Users Existence").clear();
+
+        // Use the stub user provider, and a very short timeout
+        JiveGlobals.setProperty("provider.user.className", Fixtures.StubUserProvider.class.getName());
+        JiveGlobals.setProperty("usermanager.remote-disco-info-timeout-seconds", "0");
+
+        final XMPPServer xmppServer = Fixtures.mockXMPPServer();
+        iqRouter = xmppServer.getIQRouter();
+
+        userManager = new UserManager(xmppServer);
+        userManager.createUser(USER_ID, "change me", "Test User Name", "test-email@example.com");
+    }
+
+    @Test
+    public void isRegisteredUserWillReturnTrueForLocalUsers() {
+
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, Fixtures.XMPP_DOMAIN, null));
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void isRegisteredUserWillReturnFalseForLocalNonUsers() {
+
+        final boolean result = userManager.isRegisteredUser(new JID("unknown-user", Fixtures.XMPP_DOMAIN, null));
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void isRegisteredUserWillReturnTrueForRemoteUsers() {
+
+        final AtomicReference<IQResultListener> iqListener = new AtomicReference<>();
+        doAnswer(invocationOnMock -> {
+            final IQResultListener listener = invocationOnMock.getArgument(1);
+            iqListener.set(listener);
+            return null;
+        }).when(iqRouter).addIQResultListener(any(), any());
+
+        doAnswer(invocationOnMock -> {
+            iqListener.get().receivedAnswer(Fixtures.iqFrom(USER_FOUND_RESULT));
+            return null;
+        }).when(iqRouter).route(any());
+
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null));
+
+        assertThat(result, is(true));
+        verify(iqRouter).route(any());
+    }
+
+    @Test
+    public void isRegisteredUserWillReturnFalseForUnknownRemoteUsers() {
+
+        final AtomicReference<IQResultListener> iqListener = new AtomicReference<>();
+        doAnswer(invocationOnMock -> {
+            final IQResultListener listener = invocationOnMock.getArgument(1);
+            iqListener.set(listener);
+            return null;
+        }).when(iqRouter).addIQResultListener(any(), any());
+
+        doAnswer(invocationOnMock -> {
+            final IQ iq = invocationOnMock.getArgument(0);
+            final Element childElement = iq.getChildElement();
+            final IQ response = IQ.createResultIQ(iq);
+            response.setChildElement(childElement.createCopy());
+            response.setError(new PacketError(PacketError.Condition.item_not_found, PacketError.Condition.item_not_found.getDefaultType()));
+            iqListener.get().receivedAnswer(response);
+            return null;
+        }).when(iqRouter).route(any());
+
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null));
+
+        assertThat(result, is(false));
+        verify(iqRouter).route(any());
+    }
+
+    @Test
+    public void isRegisteredUserWillReturnFalseForATimeout() {
+
+        final AtomicReference<IQResultListener> iqListener = new AtomicReference<>();
+        doAnswer(invocationOnMock -> {
+            final IQResultListener listener = invocationOnMock.getArgument(1);
+            iqListener.set(listener);
+            return null;
+        }).when(iqRouter).addIQResultListener(any(), any());
+
+        doAnswer(invocationOnMock -> {
+            final IQ iq = invocationOnMock.getArgument(0);
+            iqListener.get().answerTimeout(iq.getID());
+            return null;
+        }).when(iqRouter).route(any());
+
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null));
+
+        assertThat(result, is(false));
+        verify(iqRouter).route(any());
+    }
+
+    @Test
+    public void isRegisteredUserWillReturnFalseNoAnswer() {
+
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null));
+
+        assertThat(result, is(false));
+        verify(iqRouter).route(any());
+    }
+
+}


### PR DESCRIPTION
Note; there can still be a considerable delay when viewing groups with users of another domain that do not exist; this delay is the value of `usermanager.remote-disco-info-timeout-seconds` (default: 1 minute).

Once viewed, their lack of existence is cached in the `Remote Users Existence` cache (default: 30 minutes) so subsequent calls are much quicker until that cache expires.

Note; this caching/timeout behaviour is unchanged from before. It's just that the code no longer uses inappropriate thread synchronisation methods. 