### PR TITLE
OF-1383: Add library removed from Java 11 for backwards compatibility.

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -349,6 +349,11 @@
             <groupId>org.directwebremoting</groupId>
             <artifactId>dwr</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
 
         <!-- Database Drivers -->
         <dependency>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -86,29 +86,6 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>post-1.8</id>
-            <activation>
-                <jdk>[1.9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <compilerArgs>
-                                <arg>--add-modules</arg>
-                                <arg>java.xml.bind</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <dependencies>
         <!-- Ignite Realtime -->
         <dependency>


### PR DESCRIPTION
Openfire uses javax.xml.bind.DatatypeConverterImpl#DatatypeConverterImpl, a class that has been removed from Java 11.

This commit adds a library that provides this class, JaxB API, as a dependency to XMPPServer. This makes the class available in Java 11.