### PR TITLE
OF-1731: http-bind bug fixes + config tweak

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
@@ -100,6 +100,7 @@ public class HttpSessionManager {
         final int maxClientPoolSize = JiveGlobals.getIntProperty( "xmpp.client.processing.threads", 8 );
         final int maxPoolSize = JiveGlobals.getIntProperty("xmpp.httpbind.worker.threads", maxClientPoolSize );
         final int keepAlive = JiveGlobals.getIntProperty( "xmpp.httpbind.worker.timeout", 60 );
+        final int sessionCleanupCheck = JiveGlobals.getIntProperty("xmpp.httpbind.worker.cleanupcheck", 30);
 
         sendPacketPool = new ThreadPoolExecutor(getCorePoolSize(maxPoolSize), maxPoolSize, keepAlive, TimeUnit.SECONDS,
                 new LinkedBlockingQueue<Runnable>(), // unbounded task queue
@@ -110,7 +111,7 @@ public class HttpSessionManager {
 
         // Periodically check for Sessions that need a cleanup.
         inactivityTask = new HttpSessionReaper();
-        TaskEngine.getInstance().schedule( inactivityTask, 30 * JiveConstants.SECOND, 30 * JiveConstants.SECOND );
+        TaskEngine.getInstance().schedule( inactivityTask, 30 * JiveConstants.SECOND, sessionCleanupCheck * JiveConstants.SECOND);
     }
 
     /**


### PR DESCRIPTION
Got the OK from my employer to feed back some changes we maintained. This is the first of a few sets of changes, so if you want some other way to discuss or review, don't hesitate.

I realise you maybe want this split up with some discussion / rejection of each - that's fine - I realise your time is precious!

Issues these are to fix were seen by using an http-bind load tester (I can't release) along with using network parameters under linux to simulate 3G connections with out-of-order, duplication etc.

Contents:

(1) Unsynchronized use of packetsToSend - we've seen nullpointer exceptions in the server logs where the use of "packetsToSend.add" without a guard means that where they are being removed it's possible to get stale references

(2) sendPendingPackets - the logic there seems to only flush packets from the first collection removed - the tweak loops around all collections that are pending

(3)  onTimeout - we've seen cases of dangling threads + connections as the timeout handling code itself wasn't timing out - thus the tweak to use "deliverOnTimeout"

(4) overactivity bounds difference - we've had http-bind sessions closed prematurely due to a difference in the bounds checking - this change brings the bounds into line and resolves the premature closes we've seen

(5) A tweak to allow customising how often the http-session cleaner is run (we like to run it often)