### PR TITLE
OF-1809 Allow Openfire to include more then one XDataForm

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
@@ -108,7 +108,7 @@ public class AdHocCommandHandler extends IQHandler
 
     @Override
     public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
-        return null;
+        return Collections.<DataForm>emptySet();
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
@@ -107,8 +107,8 @@ public class AdHocCommandHandler extends IQHandler
     }
 
     @Override
-    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
+    public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
+        return DiscoInfoProvider.super.getExtendedInfos(name, node, senderJID);
     }
 
     @Override
@@ -240,5 +240,10 @@ public class AdHocCommandHandler extends IQHandler
     private void stopCommand(AdHocCommand command) {
         infoHandler.removeServerNodeInfoProvider(command.getCode());
         itemsHandler.removeServerNodeInfoProvider(command.getCode());
+    }
+
+    @Override
+    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+        return null;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
@@ -244,6 +244,6 @@ public class AdHocCommandHandler extends IQHandler
 
     @Override
     public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
+        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
@@ -108,7 +108,7 @@ public class AdHocCommandHandler extends IQHandler
 
     @Override
     public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
-        return DiscoInfoProvider.super.getExtendedInfos(name, node, senderJID);
+        return null;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
@@ -244,6 +244,6 @@ public class AdHocCommandHandler extends IQHandler
 
     @Override
     public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
+        return null;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoInfoProvider.java
@@ -21,6 +21,8 @@ import org.xmpp.forms.DataForm;
 import org.xmpp.packet.JID;
 
 import java.util.Iterator;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * A DiscoInfoProvider is responsible for providing information about a JID's name and its node. For
@@ -67,8 +69,24 @@ public interface DiscoInfoProvider {
      * @param node the requested disco node.
      * @param senderJID the XMPPAddress of user that sent the disco info request.
      * @return an XDataForm with the extended information about the entity or null if none.
+     * @deprecated Replaced by {@link #getExtendedInfos(String, String, JID)}
      */
+    @Deprecated
     DataForm getExtendedInfo( String name, String node, JID senderJID );
+
+    /**
+     * Returns a collection of XDataForm with the extended information about the
+     * entity or null if none. Each bit of information about the entity must be
+     * included as a value of a field of the form.
+     *
+     * @param name the recipient JID's name.
+     * @param node the requested disco node.
+     * @param senderJID the XMPPAddress of user that sent the disco info request.
+     * @return A collection of XDataForms with the extended information about the entity or an empty collection if none.
+     */
+    default Set<DataForm> getExtendedInfos( String name, String node, JID senderJID ) {
+        return Collections.singleton( getExtendedInfo( name, node, senderJID ));
+    }
 
     /**
      * Returns true if we can provide information related to the requested name and node. For

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -16,9 +16,12 @@
 
 package org.jivesoftware.openfire.disco;
 
+import org.apache.juli.logging.Log;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.QName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jivesoftware.openfire.IQHandlerInfo;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
@@ -66,6 +69,7 @@ import java.util.concurrent.locks.Lock;
  */
 public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListener {
 
+    private static final Logger Log = LoggerFactory.getLogger(IQDiscoInfoHandler.class);
     public static final String NAMESPACE_DISCO_INFO = "http://jabber.org/protocol/disco#info";
     private Map<String, DiscoInfoProvider> entities = new HashMap<>();
     private Set<String> localServerFeatures = new CopyOnWriteArraySet<>();
@@ -692,7 +696,19 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
 
             @Override
             public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-                return null;
+                try {
+                    Set<DataForm> dataForms = getExtendedInfos(name, node, senderJID);
+                    if(dataForms != null && dataForms.size() == 1){
+                        return dataForms.iterator().next();
+                    }else if (dataForms != null && dataForms.size() > 1){
+                        Log.warn("Set Data List contains more than one DataForm");
+                        return dataForms.iterator().next();
+                    } else {
+                        return null;
+                    }    
+                } catch (Exception e) {
+                    return null;
+                } 
             }
         };
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -696,17 +696,26 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
 
             @Override
             public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-                Set<DataForm> dataForms = getExtendedInfos(name, node, senderJID);
-                if(dataForms != null && dataForms.size() == 1){
-                    return dataForms.iterator().next();
-                }else if (dataForms != null && dataForms.size() > 1){
-                    Log.warn("Set Data List contains "+dataForms.size()+" DataForms."+
-                    "Only the first one of the DataForms will be returned.");
-                    return dataForms.iterator().next();
-                } else {
-                    return null;
-                }     
+                return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
             }
         };
+    }
+
+    /**
+     * return the first DataForm for a Collections
+     * of Set DataForms
+     * @param dataForms
+     * @return DataForm .
+     */
+    public static DataForm getFirstDataForm(Set<DataForm> dataForms){
+        if(dataForms != null && dataForms.size() == 1){
+            return dataForms.iterator().next();
+        }else if (dataForms != null && dataForms.size() > 1){
+            Log.warn("Set Data List contains "+dataForms.size()+" DataForms."+
+            "Only the first one of the DataForms will be returned.");
+            return dataForms.iterator().next();
+        } else {
+            return null;
+        }
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -193,10 +193,13 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                 }
 
                 // Add to the reply the extended info (XDataForm) provided by the DiscoInfoProvider
-                DataForm dataForm = infoProvider.getExtendedInfo(name, node, packet.getFrom());
-                if (dataForm != null) {
-                    queryElement.add(dataForm.getElement());
+                Set<DataForm>  dataForms = infoProvider.getExtendedInfos(name, node, packet.getFrom());
+                for(DataForm dataForm : dataForms){
+                    if (dataForm != null) {
+                        queryElement.add(dataForm.getElement());
+                    }
                 }
+                
             }
             else {
                 // If the DiscoInfoProvider has no information for the requested name and node 
@@ -630,12 +633,11 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                     return false;
                 }
             }
-
             @Override
-            public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+            public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
                 if (node != null && serverNodeProviders.get(node) != null) {
                     // Redirect the request to the disco info provider of the specified node
-                    return serverNodeProviders.get(node).getExtendedInfo(name, node, senderJID);
+                    return serverNodeProviders.get(node).getExtendedInfos(name, node, senderJID);
                 }
                 if (name == null || name.equals(XMPPServer.getInstance().getServerInfo().getXMPPDomain())) {
                     // Answer extended info of the server itself.
@@ -677,13 +679,19 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                                 continue;
                             }
                         }
-
-                        return dataForm;
+                        final Set<DataForm> dataForms = new HashSet<>();
+                        dataForms.add(dataForm);
+                        return dataForms;
                     }
                 }
                 if (node != null && name != null) {
-                    return XMPPServer.getInstance().getIQPEPHandler().getExtendedInfo(name, node, senderJID);
+                    return XMPPServer.getInstance().getIQPEPHandler().getExtendedInfos(name, node, senderJID);
                 }
+                return null;
+            }
+
+            @Override
+            public DataForm getExtendedInfo(String name, String node, JID senderJID) {
                 return null;
             }
         };

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -696,19 +696,16 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
 
             @Override
             public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-                try {
-                    Set<DataForm> dataForms = getExtendedInfos(name, node, senderJID);
-                    if(dataForms != null && dataForms.size() == 1){
-                        return dataForms.iterator().next();
-                    }else if (dataForms != null && dataForms.size() > 1){
-                        Log.warn("Set Data List contains more than one DataForm");
-                        return dataForms.iterator().next();
-                    } else {
-                        return null;
-                    }    
-                } catch (Exception e) {
+                Set<DataForm> dataForms = getExtendedInfos(name, node, senderJID);
+                if(dataForms != null && dataForms.size() == 1){
+                    return dataForms.iterator().next();
+                }else if (dataForms != null && dataForms.size() > 1){
+                    Log.warn("Set Data List contains "+dataForms.size()+" DataForms."+
+                    "Only the first one of the DataForms will be returned.");
+                    return dataForms.iterator().next();
+                } else {
                     return null;
-                } 
+                }     
             }
         };
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -709,11 +709,11 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
      */
     public static DataForm getFirstDataForm(Set<DataForm> dataForms){
         if(dataForms != null && dataForms.size() == 1){
-            return dataForms.iterator().next();
+            return dataForms.stream().findFirst().get();
         }else if (dataForms != null && dataForms.size() > 1){
             Log.warn("Set Data List contains "+dataForms.size()+" DataForms."+
             "Only the first one of the DataForms will be returned.");
-            return dataForms.iterator().next();
+            return dataForms.stream().findFirst().get();
         } else {
             return null;
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
@@ -382,7 +382,7 @@ public class FileTransferProxy extends BasicModule
     
     @Override
     public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
-        return DiscoInfoProvider.super.getExtendedInfos(name, node, senderJID);
+        return null;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
@@ -461,6 +461,6 @@ public class FileTransferProxy extends BasicModule
 
     @Override
     public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
+        return null;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
@@ -378,10 +378,10 @@ public class FileTransferProxy extends BasicModule
         return Arrays.asList(FileTransferManager.NAMESPACE_BYTESTREAMS,
                              "http://jabber.org/protocol/disco#info").iterator();
     }
-
+    
     @Override
-    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
+    public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
+        return DiscoInfoProvider.super.getExtendedInfos(name, node, senderJID);
     }
 
     @Override
@@ -456,5 +456,10 @@ public class FileTransferProxy extends BasicModule
         @Override
         public void xmlPropertyDeleted(String property, Map params) {
         }
+    }
+
+    @Override
+    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+        return null;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
@@ -386,6 +386,11 @@ public class FileTransferProxy extends BasicModule
     }
 
     @Override
+    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+        return null;
+    }
+    
+    @Override
     public boolean hasInfo(String name, String node, JID senderJID) {
         return true;
     }
@@ -457,10 +462,5 @@ public class FileTransferProxy extends BasicModule
         @Override
         public void xmlPropertyDeleted(String property, Map params) {
         }
-    }
-
-    @Override
-    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
@@ -382,7 +382,7 @@ public class FileTransferProxy extends BasicModule
     
     @Override
     public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
-        return null;
+        return Collections.<DataForm>emptySet();
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
@@ -36,6 +36,7 @@ import org.jivesoftware.openfire.disco.DiscoInfoProvider;
 import org.jivesoftware.openfire.disco.DiscoItem;
 import org.jivesoftware.openfire.disco.DiscoItemsProvider;
 import org.jivesoftware.openfire.disco.DiscoServerItem;
+import org.jivesoftware.openfire.disco.IQDiscoInfoHandler;
 import org.jivesoftware.openfire.disco.ServerItemsProvider;
 import org.jivesoftware.openfire.filetransfer.FileTransferManager;
 import org.jivesoftware.util.JiveGlobals;
@@ -460,6 +461,6 @@ public class FileTransferProxy extends BasicModule
 
     @Override
     public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
+        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
@@ -178,6 +178,11 @@ public class IQOfflineMessagesHandler extends IQHandler implements ServerFeature
     }
 
     @Override
+    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
+    }
+    
+    @Override
     public boolean hasInfo(String name, String node, JID senderJID) {
         return NAMESPACE.equals(node) && userManager.isRegisteredUser(senderJID.getNode());
     }
@@ -224,10 +229,5 @@ public class IQOfflineMessagesHandler extends IQHandler implements ServerFeature
         if (session != null) {
             session.setOfflineFloodStopped(true);
         }
-    }
-
-    @Override
-    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
@@ -45,8 +45,10 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Implements JEP-0013: Flexible Offline Message Retrieval. Allows users to request number of
@@ -155,7 +157,7 @@ public class IQOfflineMessagesHandler extends IQHandler implements ServerFeature
     }
 
     @Override
-    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+    public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
         // Mark that offline messages shouldn't be sent when the user becomes available
         stopOfflineFlooding(senderJID);
 
@@ -169,8 +171,10 @@ public class IQOfflineMessagesHandler extends IQHandler implements ServerFeature
         final FormField field2 = dataForm.addField();
         field2.setVariable("number_of_messages");
         field2.addValue(String.valueOf(messageStore.getMessages(senderJID.getNode(), false).size()));
-
-        return dataForm;
+        
+        final Set<DataForm> dataForms = new HashSet<>();
+        dataForms.add(dataForm);
+        return dataForms;
     }
 
     @Override
@@ -220,5 +224,10 @@ public class IQOfflineMessagesHandler extends IQHandler implements ServerFeature
         if (session != null) {
             session.setOfflineFloodStopped(true);
         }
+    }
+
+    @Override
+    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+        return null;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
@@ -228,6 +228,6 @@ public class IQOfflineMessagesHandler extends IQHandler implements ServerFeature
 
     @Override
     public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
+        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
@@ -40,6 +40,7 @@ import org.jivesoftware.openfire.disco.DiscoInfoProvider;
 import org.jivesoftware.openfire.disco.DiscoItem;
 import org.jivesoftware.openfire.disco.DiscoItemsProvider;
 import org.jivesoftware.openfire.disco.DiscoServerItem;
+import org.jivesoftware.openfire.disco.IQDiscoInfoHandler;
 import org.jivesoftware.openfire.disco.ServerItemsProvider;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
@@ -492,6 +493,6 @@ public class MediaProxyService extends BasicModule
 
     @Override
     public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
+        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
@@ -494,6 +494,6 @@ public class MediaProxyService extends BasicModule
 
     @Override
     public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
+        return null;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
@@ -21,6 +21,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -352,7 +353,7 @@ public class MediaProxyService extends BasicModule
     
     @Override
     public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
-        return null;
+        return Collections.<DataForm>emptySet();
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
@@ -352,7 +352,7 @@ public class MediaProxyService extends BasicModule
     
     @Override
     public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
-        return DiscoInfoProvider.super.getExtendedInfos(name, node, senderJID);
+        return null;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.dom4j.Attribute;
 import org.dom4j.DocumentHelper;
@@ -347,10 +348,10 @@ public class MediaProxyService extends BasicModule
         return Arrays.asList(NAMESPACE,
                 "http://jabber.org/protocol/disco#info").iterator();
     }
-
+    
     @Override
-    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
+    public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
+        return DiscoInfoProvider.super.getExtendedInfos(name, node, senderJID);
     }
 
     @Override
@@ -487,5 +488,10 @@ public class MediaProxyService extends BasicModule
      */
     public void setEchoPort(int echoPort) {
         this.echoPort = echoPort;
+    }
+
+    @Override
+    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+        return null;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1597,7 +1597,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     }
 
     @Override
-    public DataForm getExtendedInfo(final String name, final String node, final JID senderJID) {
+    public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
         if (name != null && node == null) {
             // Answer the extended info of a given room
             final MUCRoom room = getChatRoom(name);
@@ -1633,8 +1633,9 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                 fieldDate.setVariable("x-muc#roominfo_creationdate");
                 fieldDate.setLabel(LocaleUtils.getLocalizedString("muc.extended.info.creationdate"));
                 fieldDate.addValue(XMPPDateTimeFormat.format(room.getCreationDate()));
-
-                return dataForm;
+                final Set<DataForm> dataForms = new HashSet<>();
+                dataForms.add(dataForm);
+                return dataForms;
             }
         }
         return null;
@@ -1810,6 +1811,11 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     @Override
     public boolean isHidden() {
         return isHidden;
+    }
+
+    @Override
+    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+        return null;
     }
 
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1815,7 +1815,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
 
     @Override
     public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
+        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
     }
 
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -705,14 +705,20 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
     }
 
     @Override
-    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+    public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
         String recipientJID = XMPPServer.getInstance().createJID(name, null, true).toBareJID();
         PEPService pepService = pepServiceManager.getPEPService(recipientJID);
         if (node != null) {
             // Answer the extended info of a given node
-            Node pubNode = pepService.getNode(node);
+            Collection<Node> pubNodes = pepService.getNodes();
+            final Set<DataForm> dataForms = new HashSet<>();
+            for(Node nod :pubNodes){
+                if(nod.equals(pepService.getNode(node))){
+                   dataForms.add(nod.getMetadataForm());
+                }
+            }
             // Get the metadata data form
-            return pubNode.getMetadataForm();
+            return dataForms;
         }
         return null;
     }
@@ -753,5 +759,10 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
                 // Do nothing
             }
         }    	
+    }
+
+    @Override
+    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+        return null;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -763,6 +763,6 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
 
     @Override
     public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
+        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -710,14 +710,10 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
         PEPService pepService = pepServiceManager.getPEPService(recipientJID);
         if (node != null) {
             // Answer the extended info of a given node
-            Collection<Node> pubNodes = pepService.getNodes();
-            final Set<DataForm> dataForms = new HashSet<>();
-            for(Node nod :pubNodes){
-                if(nod.equals(pepService.getNode(node))){
-                   dataForms.add(nod.getMetadataForm());
-                }
-            }
+            Node pubNode = pepService.getNode(node);
             // Get the metadata data form
+            final Set<DataForm> dataForms = new HashSet<>();
+            dataForms.add(pubNode.getMetadataForm());
             return dataForms;
         }
         return null;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -886,6 +886,6 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
 
     @Override
     public DataForm getExtendedInfo(String name, String node, JID senderJID) {
-        return null;
+        return IQDiscoInfoHandler.getFirstDataForm(getExtendedInfos(name, node, senderJID));
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -699,17 +699,13 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
     public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
         if (name == null && node != null) {
             // Answer the extended info of a given node
-            Collection<Node> pubNodes = getNodes();
+            Node pubNode = getNode(node);
             Set<DataForm> dataForms = new HashSet<>();
-            for (Node nod:pubNodes){
-                if(nod.equals(getNode(node))){
-                    if (canDiscoverNode(nod)) {
-                        // Get the metadata data form
-                        dataForms.add(nod.getMetadataForm());
-                    }
-                }
+            if (canDiscoverNode(pubNode)) {
+                dataForms.add(pubNode.getMetadataForm());
+                // Get the metadata data form
+                return dataForms;
             }
-            return dataForms;
         }
         return null;
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -18,9 +18,11 @@ package org.jivesoftware.openfire.pubsub;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -692,16 +694,22 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
         }
         return features.iterator();
     }
-
+    
     @Override
-    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+    public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
         if (name == null && node != null) {
             // Answer the extended info of a given node
-            Node pubNode = getNode(node);
-            if (canDiscoverNode(pubNode)) {
-                // Get the metadata data form
-                return pubNode.getMetadataForm();
+            Collection<Node> pubNodes = getNodes();
+            Set<DataForm> dataForms = new HashSet<>();
+            for (Node nod:pubNodes){
+                if(nod.equals(getNode(node))){
+                    if (canDiscoverNode(nod)) {
+                        // Get the metadata data form
+                        dataForms.add(nod.getMetadataForm());
+                    }
+                }
             }
+            return dataForms;
         }
         return null;
     }
@@ -874,5 +882,10 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
     @Override
     public void xmlPropertyDeleted(String property, Map<String, Object> params) {
         // Do nothing
+    }
+
+    @Override
+    public DataForm getExtendedInfo(String name, String node, JID senderJID) {
+        return null;
     }
 }


### PR DESCRIPTION
https://xmpp.org/extensions/xep-0128.html#impl defines that a Service Discovery Info response can include more than one "extended info" dataform.

Openfire should allow for this. It currently allows for at most one form.

Openfire should be modified to allow for a set of dataforms to be returned. At the same time, it is desirable that the API change does not break existing (third party) code.