### PR TITLE
OF-1790: Database update scripts should handle empty table.

### DIFF
--- a/distribution/src/database/upgrade/30/openfire_db2.sql
+++ b/distribution/src/database/upgrade/30/openfire_db2.sql
@@ -1,3 +1,3 @@
-INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT coalesce(max(messageID), 1) FROM ofMucConversationLog) );
 
 UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/30/openfire_hsqldb.sql
@@ -1,3 +1,3 @@
-INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT coalesce(max(messageID), 1) FROM ofMucConversationLog) );
 
 UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/30/openfire_mysql.sql
@@ -1,3 +1,3 @@
-INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT coalesce(max(messageID), 1) FROM ofMucConversationLog) );
 
 UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/30/openfire_oracle.sql
@@ -1,3 +1,3 @@
-INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT coalesce(max(messageID), 1) FROM ofMucConversationLog) );
 
 UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/30/openfire_postgresql.sql
@@ -1,3 +1,3 @@
-INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT coalesce(max(messageID), 1) FROM ofMucConversationLog) );
 
 UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/30/openfire_sqlserver.sql
@@ -1,3 +1,3 @@
-INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT coalesce(max(messageID), 1) FROM ofMucConversationLog) );
 
 UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/30/openfire_sybase.sql
@@ -1,3 +1,3 @@
-INSERT INTO ofID (idType, id) VALUES (27, (SELECT max(messageID) FROM ofMucConversationLog) );
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT coalesce(max(messageID), 1) FROM ofMucConversationLog) );
 
 UPDATE ofVersion SET version = 30 WHERE name = 'openfire';


### PR DESCRIPTION
This modifies the update script to handle a scenario of an upgrade (as opposed to a fresh installation), but without having any logged MUC messages.