### PR TITLE
httpbind: Improved Logging / Diagnostics

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
@@ -340,7 +340,9 @@ public class HttpBindServlet extends HttpServlet {
 
         @Override
         public void onDataAvailable() throws IOException {
-            Log.trace("Data is available to be read from [" + remoteAddress + "]");
+            if( Log.isTraceEnabled() ) {
+                Log.trace("Data is available to be read from [" + remoteAddress + "]");
+            }
 
             final ServletInputStream inputStream = context.getRequest().getInputStream();
 
@@ -353,13 +355,17 @@ public class HttpBindServlet extends HttpServlet {
 
         @Override
         public void onAllDataRead() throws IOException {
-            Log.trace("All data has been read from [" + remoteAddress + "]");
+            if( Log.isTraceEnabled() ) {
+                Log.trace("All data has been read from [" + remoteAddress + "]");
+            }
             processContent(context, outStream.toString(StandardCharsets.UTF_8.name()));
         }
 
         @Override
         public void onError(Throwable throwable) {
-            Log.warn("Error reading request data from [" + remoteAddress + "]", throwable);
+            if( Log.isWarnEnabled() ) {
+                Log.warn("Error reading request data from [" + remoteAddress + "]", throwable);
+            }
             try {
                 sendLegacyError(context, BoshBindingError.badRequest);
             } catch (IOException ex) {
@@ -385,7 +391,9 @@ public class HttpBindServlet extends HttpServlet {
             // This method may be invoked multiple times and by different threads, e.g. when writing large byte arrays.
             // Make sure a write/complete operation is only done, if no other write is pending, i.e. if isReady() == true
             // Otherwise WritePendingException is thrown.
-            Log.trace("Data can be written to [" + remoteAddress + "]");
+            if( Log.isTraceEnabled() ) {
+                Log.trace("Data can be written to [" + remoteAddress + "]");
+            }
             synchronized ( context )
             {
                 final ServletOutputStream servletOutputStream = context.getResponse().getOutputStream();
@@ -412,7 +420,9 @@ public class HttpBindServlet extends HttpServlet {
 
         @Override
         public void onError(Throwable throwable) {
-            Log.warn("Error writing response data to [" + remoteAddress + "]", throwable);
+            if( Log.isWarnEnabled() ) {
+                Log.warn("Error writing response data to [" + remoteAddress + "]", throwable);
+            }
             synchronized ( context )
             {
                 context.complete();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
@@ -323,15 +323,25 @@ public class HttpSessionManager {
 
         @Override
         public void run() {
+            boolean logHttpbindEnabled = JiveGlobals.getBooleanProperty("log.httpbind.enabled", false);
             long currentTime = System.currentTimeMillis();
             for (HttpSession session : sessionMap.values()) {
                 try {
                     long lastActive = currentTime - session.getLastActivity();
-                    if (Log.isDebugEnabled()) {
-                        Log.debug("Session was last active {} ms ago: {}", lastActive, session );
+                    if( lastActive >= 1 && logHttpbindEnabled && Log.isInfoEnabled()) {
+                        Log.info("Session {} was last active {} ms ago: {} from IP {} " +
+                                " currently on rid {}",
+                                session.getStreamID(),
+                                lastActive,
+                                session.getAddress(), // JID
+                                session.getConnection().getHostAddress(),
+                                session.getLastAcknowledged()); // RID
                     }
                     if (lastActive > session.getInactivityTimeout() * JiveConstants.SECOND) {
-                        Log.info("Closing idle session: {}", session);
+                        Log.info("Closing idle session {}: {} from IP {}",
+                                session.getStreamID(),
+                                session.getAddress(),
+                                session.getConnection().getHostAddress());
                         session.close();
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
Didn't include this in the original httpbind pull request - it's a lot of noise for what are only logging changes (and I wanted to clean up our version so it was less verbose). Hope that's not too annoying.

Contents:

(1) Removes some unnecessary string concatenation on the hot path in HttpBindServlet.onDataAvailable/Read/WritePossible, HttpSession.checkOveractivity

(2) Improve lifecycle logging - use streamID where applicable to streamline issue diagnosis

Possible modification: One change to this approach might be to place the lifecycle logging ("session ## created etc") behind a different logging switch in JiveGlobals to the raw RECV and SEND. I leave this for the feedback cycle.

Thanks for your time, patience and help @guusdk and @GregDThomas - this is the last of my pull requests (for now at least .-) ).