### PR TITLE
OF-1818: Some errors in Openfire sybase db script and last 5 upgrade scripts are corrected.

### DIFF
--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -1,10 +1,9 @@
-
 CREATE TABLE ofUser (
   username              NVARCHAR(64)    NOT NULL,
-  storedKey             VARCHAR(32),
-  serverKey             VARCHAR(32),
-  salt                  VARCHAR(32),
-  iterations            INTEGER,
+  storedKey             VARCHAR(32)     NULL,
+  serverKey             VARCHAR(32)     NULL,
+  salt                  VARCHAR(32)     NULL,
+  iterations            INTEGER         NULL,
   plainPassword         NVARCHAR(32)    NULL,
   encryptedPassword     NVARCHAR(255)   NULL,
   name                  NVARCHAR(100)   NULL,
@@ -12,8 +11,8 @@ CREATE TABLE ofUser (
   creationDate          CHAR(15)        NOT NULL,
   modificationDate      CHAR(15)        NOT NULL,
   CONSTRAINT ofUser_pk PRIMARY KEY (username)
-);
-CREATE INDEX ofUser_cDate_idx ON ofUser (creationDate ASC);
+)
+CREATE INDEX ofUser_cDate_idx ON ofUser (creationDate ASC)
 
 
 CREATE TABLE ofUserProp (
@@ -21,7 +20,7 @@ CREATE TABLE ofUserProp (
   name                  NVARCHAR(100)   NOT NULL,
   propValue             TEXT            NOT NULL,
   CONSTRAINT ofUserProp_pk PRIMARY KEY (username, name)
-);
+)
 
 
 CREATE TABLE ofUserFlag (
@@ -30,9 +29,9 @@ CREATE TABLE ofUserFlag (
   startTime             CHAR(15),
   endTime               CHAR(15),
   CONSTRAINT ofUserFlag_pk PRIMARY KEY (username, name)
-);
-CREATE INDEX ofUserFlag_sTime_idx ON ofUserFlag (startTime ASC);
-CREATE INDEX ofUserFlag_eTime_idx ON ofUserFlag (endTime ASC);
+)
+CREATE INDEX ofUserFlag_sTime_idx ON ofUserFlag (startTime ASC)
+CREATE INDEX ofUserFlag_eTime_idx ON ofUserFlag (endTime ASC)
 
 
 CREATE TABLE ofOffline (
@@ -42,29 +41,29 @@ CREATE TABLE ofOffline (
   messageSize           INTEGER         NOT NULL,
   stanza                TEXT            NOT NULL,
   CONSTRAINT ofOffline_pk PRIMARY KEY (username, messageID)
-);
- 
+)
+
 
 CREATE TABLE ofPresence (
   username              NVARCHAR(64)    NOT NULL,
   offlinePresence       TEXT,
   offlineDate           CHAR(15)        NOT NULL,
   CONSTRAINT ofPresence_pk PRIMARY KEY (username)
-);
+)
 
 
 CREATE TABLE ofRoster (
   rosterID              INTEGER         NOT NULL,
   username              NVARCHAR(64)    NOT NULL,
-  jid                   TEXT            NOT NULL,
+  jid                   NVARCHAR(1024)   NOT NULL,
   sub                   INTEGER         NOT NULL,
   ask                   INTEGER         NOT NULL,
   recv                  INTEGER         NOT NULL,
   nick                  NVARCHAR(255)   NULL,
   CONSTRAINT ofRoster_pk PRIMARY KEY (rosterID)
-);
-CREATE INDEX ofRoster_username_idx ON ofRoster (username ASC);
-CREATE INDEX ofRoster_jid_idx ON ofRoster (jid ASC);
+)
+CREATE INDEX ofRoster_username_idx ON ofRoster (username ASC)
+CREATE INDEX ofRoster_jid_idx ON ofRoster (jid ASC)
 
 
 CREATE TABLE ofRosterGroups (
@@ -72,23 +71,23 @@ CREATE TABLE ofRosterGroups (
   rank                  INTEGER         NOT NULL,
   groupName             NVARCHAR(255)   NOT NULL,
   CONSTRAINT ofRosterGroups_pk PRIMARY KEY (rosterID, rank)
-);
-CREATE INDEX ofRosterGroups_rosterid_idx ON ofRosterGroups (rosterID ASC);
-ALTER TABLE ofRosterGroups ADD CONSTRAINT ofRosterGroups_rosterID_fk FOREIGN KEY (rosterID) REFERENCES ofRoster;
+)
+CREATE INDEX ofRosterGroups_rosterid_idx ON ofRosterGroups (rosterID ASC)
+ALTER TABLE ofRosterGroups ADD CONSTRAINT ofRosterGroups_rosterID_fk FOREIGN KEY (rosterID) REFERENCES ofRoster
 
 
 CREATE TABLE ofVCard (
   username              NVARCHAR(64)    NOT NULL,
   vcard                 TEXT            NOT NULL,
   CONSTRAINT ofVCard_pk PRIMARY KEY (username)
-);
+)
 
 
 CREATE TABLE ofGroup (
   groupName             NVARCHAR(50)   NOT NULL,
   description           NVARCHAR(255)  NULL,
   CONSTRAINT ofGroup_pk PRIMARY KEY (groupName)
-);
+)
 
 
 CREATE TABLE ofGroupProp (
@@ -96,7 +95,7 @@ CREATE TABLE ofGroupProp (
    name                 NVARCHAR(100)  NOT NULL,
    propValue            TEXT           NOT NULL,
    CONSTRAINT ofGroupProp_pk PRIMARY KEY (groupName, name)
-);
+)
 
 
 CREATE TABLE ofGroupUser (
@@ -104,30 +103,30 @@ CREATE TABLE ofGroupUser (
   username              NVARCHAR(100)   NOT NULL,
   administrator         INTEGER         NOT NULL,
   CONSTRAINT ofGroupUser_pk PRIMARY KEY (groupName, username, administrator)
-);
+)
 
 
 CREATE TABLE ofID (
   idType                INTEGER         NOT NULL,
   id                    INTEGER         NOT NULL,
   CONSTRAINT ofID_pk PRIMARY KEY (idType)
-);
+)
 
 
 CREATE TABLE ofProperty (
   name         NVARCHAR(100) NOT NULL,
   propValue    TEXT NOT NULL,
   encrypted    INTEGER,
-  iv           CHAR(24),
+  iv           CHAR(24) NULL,
   CONSTRAINT ofProperty_pk PRIMARY KEY (name)
-);
+)
 
 
 CREATE TABLE ofVersion (
   name     NVARCHAR(50) NOT NULL,
   version  INTEGER  NOT NULL,
   CONSTRAINT ofVersion_pk PRIMARY KEY (name)
-);
+)
 
 CREATE TABLE ofExtComponentConf (
   subdomain             NVARCHAR(255)    NOT NULL,
@@ -135,14 +134,14 @@ CREATE TABLE ofExtComponentConf (
   secret                NVARCHAR(255)    NULL,
   permission            NVARCHAR(10)     NOT NULL,
   CONSTRAINT ofExtComponentConf_pk PRIMARY KEY (subdomain)
-);
+)
 
 CREATE TABLE ofRemoteServerConf (
   xmppDomain            NVARCHAR(255)    NOT NULL,
   remotePort            INTEGER          NULL,
   permission            NVARCHAR(10)     NOT NULL,
   CONSTRAINT ofRemoteServerConf_pk PRIMARY KEY (xmppDomain)
-);
+)
 
 CREATE TABLE ofPrivacyList (
   username              NVARCHAR(64)    NOT NULL,
@@ -150,44 +149,44 @@ CREATE TABLE ofPrivacyList (
   isDefault             INT             NOT NULL,
   list                  TEXT            NOT NULL,
   CONSTRAINT ofPrivacyList_pk PRIMARY KEY (username, name)
-);
-CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
+)
+CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault)
 
 CREATE TABLE ofSASLAuthorized (
   username            NVARCHAR(64)   NOT NULL,
   principal           NVARCHAR(4000) NOT NULL,
   CONSTRAINT ofSASLAuthorized_pk PRIMARY KEY (username, principal)
-);
+)
 
 CREATE TABLE ofSecurityAuditLog (
   msgID                 INTEGER         NOT NULL,
   username              NVARCHAR(64)    NOT NULL,
-  entryStamp            INTEGER         NOT NULL,
+  entryStamp            BIGINT         NOT NULL,
   summary               NVARCHAR(255)   NOT NULL,
   node                  NVARCHAR(255)   NOT NULL,
   details               TEXT,
   CONSTRAINT ofSecurityAuditLog_pk PRIMARY KEY (msgID)
-);
-CREATE INDEX ofSecurityAuditLog_tstamp_idx ON ofSecurityAuditLog (entryStamp);
-CREATE INDEX ofSecurityAuditLog_uname_idx ON ofSecurityAuditLog (username);
+)
+CREATE INDEX ofSecurityAuditLog_tstamp_idx ON ofSecurityAuditLog (entryStamp)
+CREATE INDEX ofSecurityAuditLog_uname_idx ON ofSecurityAuditLog (username)
 
 /* MUC Tables */
 
 CREATE TABLE ofMucService (
   serviceID           INT           NOT NULL,
   subdomain           NVARCHAR(255) NOT NULL,
-  description         NVARCHAR(255),
+  description         NVARCHAR(255) NULL,
   isHidden            INT           NOT NULL,
   CONSTRAINT ofMucService_pk PRIMARY KEY (subdomain)
-);
-CREATE INDEX ofMucService_serviceid_idx ON ofMucService(serviceID);
+)
+CREATE INDEX ofMucService_serviceid_idx ON ofMucService(serviceID)
 
 CREATE TABLE ofMucServiceProp (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(100) NOT NULL,
   propValue           TEXT          NOT NULL,
   CONSTRAINT ofMucServiceProp_pk PRIMARY KEY (serviceID, name)
-);
+)
 
 CREATE TABLE ofMucRoom (
   serviceID           INT           NOT NULL,
@@ -215,23 +214,23 @@ CREATE TABLE ofMucRoom (
   canRegister         INT           NOT NULL,
   allowpm             INT           NULL,
   CONSTRAINT ofMucRoom_pk PRIMARY KEY (serviceID, name)
-);
-CREATE INDEX ofMucRoom_roomid_idx on ofMucRoom(roomID);
-CREATE INDEX ofMucRoom_serviceid_idx on ofMucRoom(sericeID);
+)
+CREATE INDEX ofMucRoom_roomid_idx on ofMucRoom(roomID)
+CREATE INDEX ofMucRoom_serviceid_idx on ofMucRoom(serviceID)
 
 CREATE TABLE ofMucRoomProp (
   roomID                INT             NOT NULL,
   name                  NVARCHAR(100)   NOT NULL,
   propValue             TEXT            NOT NULL,
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
-);
+)
 
 CREATE TABLE ofMucAffiliation (
   roomID              INT            NOT NULL,
   jid                 VARCHAR(255)   NOT NULL,
   affiliation         INT            NOT NULL,
   CONSTRAINT ofMucAffiliation_pk PRIMARY KEY (roomID,jid)
-);
+)
 
 CREATE TABLE ofMucMember (
   roomID              INT            NOT NULL,
@@ -243,7 +242,7 @@ CREATE TABLE ofMucMember (
   email               NVARCHAR(100)  NULL,
   faqentry            NVARCHAR(100)  NULL,
   CONSTRAINT ofMucMember_pk PRIMARY KEY (roomID,jid)
-);
+)
 
 CREATE TABLE ofMucConversationLog (
   roomID              INT            NOT NULL,
@@ -254,9 +253,9 @@ CREATE TABLE ofMucConversationLog (
   subject             NVARCHAR(255)  NULL,
   body                TEXT           NULL,
   stanza                TEXT           NULL
-);
-CREATE INDEX ofMucConversationLog_time_idx ON ofMucConversationLog (logTime);
-CREATE INDEX ofMucConversationLog_msg_id ON ofMucConversationLog (messageID);
+)
+CREATE INDEX ofMucConversationLog_time_idx ON ofMucConversationLog (logTime)
+CREATE INDEX ofMucConversationLog_msg_id ON ofMucConversationLog (messageID)
 
 
 /* PubSub Tables */
@@ -292,7 +291,7 @@ CREATE TABLE ofPubsubNode (
   associationPolicy   NVARCHAR(15)   NULL,
   maxLeafNodes        INT            NULL,
   CONSTRAINT ofPubsubNode_pk PRIMARY KEY (serviceID, nodeID)
-);
+)
 
 CREATE TABLE ofPubsubNodeJIDs (
   serviceID           NVARCHAR(100)  NOT NULL,
@@ -300,14 +299,14 @@ CREATE TABLE ofPubsubNodeJIDs (
   jid                 NVARCHAR(1024) NOT NULL,
   associationType     NVARCHAR(20)   NOT NULL,
   CONSTRAINT ofPubsubNodeJIDs_pk PRIMARY KEY (serviceID, nodeID, jid)
-);
+)
 
 CREATE TABLE ofPubsubNodeGroups (
   serviceID           NVARCHAR(100)  NOT NULL,
   nodeID              NVARCHAR(100)  NOT NULL,
   rosterGroup         NVARCHAR(100)  NOT NULL
-);
-CREATE INDEX ofPubsubNodeGroups_idx ON ofPubsubNodeGroups (serviceID, nodeID);
+)
+CREATE INDEX ofPubsubNodeGroups_idx ON ofPubsubNodeGroups (serviceID, nodeID)
 
 CREATE TABLE ofPubsubAffiliation (
   serviceID           NVARCHAR(100)  NOT NULL,
@@ -315,7 +314,7 @@ CREATE TABLE ofPubsubAffiliation (
   jid                 NVARCHAR(1024) NOT NULL,
   affiliation         NVARCHAR(10)   NOT NULL,
   CONSTRAINT ofPubsubAffiliation_pk PRIMARY KEY (serviceID, nodeID, jid)
-);
+)
 
 CREATE TABLE ofPubsubItem (
   serviceID           NVARCHAR(100)  NOT NULL,
@@ -325,7 +324,7 @@ CREATE TABLE ofPubsubItem (
   creationDate        CHAR(15)       NOT NULL,
   payload             TEXT           NULL,
   CONSTRAINT ofPubsubItem_pk PRIMARY KEY (serviceID, nodeID, id)
-);
+)
 
 CREATE TABLE ofPubsubSubscription (
   serviceID           NVARCHAR(100)  NOT NULL,
@@ -344,7 +343,7 @@ CREATE TABLE ofPubsubSubscription (
   subscriptionDepth   INT            NOT NULL,
   keyword             NVARCHAR(200)  NULL,
   CONSTRAINT ofPubsubSubscription_pk PRIMARY KEY (serviceID, nodeID, id)
-);
+)
 
 CREATE TABLE ofPubsubDefaultConf (
   serviceID           NVARCHAR(100) NOT NULL,
@@ -366,21 +365,21 @@ CREATE TABLE ofPubsubDefaultConf (
   associationPolicy   NVARCHAR(15)  NOT NULL,
   maxLeafNodes        INT           NOT NULL,
   CONSTRAINT ofPubsubDefaultConf_pk PRIMARY KEY (serviceID, leaf)
-);
+)
 
 /* Finally, insert default table values. */
 
-INSERT INTO ofID (idType, id) VALUES (18, 1);
-INSERT INTO ofID (idType, id) VALUES (19, 1);
-INSERT INTO ofID (idType, id) VALUES (23, 1);
-INSERT INTO ofID (idType, id) VALUES (26, 2);
-INSERT INTO ofID (idType, id) VALUES (27, 1);
+INSERT INTO ofID (idType, id) VALUES (18, 1)
+INSERT INTO ofID (idType, id) VALUES (19, 1)
+INSERT INTO ofID (idType, id) VALUES (23, 1)
+INSERT INTO ofID (idType, id) VALUES (26, 2)
+INSERT INTO ofID (idType, id) VALUES (27, 1)
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 30);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 30)
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)
-    VALUES ('admin', 'admin', 'Administrator', 'admin@example.com', '0', '0');
+    VALUES ('admin', 'admin', 'Administrator', 'admin@example.com', '0', '0')
 
 /* Entry for default conference service */
-INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
+INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0)

--- a/distribution/src/database/upgrade/26/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/26/openfire_sybase.sql
@@ -1,4 +1,5 @@
+/*Encrypted column with default value 0 i.e false*/
 ALTER TABLE ofProperty
-  ADD encrypted   INTEGER;
+  ADD encrypted   INTEGER DEFAULT 0
 
-UPDATE ofVersion SET version = 26 WHERE name = 'openfire';
+UPDATE ofVersion SET version = 26 WHERE name = 'openfire'

--- a/distribution/src/database/upgrade/27/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/27/openfire_sybase.sql
@@ -1,4 +1,4 @@
 ALTER TABLE ofProperty
-  ADD iv   CHAR(24);
+  ADD iv   CHAR(24) NULL
 
-UPDATE ofVersion SET version = 27 WHERE name = 'openfire';
+UPDATE ofVersion SET version = 27 WHERE name = 'openfire'

--- a/distribution/src/database/upgrade/28/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/28/openfire_sybase.sql
@@ -1,3 +1,3 @@
 /* The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java */
 /* Update version */
-UPDATE ofVersion SET version = 28 WHERE name = 'openfire';
+UPDATE ofVersion SET version = 28 WHERE name = 'openfire'

--- a/distribution/src/database/upgrade/29/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/29/openfire_sybase.sql
@@ -1,5 +1,5 @@
 /* Only when the update in 28 succeeded, drop the table that was used as its source. */
-DROP TABLE ofPrivate;
+DROP TABLE ofPrivate
 
 /* Update version */
-UPDATE ofVersion SET version = 29 WHERE name = 'openfire';
+UPDATE ofVersion SET version = 29 WHERE name = 'openfire'

--- a/distribution/src/database/upgrade/30/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/30/openfire_sybase.sql
@@ -1,3 +1,3 @@
-INSERT INTO ofID (idType, id) VALUES (27, (SELECT coalesce(max(messageID), 1) FROM ofMucConversationLog) );
+INSERT INTO ofID (idType, id) (SELECT 27, coalesce(max(messageID), 1) FROM ofMucConversationLog)
 
-UPDATE ofVersion SET version = 30 WHERE name = 'openfire';
+UPDATE ofVersion SET version = 30 WHERE name = 'openfire'


### PR DESCRIPTION
In Sybase every column should be defined NONNULL/NULL constraint, observed some columns without NONNULL/NULL, fixed by adding NULL to columns.
Semicolons are removed because it stopping script to execute in Sybase.
Corrected some datatypes which are not supporting for Sybase.
Column name "serviceID" is corrected in index "ofMucRoom_serviceid_idx".
Also, corrected last 5 upgrade scripts.