### PR TITLE
OF-1800: Cache low effectivity calculation improvement

### DIFF
--- a/xmppserver/src/main/webapp/system-cache.jsp
+++ b/xmppserver/src/main/webapp/system-cache.jsp
@@ -197,7 +197,6 @@
         int entries = cache.size();
         memUsed = (double)cache.getCacheSize()/(1024*1024);
         totalMem = (double)cache.getMaxCacheSize()/(1024*1024);
-        freeMem = 100 - 100*memUsed/totalMem;
         usedMem = 100*memUsed/totalMem;
         hits = cache.getCacheHits();
         misses = cache.getCacheMisses();
@@ -208,7 +207,7 @@
         else {
             double hitValue = 100*(double)hits/(hits+misses);
             hitPercent = percentFormat.format(hitValue) + "%";
-            lowEffec = (hits > 500 && hitValue < 85.0 && freeMem < 20.0);
+            lowEffec = (hits+misses > 500 && hitValue < 85.0 && usedMem >= 80.0);
         }
         if (cache instanceof CacheWrapper && ((CacheWrapper) cache).getWrappedCache() instanceof DefaultCache) {
             culls = new Long[3];


### PR DESCRIPTION
Openfire uses various caches. The admin console displays a warning when the cache isn't very effective (hinting that reconfiguration is needed.

The current formula to determine if a cache is ineffective, combines these three parts (which all must be true):
- amount of successful cache lookups is more than 500
- percentage of successful cache lookups is less than 85%
- the amount of unused capacity in the case is 20% or less

The first condition is likely introduced with the intention to avoid having caches marked as 'ineffective' when they're hardly used (or when the system just started). However, this causes the cache to _not_ be marked 'ineffective' in a scenario where it has many, many lookups, but none of them successful (which clearly is an ineffective cache).

The first part of the formula should be based on _all_ lookups, not just on the successful ones.