### PR TITLE
Expire any admin console sessions if user admin rights revoked

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
@@ -36,6 +36,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.jivesoftware.openfire.admin.AdminManager;
 import org.jivesoftware.openfire.auth.AuthFactory;
 import org.jivesoftware.openfire.auth.AuthToken;
+import org.jivesoftware.openfire.user.User;
 import org.jivesoftware.util.ClassUtils;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.WebManager;
@@ -208,7 +209,10 @@ public class AuthCheckFilter implements Filter {
         if (!doExclude) {
             WebManager manager = new WebManager();
             manager.init(request, response, request.getSession(), context);
-            if (!(manager.getAuthToken() instanceof AuthToken.OneTimeAuthToken) && manager.getUser() == null && !authUserFromRequest(request)) {
+            boolean haveOneTimeToken = manager.getAuthToken() instanceof AuthToken.OneTimeAuthToken;
+            User loggedUser = manager.getUser();
+            boolean loggedAdmin = loggedUser == null ? false : adminManager.isUserAdmin(loggedUser.getUsername(), true);
+            if (!haveOneTimeToken && !loggedAdmin && !authUserFromRequest(request)) {
                 response.sendRedirect(getRedirectURL(request, loginPage, null));
                 return;
             }


### PR DESCRIPTION
How to reproduce on HEAD:

(1) Create a second administrator account "dan"
(2) Using web browser 1 log in as "dan" and open up the sessions list in the admin console
(3) User web browser 2 log in as other admin, and revoke the admin permission for "dan"
(4) Dan can still refresh and use the admin console

I've tested the regular paths with admin console users - but in all honesty I haven't tested the "auth token" path (although the code seems OK to my eyes).

How is the auth-token path exercised? (Clustering maybe?)