### PR TITLE
OF-1839 : add XEP-0411 support

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -193,6 +193,9 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                     // XEP-0030 requires that every entity that supports service
                     // discovery broadcasts the disco#info feature.
                     queryElement.addElement("feature").addAttribute("var", NAMESPACE_DISCO_INFO);
+                    // XEP-0411 requires that every entity that supports service
+                    // dicovery broadcasts the conversion between 'PEP' and 'Private Storage' feature
+                    queryElement.addElement("feature").addAttribute("var", "urn:xmpp:bookmarks-conversion:0");
                 }
                 // Add to the reply the multiple extended info (XDataForm) provided by the DiscoInfoProvider
                 final Set<DataForm> dataForms = infoProvider.getExtendedInfos( name, node, packet.getFrom() );

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -195,7 +195,10 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                     queryElement.addElement("feature").addAttribute("var", NAMESPACE_DISCO_INFO);
                     // XEP-0411 requires that every entity that supports service
                     // dicovery broadcasts the conversion between 'PEP' and 'Private Storage' feature
-                    queryElement.addElement("feature").addAttribute("var", "urn:xmpp:bookmarks-conversion:0");
+                    if(XMPPServer.getInstance().getPrivateStorage().isEnabled()){ 
+                        //allow only if private storage is enabled
+                       queryElement.addElement("feature").addAttribute("var", "urn:xmpp:bookmarks-conversion:0");
+                    }
                 }
                 // Add to the reply the multiple extended info (XDataForm) provided by the DiscoInfoProvider
                 final Set<DataForm> dataForms = infoProvider.getExtendedInfos( name, node, packet.getFrom() );


### PR DESCRIPTION
Openfire already supports conversion between 'PEP' and 'Private Storage' type of bookmarks, but this support predates XEP-0411.

Openfire's support should match XEP-0411.