### PR TITLE
OF-1801: Cache low effectivity should be shown more prominent

### DIFF
--- a/xmppserver/src/main/webapp/system-cache.jsp
+++ b/xmppserver/src/main/webapp/system-cache.jsp
@@ -222,7 +222,7 @@
         // OF-1365: Don't allow caches that do not expire to be purged. Many of these caches store data that cannot be recovered again.
         final boolean canPurge = cache.getMaxLifetime() > -1;
 %>
-    <tr class="<%= (lowEffec ? "jive-error" : "") %>">
+    <tr>
         <td class="c1">
             <table cellpadding="0" cellspacing="0" border="0">
             <tr>
@@ -262,7 +262,9 @@
             <%=numberFormatter.format(hits)%>/<%=numberFormatter.format(hits + misses)%>&nbsp;
         </td>
         <td class="c4" style="text-align: left; padding-left:0;">
+            <% if (lowEffec) { %><span style="color: red;"><% } %>
             (<%=hitPercent%>)
+            <% if (lowEffec) { %>*</span><% } %>
         </td>
         <td class="c4" style="text-align: center">
             <% if (culls != null) {%>


### PR DESCRIPTION
This improves the visibility of ineffective cache usage in the admin console.

This is a screenshot of ineffective caches, after the changes in this commit were applied:

![image](https://user-images.githubusercontent.com/4253898/59837803-280a3300-934e-11e9-8aea-cc4043eb6be7.png)

I've opted to both use a red color, as well as a small asterisk, to help people that have trouble seeing colors.
