### PR TITLE
Update maven plugins

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -26,7 +26,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <configuration>
                     <descriptors>
                         <descriptor>src/assembly/basic-distribution.xml</descriptor>

--- a/documentation/translator-guide.html
+++ b/documentation/translator-guide.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 
-<html>
+<html lang="en">
 <head>
 <title>Openfire: Translator Guide</title>
 <link href="style.css" rel="stylesheet" type="text/css">
@@ -52,7 +52,7 @@ The German resource bundle would contain the same keys, but different values:
 </pre>
 
 Making your own translation involves copying the English resource bundle,
-renaming the file, then translating its contents.</p>
+renaming the file, then translating its contents.
 
 <h2>Construct a Resource Bundle</h2>
 
@@ -80,33 +80,6 @@ be found at:
 
 <p>Next, use your favorite text editor to translate the English values into
 your language. The key names must not be changed.</p>
-
-<p>When translating from English, you may need to use special characters
-for your language (for example, Germans use characters like &auml;,
-&uuml;, or &szlig;). Unfortunately, all resource bundle files must be saved
-in ASCII format which doesn't allow for international characters. We
-recommend working on your translation in a text editor
-that supports all characters in your language. After finishing your translation,
-use the "native2ascii" tool (bundled with Java) to convert international
-characters to the ASCII format. To use the native2ascii tool:</p>
-
-<pre>
-    native2ascii -encoding XXX my_translation.properties openfire_i18n_YY.properties
-                               ^                         ^
-                               input file                output file
-</pre>
-
-<p>The "-encoding XXX" parameter is optional. If you don't specify it, Java will
-use the default encoding value, taken from System property "file.encoding".
-If you do specify an encoding (XXX), it must be taken from the first column of
-the table of supported encodings in the
-<a href="http://java.sun.com/j2se/1.3/docs/guide/intl/encoding.doc.html" target="_new">Supported Encodings</a>
-document. For example, if you created your translation using UTF-8 as your encoding and
-you are making a Simplified Chinese translation:</p>
-
-<pre>
-    native2ascii -encoding UTF8 my_translation.properties openfire_i18n_zh_CN.properties
- </pre>
 
 <h2>Testing Your Translation</h2>
 

--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -25,13 +25,16 @@
                   -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>native2ascii-maven-plugin</artifactId>
-                <version>1.0-beta-1</version>
+                <version>2.0.1</version>
                 <executions>
                     <execution>
-                        <id>native2ascii</id>
+                        <id>utf8-to-latin1</id>
                         <goals>
-                            <goal>native2ascii</goal>
+                            <goal>inplace</goal>
                         </goals>
+                        <configuration>
+                            <dir>${project.build.outputDirectory}</dir>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -144,7 +144,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -157,7 +157,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -170,7 +170,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -192,7 +192,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -257,6 +257,13 @@
                         <goals>
                             <goal>enforce</goal>
                         </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.5.0</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
                 <configuration>
@@ -275,6 +282,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.1.1</version>
                     <configuration>
                         <excludes>
                             <exclude>**/*_jsp.java</exclude>
@@ -284,7 +292,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.1.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.igniterealtime.openfire.plugins</groupId>
@@ -348,7 +356,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>2.7</version>
                 </plugin>
 
             </plugins>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -232,17 +232,15 @@
                   -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>native2ascii-maven-plugin</artifactId>
-                <version>1.0-beta-1</version>
+                <version>2.0.1</version>
                 <executions>
                     <execution>
-                        <id>native2ascii</id>
-                        <phase>process-resources</phase>
+                        <id>utf8-to-latin1</id>
                         <goals>
-                            <goal>native2ascii</goal>
+                            <goal>inplace</goal>
                         </goals>
                         <configuration>
-                            <encoding>UTF-8</encoding>
-                            <workDir>${project.build.directory}/i18n/</workDir>
+                            <dir>${project.build.directory}/i18n/</dir>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -170,7 +170,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -200,7 +200,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.1.1</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -223,7 +223,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.2.2</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -245,19 +245,19 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.8.0</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.1.1</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>3.1.0</version>
                 </plugin>
 
                 <plugin>
@@ -269,7 +269,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>2.7</version>
                 </plugin>
 
             </plugins>
@@ -295,6 +295,13 @@
                         <goals>
                             <goal>enforce</goal>
                         </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.5.0</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
                 <configuration>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.2.2</version>
                 <configuration>
                     <!-- Exclude JSP files, they will be compiled -->
                     <warSourceExcludes>**/*.jsp,**/*.jspf,WEB-INF/lib/*.*</warSourceExcludes>
@@ -82,8 +82,9 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M2</version>
+                <version>3.0.0-M3</version>
                 <configuration>
                     <systemPropertyVariables>
                         <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>


### PR DESCRIPTION
I've not raised a JIRA for this; not sure if it's entirely necessary as it's essentially just a housekeeping exercise to avoid getting too far behind in plugin versions.

NB. the native2ascii-maven-plugin could be updated from 1.0-beta-1 to 2.0.1 - but that requires a change in configuration I'm not entirely comfortable in verifying correctly (https://github.com/mojohaus/native2ascii-maven-plugin/wiki/Usage:-resources)