### PR TITLE
OF-1772 Enable configurable kick reasons for admin console + timeouts

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -564,6 +564,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                     continue;
                 }
                 if (user.getLastPacketTime() < deadline) {
+                    String timeoutKickReason = JiveGlobals.getProperty("admin.mucRoom.timeoutKickReason", null);
                     // Kick the user from all the rooms that he/she had previuosly joined
                     MUCRoom room;
                     Presence kickedPresence;
@@ -571,7 +572,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                         room = role.getChatRoom();
                         try {
                             kickedPresence =
-                                    room.kickOccupant(user.getAddress(), null, null, null);
+                                    room.kickOccupant(user.getAddress(), null, null, timeoutKickReason);
                             // Send the updated presence to the room occupants
                             room.send(kickedPresence);
                         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -564,7 +564,8 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                     continue;
                 }
                 if (user.getLastPacketTime() < deadline) {
-                    String timeoutKickReason = JiveGlobals.getProperty("admin.mucRoom.timeoutKickReason", null);
+                    String timeoutKickReason = JiveGlobals.getProperty("admin.mucRoom.timeoutKickReason",
+                            "User exceeded idle time limit.");
                     // Kick the user from all the rooms that he/she had previuosly joined
                     MUCRoom room;
                     Presence kickedPresence;
@@ -1641,6 +1642,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
      * Adds an extra Disco feature to the list of features returned for the conference service.
      * @param feature Feature to add.
      */
+    @Override
     public void addExtraFeature(final String feature) {
         extraDiscoFeatures.add(feature);
     }
@@ -1649,6 +1651,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
      * Removes an extra Disco feature from the list of features returned for the conference service.
      * @param feature Feature to remove.
      */
+    @Override
     public void removeExtraFeature(final String feature) {
         extraDiscoFeatures.remove(feature);
     }
@@ -1659,6 +1662,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
      * @param name Descriptive name for identity.  e.g. Public Chatrooms
      * @param type Type for identity.  e.g. text
      */
+    @Override
     public void addExtraIdentity(final String category, final String name, final String type) {
         final Element identity = DocumentHelper.createElement("identity");
         identity.addAttribute("category", category);
@@ -1671,6 +1675,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
      * Removes an extra Disco identity from the list of identities returned for the conference service.
      * @param name Name of identity to remove.
      */
+    @Override
     public void removeExtraIdentity(final String name) {
         final Iterator<Element> iter = extraDiscoIdentities.iterator();
         while (iter.hasNext()) {

--- a/xmppserver/src/main/webapp/muc-room-occupants.jsp
+++ b/xmppserver/src/main/webapp/muc-room-occupants.jsp
@@ -21,6 +21,7 @@
                  org.jivesoftware.util.ParamUtils,
                  org.jivesoftware.util.StringUtils,
                  org.jivesoftware.util.CookieUtils,
+                 org.jivesoftware.util.JiveGlobals,
                  java.net.URLEncoder,
                  java.text.DateFormat"
     errorPage="error.jsp"
@@ -61,10 +62,11 @@
 
     // Kick nick specified
     if (kick != null) {
+        String consoleKickReason = JiveGlobals.getProperty("admin.mucRoom.consoleKickReason", null);
         MUCRole role = room.getOccupant(nickName);
         if (role != null) {
             try {
-                room.kickOccupant(role.getUserAddress(), XMPPServer.getInstance().createJID(webManager.getUser().getUsername(), null), null, "");
+                room.kickOccupant(role.getUserAddress(), XMPPServer.getInstance().createJID(webManager.getUser().getUsername(), null), null, consoleKickReason);
                 // Log the event
                 webManager.logEvent("kicked MUC occupant "+nickName+" from "+roomName, null);
                 // Done, so redirect


### PR DESCRIPTION
Enable JiveGlobals kick reasons when kicking via admin console or via automated timeout.

We find these useful (audit reasons) - our application always fills in a kick reason, this change allows us to do the same for the Openfire server itself.

Not sure if the keys fit OK with existing JiveGlobals hierarchy

* admin.mucRoom.timeoutKickReason
* admin.mucRoom.consoleKickReason
