### PR TITLE
DB Connection Pool Tweaks

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/database/DbConnectionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/DbConnectionManager.java
@@ -151,8 +151,11 @@ public class DbConnectionManager {
             if (loopIfNoConnection) {
                 try {
                     Thread.sleep(retryWait);
-                } catch (Exception e) {
-                    // Ignored, the thread was interrupted while waiting, so no need to log either
+                } catch (InterruptedException ex) {
+                    String msg = "Interrupted waiting for DB connection";
+                    Log.info(msg,ex);
+                    Thread.currentThread().interrupt();
+                    throw new SQLException(msg,ex);
                 }
             }
         } while (loopIfNoConnection);

--- a/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProvider.java
@@ -114,6 +114,10 @@ public class DefaultConnectionProvider implements ConnectionProvider {
         poolConfig.setTestOnBorrow(testBeforeUse);
         poolConfig.setTestOnReturn(testAfterUse);
         poolConfig.setMinIdle(minConnections);
+        if( minConnections > GenericObjectPoolConfig.DEFAULT_MAX_IDLE )
+        {
+            poolConfig.setMaxIdle(minConnections);
+        }
         poolConfig.setMaxTotal(maxConnections);
         poolConfig.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRuns);
         poolConfig.setSoftMinEvictableIdleTimeMillis(minIdleTime);


### PR DESCRIPTION
General comment: The (new) connection pool updates for recent Openfire are a welcome addition! - thanks for those changes.

One thing we (my society) perhaps do a little differently to a stock install is that we don't use the "failure looping" of the DB connection pool - we found that this means unfair queueing occurs under burst load.

We use a configuration where maxRetries = 0 with a larger maxWaitTime (2.5 seconds).

To help us get there, we made a couple of tweaks - contents:

(1) getConnection logic change - ensure sleep on failure only occurs if we are about to go around the loop and ask for another connection (when maxRetries = 0, this change stops unnecessary sleeps)

(2) poolConfig - if the minimum connections asked for in the db config are set - tweak the poolConfig so that this is allowed (via maxIdleConnections)