### PR TITLE
OF-1814: Fix delete conference service

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1327,7 +1327,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         routingTable.removeComponentRoute(getAddress());
         broadcastShutdown();
         XMPPServer.getInstance().removeServerListener( this );
-        XMPPServer.getInstance().getArchiveManager().add( archiver );
+        XMPPServer.getInstance().getArchiveManager().remove( archiver );
     }
 
     @Override


### PR DESCRIPTION
When stopping a service, the archiver should be removed, not added (again).