### PR TITLE
OF-1828 Fix that an empty string can not be inserted in ofgroupporp.propvalue

### DIFF
--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -92,7 +92,7 @@ CREATE TABLE ofGroup (
 CREATE TABLE ofGroupProp (
   groupName             VARCHAR(50)     NOT NULL,
   name                  VARCHAR2(100)   NOT NULL,
-  propValue             VARCHAR2(4000)  NOT NULL,
+  propValue             VARCHAR2(4000)  NULL,
   CONSTRAINT ofGroupProp_pk PRIMARY KEY (groupName, name)
 );
 


### PR DESCRIPTION
Hi,

please see https://discourse.igniterealtime.org/t/cannot-insert-null-into-openfire2-ofgroupprop-propvalue/52384