### PR TITLE
remove un-needed search.jar copy in build scripts

### DIFF
--- a/build/debian/build_debs.sh
+++ b/build/debian/build_debs.sh
@@ -20,8 +20,6 @@ fi
 mkdir -p $WORKDIR
 
 cp -r distribution/target/distribution-base/. $WORKDIR/
-# Need to copy in plugins that are defaulted to distribute
-cp -f plugins/search/target/search.jar $WORKDIR/plugins/
 
 mkdir -p $WORKDIR/debian
 cp build/debian/* $WORKDIR/debian/

--- a/build/rpm/build_rpms.sh
+++ b/build/rpm/build_rpms.sh
@@ -46,9 +46,6 @@ else
     export OPENFIRE_RELEASE="1"
 fi
 
-# Need to copy in plugins that are defaulted to distribute
-cp -f plugins/search/target/search.jar distribution/target/distribution-base/plugins/
-
 # generate our psuedo source tree, which is actually dist tree from maven
 cd distribution/target
 cp -r distribution-base openfire


### PR DESCRIPTION
maven already provides `search.jar` thanks to some work @GregDThomas did.