### PR TITLE
OF-1746: Add option that allows certificate revalidation to be skipped (client)

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1594,6 +1594,7 @@ system_property.xmpp.component.ssl.active=Set to true to enable legacy encrypted
 system_property.sasl.scram-sha-1.iteration-count=The number of iterations when salting a users password. Changing this \
   value will not affect existing passwords, only when passwords are updated
 system_property.xmpp.auth.anonymous=Set to true to allow anonymous login, otherwise false
+system_property.xmpp.auth.external.client.skip-cert-revalidation=Set to true to avoid validation of the client-provided PKIX certificate (for mutual authentication) other than the validation that happens when the TLS session is established.
 system_property.xmpp.client.idle=How long, in milliseconds, before idle sessions are dropped. Set to -1 to never drop idle sessions.
 system_property.xmpp.client.idle.ping=Set to true to ping idle clients, otherwise false
 system_property.cluster-monitor.service-enabled=Set to true to send messages to admins on cluster events, otherwise false


### PR DESCRIPTION
The validity of the peer-provided PKIX certificate has already been verified when the TLS session was established. There should not be a need to re-validate. This commit adds a new option that allows Openfire to be configured to skip re-validation of the certificate.