### PR TITLE
OF-1776: Make SSL TrustManager pluggable

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1598,6 +1598,7 @@ system_property.sasl.scram-sha-1.iteration-count=The number of iterations when s
   value will not affect existing passwords, only when passwords are updated
 system_property.xmpp.auth.anonymous=Set to true to allow anonymous login, otherwise false
 system_property.xmpp.auth.external.client.skip-cert-revalidation=Set to true to avoid validation of the client-provided PKIX certificate (for mutual authentication) other than the validation that happens when the TLS session is established.
+system_property.xmpp.auth.ssl.default-trustmanager-impl=The class to use as the default SSL/TLS TrustManager (which checks certificates from peers).
 system_property.xmpp.client.idle=How long, in milliseconds, before idle sessions are dropped. Set to -1 to never drop idle sessions.
 system_property.xmpp.client.idle.ping=Set to true to ping idle clients, otherwise false
 system_property.cluster-monitor.service-enabled=Set to true to send messages to admins on cluster events, otherwise false


### PR DESCRIPTION
The class that is used as the default SSL/TLS TrustManager (which checks certificates from peers) should be made configurable.