### PR TITLE
propagate saveToDb state change to other nodes in the cluster

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -2679,6 +2679,8 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         if (!savedToDB) {
             // Set that the room is now in the DB
             savedToDB = true;
+            // Notify other cluster nodes that the room is now in DB
+            CacheFactory.doClusterTask(new RoomUpdatedEvent(this)); 
             // Save the existing room owners to the DB
             for (JID owner : owners) {
                 MUCPersistenceManager.saveAffiliationToDB(


### PR DESCRIPTION
following up on 
https://discourse.igniterealtime.org/t/localmucroom-savedtodb-state-change-not-propagated-to-other-nodes/84564