### PR TITLE
OF-1797 Accelerate loading MUC rooms

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
@@ -1113,11 +1113,12 @@ public class MUCPersistenceManager {
      * @return the property value specified by name.
      */
     public static String getProperty(String subdomain, String name) {    	
-        final MUCServiceProperties newProps = new MUCServiceProperties(subdomain);
-        final MUCServiceProperties oldProps = propertyMaps.putIfAbsent(subdomain, newProps);
-        if (oldProps != null) {
-            return oldProps.get(name);
+        final MUCServiceProperties cachedProps = propertyMaps.get(subdomain);
+        if (cachedProps != null) {
+            return cachedProps.get(name);
         } else {
+            final MUCServiceProperties newProps = new MUCServiceProperties(subdomain);
+            propertyMaps.putIfAbsent(subdomain, newProps);
             return newProps.get(name);
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
@@ -1113,14 +1113,8 @@ public class MUCPersistenceManager {
      * @return the property value specified by name.
      */
     public static String getProperty(String subdomain, String name) {    	
-        final MUCServiceProperties cachedProps = propertyMaps.get(subdomain);
-        if (cachedProps != null) {
-            return cachedProps.get(name);
-        } else {
-            final MUCServiceProperties newProps = new MUCServiceProperties(subdomain);
-            propertyMaps.putIfAbsent(subdomain, newProps);
-            return newProps.get(name);
-        }
+        final MUCServiceProperties props = propertyMaps.computeIfAbsent( subdomain, MUCServiceProperties::new );
+        return props.get(name);
     }
 
     /**
@@ -1234,12 +1228,8 @@ public class MUCPersistenceManager {
      * @return a List of all immediate children property names (Strings).
      */
     public static List<String> getPropertyNames(String subdomain, String parent) {
-        MUCServiceProperties properties = new MUCServiceProperties(subdomain);
-        final MUCServiceProperties oldProps = propertyMaps.putIfAbsent(subdomain, properties);
-        if (oldProps != null) {
-            properties = oldProps;
-        } 
-        return new ArrayList<>(properties.getChildrenNames(parent));
+        final MUCServiceProperties props = propertyMaps.computeIfAbsent( subdomain, MUCServiceProperties::new );
+        return new ArrayList<>(props.getChildrenNames(parent));
     }
 
     /**
@@ -1254,13 +1244,8 @@ public class MUCPersistenceManager {
      * @return all child property values for the given parent.
      */
     public static List<String> getProperties(String subdomain, String parent) {
-        MUCServiceProperties properties = new MUCServiceProperties(subdomain);
-        final MUCServiceProperties oldProps = propertyMaps.putIfAbsent(subdomain, properties);
-        if (oldProps != null) {
-            properties = oldProps;
-        } 
-
-        Collection<String> propertyNames = properties.getChildrenNames(parent);
+        final MUCServiceProperties props = propertyMaps.computeIfAbsent( subdomain, MUCServiceProperties::new );
+        Collection<String> propertyNames = props.getChildrenNames(parent);
         List<String> values = new ArrayList<>();
         for (String propertyName : propertyNames) {
             String value = getProperty(subdomain, propertyName);
@@ -1279,12 +1264,8 @@ public class MUCPersistenceManager {
      * @return a List of all property names (Strings).
      */
     public static List<String> getPropertyNames(String subdomain) {
-        MUCServiceProperties properties = new MUCServiceProperties(subdomain);
-        final MUCServiceProperties oldProps = propertyMaps.putIfAbsent(subdomain, properties);
-        if (oldProps != null) {
-            properties = oldProps;
-        } 
-        return new ArrayList<>(properties.getPropertyNames());
+        final MUCServiceProperties props = propertyMaps.computeIfAbsent( subdomain, MUCServiceProperties::new );
+        return new ArrayList<>(props.getPropertyNames());
     }
 
     /**


### PR DESCRIPTION
Hi, I tested Openfire 4.2.3 with 200,000 MUC rooms. And I found out loading MUC rooms can be very slow in proportion to the number of rooms. In my case, it needed over 1 hour to start Openfire.
I identified the cause in MUCPersistenceManager. (This problem still exists in Openfire 4.3 or later)
- After fetching MUC rooms from `ofmucroom` table, each `LocalMUCRoom` loads its default properties from `ofmucserviceprop` table with MUCPersistenceManager. This process calls `SELECT` SQL about 200,000 * 12 times (the 12 is the number of LocalMUCRoom.xxx fields). In the end, the more MUC rooms the more time needed.

I tweaked MUCPersistenceManager.getProperty just a little bit. By this fix, Openfire startup time become about 90 seconds in 200,000 MUC room.

Please review.