### PR TITLE
OF-1817: Fix a ClassCastException in LocalMUCRoom.java

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryRequest.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryRequest.java
@@ -131,7 +131,7 @@ public class HistoryRequest {
      * @param joinRole the user that will receive the history.
      * @param roomHistory the history of the room.
      */
-    public void sendHistory(LocalMUCRole joinRole, MUCRoomHistory roomHistory) {
+    public void sendHistory(MUCRole joinRole, MUCRoomHistory roomHistory) {
         if (!isConfigured()) {
             Iterator<Message> history = roomHistory.getMessageHistory();
             while (history.hasNext()) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -21,7 +21,6 @@ import org.jivesoftware.database.JiveID;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.muc.spi.IQAdminHandler;
 import org.jivesoftware.openfire.muc.spi.IQOwnerHandler;
-import org.jivesoftware.openfire.muc.spi.LocalMUCRole;
 import org.jivesoftware.openfire.muc.spi.LocalMUCUser;
 import org.jivesoftware.openfire.user.UserAlreadyExistsException;
 import org.jivesoftware.openfire.user.UserNotFoundException;
@@ -247,7 +246,7 @@ public interface MUCRoom extends Externalizable, Result {
      * @throws NotAcceptableException       If the registered user is trying to join with a
      *                                      nickname different than the reserved nickname.
      */
-    LocalMUCRole joinRoom(String nickname, String password, HistoryRequest historyRequest, LocalMUCUser user,
+    MUCRole joinRoom(String nickname, String password, HistoryRequest historyRequest, LocalMUCUser user,
             Presence presence) throws UnauthorizedException, UserAlreadyExistsException,
             RoomLockedException, ForbiddenException, RegistrationRequiredException,
             ConflictException, ServiceUnavailableException, NotAcceptableException;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -549,7 +549,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
     }
 
     @Override
-    public LocalMUCRole joinRoom(String nickname, String password, HistoryRequest historyRequest,
+    public MUCRole joinRoom(String nickname, String password, HistoryRequest historyRequest,
             LocalMUCUser user, Presence presence) throws UnauthorizedException,
             UserAlreadyExistsException, RoomLockedException, ForbiddenException,
             RegistrationRequiredException, ConflictException, ServiceUnavailableException,
@@ -560,7 +560,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
                 throw new UnauthorizedException();
             }
         }
-        LocalMUCRole joinRole = null;
+        MUCRole joinRole = null;
         lock.writeLock().lock();
         boolean clientOnlyJoin = false;
         // A "client only join" here is one where the client is already joined, but has re-joined.
@@ -682,7 +682,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
                 occupantsByFullJID.put(user.getAddress(), joinRole);
             } else {
                 // Grab the existing one.
-                joinRole = (LocalMUCRole) occupantsByFullJID.get(user.getAddress());
+                joinRole = occupantsByFullJID.get(user.getAddress());
                 joinRole.setPresence( presence ); // OF-1581: Use latest presence information.
            }
         }
@@ -764,7 +764,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
      *
      * @param joinRole the role of the new occupant in the room.
      */
-    private void sendInitialPresences(LocalMUCRole joinRole) {
+    private void sendInitialPresences(MUCRole joinRole) {
         for (MUCRole occupant : occupantsByFullJID.values()) {
             if (occupant == joinRole) {
                 continue;


### PR DESCRIPTION
When using the Openfire with the hazelcast plugin we had some ClassCastExceptions in the LocalMucRoom at line 685 like: 

`java.lang.ClassCastException: org.jivesoftware.openfire.plugin.session.RemoteClientSession cannot be cast to org.jivesoftware.openfire.session.LocalClientSession`

For my bad, I don't have the full stack trace.

With this pull request this error does not occur anymore. It lets the three classes use the interface and not the implementing class.

This may only fix one symptom of another problem.
