### PR TITLE
OF-1835: Prevent NPE when resuming faulty SM session

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -269,6 +269,11 @@ public class StreamManager {
             sendError(new PacketError(PacketError.Condition.unexpected_request));
             return;
         }
+        if (otherSession.getStreamManager().namespace == null) {
+            Log.debug("Not allowing a client to resume a session, the session to be resumed disabled SM functionality as a response to an earlier error." );
+            sendError(new PacketError(PacketError.Condition.unexpected_request));
+            return;
+        }
         if (!otherSession.getStreamManager().namespace.equals(namespace)) {
             Log.debug("Not allowing a client to resume a session, the session to be resumed used a different version ({}) of the session management resumption feature as compared to the version that's requested now: {}.", otherSession.getStreamManager().namespace, namespace);
             sendError(new PacketError(PacketError.Condition.unexpected_request));


### PR DESCRIPTION
The error handler of SM sets the namespace to null, causing an NPE when the client tries to resume that session. This in turn causes the socket to be closed abruptly, which triggers a reconnect loop in Conversations.