### PR TITLE
Travis: explicitly define distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: java
 addons:


### PR DESCRIPTION
Recently, the default distribution used by Travis was changed from 'trusty' to 'xenial'. See https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

In Xenial, oraclejdk8 is not available (although openjdk8 is).

Openfire depends on oraclejdk8. This commit explicitly defines 'trusty' to be used, which should make oraclejdk8 available again.