### PR TITLE
Update OpenfireX509TrustManager.getAcceptedIssuers

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManager.java
@@ -112,6 +112,11 @@ public class OpenfireX509TrustManager implements X509TrustManager
     @Override
     public X509Certificate[] getAcceptedIssuers()
     {
+        if (JiveGlobals.getBooleanProperty("xmpp.client.certificate.sendtrustedissuerList", false)) {
+            // Answer an empty list 
+            return new X509Certificate[0];
+        }
+        
         final Set<X509Certificate> result;
         if ( checkValidity )
         {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManager.java
@@ -3,7 +3,7 @@ package org.jivesoftware.openfire.keystore;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.jivesoftware.util.JiveGlobals;
 import javax.net.ssl.*;
 import java.security.*;
 import java.security.cert.*;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManager.java
@@ -112,7 +112,7 @@ public class OpenfireX509TrustManager implements X509TrustManager
     @Override
     public X509Certificate[] getAcceptedIssuers()
     {
-        if (JiveGlobals.getBooleanProperty("xmpp.client.certificate.sendtrustedissuerList", false)) {
+        if (JiveGlobals.getBooleanProperty("xmpp.client.certificate.sendtrustedissuerlist", false)) {
             // Answer an empty list 
             return new X509Certificate[0];
         }


### PR DESCRIPTION
Add new property xmpp.client.certificate.sendtrustedissuerlist (true, false) to manage, if 
the CertificateRequest message, sent to the client, has the list of CAs (distinguished names in Server Hello).

The property xmpp.client.certificate.sendtrustedissuerlist can be inserted as constant into ConnectionSettings.java
"...src\xmppserver\src\main\java\org\jivesoftware\openfire\session\ConnectionSettings.java"

![CertRequest](https://user-images.githubusercontent.com/54146641/63107981-2f347280-bf86-11e9-89e3-d7f59e7f0919.png)
