### PR TITLE
OF-1784: Don't write error when data cannot be written.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/ConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/ConnectionHandler.java
@@ -19,12 +19,14 @@ package org.jivesoftware.openfire.nio;
 import org.apache.mina.core.service.IoHandlerAdapter;
 import org.apache.mina.core.session.IdleStatus;
 import org.apache.mina.core.session.IoSession;
+import org.apache.mina.core.write.WriteException;
 import org.dom4j.io.XMPPPacketReader;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.net.MXParser;
 import org.jivesoftware.openfire.net.ServerTrafficCounter;
 import org.jivesoftware.openfire.net.StanzaHandler;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
+import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParserException;
@@ -151,7 +153,11 @@ public abstract class ConnectionHandler extends IoHandlerAdapter {
             }
 
             final Connection connection = (Connection) session.getAttribute( CONNECTION );
-            connection.deliverRawText( error.toXML() );
+
+            // OF-1784: Don't write an error when the source problem is an issue with writing data.
+            if ( !(cause instanceof WriteException) ) {
+                connection.deliverRawText( error.toXML() );
+            }
         } finally {
             final Connection connection = (Connection) session.getAttribute( CONNECTION );
             if (connection != null) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/ConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/ConnectionHandler.java
@@ -155,7 +155,7 @@ public abstract class ConnectionHandler extends IoHandlerAdapter {
             final Connection connection = (Connection) session.getAttribute( CONNECTION );
 
             // OF-1784: Don't write an error when the source problem is an issue with writing data.
-            if ( !(cause instanceof WriteException) ) {
+            if ( JiveGlobals.getBooleanProperty( "xmpp.skip-error-delivery-on-write-error.disable", false ) || !(cause instanceof WriteException) ) {
                 connection.deliverRawText( error.toXML() );
             }
         } finally {


### PR DESCRIPTION
While processing an exception that relates to Openfire not being able to write data to peers,
do not try to write an error to that peer (as we've previously established that writing things
to the peer is problematic).