### PR TITLE
OF-1705: Update NodeID in ClientRoute

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -1580,15 +1580,17 @@ public class SessionManager extends BasicModule implements ClusterEventListener
     }
 
     @Override
-    public void joinedCluster() {
-        // Upon joining a cluster, the server gets a new ID. Here, all old IDs are replaced with the new identity.
+    public void joinedCluster()
+    {
+        // Upon joining a cluster, the server can get a new ID. Here, all old IDs are replaced with the new identity.
         final NodeID defaultNodeID = server.getDefaultNodeID();
         final NodeID nodeID = server.getNodeID();
-
-        CacheUtil.replaceValueInMultivaluedCache( componentSessionsCache, defaultNodeID, nodeID );
-        CacheUtil.replaceValueInCache( multiplexerSessionsCache, defaultNodeID, nodeID );
-        CacheUtil.replaceValueInCache( incomingServerSessionsCache, defaultNodeID, nodeID );
-
+        if ( !defaultNodeID.equals( nodeID ) ) // In more recent versions of Openfire, the ID does not change.
+        {
+            CacheUtil.replaceValueInMultivaluedCache( componentSessionsCache, defaultNodeID, nodeID );
+            CacheUtil.replaceValueInCache( multiplexerSessionsCache, defaultNodeID, nodeID );
+            CacheUtil.replaceValueInCache( incomingServerSessionsCache, defaultNodeID, nodeID );
+        }
         // Track information about local sessions and share it with other cluster nodes.
         // Note that, unlike other caches, this cache is populated only when clustering is enabled.
         for (ClientSession session : routingTable.getClientsRoutes(true)) {
@@ -1607,9 +1609,12 @@ public class SessionManager extends BasicModule implements ClusterEventListener
             // Upon leaving a cluster, the server uses its non-clustered/default ID again. Here, all clustered IDs are replaced with the new identity.
             final NodeID defaultNodeID = server.getDefaultNodeID();
             final NodeID nodeID = server.getNodeID();
-            CacheUtil.replaceValueInMultivaluedCache( componentSessionsCache, nodeID, defaultNodeID );
-            CacheUtil.replaceValueInCache( multiplexerSessionsCache, nodeID, defaultNodeID );
-            CacheUtil.replaceValueInCache( incomingServerSessionsCache, nodeID, defaultNodeID );
+            if ( !defaultNodeID.equals( nodeID ) ) // In more recent versions of Openfire, the ID does not change.
+            {
+                CacheUtil.replaceValueInMultivaluedCache( componentSessionsCache, nodeID, defaultNodeID );
+                CacheUtil.replaceValueInCache( multiplexerSessionsCache, nodeID, defaultNodeID );
+                CacheUtil.replaceValueInCache( incomingServerSessionsCache, nodeID, defaultNodeID );
+            }
 
             // The local cluster node left the cluster.
             //

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
@@ -588,10 +588,13 @@ public class InternalComponentManager extends BasicModule implements ClusterEven
     @Override
     public void joinedCluster()
     {
-        // Upon joining a cluster, the server gets a new ID. Here, all old IDs are replaced with the new identity.
+        // Upon joining a cluster, the server can get a new ID. Here, all old IDs are replaced with the new identity.
         final NodeID defaultNodeID = XMPPServer.getInstance().getDefaultNodeID();
         final NodeID nodeID = XMPPServer.getInstance().getNodeID();
-        CacheUtil.replaceValueInMultivaluedCache( componentCache, defaultNodeID, nodeID );
+        if ( !defaultNodeID.equals( nodeID ) ) // In more recent versions of Openfire, the ID does not change.
+        {
+            CacheUtil.replaceValueInMultivaluedCache( componentCache, defaultNodeID, nodeID );
+        }
 
         // We joined a cluster. Determine what components run on other nodes,
         // and raise events for those that are not running on this node.
@@ -637,7 +640,10 @@ public class InternalComponentManager extends BasicModule implements ClusterEven
         // Upon leaving a cluster, the server uses its non-clustered/default ID again. Here, all clustered IDs are replaced with the new identity.
         final NodeID defaultNodeID = XMPPServer.getInstance().getDefaultNodeID();
         final NodeID nodeID = XMPPServer.getInstance().getNodeID();
-        CacheUtil.replaceValueInMultivaluedCache( componentCache, nodeID, defaultNodeID );
+        if ( !defaultNodeID.equals( nodeID ) ) // In more recent versions of Openfire, the ID does not change.
+        {
+            CacheUtil.replaceValueInMultivaluedCache( componentCache, nodeID, defaultNodeID );
+        }
 
         // The local cluster node left the cluster.
         //

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ClientRoute.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ClientRoute.java
@@ -46,6 +46,10 @@ public class ClientRoute implements Cacheable, Externalizable {
         return nodeID;
     }
 
+    public void setNodeID( final NodeID nodeID )
+    {
+        this.nodeID = nodeID;
+    }
 
     public boolean isAvailable() {
         return available;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -42,6 +42,8 @@ import org.xmpp.packet.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Routing table that stores routes to client sessions, outgoing server sessions
@@ -1049,6 +1051,10 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         final NodeID nodeID = server.getNodeID();
         CacheUtil.replaceValueInCache( serversCache, defaultNodeID, nodeID );
         CacheUtil.replaceValueInMultivaluedCache( componentsCache, defaultNodeID, nodeID );
+        CacheUtil.replaceValueInCacheByMapping( usersCache,
+                                                clientRoute -> { if ( clientRoute.getNodeID().equals( defaultNodeID ) ) { clientRoute.setNodeID( nodeID ); } return clientRoute; } );
+        CacheUtil.replaceValueInCacheByMapping( anonymousUsersCache,
+                                                clientRoute -> { if ( clientRoute.getNodeID().equals( defaultNodeID ) ) { clientRoute.setNodeID( nodeID ); } return clientRoute; } );
 
         // Broadcast presence of local sessions to remote sessions when subscribed to presence
         // Probe presences of remote sessions when subscribed to presence of local session
@@ -1077,6 +1083,10 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             final NodeID nodeID = server.getNodeID();
             CacheUtil.replaceValueInCache( serversCache, nodeID, defaultNodeID );
             CacheUtil.replaceValueInMultivaluedCache( componentsCache, nodeID, defaultNodeID );
+            CacheUtil.replaceValueInCacheByMapping( usersCache,
+                                                    clientRoute -> { if ( clientRoute.getNodeID().equals( nodeID ) ) { clientRoute.setNodeID( defaultNodeID ); } return clientRoute; } );
+            CacheUtil.replaceValueInCacheByMapping( anonymousUsersCache,
+                                                    clientRoute -> { if ( clientRoute.getNodeID().equals( nodeID ) ) { clientRoute.setNodeID( defaultNodeID ); } return clientRoute; } );
 
             // The local cluster node left the cluster.
             //

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1046,16 +1046,18 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     @Override
     public void joinedCluster()
     {
-        // Upon joining a cluster, the server gets a new ID. Here, all old IDs are replaced with the new identity.
+        // Upon joining a cluster, the server can get a new ID. Here, all old IDs are replaced with the new identity.
         final NodeID defaultNodeID = server.getDefaultNodeID();
         final NodeID nodeID = server.getNodeID();
-        CacheUtil.replaceValueInCache( serversCache, defaultNodeID, nodeID );
-        CacheUtil.replaceValueInMultivaluedCache( componentsCache, defaultNodeID, nodeID );
-        CacheUtil.replaceValueInCacheByMapping( usersCache,
-                                                clientRoute -> { if ( clientRoute.getNodeID().equals( defaultNodeID ) ) { clientRoute.setNodeID( nodeID ); } return clientRoute; } );
-        CacheUtil.replaceValueInCacheByMapping( anonymousUsersCache,
-                                                clientRoute -> { if ( clientRoute.getNodeID().equals( defaultNodeID ) ) { clientRoute.setNodeID( nodeID ); } return clientRoute; } );
-
+        if ( !defaultNodeID.equals( nodeID ) ) // In more recent versions of Openfire, the ID does not change.
+        {
+            CacheUtil.replaceValueInCache( serversCache, defaultNodeID, nodeID );
+            CacheUtil.replaceValueInMultivaluedCache( componentsCache, defaultNodeID, nodeID );
+            CacheUtil.replaceValueInCacheByMapping( usersCache,
+                                                    clientRoute -> { if ( clientRoute.getNodeID().equals( defaultNodeID ) ) { clientRoute.setNodeID( nodeID ); } return clientRoute; } );
+            CacheUtil.replaceValueInCacheByMapping( anonymousUsersCache,
+                                                    clientRoute -> { if ( clientRoute.getNodeID().equals( defaultNodeID ) ) { clientRoute.setNodeID( nodeID ); } return clientRoute; } );
+        }
         // Broadcast presence of local sessions to remote sessions when subscribed to presence
         // Probe presences of remote sessions when subscribed to presence of local session
         // Send pending subscription requests to local sessions from remote sessions
@@ -1081,13 +1083,15 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             // Upon leaving a cluster, the server uses its non-clustered/default ID again. Here, all clustered IDs are replaced with the new identity.
             final NodeID defaultNodeID = server.getDefaultNodeID();
             final NodeID nodeID = server.getNodeID();
-            CacheUtil.replaceValueInCache( serversCache, nodeID, defaultNodeID );
-            CacheUtil.replaceValueInMultivaluedCache( componentsCache, nodeID, defaultNodeID );
-            CacheUtil.replaceValueInCacheByMapping( usersCache,
-                                                    clientRoute -> { if ( clientRoute.getNodeID().equals( nodeID ) ) { clientRoute.setNodeID( defaultNodeID ); } return clientRoute; } );
-            CacheUtil.replaceValueInCacheByMapping( anonymousUsersCache,
-                                                    clientRoute -> { if ( clientRoute.getNodeID().equals( nodeID ) ) { clientRoute.setNodeID( defaultNodeID ); } return clientRoute; } );
-
+            if ( !defaultNodeID.equals( nodeID ) ) // In more recent versions of Openfire, the ID does not change.
+            {
+                CacheUtil.replaceValueInCache( serversCache, nodeID, defaultNodeID );
+                CacheUtil.replaceValueInMultivaluedCache( componentsCache, nodeID, defaultNodeID );
+                CacheUtil.replaceValueInCacheByMapping( usersCache,
+                                                        clientRoute -> { if ( clientRoute.getNodeID().equals( nodeID ) ) { clientRoute.setNodeID( defaultNodeID ); } return clientRoute; } );
+                CacheUtil.replaceValueInCacheByMapping( anonymousUsersCache,
+                                                        clientRoute -> { if ( clientRoute.getNodeID().equals( nodeID ) ) { clientRoute.setNodeID( defaultNodeID ); } return clientRoute; } );
+            }
             // The local cluster node left the cluster.
             //
             // Determine what routes were available only on other cluster nodes than the local one.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheUtil.java
@@ -402,7 +402,7 @@ public class CacheUtil
                 lock.lock();
 
                 final V modifiedValue = mapper.apply( entry.getValue() );
-                if ( modifiedValue.equals( entry.getValue() ) )
+                if ( !modifiedValue.equals( entry.getValue() ) )
                 {
                     // The cluster-based cache needs an explicit 'put' to cause the change to propagate.
                     cache.put( entry.getKey(), modifiedValue );


### PR DESCRIPTION
The ClientRoute class contains a reference to the server NodeID. This value must be updated when joining/leaving a cluster.