### PR TITLE
skip travis deployment step for non-ignite builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
 install: true
 deploy:
   provider: script
-  script: mvn deploy --settings target/ci-tooling/maven-settings-for-openfire-plugins.xml  -P ci
+  script: if [ "$TRAVIS_REPO_SLUG" = "igniterealtime/Openfire" ]; then mvn deploy --settings target/ci-tooling/maven-settings-for-openfire-plugins.xml -P ci; else echo "Skip deploy"; fi
   skip_cleanup: true
   on:
     all_branches: true


### PR DESCRIPTION
Developers that have Openfire forked and setup for Travis will always see failures due to `deploy` failing (rightfully so).  This change should skip the `deploy` script when travis is run on the forked repos.  This change [worked](https://travis-ci.org/akrherz/Openfire/builds/551854288) for me.