### PR TITLE
OF-1826: Prevent NPE in new DataForms implementation.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -195,10 +195,9 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                     queryElement.addElement("feature").addAttribute("var", NAMESPACE_DISCO_INFO);
                 }
                 // Add to the reply the multiple extended info (XDataForm) provided by the DiscoInfoProvider
-                Iterator<DataForm> dataForms = infoProvider.getExtendedInfos(name, node, packet.getFrom()).iterator();
-                while (dataForms.hasNext()) {
-                    final DataForm dataForm = dataForms.next();
-                    queryElement.add(dataForm.getElement());
+                final Set<DataForm> dataForms = infoProvider.getExtendedInfos( name, node, packet.getFrom() );
+                if ( dataForms != null ) {
+                    dataForms.forEach( dataForm -> queryElement.add( dataForm.getElement() ) );
                 }
             }
             else {
@@ -710,7 +709,7 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                 if (node != null && name != null) {
                     return XMPPServer.getInstance().getIQPEPHandler().getExtendedInfos(name, node, senderJID);
                 }
-                return null;
+                return Collections.emptySet();
             }
         };
     }


### PR DESCRIPTION
The implementation introduced by OF-1809 causes collections of DataForm instances to be processed.

The new contract defines that a set must be present - null values are not allowed.

It's easy to overlook this new contract. For example, our own code returned a null value, instead of an empty collection.

This commit modifies the return of a null value (it now returns an empty value). Additionally, this PR adds a guard for problems like this, by explicitly checking of a value is null.