### PR TITLE
Fix and improve docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
 FROM maven:3.5-jdk-8
 WORKDIR /usr/src
-COPY . .
+
+COPY ./pom.xml .
+COPY ./i18n/pom.xml ./i18n/
+COPY ./xmppserver/pom.xml ./xmppserver/
+COPY ./starter/pom.xml ./starter/
+COPY ./starter/libs/* ./starter/libs/
+COPY ./plugins/pom.xml ./plugins/
+COPY ./plugins/openfire-plugin-assembly-descriptor/pom.xml ./plugins/openfire-plugin-assembly-descriptor/
+COPY ./distribution/pom.xml ./distribution/
 RUN mvn dependency:go-offline
+
+COPY . .
 RUN mvn package
 
 FROM openjdk:8-jre

--- a/build/docker/entrypoint.sh
+++ b/build/docker/entrypoint.sh
@@ -52,9 +52,10 @@ rewire_openfire
 initialize_data_dir
 initialize_log_dir
 
+JAVACMD=`which java 2> /dev/null `
 # default behaviour is to launch openfire
 if [[ -z ${1} ]]; then
-  exec start-stop-daemon --start --chuid ${OPENFIRE_USER}:${OPENFIRE_USER} --exec /usr/bin/java -- \
+  exec start-stop-daemon --start --chuid ${OPENFIRE_USER}:${OPENFIRE_USER} --exec $JAVACMD -- \
     -server \
     -DopenfireHome="${OPENFIRE_DIR}" \
     -Dopenfire.lib.dir=${OPENFIRE_DIR}/lib \


### PR DESCRIPTION
**Fixes entrypoint.sh**

The absolute path of java didn't match of that of the JRE image.
Fixed to be agnostic, by using `which java`

**Improved maven caching during Docker builds**

Previously would only cache if the entire source was unchanged.
Now, by only copying over items explicitly required to resolve maven deps, will cache if all pom files remain unchanged.