### PR TITLE
OF-1790: Initialize ofID sequences.

### DIFF
--- a/distribution/src/database/openfire_db2.sql
+++ b/distribution/src/database/openfire_db2.sql
@@ -384,8 +384,9 @@ INSERT INTO ofID (idType, id) VALUES (18, 1);
 INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
+INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 30);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_hsqldb.sql
+++ b/distribution/src/database/openfire_hsqldb.sql
@@ -370,8 +370,9 @@ INSERT INTO ofID (idType, id) VALUES (18, 1);
 INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
+INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 30);
 
 // Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -360,8 +360,9 @@ INSERT INTO ofID (idType, id) VALUES (18, 1);
 INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
+INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 30);
 
 # Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -368,8 +368,9 @@ INSERT INTO ofID (idType, id) VALUES (18, 1);
 INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
+INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 30);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -376,8 +376,9 @@ INSERT INTO ofID (idType, id) VALUES (18, 1);
 INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
+INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 30);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -373,8 +373,9 @@ INSERT INTO ofID (idType, id) VALUES (18, 1);
 INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
+INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 30);
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -374,8 +374,9 @@ INSERT INTO ofID (idType, id) VALUES (18, 1);
 INSERT INTO ofID (idType, id) VALUES (19, 1);
 INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
+INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 29);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 30);
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/upgrade/30/openfire_db2.sql
+++ b/distribution/src/database/upgrade/30/openfire_db2.sql
@@ -1,0 +1,3 @@
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+
+UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/30/openfire_hsqldb.sql
@@ -1,0 +1,3 @@
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+
+UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/30/openfire_mysql.sql
@@ -1,0 +1,3 @@
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+
+UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/30/openfire_oracle.sql
@@ -1,0 +1,3 @@
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+
+UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/30/openfire_postgresql.sql
@@ -1,0 +1,3 @@
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+
+UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/30/openfire_sqlserver.sql
@@ -1,0 +1,3 @@
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+
+UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/30/openfire_sybase.sql
@@ -1,0 +1,3 @@
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+
+UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
@@ -68,7 +68,7 @@ public class SchemaManager {
     /**
      * Current Openfire database schema version.
      */
-    private static final int DATABASE_VERSION = 29;
+    private static final int DATABASE_VERSION = 30;
 
     /**
      * Checks the Openfire database schema to ensure that it's installed and up to date.


### PR DESCRIPTION
An earlier change introduced a new ofID-based sequence used for messageID, when writing MUC messages to the database. This commit initializes the counter that's used to the highest value that has already been logged.