### PR TITLE
OF-1804: Retain original formatting when logging messages

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/ConversationLogEntry.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/ConversationLogEntry.java
@@ -59,7 +59,7 @@ class ConversationLogEntry {
         this.date = date;
         this.subject = message.getSubject();
         this.body = message.getBody();
-        this.stanza = message.toString();
+        this.stanza = message.toXML();
         this.sender = sender;
         this.roomID = room.getID();
         this.nickname = message.getFrom().getResource();


### PR DESCRIPTION
toString() applies a pretty print formatter, which mangles the formatting of message text. This introduces https://github.com/igniterealtime/openfire-monitoring-plugin/issues/36