### PR TITLE
Ignore flaky test that fails in slower environments

### DIFF
--- a/xmppserver/src/test/java/org/jivesoftware/openfire/handler/IQEntityTimeHandlerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/handler/IQEntityTimeHandlerTest.java
@@ -2,6 +2,7 @@ package org.jivesoftware.openfire.handler;
 
 import org.dom4j.Element;
 import org.jivesoftware.util.XMPPDateTimeFormat;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.xmpp.packet.IQ;
 
@@ -47,7 +48,7 @@ public class IQEntityTimeHandlerTest {
         assertEquals(iqEntityTimeHandler.getUtcDate(date), DatatypeConverter.printDateTime(calendar));
     }
 
-    @Test
+    @Test @Ignore
     public void testPerformanceDatatypeConvertVsXMPPDateFormat() {
 
         Date date = new Date();


### PR DESCRIPTION
Disables a test that fails the mvn package step when running in a docker environment (and presumably any lower-resource build environment).

Disabling felt sensible - I'm uncertain of the value of the assertions (1 million runs of an inbuilt Java date formatting function must take <2s, 1 million runs of an Openfire date formatiing function must take <4s) - why would we want the performance of an inbuilt Java function to block building in a slower env, and where did those thresholds come from?

V happy to take input on this PR - maybe this needs deleting, or perhaps someone knows the legacy of this check?