### PR TITLE
OF-1699 revisited

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -238,6 +238,17 @@ public class XMPPServer {
     }
 
     /**
+     * TODO: (2019-04-24) Remove and replace with <a href="https://github.com/mockito/mockito/issues/1013">Mockito mocking of static methods</a>, when available
+     *
+     * @param instance the mock/stub/spy XMPPServer to return when {@link #getInstance()} is called.
+     * @deprecated - for test use only
+     */
+    @Deprecated
+    public static void setInstance(final XMPPServer instance) {
+        XMPPServer.instance = instance;
+    }
+
+    /**
      * Creates a server and starts it.
      */
     public XMPPServer() {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -29,8 +29,20 @@ import java.net.UnknownHostException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimerTask;
+import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Future;
 
 import org.dom4j.Document;
 import org.dom4j.io.SAXReader;
@@ -1768,16 +1780,24 @@ public class XMPPServer {
         return started;
     }
 
-    public void sendMessageToAdmins(final String message) {
-        final MessageRouter messageRouter = getMessageRouter();
-        final Collection<JID> admins = XMPPServer.getInstance().getAdmins();
-        final Message notification = new Message();
-        notification.setFrom(getServerInfo().getXMPPDomain());
-        notification.setBody(message);
-        admins.forEach(jid -> {
-            logger.debug("Sending message to admin [jid={}, message={}]", jid, message);
-            notification.setTo(jid);
-            messageRouter.route(notification);
+    /**
+     * Asynchronously send a message to every administrator on the system.
+     *
+     * @param message The message to send
+     * @return the future result of sending the message.
+     */
+    public Future<?> sendMessageToAdmins(final String message) {
+        return TaskEngine.getInstance().submit(() -> {
+            final MessageRouter messageRouter = getMessageRouter();
+            final Collection<JID> admins = XMPPServer.getInstance().getAdmins();
+            final Message notification = new Message();
+            notification.setFrom(getServerInfo().getXMPPDomain());
+            notification.setBody(message);
+            admins.forEach(jid -> {
+                logger.debug("Sending message to admin [jid={}, message={}]", jid, message);
+                notification.setTo(jid);
+                messageRouter.route(notification);
+            });
         });
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/cluster/ClusterMonitorTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/cluster/ClusterMonitorTest.java
@@ -36,6 +36,9 @@ public class ClusterMonitorTest {
 
         Fixtures.clearExistingProperties();
 
+        //noinspection deprecation
+        XMPPServer.setInstance(xmppServer);
+
         doReturn(xmppServerInfo).when(xmppServer).getServerInfo();
 
         doReturn(THIS_HOST_NAME).when(xmppServerInfo).getHostname();


### PR DESCRIPTION
During testing of split brain recovery (https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/23) it became clear that the cluster monitoring introduced in https://github.com/igniterealtime/Openfire/pull/1332 had two (minor) flaws;
* When the junior node loses network connectivity, it attempts to send a message as it is now senior; this message can be stored in the DB, which may also be inaccessible. This all takes some time (a few seconds) to fail. To avoid slowing down the (synchronous) raising of ClusterEventListener events the sending of messages is now done in a background thread.
* Ensure existing remote node names are cached when the local node joins the cluster, as well as when new remote nodes join.