### PR TITLE
OF-1793: Contact List Sharing for LDAP groups shows wrong setting.

### DIFF
--- a/xmppserver/src/main/webapp/group-edit.jsp
+++ b/xmppserver/src/main/webapp/group-edit.jsp
@@ -481,7 +481,7 @@
         <table width="80%" cellpadding="3" cellspacing="0" border="0">
             <tr>
                 <td width="1%">
-                    <input type="radio" name="enableRosterGroups" value="false" id="rb201" ${group.properties['sharedRoster.showInRoster'] eq 'nobody' ? "checked" : ""} onClick="toggleReadOnly();">
+                    <input type="radio" name="enableRosterGroups" value="false" id="rb201" ${empty group.properties['sharedRoster.showInRoster'] or group.properties['sharedRoster.showInRoster'] eq 'nobody' ? "checked" : ""} onClick="toggleReadOnly();">
                 </td>
                 <td width="99%">
                     <label for="rb201"><fmt:message key="group.edit.share_not_in_rosters" /></label>
@@ -489,7 +489,7 @@
             </tr>
             <tr>
                 <td width="1%" valign="top">
-                    <input type="radio" name="enableRosterGroups" value="true" id="rb202" ${group.properties['sharedRoster.showInRoster'] eq 'nobody' ? "" : "checked"} onClick="toggleReadOnly();"">
+                    <input type="radio" name="enableRosterGroups" value="true" id="rb202" ${empty group.properties['sharedRoster.showInRoster'] or group.properties['sharedRoster.showInRoster'] eq 'nobody' ? "" : "checked"} onClick="toggleReadOnly();"">
                 </td>
                 <td width="99%">
                     <label for="rb202"><fmt:message key="group.edit.share_in_rosters" /></label>


### PR DESCRIPTION
Groups imported through LDAP initially have no properties. The admin console checks the Contact List Sharing configuration of a group, by evaluating the value of the sharedRoster.showInRoster property. Previously, this needed to have the value 'nobody' for the group to be marked as 'unshared'. This commit ensures that a group is also shown to be 'unshared' if the property is not set at all.