### PR TITLE
OF-1802: Fix IQ error when using invalid resource during bind.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
@@ -89,7 +89,7 @@ public class IQBindHandler extends IQHandler {
             try {
                 resource = JID.resourceprep(resource);
             }
-            catch (StringprepException e) {
+            catch (StringprepException | IllegalArgumentException e) {
                 reply.setChildElement(packet.getChildElement().createCopy());
                 reply.setError(PacketError.Condition.jid_malformed);
                 // Send the error directly since a route does not exist at this point.


### PR DESCRIPTION
The missing 'catch' statement caused the exception to be handled by the caller class, which applies a generic error.