### PR TITLE
OF-1811: Prevent NPE in GroupManager

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -364,6 +364,10 @@ public class GroupManager {
                 }
             }
         }
+
+        if (coGroup.isAbsent() ) {
+            throw new GroupNotFoundException( "Group with name " + name + " not found (cached)." );
+        };
         return coGroup.get();
     }
 


### PR DESCRIPTION
This commit ensures that a previously cached negative result ('no such group') causes an exception to be thrown, rather than null to be returned.