### PR TITLE
OF-1827: Make SSLContext protocol configurable

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1594,6 +1594,7 @@ system_property.hybridAuthProvider.primaryProvider.className=The first class the
 system_property.hybridAuthProvider.secondaryProvider.className=The second class the HybridAuthProvider should to use to authenticate users
 system_property.hybridAuthProvider.tertiaryProvider.className=The third class the HybridAuthProvider should to use to authenticate users
 system_property.admin.authorizedJIDs=The bare JID of every admin user for the DefaultAdminProvider
+system_property.xmpp.auth.ssl.context_protocol=The TLS protocol to use for encryption context initialization, overriding the Java default.
 system_property.xmpp.socket.ssl.active=Set to true to enable legacy encrypted connections for clients, otherwise false
 system_property.xmpp.component.ssl.active=Set to true to enable legacy encrypted connections for external components, otherwise false
 system_property.sasl.scram-sha-1.iteration-count=The number of iterations when salting a users password. Changing this \

--- a/xmppserver/src/main/java/org/jivesoftware/util/SimpleSSLSocketFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SimpleSSLSocketFactory.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.util;
 
+import org.jivesoftware.openfire.spi.EncryptionArtifactFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,7 @@ public class SimpleSSLSocketFactory extends SSLSocketFactory implements Comparat
     public SimpleSSLSocketFactory() {
 
         try {
-            final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+            final SSLContext sslContext = EncryptionArtifactFactory.getUninitializedSSLContext();
             sslContext.init(null, // KeyManager not required
                             new TrustManager[] { new DummyTrustManager() },
                             new java.security.SecureRandom());


### PR DESCRIPTION
This commit removes the hardcoded TLSv1 protocol that was used to initialize most SSLContexts. It is replaces by a Java-provided default, which can be overridden by a new property, xmpp.auth.ssl.context_protocol.