### PR TITLE
OF-1781: Fix download of plugins via admin console

### DIFF
--- a/xmppserver/src/main/webapp/available-plugins.jsp
+++ b/xmppserver/src/main/webapp/available-plugins.jsp
@@ -149,15 +149,15 @@
 <script type="text/javascript">
 
     var downloading;
-    function downloadPlugin(url, id) {
+    function downloadPlugin(url, version, id) {
         downloading = true;
         document.getElementById(id + "-image").innerHTML = '<img src="images/working-16x16.gif" border="0"/>';
         document.getElementById(id).style.background = "#FFFFCC";
-        setTimeout("startDownload('" + url + "','" + id + "')", 5000);
+        setTimeout("startDownload('" + url + "','" + version + "','" + id + "')", 1000);
     }
 
-    function startDownload(url, id) {
-        downloader.installPlugin(url, id, downloadComplete);
+    function startDownload(url, version, id) {
+        downloader.installPlugin(url, version, id, downloadComplete);
     }
 
     function downloadComplete(status) {
@@ -318,7 +318,7 @@
                                             <c:out value="${admin:byteFormat( notInstalledPlugin.fileSize )}"/>
                                         </td>
                                         <td width="1%" align="center" valign="top" class="line-bottom-border">
-                                            <a href="javascript:downloadPlugin('${fn:escapeXml(notInstalledPlugin.downloadURL)}', '${notInstalledPlugin.hashCode}')">
+                                            <a href="javascript:downloadPlugin('${fn:escapeXml(notInstalledPlugin.downloadURL)}', '${notInstalledPlugin.version}', '${notInstalledPlugin.hashCode}')">
                                                 <span id="${notInstalledPlugin.hashCode}-image">
                                                     <img src="images/add-16x16.gif" width="16" height="16" border="0" alt="<fmt:message key="plugin.available.download" />">
                                                 </span>


### PR DESCRIPTION
Additionally, it no longer takes 5 seconds before the download starts. I've left a 1 second interval, for the spinner to show (which I guess is expected UX).