### PR TITLE
4.1.5-based Pubsub improvements

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -28,8 +28,8 @@
     <property name="version.revision" value="5"/>
     <property name="version.extra" value=""/>    <!-- For 'beta' or 'alpha' -->
 
-	<property name="javac.source" value="1.7"/>
-	<property name="javac.target" value="1.7"/>
+	<property name="javac.source" value="1.8"/>
+	<property name="javac.target" value="1.8"/>
     <property name="dist.prefix" value="openfire"/>
 
     <property file="${basedir}/build/build.properties"/>

--- a/src/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/src/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -147,24 +147,28 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
                     Log.warn("Rejected available presence: " + presence + " - " + session);
                     return;
                 }
-                broadcastUpdate(presence.createCopy());
+
                 if (session != null) {
                     session.setPresence(presence);
-                    if (!session.isInitialized()) {
-                        initSession(session);
-                        session.setInitialized(true);
-                    }
                 }
+
+                broadcastUpdate(presence.createCopy());
+
+                if (session != null && !session.isInitialized()) {
+                    initSession(session);
+                    session.setInitialized(true);
+                }
+
                 // Notify the presence manager that the user is now available. The manager may
                 // remove the last presence status sent by the user when he went offline.
                 presenceManager.userAvailable(presence);
             }
             else if (Presence.Type.unavailable == type) {
-                broadcastUpdate(presence.createCopy());
-                broadcastUnavailableForDirectedPresences(presence);
                 if (session != null) {
                     session.setPresence(presence);
                 }
+                broadcastUpdate(presence.createCopy());
+                broadcastUnavailableForDirectedPresences(presence);
                 // Notify the presence manager that the user is now unavailable. The manager may
                 // save the last presence status sent by the user and keep track when the user
                 // went offline.
@@ -472,7 +476,7 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
         if (localServer.isLocal(from)) {
             // Remove the registry of directed presences of this user
         	Collection<DirectedPresence> directedPresences = null;
-        	
+
         	Lock lock = CacheFactory.getLock(from.toString(), directedPresencesCache);
         	try {
         		lock.lock();

--- a/src/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/src/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -533,6 +533,16 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
         }
     }
 
+    /**
+     * Checks if the packet is a presence stanza that intends to reflect an update back to the client from which the update originated.
+     *
+     * @param packet The stanza (cannot be null.
+     * @return true if the packet is presence reflection, otherwise false.
+     */
+    public static boolean isPresenceUpdateReflection( final Packet packet ) {
+        return packet instanceof Presence && packet.getTo() != null && packet.getTo().equals( packet.getFrom() );
+    }
+
     @Override
 	public void initialize(XMPPServer server) {
         super.initialize(server);

--- a/src/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/src/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -283,6 +283,8 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
         }
         // Auto Creation of nodes is supported in PEP
         features.add("http://jabber.org/protocol/pubsub#auto-create");
+        features.add("http://jabber.org/protocol/pubsub#auto-subscribe");
+        features.add("http://jabber.org/protocol/pubsub#filtered-notifications");
         return features.iterator();
     }
 

--- a/src/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/src/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -53,10 +53,7 @@ import org.jivesoftware.openfire.roster.RosterEventListener;
 import org.jivesoftware.openfire.roster.RosterItem;
 import org.jivesoftware.openfire.roster.RosterManager;
 import org.jivesoftware.openfire.session.ClientSession;
-import org.jivesoftware.openfire.user.PresenceEventDispatcher;
-import org.jivesoftware.openfire.user.PresenceEventListener;
-import org.jivesoftware.openfire.user.User;
-import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.jivesoftware.openfire.user.*;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -329,40 +326,17 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
             packet.setTo(jidFrom);
 
             if (packet.getType() == IQ.Type.set) {
-                PEPService pepService = pepServiceManager.getPEPService(jidFrom);
 
-                // If no service exists yet for jidFrom, create one.
-                if (pepService == null) {
-                	try {
-                		pepService = pepServiceManager.create(senderJID);                		
-                	} catch (IllegalArgumentException ex) {
-            			final IQ reply = IQ.createResultIQ(packet);
-            			reply.setChildElement(packet.getChildElement().createCopy());
-            			reply.setError(PacketError.Condition.not_allowed);
-            			return reply;
-                	}
-
-            		// Probe presences
-            		pepServiceManager.start(pepService);
-
-            		// Those who already have presence subscriptions to jidFrom
-					// will now automatically be subscribed to this new
-					// PEPService.
-					try {
-						final RosterManager rm = XMPPServer.getInstance()
-								.getRosterManager();
-						final Roster roster = rm.getRoster(senderJID.getNode());
-						for (final RosterItem item : roster.getRosterItems()) {
-							if (item.getSubStatus() == RosterItem.SUB_BOTH
-									|| item.getSubStatus() == RosterItem.SUB_FROM) {
-								createSubscriptionToPEPService(pepService, item
-										.getJid(), senderJID);
-							}
-						}
-					} catch (UserNotFoundException e) {
-						// Do nothing
-					}
+                // Only service local, registered users.
+                if (!XMPPServer.getInstance().isLocal(senderJID) || !UserManager.getInstance().isRegisteredUser( senderJID.getNode()))
+                {
+                    final IQ reply = IQ.createResultIQ(packet);
+                    reply.setChildElement(packet.getChildElement().createCopy());
+                    reply.setError(PacketError.Condition.not_allowed);
+                    return reply;
                 }
+
+                PEPService pepService = pepServiceManager.getPEPService(jidFrom);
 
                 // If publishing a node, and the node doesn't exist, create it.
                 final Element childElement = packet.getChildElement();
@@ -391,18 +365,8 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
                 // Process with PubSub as usual.
                 pepServiceManager.process(pepService, packet);
             } else if (packet.getType() == IQ.Type.get) {
-                final PEPService pepService = pepServiceManager.getPEPService(jidFrom);            	
-                
-                if (pepService != null) {
-                	pepServiceManager.process(pepService, packet);
-                } else {
-                    // Process with PubSub using a dummyService. In the case where an IQ packet is sent to
-                    // a user who does not have a PEP service, we wish to utilize the error reporting flow
-                    // already present in the PubSubEngine. This gives the illusion that every user has a
-                    // PEP service, as required by the specification.
-                    PEPService dummyService = new PEPService(XMPPServer.getInstance(), senderJID.toBareJID());
-                    pepServiceManager.process(dummyService, packet);
-                }
+                final PEPService pepService = pepServiceManager.getPEPService(jidFrom);
+                pepServiceManager.process(pepService, packet);
             }
         }
         else if (packet.getType() == IQ.Type.get || packet.getType() == IQ.Type.set) {
@@ -411,17 +375,7 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
             final String jidTo = packet.getTo().toBareJID();
 
             final PEPService pepService = pepServiceManager.getPEPService(jidTo);
-
-            if (pepService != null) {
-            	pepServiceManager.process(pepService, packet);
-            } else {
-                // Process with PubSub using a dummyService. In the case where an IQ packet is sent to
-                // a user who does not have a PEP service, we wish to utilize the error reporting flow
-                // already present in the PubSubEngine. This gives the illusion that every user has a
-                // PEP service, as required by the specification.
-                PEPService dummyService = new PEPService(XMPPServer.getInstance(), senderJID.toBareJID());
-                pepServiceManager.process(dummyService, packet);
-            }
+            pepServiceManager.process(pepService, packet);
         } else {
             // Ignore IQ packets of type 'error' or 'result'.
             return null;
@@ -429,6 +383,31 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
 
         // Other error flows were handled in pubSubEngine.process(...)
         return null;
+    }
+
+    /**
+     * Populates the PEPService instance with subscriptions. The subscriptions that
+     * are added to the PEPService are based on the roster of the owner of the PEPService:
+     * every entity that's subscribed to the presence of the owner, is added as a
+     * subscriber of the PEPService.
+     *
+     * This method adds, but does not remove of update existing subscriptions.
+     *
+     * @param pepService The PEPService to be populated with subscriptions.
+     */
+    public void addSubscriptionForRosterItems( final PEPService pepService )
+    {
+        try {
+            final RosterManager rm = XMPPServer.getInstance().getRosterManager();
+            final Roster roster = rm.getRoster(pepService.getAddress().getNode());
+            for (final RosterItem item : roster.getRosterItems()) {
+                if (item.getSubStatus() == RosterItem.SUB_BOTH || item.getSubStatus() == RosterItem.SUB_FROM) {
+                    createSubscriptionToPEPService(pepService, item.getJid(), pepService.getAddress());
+                }
+            }
+        } catch (UserNotFoundException e) {
+            Log.warn("Attempting to manage subscriptions for a PEP node that is associated to an unrecognized user: {}", pepService.getAddress(), e);
+        }
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/pep/PEPService.java
+++ b/src/java/org/jivesoftware/openfire/pep/PEPService.java
@@ -35,15 +35,7 @@ import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.commands.AdHocCommandManager;
 import org.jivesoftware.openfire.entitycaps.EntityCapabilities;
 import org.jivesoftware.openfire.entitycaps.EntityCapabilitiesManager;
-import org.jivesoftware.openfire.pubsub.CollectionNode;
-import org.jivesoftware.openfire.pubsub.DefaultNodeConfiguration;
-import org.jivesoftware.openfire.pubsub.Node;
-import org.jivesoftware.openfire.pubsub.NodeSubscription;
-import org.jivesoftware.openfire.pubsub.PendingSubscriptionsCommand;
-import org.jivesoftware.openfire.pubsub.PubSubEngine;
-import org.jivesoftware.openfire.pubsub.PubSubPersistenceManager;
-import org.jivesoftware.openfire.pubsub.PubSubService;
-import org.jivesoftware.openfire.pubsub.PublishedItem;
+import org.jivesoftware.openfire.pubsub.*;
 import org.jivesoftware.openfire.pubsub.models.AccessModel;
 import org.jivesoftware.openfire.pubsub.models.PublisherModel;
 import org.jivesoftware.openfire.roster.Roster;
@@ -142,7 +134,7 @@ public class PEPService implements PubSubService, Cacheable {
         adHocCommandManager.addCommand(new PendingSubscriptionsCommand(this));
 
         // Load default configuration for leaf nodes
-        leafDefaultConfiguration = PubSubPersistenceManager.loadDefaultConfiguration(this, true);
+        leafDefaultConfiguration = PubSubPersistenceProviderManager.getInstance().getProvider().loadDefaultConfiguration( this, true);
         if (leafDefaultConfiguration == null) {
             // Create and save default configuration for leaf nodes;
             leafDefaultConfiguration = new DefaultNodeConfiguration(true);
@@ -160,10 +152,10 @@ public class PEPService implements PubSubService, Cacheable {
             leafDefaultConfiguration.setSendItemSubscribe(true);
             leafDefaultConfiguration.setSubscriptionEnabled(true);
             leafDefaultConfiguration.setReplyPolicy(null);
-            PubSubPersistenceManager.createDefaultConfiguration(this, leafDefaultConfiguration);
+            PubSubPersistenceProviderManager.getInstance().getProvider().createDefaultConfiguration(this, leafDefaultConfiguration);
         }
         // Load default configuration for collection nodes
-        collectionDefaultConfiguration = PubSubPersistenceManager.loadDefaultConfiguration(this, false);
+        collectionDefaultConfiguration = PubSubPersistenceProviderManager.getInstance().getProvider().loadDefaultConfiguration(this, false);
         if (collectionDefaultConfiguration == null) {
             // Create and save default configuration for collection nodes;
             collectionDefaultConfiguration = new DefaultNodeConfiguration(false);
@@ -179,11 +171,11 @@ public class PEPService implements PubSubService, Cacheable {
             collectionDefaultConfiguration.setReplyPolicy(null);
             collectionDefaultConfiguration.setAssociationPolicy(CollectionNode.LeafNodeAssociationPolicy.all);
             collectionDefaultConfiguration.setMaxLeafNodes(-1);
-            PubSubPersistenceManager.createDefaultConfiguration(this, collectionDefaultConfiguration);
+            PubSubPersistenceProviderManager.getInstance().getProvider().createDefaultConfiguration(this, collectionDefaultConfiguration);
         }
 
         // Load nodes to memory
-        PubSubPersistenceManager.loadNodes(this);
+        PubSubPersistenceProviderManager.getInstance().getProvider().loadNodes(this);
         // Ensure that we have a root collection node
         if (nodes.isEmpty()) {
             // Create root collection node

--- a/src/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * $RCSfile: $
  * $Revision: $
  * $Date: $
@@ -20,6 +20,9 @@
 
 package org.jivesoftware.openfire.pubsub;
 
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,6 +32,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.dom4j.Element;
 import org.jivesoftware.util.LocaleUtils;
+import org.jivesoftware.util.cache.CacheSizes;
+import org.jivesoftware.util.cache.CannotCalculateSizeException;
+import org.jivesoftware.util.cache.ExternalizableUtil;
 import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
 import org.xmpp.packet.JID;
@@ -72,6 +78,9 @@ public class CollectionNode extends Node {
         this.maxLeafNodes = defaultConfiguration.getMaxLeafNodes();
     }
 
+    public CollectionNode() { // to be used only for serialization;
+        super();
+    }
 
     @Override
 	protected void configure(FormField field) throws NotAcceptableException {
@@ -494,5 +503,40 @@ public class CollectionNode extends Node {
          * Only those on a whitelist may associate leaf nodes with the collection.
          */
         whitelist
+    }
+
+    @Override
+    public int getCachedSize() throws CannotCalculateSizeException
+    {
+        int size = super.getCachedSize(); // parent.
+        size += CacheSizes.sizeOfMap( nodes );
+        size += CacheSizes.sizeOfInt(); // associationPolicy
+        size += CacheSizes.sizeOfCollection( associationTrusted );
+        size += CacheSizes.sizeOfInt(); // maxLeafNodes
+        return size;
+    }
+
+    @Override
+    public void writeExternal( ObjectOutput out ) throws IOException
+    {
+        super.writeExternal( out );
+
+        final ExternalizableUtil util = ExternalizableUtil.getInstance();
+        util.writeExternalizableMap( out, nodes );
+        util.writeSafeUTF( out, associationPolicy.name() );
+        util.writeSerializableCollection( out, associationTrusted );
+        util.writeInt( out, maxLeafNodes );
+    }
+
+    @Override
+    public void readExternal( ObjectInput in ) throws IOException, ClassNotFoundException
+    {
+        super.readExternal( in );
+
+        final ExternalizableUtil util = ExternalizableUtil.getInstance();
+        util.readExternalizableMap( in, nodes, getClass().getClassLoader() );
+        associationPolicy = LeafNodeAssociationPolicy.valueOf( util.readSafeUTF( in ) );
+        util.readSerializableCollection( in, associationTrusted, getClass().getClassLoader() );
+        maxLeafNodes = util.readInt( in );
     }
 }

--- a/src/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
@@ -23,6 +23,10 @@ package org.jivesoftware.openfire.pubsub;
 import org.jivesoftware.util.LocaleUtils;
 import org.jivesoftware.openfire.pubsub.models.AccessModel;
 import org.jivesoftware.openfire.pubsub.models.PublisherModel;
+import org.jivesoftware.util.cache.Cache;
+import org.jivesoftware.util.cache.CacheSizes;
+import org.jivesoftware.util.cache.Cacheable;
+import org.jivesoftware.util.cache.CannotCalculateSizeException;
 import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
 
@@ -33,7 +37,7 @@ import org.xmpp.forms.FormField;
  *
  * @author Matt Tucker
  */
-public class DefaultNodeConfiguration {
+public class DefaultNodeConfiguration implements Cacheable {
 
     /**
      * Flag indicating whether this default configutation belongs to a leaf node or not.
@@ -560,5 +564,23 @@ public class DefaultNodeConfiguration {
         }
 
         return form;
+    }
+
+    /**
+     * Returns the approximate size of the Object in bytes. The size should be
+     * considered to be a best estimate of how much memory the Object occupies
+     * and may be based on empirical trials or dynamic calculations.<p>
+     *
+     * @return the size of the Object in bytes.
+     */
+    @Override
+    public int getCachedSize() throws CannotCalculateSizeException
+    {
+        int size = CacheSizes.sizeOfObject(); // overhead of the class itself.
+        size += (9 * CacheSizes.sizeOfBoolean()); // nine boolean properties.
+        size += (3 * CacheSizes.sizeOfInt()); // three int properties.
+        size += (4 * CacheSizes.sizeOfObject()); // 4 references to other classes / enums
+        size += CacheSizes.sizeOfString( language );
+        return size;
     }
 }

--- a/src/java/org/jivesoftware/openfire/pubsub/DefaultPubSubPersistenceProvider.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/DefaultPubSubPersistenceProvider.java
@@ -51,9 +51,9 @@ import java.util.stream.Collectors;
  *
  * @author Matt Tucker
  */
-public class PubSubPersistenceManager implements PubSubPersistenceProvider {
+public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvider {
 
-    private static final Logger log = LoggerFactory.getLogger(PubSubPersistenceManager.class);
+    private static final Logger log = LoggerFactory.getLogger( DefaultPubSubPersistenceProvider.class);
 
     private static final String PERSISTENT_NODES = "SELECT serviceID, nodeID, maxItems " +
     		"FROM ofPubsubNode WHERE leaf=1 AND persistItems=1 AND maxItems > 0";

--- a/src/java/org/jivesoftware/openfire/pubsub/DefaultPubSubPersistenceProvider.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/DefaultPubSubPersistenceProvider.java
@@ -22,7 +22,9 @@ package org.jivesoftware.openfire.pubsub;
 
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.database.DbConnectionManager.DatabaseType;
+import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.cluster.ClusterManager;
+import org.jivesoftware.openfire.pep.PEPService;
 import org.jivesoftware.openfire.pubsub.cluster.FlushTask;
 import org.jivesoftware.openfire.pubsub.models.AccessModel;
 import org.jivesoftware.openfire.pubsub.models.PublisherModel;
@@ -199,6 +201,8 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
             "presenceBased, sendItemSubscribe, publisherModel, subscriptionEnabled, " +
             "accessModel, language, replyPolicy, associationPolicy, maxLeafNodes) " +
             "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+
+    private final static String GET_PEP_SERVICE = "SELECT DISTINCT serviceID FROM ofPubsubNode WHERE serviceID=?";
 
     /**
      * Pseudo-random number generator is used to offset timing for scheduled tasks
@@ -1876,7 +1880,9 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
                                     CollectionNode.LeafNodeAssociationPolicy.valueOf(rs.getString(15)));
                             config.setMaxLeafNodes(rs.getInt(16));
                         }
-                        defaultNodeConfigurationCache.put( key, config );
+                        if ( config != null ) {
+                            defaultNodeConfigurationCache.put( key, config );
+                        }
                         result = config;
                     }
                     catch (Exception sqle) {
@@ -1936,7 +1942,9 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
                 pstmt.setInt(18, config.getMaxLeafNodes());
                 pstmt.executeUpdate();
 
-                defaultNodeConfigurationCache.put( key, config );
+                if ( config != null ) {
+                    defaultNodeConfigurationCache.put( key, config );
+                }
             }
             catch (SQLException sqle) {
                 log.error(sqle.getMessage(), sqle);
@@ -2241,6 +2249,35 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
             }
 		}
 	}
+
+    @Override
+    public PEPService loadPEPServiceFromDB(String jid) {
+        PEPService pepService = null;
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            con = DbConnectionManager.getConnection();
+            // Get all PEP services
+            pstmt = con.prepareStatement(GET_PEP_SERVICE);
+            pstmt.setString(1, jid);
+            rs = pstmt.executeQuery();
+            // Restore old PEPService
+            while (rs.next()) {
+                String serviceID = rs.getString(1);
+
+                // Create a new PEPService
+                pepService = new PEPService(XMPPServer.getInstance(), serviceID);
+            }
+        } catch (SQLException sqle) {
+            log.error(sqle.getMessage(), sqle);
+        } finally {
+            DbConnectionManager.closeConnection(rs, pstmt, con);
+        }
+
+        return pepService;
+    }
 
 	private static String encodeWithComma(Collection<String> strings) {
         StringBuilder sb = new StringBuilder(90);

--- a/src/java/org/jivesoftware/openfire/pubsub/InMemoryPubSubPersistenceProvider.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/InMemoryPubSubPersistenceProvider.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.pubsub;
+
+import org.jivesoftware.openfire.cluster.ClusterManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * An memory-based PubSub persistence provider.
+ *
+ * Note that any data stored in this provider will not survive a restart of the JVM.
+ */
+// FIXME: make compatible with clustering.
+public class InMemoryPubSubPersistenceProvider implements PubSubPersistenceProvider
+{
+    private static final Logger log = LoggerFactory.getLogger( InMemoryPubSubPersistenceProvider.class );
+
+    private final ConcurrentHashMap<Node.UniqueIdentifier, Node> uidToNodeMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, List<Node.UniqueIdentifier>> serviceIdToNodeIdsMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, DefaultNodeConfiguration> serviceIdToDefaultLeafNodeConfigMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, DefaultNodeConfiguration> serviceIdToDefaultNodeConfigMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Node.UniqueIdentifier, List<PublishedItem>> uidToPublishedItemMap = new ConcurrentHashMap<>();
+
+    public void initialize()
+    {
+        log.debug( "Initializing" );
+    }
+
+    public void shutdown()
+    {
+        log.debug( "Shutting down" );
+    }
+
+    @Override
+    public void createNode( Node node )
+    {
+        log.debug( "Creating node: {}", node.getUniqueIdentifier() );
+
+        synchronized ( node.getUniqueIdentifier().toString().intern() )
+        {
+            uidToNodeMap.put( node.getUniqueIdentifier(), node );
+            serviceIdToNodeIdsMap.compute( node.getService().getServiceID(), ( s, list ) -> {
+                if ( list != null )
+                {
+                    if ( !list.contains( node.getUniqueIdentifier() ) )
+                    {
+                        list.add( node.getUniqueIdentifier() );
+                    }
+                    return list;
+                }
+                else
+                {
+                    List<Node.UniqueIdentifier> newList = new ArrayList<>();
+                    newList.add( node.getUniqueIdentifier() );
+                    return newList;
+                }
+            } );
+        }
+    }
+
+    @Override
+    public void updateNode( Node node )
+    {
+        log.debug( "Updating node: {}", node.getUniqueIdentifier() );
+
+        synchronized ( node.getUniqueIdentifier().toString().intern() )
+        {
+            uidToNodeMap.put( node.getUniqueIdentifier(), node );
+        }
+    }
+
+    @Override
+    public void removeNode( Node node )
+    {
+        log.debug( "Removing node: {}", node.getUniqueIdentifier() );
+
+        synchronized ( node.getUniqueIdentifier().toString().intern() )
+        {
+            uidToNodeMap.remove( node.getUniqueIdentifier() );
+            try
+            {
+                serviceIdToNodeIdsMap.computeIfPresent( node.getService().getServiceID(), ( s, list ) -> {
+                    list.remove( node.getUniqueIdentifier() );
+                    return list.isEmpty() ? null : list;
+                } );
+                if ( node instanceof LeafNode )
+                {
+                    purgeNode( (LeafNode) node );
+                }
+            }
+            catch ( Exception e )
+            {
+                log.warn( "MemOnlyPubSubPersistenceManager removeNode " + node.getUniqueIdentifier().toString() + "  unexpected exception.", e );
+            }
+        }
+    }
+
+    @Override
+    public void loadNodes( PubSubService service )
+    {
+        log.debug( "Loading nodes for service: {}", service.getServiceID() );
+
+        final List<Node.UniqueIdentifier> listUniqueIds = serviceIdToNodeIdsMap.get( service.getServiceID() );
+        if ( listUniqueIds != null )
+        {
+            for ( Node.UniqueIdentifier uniqueId : listUniqueIds )
+            {
+                synchronized ( uniqueId.toString().intern() )
+                {
+                    Node node = uidToNodeMap.get( uniqueId );
+                    if ( node != null )
+                    {
+                        service.addNode( node );
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void loadNode( PubSubService service, String nodeId )
+    {
+        final Node.UniqueIdentifier uniqueIdentifier = new Node.UniqueIdentifier( service.getServiceID(), nodeId );
+        log.debug( "Loading node: {}", uniqueIdentifier );
+        synchronized ( uniqueIdentifier.toString().intern() )
+        {
+            final Node node = uidToNodeMap.get( uniqueIdentifier );
+            if ( node != null )
+            {
+                service.addNode( node );
+            }
+        }
+    }
+
+    @Override
+    public void loadSubscription( PubSubService service, Node node, String subId )
+    {
+        // Affiliate change should already be stored in the node.
+        log.debug( "Loading subscription {} for node: {} (NOP)", subId, node.getUniqueIdentifier() );
+    }
+
+    @Override
+    public void createAffiliation( Node node, NodeAffiliate affiliate )
+    {
+        // Affiliate change should already be stored in the node.
+        log.debug( "Creating node affiliation (NOP): {} {}", node.getUniqueIdentifier(), affiliate.toString() );
+    }
+
+    @Override
+    public void updateAffiliation( Node node, NodeAffiliate affiliate )
+    {
+        // Affiliate change should already be stored in the node.
+        log.debug( "Updating node affiliation (NOP): {} {}", node.getUniqueIdentifier(), affiliate.toString() );
+    }
+
+    @Override
+    public void removeAffiliation( Node node, NodeAffiliate affiliate )
+    {
+        // Affiliate change should already be stored in the node.
+        log.debug( "Removing node affiliation (NOP): {} {}", node.getUniqueIdentifier(), affiliate.toString() );
+    }
+
+    @Override
+    public void createSubscription( Node node, NodeSubscription subscription )
+    {
+        // Subscription change should already be stored in the node.
+        log.debug( "Creating node subscription (NOP): {} {}", node.getUniqueIdentifier(), subscription.getID() );
+    }
+
+    @Override
+    public void updateSubscription( Node node, NodeSubscription subscription )
+    {
+        // Subscription change should already be stored in the node.
+        log.debug( "Updating node subscription (NOP): {} {}", node.getUniqueIdentifier(), subscription.getID() );
+    }
+
+    @Override
+    public void removeSubscription( NodeSubscription subscription )
+    {
+        // Subscription change should already be stored in the node.
+        log.debug( "Removing node subscription (NOP): {} {}", subscription.getNode().getUniqueIdentifier(), subscription.getID() );
+    }
+
+    @Override
+    public void flushPendingItems( Node.UniqueIdentifier nodeUniqueId )
+    {
+        log.debug( "Flushing pending items for node {} (NOP)", nodeUniqueId );
+        // Do nothing. In-memory state does not need 'flushing' to a persistent backend.
+    }
+
+    @Override
+    public void flushPendingItems()
+    {
+        log.debug( "Flushing all pending items (NOP)." );
+        // Do nothing. In-memory state does not need 'flushing' to a persistent backend.
+    }
+
+    @Override
+    public void flushPendingItems( Node.UniqueIdentifier nodeUniqueId, boolean sendToCluster )
+    {
+        log.debug( "Flushing pending items for node {} (send to cluster: {}) (NOP)", nodeUniqueId, sendToCluster );
+        // Do nothing. In-memory state does not need 'flushing' to a persistent backend.
+    }
+
+    @Override
+    public void flushPendingItems( boolean sendToCluster )
+    {
+        log.debug( "Flushing all pending items (send to cluster: {}) (NOP).", sendToCluster );
+        // Do nothing. In-memory state does not need 'flushing' to a persistent backend.
+    }
+
+    @Override
+    public DefaultNodeConfiguration loadDefaultConfiguration( PubSubService service, boolean isLeafType )
+    {
+        log.debug( "Loading default node configuration for service {} (for leaf type: {}).", service.getServiceID(), isLeafType );
+
+        if ( isLeafType )
+        {
+            return serviceIdToDefaultLeafNodeConfigMap.get( service.getServiceID() );
+        }
+        return serviceIdToDefaultNodeConfigMap.get( service.getServiceID() );
+    }
+
+    @Override
+    public void createDefaultConfiguration( PubSubService service, DefaultNodeConfiguration config )
+    {
+        log.debug( "Creating default node configuration for service {} (for leaf type: {}).", service.getServiceID(), config.isLeaf() );
+
+        if ( config.isLeaf() )
+        {
+            serviceIdToDefaultLeafNodeConfigMap.put( service.getServiceID(), config );
+        }
+        else
+        {
+            serviceIdToDefaultNodeConfigMap.put( service.getServiceID(), config );
+        }
+    }
+
+    @Override
+    public void updateDefaultConfiguration( PubSubService service, DefaultNodeConfiguration config )
+    {
+        log.debug( "Updating default node configuration for service {} (for leaf type: {}).", service.getServiceID(), config.isLeaf() );
+        if ( config.isLeaf() )
+        {
+            serviceIdToDefaultLeafNodeConfigMap.put( service.getServiceID(), config );
+        }
+        else
+        {
+            serviceIdToDefaultNodeConfigMap.put( service.getServiceID(), config );
+        }
+    }
+
+    @Override
+    public void savePublishedItem( PublishedItem item )
+    {
+        log.debug( "Saving published item for node {}: {}", item.getNode().getUniqueIdentifier(), item.getID() );
+        synchronized ( item.getNode().getUniqueIdentifier().toString().intern() )
+        {
+            uidToPublishedItemMap.compute( item.getNode().getUniqueIdentifier(), ( s, list ) -> {
+                if ( list != null )
+                {
+                    if ( list.stream().noneMatch( i -> item.getItemKey().equals( i.getItemKey() ) ) )
+                    {
+                        list.add( item );
+                    }
+                    return list;
+                }
+                else
+                {
+                    List<PublishedItem> newList = new ArrayList<>();
+                    newList.add( item );
+                    return newList;
+                }
+            } );
+        }
+    }
+
+    @Override
+    public void removePublishedItem( PublishedItem item )
+    {
+        log.debug( "Removing published item for node {}: {}", item.getNode().getUniqueIdentifier(), item.getID() );
+        synchronized ( item.getNode().getUniqueIdentifier().toString().intern() )
+        {
+            uidToPublishedItemMap.compute( item.getNode().getUniqueIdentifier(), ( s, list ) -> {
+                if ( list != null )
+                {
+                    list.removeIf( publishedItem -> item.getItemKey().equals( publishedItem.getItemKey() ) );
+                }
+                return list;
+            } );
+        }
+    }
+
+    @Override
+    public List<PublishedItem> getPublishedItems( LeafNode node )
+    {
+        log.debug( "Getting published items for node {}", node.getUniqueIdentifier() );
+        List<PublishedItem> publishedItems;
+        synchronized ( node.getUniqueIdentifier().toString().intern() )
+        {
+            final List<PublishedItem> items = uidToPublishedItemMap.get( node.getUniqueIdentifier() );
+            publishedItems = items != null ? items : new ArrayList<>();
+        }
+        return publishedItems;
+    }
+
+    @Override
+    public List<PublishedItem> getPublishedItems( LeafNode node, int maxRows )
+    {
+        log.debug( "Getting published items for node {} (max: {}).", node.getUniqueIdentifier(), maxRows );
+        List<PublishedItem> publishedItems = getPublishedItems( node );
+        if ( publishedItems.size() > maxRows )
+        {
+            publishedItems = publishedItems.subList( publishedItems.size() - maxRows, publishedItems.size() );
+        }
+        return publishedItems;
+    }
+
+    @Override
+    public PublishedItem getLastPublishedItem( LeafNode node )
+    {
+        log.debug( "Getting last published item for node {}", node.getUniqueIdentifier() );
+        PublishedItem lastPublishedItem = null;
+        synchronized ( node.getUniqueIdentifier().toString().intern() )
+        {
+            final List<PublishedItem> publishedItems = uidToPublishedItemMap.get( node.getUniqueIdentifier() );
+            if ( publishedItems != null && !publishedItems.isEmpty() )
+            {
+                lastPublishedItem = publishedItems.get( publishedItems.size() - 1 );
+            }
+        }
+        return lastPublishedItem;
+    }
+
+    @Override
+    public PublishedItem getPublishedItem( LeafNode node, String itemID )
+    {
+        log.debug( "Getting published item {} for node {}", itemID, node.getUniqueIdentifier() );
+
+        PublishedItem lastPublishedItem = null;
+        synchronized ( node.getUniqueIdentifier().toString().intern() )
+        {
+            final List<PublishedItem> publishedItems = uidToPublishedItemMap.get( node.getUniqueIdentifier() );
+            if ( publishedItems != null )
+            {
+                final List<PublishedItem> collect = publishedItems.stream().filter( publishedItem -> publishedItem.getItemKey().equals( itemID ) ).collect( Collectors.toList() );
+                if ( !collect.isEmpty() )
+                {
+                    if ( collect.size() > 1 )
+                    {
+                        log.warn( "Detected duplicate item key " + itemID + " usage for node " + node.getUniqueIdentifier().toString() );
+                    }
+                    lastPublishedItem = collect.get( collect.size() - 1 );
+                }
+            }
+        }
+        return lastPublishedItem;
+    }
+
+    @Deprecated
+    public void saveSubscription( Node node, NodeSubscription subscription, boolean create )
+    {
+        if ( create )
+        {
+            createSubscription( node, subscription );
+        }
+        else
+        {
+            updateSubscription( node, subscription );
+        }
+    }
+
+    @Deprecated
+    public void saveAffiliation( Node node, NodeAffiliate affiliate, boolean create )
+    {
+        if ( create )
+        {
+            createAffiliation( node, affiliate );
+        }
+        else
+        {
+            updateAffiliation( node, affiliate );
+        }
+    }
+
+    @Override
+    public void purgeNode( LeafNode leafNode )
+    {
+        Node.UniqueIdentifier uid = leafNode.getUniqueIdentifier();
+        log.debug( "Purging node {}", uid );
+        synchronized ( uid.toString().intern() )
+        {
+            uidToPublishedItemMap.remove( uid );
+            Node node = uidToNodeMap.remove( uid );
+            if ( node != null )
+            {
+                String serviceId = node.getService().getServiceID();
+                serviceIdToNodeIdsMap.compute( serviceId, ( s, list ) -> {
+                    if ( list != null )
+                    {
+                        list.remove( uid );
+                        return list;
+                    }
+                    return list;
+                } );
+            }
+        }
+    }
+}

--- a/src/java/org/jivesoftware/openfire/pubsub/LeafNode.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/LeafNode.java
@@ -249,7 +249,7 @@ public class LeafNode extends Node {
                 // Add the new published item to the queue of items to add to the database. The
                 // queue is going to be processed by another thread
                 if (isPersistPublishedItems()) {
-                	PubSubPersistenceManager.savePublishedItem(newItem);
+                    PubSubPersistenceProviderManager.getInstance().getProvider().savePublishedItem(newItem);
                 }
             }
         }
@@ -286,7 +286,7 @@ public class LeafNode extends Node {
     public void deleteItems(List<PublishedItem> toDelete) {
         // Remove deleted items from the database
         for (PublishedItem item : toDelete) {
-            PubSubPersistenceManager.removePublishedItem(item);
+            PubSubPersistenceProviderManager.getInstance().getProvider().removePublishedItem(item);
             if (lastPublished != null && lastPublished.getID().equals(item.getID())) {
                 lastPublished = null;
             }
@@ -353,7 +353,7 @@ public class LeafNode extends Node {
                 return lastPublished;
             }
         }
-        return PubSubPersistenceManager.getPublishedItem(this, itemID);
+        return PubSubPersistenceProviderManager.getInstance().getProvider().getPublishedItem(this, itemID);
     }
 
     @Override
@@ -363,7 +363,7 @@ public class LeafNode extends Node {
 
     @Override
     public synchronized List<PublishedItem> getPublishedItems(int recentItems) {
-        List<PublishedItem> publishedItems = PubSubPersistenceManager.getPublishedItems(this, recentItems);
+        List<PublishedItem> publishedItems = PubSubPersistenceProviderManager.getInstance().getProvider().getPublishedItems(this, recentItems);
         if (lastPublished != null) {
             // The persistent items may not contain the last item, if it wasn't persisted anymore (e.g. if node configuration changed).
             // Therefore check, if the last item has been persisted.
@@ -390,7 +390,7 @@ public class LeafNode extends Node {
     @Override
 	public synchronized PublishedItem getLastPublishedItem() {
     	if (lastPublished == null){
-    		lastPublished = PubSubPersistenceManager.getLastPublishedItem(this);
+    		lastPublished = PubSubPersistenceProviderManager.getInstance().getProvider().getLastPublishedItem(this);
     	}
     	return lastPublished;
     }
@@ -427,7 +427,7 @@ public class LeafNode extends Node {
      * published items will be deleted with the exception of the last published item.
      */
     public void purge() {
-        PubSubPersistenceManager.purgeNode(this);
+        PubSubPersistenceProviderManager.getInstance().getProvider().purgeNode(this);
         // Broadcast purge notification to subscribers
         // Build packet to broadcast to subscribers
         Message message = new Message();

--- a/src/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -340,7 +340,11 @@ public abstract class Node {
 
         if (savedToDB) {
             // Add or update the affiliate in the database
-            PubSubPersistenceManager.saveAffiliation(this, affiliate, created);
+            if ( created ) {
+                PubSubPersistenceManager.createAffiliation(this, affiliate);
+            } else {
+                PubSubPersistenceManager.updateAffiliation(this, affiliate);
+            }
         }
         
         // Update the other members with the new affiliation
@@ -1753,12 +1757,12 @@ public abstract class Node {
             // Set that the node is now in the DB
             setSavedToDB(true);
             // Save the existing node affiliates to the DB
-            for (NodeAffiliate affialiate : affiliates) {
-                PubSubPersistenceManager.saveAffiliation(this, affialiate, true);
+            for (NodeAffiliate affiliate : affiliates) {
+                PubSubPersistenceManager.createAffiliation(this, affiliate);
             }
             // Add new subscriptions to the database
             for (NodeSubscription subscription : subscriptionsByID.values()) {
-                PubSubPersistenceManager.saveSubscription(this, subscription, true);
+                PubSubPersistenceManager.createSubscription(this, subscription);
             }
             // Add the new node to the list of available nodes
             service.addNode(this);
@@ -2088,7 +2092,7 @@ public abstract class Node {
 
         if (savedToDB) {
             // Add the new subscription to the database
-            PubSubPersistenceManager.saveSubscription(this, subscription, true);
+            PubSubPersistenceManager.createSubscription(this, subscription);
         }
 
         if (originalIQ != null) {

--- a/src/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * $RCSfile: $
  * $Revision: $
  * $Date: $
@@ -20,28 +20,26 @@
 
 package org.jivesoftware.openfire.pubsub;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import org.dom4j.Element;
 import org.jivesoftware.openfire.SessionManager;
+import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.cluster.ClusterManager;
-import org.jivesoftware.openfire.pubsub.cluster.AffiliationTask;
-import org.jivesoftware.openfire.pubsub.cluster.CancelSubscriptionTask;
-import org.jivesoftware.openfire.pubsub.cluster.ModifySubscriptionTask;
-import org.jivesoftware.openfire.pubsub.cluster.NewSubscriptionTask;
-import org.jivesoftware.openfire.pubsub.cluster.RemoveNodeTask;
+import org.jivesoftware.openfire.pubsub.cluster.*;
 import org.jivesoftware.openfire.pubsub.models.AccessModel;
 import org.jivesoftware.openfire.pubsub.models.PublisherModel;
 import org.jivesoftware.util.LocaleUtils;
 import org.jivesoftware.util.StringUtils;
-import org.jivesoftware.util.cache.CacheFactory;
+import org.jivesoftware.util.cache.*;
 import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * A virtual location to which information can be published and from which event
@@ -50,7 +48,7 @@ import org.xmpp.packet.Message;
  *
  * @author Matt Tucker
  */
-public abstract class Node {
+public abstract class Node implements Cacheable, Externalizable {
 
     /**
      * Reference to the publish and subscribe service.
@@ -186,6 +184,8 @@ public abstract class Node {
     protected Map<String, NodeSubscription> subscriptionsByJID =
             new ConcurrentHashMap<>();
 
+    Node() {} // to be used only for serialization;
+
     Node(PubSubService service, CollectionNode parent, String nodeID, JID creator) {
         this.service = service;
         this.parent = parent;
@@ -209,9 +209,15 @@ public abstract class Node {
         this.replyPolicy = defaultConfiguration.getReplyPolicy();
     }
 
+    /**
+     * Returns an identifier for this node that is unique within the XMPP domain.
+     *
+     * @return A unique identifier for this node.
+     */
     public UniqueIdentifier getUniqueIdentifier() {
         return new UniqueIdentifier( this.service.getServiceID(), this.nodeID );
     }
+
     /**
      * Adds a new affiliation or updates an existing affiliation of the specified entity JID
      * to become a node owner.
@@ -1825,8 +1831,6 @@ public abstract class Node {
     /**
      * Deletes this node from memory and the database. Subscribers are going to be notified
      * that the node has been deleted after the node was successfully deleted.
-     *
-     * @return true if the node was successfully deleted.
      */
     public void delete() {
         // Delete node from the database
@@ -2312,26 +2316,19 @@ public abstract class Node {
 
     /**
      * A unique identifier for a node, in context of all services in the system.
+     *
+     * The properties that uniquely identify a node are its service, and its nodeId.
      */
-    public static class UniqueIdentifier
+    public static class UniqueIdentifier extends PubSubService.UniqueIdentifier implements Serializable
     {
-        private final String serviceId;
         private final String nodeId;
 
         public UniqueIdentifier( final String serviceId, final String nodeId ) {
-            if ( serviceId == null ) {
-                throw new IllegalArgumentException( "Argument 'serviceId' cannot be null." );
-            }
+            super( serviceId );
             if ( nodeId == null ) {
                 throw new IllegalArgumentException( "Argument 'nodeId' cannot be null." );
             }
-            this.serviceId = serviceId;
             this.nodeId = nodeId;
-        }
-
-        public String getServiceId()
-        {
-            return serviceId;
         }
 
         public String getNodeId()
@@ -2344,24 +2341,200 @@ public abstract class Node {
         {
             if ( this == o ) { return true; }
             if ( o == null || getClass() != o.getClass() ) { return false; }
+            if ( !super.equals( o ) ) { return false; }
             final UniqueIdentifier that = (UniqueIdentifier) o;
-            return serviceId.equals( that.serviceId ) &&
-                    nodeId.equals( that.nodeId );
+            return nodeId.equals( that.nodeId );
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash( serviceId, nodeId );
+            return Objects.hash( super.hashCode(), nodeId );
         }
 
         @Override
         public String toString()
         {
-            return "UniqueIdentifier{" +
-                    "serviceId='" + serviceId + '\'' +
+            return "Node.UniqueIdentifier{" +
+                    "serviceId='" + getServiceId() + '\'' +
                     ", nodeId='" + nodeId + '\'' +
                     '}';
+        }
+    }
+
+    @Override
+    public int getCachedSize() throws CannotCalculateSizeException {
+
+        // Please keep this ordered alphabetically for easier maintenance.
+
+        int size = CacheSizes.sizeOfObject(); // object overhead.
+        size += CacheSizes.sizeOfInt(); // accessModel
+        size += CacheSizes.sizeOfCollection( affiliates );
+        size += CacheSizes.sizeOfString( bodyXSLT );
+        size += CacheSizes.sizeOfCollection( contacts );
+        size += CacheSizes.sizeOfDate(); // creationDate
+        size += CacheSizes.sizeOfAnything( creator );
+        size += CacheSizes.sizeOfString( dataformXSLT );
+        size += CacheSizes.sizeOfBoolean(); // deliverPayloads
+        size += CacheSizes.sizeOfString( description );
+        size += CacheSizes.sizeOfString( language );
+        size += CacheSizes.sizeOfDate(); // modificationDate
+        size += CacheSizes.sizeOfString( name );
+        size += CacheSizes.sizeOfString( nodeID );
+        size += CacheSizes.sizeOfBoolean(); // notifyConfigChanges
+        size += CacheSizes.sizeOfBoolean(); // notifyDelete
+        size += CacheSizes.sizeOfBoolean(); // notifyRetract
+        size += CacheSizes.sizeOfObject(); // parent (reference, parent itself will already be in the cache).
+        size += CacheSizes.sizeOfString( payloadType );
+        size += CacheSizes.sizeOfBoolean(); // presenceBasedDelivery
+        size += CacheSizes.sizeOfInt(); // publisherModel
+        size += CacheSizes.sizeOfInt(); // replyPolicy
+        size += CacheSizes.sizeOfCollection( replyRooms );
+        size += CacheSizes.sizeOfCollection( replyTo );
+        size += CacheSizes.sizeOfCollection( rosterGroupsAllowed );
+        size += CacheSizes.sizeOfBoolean(); // savedToDB
+        size += CacheSizes.sizeOfInt(); // service (reference, the instance is re-used by other nodes.
+        size += CacheSizes.sizeOfBoolean(); // subscriptionConfigurationRequired
+        size += CacheSizes.sizeOfBoolean(); // subscriptionEnabled
+        size += 350 * subscriptionsByID.size(); // 350 bytes per entry is a guestimate.
+        size += 350 * subscriptionsByJID.size(); // 350 bytes per entry is a guestimate.
+        return size;
+    }
+
+    @Override
+    public void writeExternal( ObjectOutput out ) throws IOException
+    {
+        final ExternalizableUtil util = ExternalizableUtil.getInstance();
+        util.writeSafeUTF( out, accessModel.getName() );
+
+        util.writeLong( out, affiliates.size() );
+        for ( final NodeAffiliate affiliate : affiliates )
+        {
+            util.writeSerializable( out, affiliate.getJID() );
+            util.writeBoolean( out, affiliate.getAffiliation() != null );
+            if ( affiliate.getAffiliation() != null ) {
+                util.writeSafeUTF( out, affiliate.getAffiliation().name() );
+            }
+        }
+
+        util.writeSafeUTF( out, bodyXSLT );
+        util.writeSerializableCollection( out, contacts );
+        util.writeSerializable( out, creationDate );
+        util.writeSerializable( out, creator );
+        util.writeSafeUTF( out, dataformXSLT );
+        util.writeBoolean( out, deliverPayloads );
+        util.writeSafeUTF( out, description );
+        util.writeSafeUTF( out, language );
+        util.writeSerializable( out, modificationDate );
+        util.writeSafeUTF( out, name );
+        util.writeSafeUTF( out, nodeID );
+        util.writeBoolean( out, notifyConfigChanges );
+        util.writeBoolean( out, notifyDelete );
+        util.writeBoolean( out, notifyRetract );
+        util.writeSafeUTF( out, parent.getNodeID() );
+        util.writeSafeUTF( out, payloadType );
+        util.writeBoolean( out, presenceBasedDelivery );
+        util.writeSafeUTF( out, publisherModel.getName() );
+        util.writeSafeUTF( out, replyPolicy.name() );
+        util.writeSerializableCollection( out, replyRooms );
+        util.writeSerializableCollection( out, replyTo );
+        util.writeSerializableCollection( out, rosterGroupsAllowed );
+        util.writeBoolean( out, savedToDB );
+        util.writeSerializable( out, service.getAddress() );
+        util.writeBoolean( out, subscriptionConfigurationRequired );
+        util.writeBoolean( out, subscriptionEnabled );
+
+        // write out subscriptions once. When reading, use them to populate both maps.
+        final Collection<NodeSubscription> subscriptions = subscriptionsByID.values();
+        util.writeInt( out, subscriptions.size() );
+        for ( final NodeSubscription subscription : subscriptions )
+        {
+            util.writeSerializable( out, subscription.getOwner() );
+            util.writeSerializable( out, subscription.getJID() );
+            util.writeSafeUTF( out, subscription.getState().name() );
+            util.writeSafeUTF( out, subscription.getID() );
+        }
+    }
+
+    @Override
+    public void readExternal( ObjectInput in ) throws IOException, ClassNotFoundException
+    {
+        final ExternalizableUtil util = ExternalizableUtil.getInstance();
+
+        accessModel = AccessModel.valueOf( util.readSafeUTF( in ) );
+
+        final long affiliatesSize = util.readLong( in );
+        final List<NodeAffiliate> tmpAffiliates = new ArrayList<>();
+        for ( int i = 0; i<affiliatesSize; i++ ) {
+            final JID affiliateJID = (JID) util.readSerializable( in );
+            final NodeAffiliate affiliate = new NodeAffiliate( this, affiliateJID );
+            if ( util.readBoolean( in ) ) {
+                affiliate.setAffiliation( NodeAffiliate.Affiliation.valueOf( util.readSafeUTF( in ) ) );
+            }
+            tmpAffiliates.add( affiliate );
+        }
+        affiliates = new CopyOnWriteArrayList<>( tmpAffiliates ); // pass them all in, in one go, to prevent iterations where arrays are copied in each iteration.
+
+        bodyXSLT = util.readSafeUTF( in );
+        util.readSerializableCollection( in, contacts, getClass().getClassLoader() );
+        creationDate = (Date) util.readSerializable( in );
+        creator = (JID) util.readSerializable( in );
+        dataformXSLT = util.readSafeUTF( in );
+        deliverPayloads = util.readBoolean( in );
+        description = util.readSafeUTF( in );
+        language = util.readSafeUTF( in );
+        modificationDate = (Date) util.readSerializable( in );
+        name = util.readSafeUTF( in );
+        nodeID = util.readSafeUTF( in );
+        notifyConfigChanges = util.readBoolean( in );
+        notifyDelete = util.readBoolean( in );
+        notifyRetract = util.readBoolean( in );
+        final String parentId = util.readSafeUTF( in );
+        payloadType = util.readSafeUTF( in );
+        presenceBasedDelivery = util.readBoolean( in );
+        publisherModel = PublisherModel.valueOf( util.readSafeUTF( in ) );
+        replyPolicy = ItemReplyPolicy.valueOf( util.readSafeUTF( in ) );
+        util.readSerializableCollection( in, replyRooms, getClass().getClassLoader() );
+        util.readSerializableCollection( in, replyTo, getClass().getClassLoader() );
+        util.readSerializableCollection( in, rosterGroupsAllowed, getClass().getClassLoader() );
+        savedToDB = util.readBoolean( in );
+        final JID serviceAddress = (JID) util.readSerializable( in );
+        subscriptionConfigurationRequired = util.readBoolean( in );
+        subscriptionEnabled = util.readBoolean( in );
+
+        final int subscriptionCount = util.readInt( in );
+        for ( int i = 0; i < subscriptionCount; i++ )
+        {
+            final Node node = this;
+            final JID owner = (JID) util.readSerializable( in );
+            final JID jid = (JID) util.readSerializable( in );
+            final NodeSubscription.State state = NodeSubscription.State.valueOf( util.readSafeUTF( in ) );
+            final String id = util.readSafeUTF( in );
+            final NodeSubscription subscription = new NodeSubscription( node, owner, jid, state, id );
+
+            subscriptionsByID.put( subscription.getID(), subscription );
+            subscriptionsByJID.put( subscription.getJID().toString(), subscription );
+        }
+
+        final PubSubModule pubSubModule = XMPPServer.getInstance().getPubSubModule();
+        if ( pubSubModule.getAddress().equals( serviceAddress) ) {
+            service = pubSubModule;
+        } else {
+            service = XMPPServer.getInstance().getIQPEPHandler().getServiceManager().getPEPService( serviceAddress.toBareJID() );
+        }
+        if ( service == null ) {
+            // The service is neither a pubsubmodule, nor PEP service. Is there a new
+            // implementation of PubSubService that needs to be added to this code?
+            throw new IllegalStateException();
+        }
+
+        if ( service.getRootCollectionNode() != null && service.getRootCollectionNode().getNodeID().equals( parentId ) ) {
+            parent = service.getRootCollectionNode();
+        } else {
+            parent = (CollectionNode) service.getNode( parentId );
+        }
+        if ( parent == null ) {
+            throw new IllegalStateException();
         }
     }
 }

--- a/src/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -1826,40 +1826,37 @@ public abstract class Node {
      *
      * @return true if the node was successfully deleted.
      */
-    public boolean delete() {
+    public void delete() {
         // Delete node from the database
-        if (PubSubPersistenceManager.removeNode(this)) {
-            // Remove this node from the parent node (if any)
-            if (parent != null) {
-                parent.removeChildNode(this);
-            }
-            deletingNode();
-            // Broadcast delete notification to subscribers (if enabled)
-            if (isNotifiedOfDelete()) {
-                // Build packet to broadcast to subscribers
-                Message message = new Message();
-                Element event = message.addChildElement("event", "http://jabber.org/protocol/pubsub#event");
-                Element items = event.addElement("delete");
-                items.addAttribute("node", nodeID);
-                // Send notification that the node was deleted
-                broadcastNodeEvent(message, true);
-            }
-            // Notify the parent (if any) that the node has been removed from the parent node
-            if (parent != null) {
-                parent.childNodeDeleted(this);
-            }
-            // Remove presence subscription when node was deleted.
-            cancelPresenceSubscriptions();
-            // Remove the node from memory
-            service.removeNode(getNodeID());
-            CacheFactory.doClusterTask(new RemoveNodeTask(this));
-            // Clear collections in memory (clear them after broadcast was sent)
-            affiliates.clear();
-            subscriptionsByID.clear();
-            subscriptionsByJID.clear();
-            return true;
+        PubSubPersistenceManager.removeNode(this);
+        // Remove this node from the parent node (if any)
+        if (parent != null) {
+            parent.removeChildNode(this);
         }
-        return false;
+        deletingNode();
+        // Broadcast delete notification to subscribers (if enabled)
+        if (isNotifiedOfDelete()) {
+            // Build packet to broadcast to subscribers
+            Message message = new Message();
+            Element event = message.addChildElement("event", "http://jabber.org/protocol/pubsub#event");
+            Element items = event.addElement("delete");
+            items.addAttribute("node", nodeID);
+            // Send notification that the node was deleted
+            broadcastNodeEvent(message, true);
+        }
+        // Notify the parent (if any) that the node has been removed from the parent node
+        if (parent != null) {
+            parent.childNodeDeleted(this);
+        }
+        // Remove presence subscription when node was deleted.
+        cancelPresenceSubscriptions();
+        // Remove the node from memory
+        service.removeNode(getNodeID());
+        CacheFactory.doClusterTask(new RemoveNodeTask(this));
+        // Clear collections in memory (clear them after broadcast was sent)
+        affiliates.clear();
+        subscriptionsByID.clear();
+        subscriptionsByJID.clear();
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * $RCSfile: $
  * $Revision: $
  * $Date: $
@@ -20,6 +20,7 @@
 
 package org.jivesoftware.openfire.pubsub;
 
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -27,6 +28,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.dom4j.Element;
+import org.jivesoftware.util.cache.CacheSizes;
+import org.jivesoftware.util.cache.Cacheable;
+import org.jivesoftware.util.cache.CannotCalculateSizeException;
+import org.jivesoftware.util.cache.ExternalizableUtil;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 
@@ -37,8 +42,8 @@ import org.xmpp.packet.Message;
  *
  * @author Matt Tucker
  */
-public class NodeAffiliate {
-
+public class NodeAffiliate implements Cacheable
+{
     private JID jid;
     private Node node;
 
@@ -283,6 +288,23 @@ public class NodeAffiliate {
 	public String toString() {
         return super.toString() + " - JID: " + getJID() + " - Affiliation: " +
                 getAffiliation().name();
+    }
+
+    /**
+     * Returns the approximate size of the Object in bytes. The size should be
+     * considered to be a best estimate of how much memory the Object occupies
+     * and may be based on empirical trials or dynamic calculations.<p>
+     *
+     * @return the size of the Object in bytes.
+     */
+    @Override
+    public int getCachedSize() throws CannotCalculateSizeException
+    {
+        int size = CacheSizes.sizeOfObject();
+        size += CacheSizes.sizeOfAnything( jid );
+        size += CacheSizes.sizeOfInt(); // affiliation
+        size += CacheSizes.sizeOfInt(); // reference to node
+        return size;
     }
 
     /**

--- a/src/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
@@ -496,7 +496,7 @@ public class NodeSubscription {
         }
         if (savedToDB) {
             // Update the subscription in the backend store
-            PubSubPersistenceManager.updateSubscription(node, this);
+            PubSubPersistenceProviderManager.getInstance().getProvider().updateSubscription(node, this);
         }
         // Check if the service needs to subscribe or unsubscribe from the owner presence
         if (!node.isPresenceBasedDelivery() && wasUsingPresence != !presenceStates.isEmpty()) {
@@ -861,7 +861,7 @@ public class NodeSubscription {
 
         if (savedToDB) {
             // Update the subscription in the backend store
-            PubSubPersistenceManager.updateSubscription(node, this);
+            PubSubPersistenceProviderManager.getInstance().getProvider().updateSubscription(node, this);
         }
 
         // Send last published item (if node is leaf node and subscription status is ok)

--- a/src/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
@@ -496,7 +496,7 @@ public class NodeSubscription {
         }
         if (savedToDB) {
             // Update the subscription in the backend store
-            PubSubPersistenceManager.saveSubscription(node, this, false);
+            PubSubPersistenceManager.updateSubscription(node, this);
         }
         // Check if the service needs to subscribe or unsubscribe from the owner presence
         if (!node.isPresenceBasedDelivery() && wasUsingPresence != !presenceStates.isEmpty()) {
@@ -861,7 +861,7 @@ public class NodeSubscription {
 
         if (savedToDB) {
             // Update the subscription in the backend store
-            PubSubPersistenceManager.saveSubscription(node, this, false);
+            PubSubPersistenceManager.updateSubscription(node, this);
         }
 
         // Send last published item (if node is leaf node and subscription status is ok)

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -1789,7 +1789,7 @@ public class PubSubEngine {
     }
 
     public void shutdown(PubSubService service) {
-    	PubSubPersistenceManager.shutdown();
+    	PubSubPersistenceProviderManager.getInstance().shutdown();
     	if (service != null) {
 
     		if (service.getManager() != null) {

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -1401,14 +1401,9 @@ public class PubSubEngine {
         }
 
         // Delete the node
-        if (node.delete()) {
-            // Return that node was deleted successfully
-            router.route(IQ.createResultIQ(iq));
-        }
-        else {
-            // Some error occured while trying to delete the node
-            sendErrorPacket(iq, PacketError.Condition.internal_server_error, null);
-        }
+        node.delete();
+        // Return that node was deleted successfully
+        router.route(IQ.createResultIQ(iq));
     }
 
     private void purgeNode(PubSubService service, IQ iq, Element purgeElement) {

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -336,8 +336,7 @@ public class PubSubEngine {
                     // If it is a PEP service & publisher is service owner -
                     // auto create nodes.
                     Element childElement = iq.getChildElement();
-                    Element createElement = publishElement.element("publish");
-                    CreateNodeResponse response = createNodeHelper(service, iq, childElement, createElement);
+                    CreateNodeResponse response = createNodeHelper(service, iq, childElement, publishElement);
 
                     if (response.newNode == null) {
                         // New node creation failed. Since pep#auto-create is advertised 

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -414,7 +414,7 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
         engine = new PubSubEngine(router);
 
         // Load default configuration for leaf nodes
-        leafDefaultConfiguration = PubSubPersistenceManager.loadDefaultConfiguration(this, true);
+        leafDefaultConfiguration = PubSubPersistenceProviderManager.getInstance().getProvider().loadDefaultConfiguration(this, true);
         if (leafDefaultConfiguration == null) {
             // Create and save default configuration for leaf nodes;
             leafDefaultConfiguration = new DefaultNodeConfiguration(true);
@@ -432,11 +432,11 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
             leafDefaultConfiguration.setSendItemSubscribe(true);
             leafDefaultConfiguration.setSubscriptionEnabled(true);
             leafDefaultConfiguration.setReplyPolicy(null);
-            PubSubPersistenceManager.createDefaultConfiguration(this, leafDefaultConfiguration);
+            PubSubPersistenceProviderManager.getInstance().getProvider().createDefaultConfiguration(this, leafDefaultConfiguration);
         }
         // Load default configuration for collection nodes
         collectionDefaultConfiguration =
-                PubSubPersistenceManager.loadDefaultConfiguration(this, false);
+                PubSubPersistenceProviderManager.getInstance().getProvider().loadDefaultConfiguration(this, false);
         if (collectionDefaultConfiguration == null ) {
             // Create and save default configuration for collection nodes;
             collectionDefaultConfiguration = new DefaultNodeConfiguration(false);
@@ -453,12 +453,11 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
             collectionDefaultConfiguration
                     .setAssociationPolicy(CollectionNode.LeafNodeAssociationPolicy.all);
             collectionDefaultConfiguration.setMaxLeafNodes(-1);
-            PubSubPersistenceManager
-                    .createDefaultConfiguration(this, collectionDefaultConfiguration);
+            PubSubPersistenceProviderManager.getInstance().getProvider().createDefaultConfiguration(this, collectionDefaultConfiguration);
         }
 
         // Load nodes to memory
-        PubSubPersistenceManager.loadNodes(this);
+        PubSubPersistenceProviderManager.getInstance().getProvider().loadNodes(this);
         // Ensure that we have a root collection node
         String rootNodeID = JiveGlobals.getProperty("xmpp.pubsub.root.nodeID", "");
         if (nodes.isEmpty()) {

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceManager.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceManager.java
@@ -20,23 +20,6 @@
 
 package org.jivesoftware.openfire.pubsub;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.StringTokenizer;
-import java.util.TimerTask;
-import java.util.concurrent.locks.Lock;
-
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.database.DbConnectionManager.DatabaseType;
 import org.jivesoftware.openfire.cluster.ClusterManager;
@@ -44,8 +27,6 @@ import org.jivesoftware.openfire.pubsub.cluster.FlushTask;
 import org.jivesoftware.openfire.pubsub.models.AccessModel;
 import org.jivesoftware.openfire.pubsub.models.PublisherModel;
 import org.jivesoftware.util.JiveGlobals;
-import org.jivesoftware.util.LinkedList;
-import org.jivesoftware.util.LinkedListNode;
 import org.jivesoftware.util.StringUtils;
 import org.jivesoftware.util.TaskEngine;
 import org.jivesoftware.util.cache.Cache;
@@ -53,6 +34,17 @@ import org.jivesoftware.util.cache.CacheFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
+import java.util.stream.Collectors;
 
 /**
  * A manager responsible for ensuring node persistence.
@@ -245,20 +237,89 @@ public class PubSubPersistenceManager {
     /**
      * Queue that holds the (wrapped) items that need to be added to the database.
      */
-    private static LinkedList<RetryWrapper> itemsToAdd = new LinkedList<>();
+    private static Deque<RetryWrapper> itemsToAdd = new ConcurrentLinkedDeque<>();
 
     /**
      * Queue that holds the items that need to be deleted from the database.
      */
-    private static LinkedList<PublishedItem> itemsToDelete = new LinkedList<>();
+    private static Deque<PublishedItem> itemsToDelete = new ConcurrentLinkedDeque<>();
 
     /**
-     * Keeps reference to published items that haven't been persisted yet so they 
-     * can be removed before being deleted. Note these items are wrapped via the 
+     * Keeps reference to published items that haven't been persisted yet so they
+     * can be removed before being deleted. Note these items are wrapped via the
      * RetryWrapper to allow multiple persistence attempts when needed.
      */
-    private static final HashMap<String, LinkedListNode<RetryWrapper>> itemsPending = new HashMap<>();
-    
+    private static final HashMap<String, RetryWrapper> itemsPending = new HashMap<>();
+
+    private static ConcurrentMap<String, List<NodeOperation>> nodesToProcess = new ConcurrentHashMap<>();
+
+    static class NodeOperation {
+
+        enum Action {
+            CREATE,
+            UPDATE,
+            REMOVE,
+            CREATE_AFFILIATION,
+            UPDATE_AFFILIATION,
+            REMOVE_AFFILIATION,
+            CREATE_SUBSCRIPTION,
+            UPDATE_SUBSCRIPTION,
+            REMOVE_SUBSCRIPTION
+        }
+
+        final Node node;
+        final Action action;
+        final NodeAffiliate affiliate;
+        final NodeSubscription subscription;
+
+        private NodeOperation( final Node node, final Action action, final NodeAffiliate affiliate, final NodeSubscription subscription ) {
+            if ( node == null ) {
+                throw new IllegalArgumentException( "Argument 'node' cannot be null." );
+            }
+            if ( action == null ) {
+                throw new IllegalArgumentException( "Argument 'action' cannot be null." );
+            }
+            if ( affiliate == null && Arrays.asList( Action.CREATE_AFFILIATION, Action.UPDATE_AFFILIATION, Action.REMOVE_AFFILIATION ).contains( action ) ) {
+                throw new IllegalArgumentException( "Argument 'affiliate' cannot be null when 'action' is " + action );
+            }
+            if ( subscription == null && Arrays.asList( Action.CREATE_SUBSCRIPTION, Action.UPDATE_SUBSCRIPTION, Action.REMOVE_SUBSCRIPTION ).contains( action ) ) {
+                throw new IllegalArgumentException( "Argument 'subscription' cannot be null when 'action' is " + action );
+            }
+            this.node = node;
+            this.action = action;
+            this.affiliate = affiliate;
+            this.subscription = subscription;
+        }
+
+        static NodeOperation create( final Node node ) {
+            return new NodeOperation( node, Action.CREATE, null, null );
+        }
+        static NodeOperation update( final Node node ) {
+            return new NodeOperation( node, Action.UPDATE, null, null );
+        }
+        static NodeOperation remove( final Node node ) {
+            return new NodeOperation( node, Action.REMOVE, null, null );
+        }
+        static NodeOperation createAffiliation( final Node node, final NodeAffiliate affiliate ) {
+            return new NodeOperation( node, Action.CREATE_AFFILIATION, affiliate, null );
+        }
+        static NodeOperation updateAffiliation( final Node node, final NodeAffiliate affiliate ) {
+            return new NodeOperation( node, Action.UPDATE_AFFILIATION, affiliate, null );
+        }
+        static NodeOperation removeAffiliation( final Node node, final NodeAffiliate affiliate ) {
+            return new NodeOperation( node, Action.REMOVE_AFFILIATION, affiliate, null );
+        }
+        static NodeOperation createSubscription( final Node node, final NodeSubscription subscription ) {
+            return new NodeOperation( node, Action.CREATE_SUBSCRIPTION, null, subscription);
+        }
+        static NodeOperation updateSubscription( final Node node, final NodeSubscription subscription ) {
+            return new NodeOperation( node, Action.UPDATE_SUBSCRIPTION, null, subscription );
+        }
+        static NodeOperation removeSubscription( final Node node, final NodeSubscription subscription ) {
+            return new NodeOperation( node, Action.REMOVE_SUBSCRIPTION, null, subscription );
+        }
+    }
+
     /**
      * Cache name for recently accessed published items.
      */
@@ -268,7 +329,17 @@ public class PubSubPersistenceManager {
      * Cache for recently accessed published items.
      */
     private static final Cache<String, PublishedItem> itemCache = CacheFactory.createCache(ITEM_CACHE);
-    
+
+    /**
+     * Cache name for recently accessed published items.
+     */
+    private static final String DEFAULT_CONF_CACHE = "Default Node Configurations";
+
+    /**
+     * Cache for default configurations
+     */
+    private static final Cache<String, DefaultNodeConfiguration> defaultNodeConfigurationCache = CacheFactory.createCache(DEFAULT_CONF_CACHE);
+
     static {
     	try {
         	if (MAX_ITEMS_FLUSH > 0) {
@@ -294,12 +365,105 @@ public class PubSubPersistenceManager {
 		
     }
 
+    private static void flushPendingNodes()
+    {
+        // TODO verify that this is thread-safe.
+        final Iterator<List<NodeOperation>> iterator = nodesToProcess.values().iterator();
+        while (iterator.hasNext()) {
+            final List<NodeOperation> operations = iterator.next();
+            operations.forEach( PubSubPersistenceManager::process );
+            iterator.remove();
+        }
+    }
+
+    private static void flushPendingNodes( String serviceId )
+    {
+        // TODO verify that this is thread-safe (hint: it's not!)
+        final Iterator<List<NodeOperation>> iterator = nodesToProcess.values().iterator();
+        while (iterator.hasNext()) {
+            final List<NodeOperation> operations = iterator.next();
+            if ( serviceId.equals( operations.get( 0 ).node.service.getServiceID() ) )
+            {
+                operations.forEach( PubSubPersistenceManager::process );
+                iterator.remove();
+            }
+        }
+    }
+
+    private static void flushPendingNode( String nodeId )
+    {
+        // TODO verify if this is having the desired effect. - nodes could be in a hierarchy, which could warrant for flushing the entire tree.
+        // TODO verify that this is thread-safe.
+        nodesToProcess.computeIfPresent( nodeId, ( key, operations ) -> {
+            operations.forEach( PubSubPersistenceManager::process );
+            // Returning null causes the mapping to removed from nodesToProcess.
+            return null;
+        } );
+    }
+
+    private static void process( final NodeOperation operation ) {
+        switch ( operation.action )
+        {
+            case CREATE:
+                createNodeInDatabase( operation.node );
+                break;
+
+            case UPDATE:
+                updateNodeInDatabase( operation.node );
+                break;
+
+            case REMOVE:
+                removeNodeInDatabase( operation.node );
+                break;
+
+            case CREATE_AFFILIATION:
+                createAffiliationInDatabase( operation.node, operation.affiliate );
+                break;
+
+            case UPDATE_AFFILIATION:
+                updateAffiliationInDatabase( operation.node, operation.affiliate );
+                break;
+
+            case REMOVE_AFFILIATION:
+                removeAffiliationInDatabase( operation.node, operation.affiliate );
+                break;
+
+            case CREATE_SUBSCRIPTION:
+                createSubscriptionInDatabase( operation.node, operation.subscription );
+                break;
+
+            case UPDATE_SUBSCRIPTION:
+                updateSubscriptionInDatabase( operation.node, operation.subscription );
+                break;
+
+            case REMOVE_SUBSCRIPTION:
+                removeSubscriptionInDatabase( operation.subscription );
+                break;
+
+            default:
+                throw new IllegalStateException(); // This indicates a bug in the implementation of this class.
+        }
+    }
+
+    /**
+     * Schedules the node to be created in the database.
+     *
+     * @param node The newly created node.
+     */
+    public static void createNode(Node node) {
+        final List<NodeOperation> operations = nodesToProcess.computeIfAbsent( node.getNodeID(), nodeId -> new ArrayList<>() );
+        // Don't purge pending operations. It'd be odd for operations to already exist at this stage. It'd be possible for
+        // a node to be recreated, which could mean that there's a DELETE. When there are other operations, the pre-'nodesToProcess'
+        // behavior will kick in (which would presumably lead to database constraint-related exceptions).
+        operations.add( NodeOperation.create( node ) );
+    }
+
     /**
      * Creates and stores the node configuration in the database.
      *
      * @param node The newly created node.
      */
-    public static void createNode(Node node) {
+    private static void createNodeInDatabase(Node node) {
         Connection con = null;
         PreparedStatement pstmt = null;
         boolean abortTransaction = false;
@@ -369,11 +533,32 @@ public class PubSubPersistenceManager {
     }
 
     /**
-     * Updates the node configuration in the database.
+     * Schedules the node to be updated in the database.
      *
      * @param node The updated node.
      */
     public static void updateNode(Node node) {
+        final List<NodeOperation> operations = nodesToProcess.computeIfAbsent( node.getNodeID(), nodeId -> new ArrayList<>() );
+
+        // This update can replace any pending updates (since the last create/delete or affiliation change).
+        final ListIterator<NodeOperation> iter = operations.listIterator( operations.size() );
+        while ( iter.hasPrevious() ) {
+            final NodeOperation operation = iter.previous();
+            if ( operation.action.equals( NodeOperation.Action.UPDATE ) ) {
+                iter.remove(); // This is replaced by the update that's being added.
+            } else {
+                break; // Operations that precede anything other than the last operations that are UPDATE shouldn't be replaced.
+            }
+        }
+        operations.add( NodeOperation.update( node ));
+    }
+
+    /**
+     * Updates the node configuration in the database.
+     *
+     * @param node The updated node.
+     */
+    private static void updateNodeInDatabase(Node node) {
         Connection con = null;
         PreparedStatement pstmt = null;
         boolean abortTransaction = false;
@@ -503,12 +688,23 @@ public class PubSubPersistenceManager {
     }
 
     /**
+     * Schedules the node to be removed in the database.
+     *
+     * @param node The node that is being deleted.
+     */
+    public static void removeNode(Node node) {
+        final List<NodeOperation> operations = nodesToProcess.computeIfAbsent( node.getNodeID(), nodeId -> new ArrayList<>() );
+        operations.clear(); // Any previously recorded, but as of yet unsaved operations, can be skipped.
+        operations.add( NodeOperation.remove( node ));
+    }
+
+    /**
      * Removes the specified node from the DB.
      *
      * @param node The node that is being deleted.
      * @return true If the operation was successful.
      */
-    public static boolean removeNode(Node node) {
+    private static boolean removeNodeInDatabase(Node node) {
         Connection con = null;
         PreparedStatement pstmt = null;
         boolean abortTransaction = false;
@@ -571,6 +767,10 @@ public class PubSubPersistenceManager {
      * @param service the pubsub service that is hosting the nodes.
      */
     public static void loadNodes(PubSubService service) {
+        // Make sure that all changes to nodes have been written to the database
+        // before the nodes are retrieved.
+        flushPendingNodes( service.getServiceID() );
+
         Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
@@ -671,7 +871,11 @@ public class PubSubPersistenceManager {
 	 */
 	public static void loadNode(PubSubService service, String nodeId)
 	{
-		Connection con = null;
+        // Make sure that all changes to nodes have been written to the database
+        // before the nodes are retrieved.
+	    flushPendingNode( nodeId );
+
+        Connection con = null;
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
 		Map<String, Node> nodes = new HashMap<>();
@@ -897,7 +1101,9 @@ public class PubSubPersistenceManager {
 
 	public static void loadSubscription(PubSubService service, Node node, String subId)
 	{
-		Connection con = null;
+	    flushPendingNode( node.nodeID );
+
+	    Connection con = null;
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
 		Map<String, Node> nodes = new HashMap<>();
@@ -976,28 +1182,63 @@ public class PubSubPersistenceManager {
      * @param create    True if this is a new affiliate.
      */
     public static void saveAffiliation(Node node, NodeAffiliate affiliate, boolean create) {
+        final List<NodeOperation> operations = nodesToProcess.computeIfAbsent( node.getNodeID(), nodeId -> new ArrayList<>() );
+        final NodeOperation operation;
+        if (create) {
+            operation = NodeOperation.createAffiliation( node, affiliate );
+        } else {
+
+            // This affiliation update can replace any pending updates of the same affiliate (since the last create/delete of the node or affiliation change of this affiliate to the node).
+            final ListIterator<NodeOperation> iter = operations.listIterator( operations.size() );
+            while ( iter.hasPrevious() ) {
+                final NodeOperation op = iter.previous();
+                if ( op.action.equals( NodeOperation.Action.UPDATE_AFFILIATION ) ) {
+                    if ( affiliate.getJID().equals( op.affiliate.getJID() ) ) {
+                        iter.remove(); // This is replaced by the update that's being added.
+                    }
+                } else {
+                    break; // Operations that precede anything other than the last operations that are UPDATE_AFFILIATE shouldn't be replaced.
+                }
+            }
+
+            operation = NodeOperation.updateAffiliation( node, affiliate );
+        }
+        operations.add( operation );
+    }
+
+    // Add the user to the generic affiliations table
+    private static void createAffiliationInDatabase(Node node, NodeAffiliate affiliate) {
         Connection con = null;
         PreparedStatement pstmt = null;
         try {
             con = DbConnectionManager.getConnection();
-            if (create) {
-                // Add the user to the generic affiliations table
-                pstmt = con.prepareStatement(ADD_AFFILIATION);
-                pstmt.setString(1, node.getService().getServiceID());
-                pstmt.setString(2, encodeNodeID(node.getNodeID()));
-                pstmt.setString(3, affiliate.getJID().toString());
-                pstmt.setString(4, affiliate.getAffiliation().name());
-                pstmt.executeUpdate();
-            }
-            else {
-                // Update the affiliate's data in the backend store
-                pstmt = con.prepareStatement(UPDATE_AFFILIATION);
-                pstmt.setString(1, affiliate.getAffiliation().name());
-                pstmt.setString(2, node.getService().getServiceID());
-                pstmt.setString(3, encodeNodeID(node.getNodeID()));
-                pstmt.setString(4, affiliate.getJID().toString());
-                pstmt.executeUpdate();
-            }
+            pstmt = con.prepareStatement(ADD_AFFILIATION);
+            pstmt.setString(1, node.getService().getServiceID());
+            pstmt.setString(2, encodeNodeID(node.getNodeID()));
+            pstmt.setString(3, affiliate.getJID().toString());
+            pstmt.setString(4, affiliate.getAffiliation().name());
+            pstmt.executeUpdate();
+        }
+        catch (SQLException sqle) {
+            log.error(sqle.getMessage(), sqle);
+        }
+        finally {
+            DbConnectionManager.closeConnection(pstmt, con);
+        }
+    }
+
+    // Update the affiliate's data in the backend store
+    private static void updateAffiliationInDatabase(Node node, NodeAffiliate affiliate) {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        try {
+            con = DbConnectionManager.getConnection();
+            pstmt = con.prepareStatement(UPDATE_AFFILIATION);
+            pstmt.setString(1, affiliate.getAffiliation().name());
+            pstmt.setString(2, node.getService().getServiceID());
+            pstmt.setString(3, encodeNodeID(node.getNodeID()));
+            pstmt.setString(4, affiliate.getJID().toString());
+            pstmt.executeUpdate();
         }
         catch (SQLException sqle) {
             log.error(sqle.getMessage(), sqle);
@@ -1014,6 +1255,30 @@ public class PubSubPersistenceManager {
      * @param affiliate The existing affiliation and subsription state of the user in the node.
      */
     public static void removeAffiliation(Node node, NodeAffiliate affiliate) {
+        final List<NodeOperation> operations = nodesToProcess.computeIfAbsent( node.getNodeID(), nodeId -> new ArrayList<>() );
+
+        // This affiliation removal can replace any pending creation, update or delete of the same affiliate (since the last create/delete of the node or affiliation change of this affiliate to the node).
+        final ListIterator<NodeOperation> iter = operations.listIterator( operations.size() );
+        while ( iter.hasPrevious() ) {
+            final NodeOperation operation = iter.previous();
+            if ( Arrays.asList( NodeOperation.Action.CREATE_AFFILIATION, NodeOperation.Action.UPDATE_AFFILIATION, NodeOperation.Action.REMOVE_AFFILIATION ).contains( operation.action ) ) {
+                if ( affiliate.getJID().equals( operation.affiliate.getJID() ) ) {
+                    iter.remove(); // This is replaced by the update that's being added.
+                }
+            } else {
+                break; // Operations that precede anything other than the last operations that are affiliate changes shouldn't be replaced.
+            }
+        }
+        operations.add( NodeOperation.removeAffiliation( node, affiliate ) );
+    }
+
+    /**
+     * Removes the affiliation and subsription state of the user from the DB.
+     *
+     * @param node      The node where the affiliation of the user was updated.
+     * @param affiliate The existing affiliation and subsription state of the user in the node.
+     */
+    private static void removeAffiliationInDatabase(Node node, NodeAffiliate affiliate) {
         Connection con = null;
         PreparedStatement pstmt = null;
         try {
@@ -1034,79 +1299,126 @@ public class PubSubPersistenceManager {
     }
 
     /**
-     * Updates the DB with the new subsription of the user to the node.
+     * Updates the DB with the new subscription of the user to the node.
      *
      * @param node      The node where the user has subscribed to.
      * @param subscription The new subscription of the user to the node.
      * @param create    True if this is a new affiliate.
      */
     public static void saveSubscription(Node node, NodeSubscription subscription, boolean create) {
+        final List<NodeOperation> operations = nodesToProcess.computeIfAbsent( node.getNodeID(), nodeId -> new ArrayList<>() );
+        final NodeOperation operation;
+        if (create) {
+            operation = NodeOperation.createSubscription( node, subscription );
+        } else {
+
+            // This subscription update can replace any pending updates of the same subscription (since the last create/delete of the node or subscription change of this affiliate to the node).
+            final ListIterator<NodeOperation> iter = operations.listIterator( operations.size() );
+            while ( iter.hasPrevious() ) {
+                final NodeOperation op = iter.previous();
+                if ( op.action.equals( NodeOperation.Action.UPDATE_SUBSCRIPTION ) ) {
+                    if ( subscription.getID().equals( op.subscription.getID() ) ) {
+                        iter.remove(); // This is replaced by the update that's being added.
+                    }
+                } else {
+                    break; // Operations that precede anything other than the last operations that are UPDATE_AFFILIATE shouldn't be replaced.
+                }
+            }
+
+            operation = NodeOperation.updateSubscription( node, subscription );
+        }
+        operations.add( operation );
+    }
+
+    /**
+     * Updates the DB with the new subscription of the user to the node.
+     *
+     * @param node      The node where the user has subscribed to.
+     * @param subscription The new subscription of the user to the node.
+     */
+    private static void createSubscriptionInDatabase(Node node, NodeSubscription subscription) {
         Connection con = null;
         PreparedStatement pstmt = null;
         try {
             con = DbConnectionManager.getConnection();
-            if (create) {
-                // Add the subscription of the user to the database
-                pstmt = con.prepareStatement(ADD_SUBSCRIPTION);
-                pstmt.setString(1, node.getService().getServiceID());
-                pstmt.setString(2, encodeNodeID(node.getNodeID()));
-                pstmt.setString(3, subscription.getID());
-                pstmt.setString(4, subscription.getJID().toString());
-                pstmt.setString(5, subscription.getOwner().toString());
-                pstmt.setString(6, subscription.getState().name());
-                pstmt.setInt(7, (subscription.shouldDeliverNotifications() ? 1 : 0));
-                pstmt.setInt(8, (subscription.isUsingDigest() ? 1 : 0));
-                pstmt.setInt(9, subscription.getDigestFrequency());
-                Date expireDate = subscription.getExpire();
-                if (expireDate == null) {
-                    pstmt.setString(10, null);
-                }
-                else {
-                    pstmt.setString(10, StringUtils.dateToMillis(expireDate));
-                }
-                pstmt.setInt(11, (subscription.isIncludingBody() ? 1 : 0));
-                pstmt.setString(12, encodeWithComma(subscription.getPresenceStates()));
-                pstmt.setString(13, subscription.getType().name());
-                pstmt.setInt(14, subscription.getDepth());
-                pstmt.setString(15, subscription.getKeyword());
-                pstmt.executeUpdate();
-                // Indicate the subscription that is has been saved to the database
-                subscription.setSavedToDB(true);
+            // Add the subscription of the user to the database
+            pstmt = con.prepareStatement(ADD_SUBSCRIPTION);
+            pstmt.setString(1, node.getService().getServiceID());
+            pstmt.setString(2, encodeNodeID(node.getNodeID()));
+            pstmt.setString(3, subscription.getID());
+            pstmt.setString(4, subscription.getJID().toString());
+            pstmt.setString(5, subscription.getOwner().toString());
+            pstmt.setString(6, subscription.getState().name());
+            pstmt.setInt(7, (subscription.shouldDeliverNotifications() ? 1 : 0));
+            pstmt.setInt(8, (subscription.isUsingDigest() ? 1 : 0));
+            pstmt.setInt(9, subscription.getDigestFrequency());
+            Date expireDate = subscription.getExpire();
+            if (expireDate == null) {
+                pstmt.setString(10, null);
             }
             else {
-                if (NodeSubscription.State.none == subscription.getState()) {
-                    // Remove the subscription of the user from the table
-                    pstmt = con.prepareStatement(DELETE_SUBSCRIPTION);
-                    pstmt.setString(1, node.getService().getServiceID());
-                    pstmt.setString(2, encodeNodeID(node.getNodeID()));
-                    pstmt.setString(2, subscription.getID());
-                    pstmt.executeUpdate();
+                pstmt.setString(10, StringUtils.dateToMillis(expireDate));
+            }
+            pstmt.setInt(11, (subscription.isIncludingBody() ? 1 : 0));
+            pstmt.setString(12, encodeWithComma(subscription.getPresenceStates()));
+            pstmt.setString(13, subscription.getType().name());
+            pstmt.setInt(14, subscription.getDepth());
+            pstmt.setString(15, subscription.getKeyword());
+            pstmt.executeUpdate();
+            // Indicate the subscription that is has been saved to the database
+            subscription.setSavedToDB(true);
+        }
+        catch (SQLException sqle) {
+            log.error(sqle.getMessage(), sqle);
+        }
+        finally {
+            DbConnectionManager.closeConnection(pstmt, con);
+        }
+    }
+
+    /**
+     * Updates the DB with the new subscription of the user to the node.
+     *
+     * @param node      The node where the user has subscribed to.
+     * @param subscription The new subscription of the user to the node.
+     */
+    private static void updateSubscriptionInDatabase(Node node, NodeSubscription subscription) {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        try {
+            con = DbConnectionManager.getConnection();
+            if (NodeSubscription.State.none == subscription.getState()) {
+                // Remove the subscription of the user from the table
+                pstmt = con.prepareStatement(DELETE_SUBSCRIPTION);
+                pstmt.setString(1, node.getService().getServiceID());
+                pstmt.setString(2, encodeNodeID(node.getNodeID()));
+                pstmt.setString(2, subscription.getID());
+                pstmt.executeUpdate();
+            }
+            else {
+                // Update the subscription of the user in the backend store
+                pstmt = con.prepareStatement(UPDATE_SUBSCRIPTION);
+                pstmt.setString(1, subscription.getOwner().toString());
+                pstmt.setString(2, subscription.getState().name());
+                pstmt.setInt(3, (subscription.shouldDeliverNotifications() ? 1 : 0));
+                pstmt.setInt(4, (subscription.isUsingDigest() ? 1 : 0));
+                pstmt.setInt(5, subscription.getDigestFrequency());
+                Date expireDate = subscription.getExpire();
+                if (expireDate == null) {
+                    pstmt.setString(6, null);
                 }
                 else {
-                    // Update the subscription of the user in the backend store
-                    pstmt = con.prepareStatement(UPDATE_SUBSCRIPTION);
-                    pstmt.setString(1, subscription.getOwner().toString());
-                    pstmt.setString(2, subscription.getState().name());
-                    pstmt.setInt(3, (subscription.shouldDeliverNotifications() ? 1 : 0));
-                    pstmt.setInt(4, (subscription.isUsingDigest() ? 1 : 0));
-                    pstmt.setInt(5, subscription.getDigestFrequency());
-                    Date expireDate = subscription.getExpire();
-                    if (expireDate == null) {
-                        pstmt.setString(6, null);
-                    }
-                    else {
-                        pstmt.setString(6, StringUtils.dateToMillis(expireDate));
-                    }
-                    pstmt.setInt(7, (subscription.isIncludingBody() ? 1 : 0));
-                    pstmt.setString(8, encodeWithComma(subscription.getPresenceStates()));
-                    pstmt.setString(9, subscription.getType().name());
-                    pstmt.setInt(10, subscription.getDepth());
-                    pstmt.setString(11, subscription.getKeyword());
-                    pstmt.setString(12, node.getService().getServiceID());
-                    pstmt.setString(13, encodeNodeID(node.getNodeID()));
-                    pstmt.setString(14, subscription.getID());
-                    pstmt.executeUpdate();
+                    pstmt.setString(6, StringUtils.dateToMillis(expireDate));
                 }
+                pstmt.setInt(7, (subscription.isIncludingBody() ? 1 : 0));
+                pstmt.setString(8, encodeWithComma(subscription.getPresenceStates()));
+                pstmt.setString(9, subscription.getType().name());
+                pstmt.setInt(10, subscription.getDepth());
+                pstmt.setString(11, subscription.getKeyword());
+                pstmt.setString(12, node.getService().getServiceID());
+                pstmt.setString(13, encodeNodeID(node.getNodeID()));
+                pstmt.setString(14, subscription.getID());
+                pstmt.executeUpdate();
             }
         }
         catch (SQLException sqle) {
@@ -1120,9 +1432,32 @@ public class PubSubPersistenceManager {
     /**
      * Removes the subscription of the user from the DB.
      *
-     * @param subscription The existing subsription of the user to the node.
+     * @param subscription The existing subscription of the user to the node.
      */
     public static void removeSubscription(NodeSubscription subscription) {
+        final List<NodeOperation> operations = nodesToProcess.computeIfAbsent( subscription.getNode().getNodeID(), nodeId -> new ArrayList<>() );
+
+        // This subscription removal can replace any pending creation, update or delete of the same subscription (since the last create/delete of the node or subscription change of this subscription to the node).
+        final ListIterator<NodeOperation> iter = operations.listIterator( operations.size() );
+        while ( iter.hasPrevious() ) {
+            final NodeOperation operation = iter.previous();
+            if ( Arrays.asList( NodeOperation.Action.CREATE_SUBSCRIPTION, NodeOperation.Action.UPDATE_SUBSCRIPTION, NodeOperation.Action.REMOVE_SUBSCRIPTION ).contains( operation.action ) ) {
+                if ( subscription.getID().equals( operation.subscription.getID() ) ) {
+                    iter.remove(); // This is replaced by the update that's being added.
+                }
+            } else {
+                break; // Operations that precede anything other than the last operations that are subscription changes shouldn't be replaced.
+            }
+        }
+        operations.add( NodeOperation.removeSubscription( subscription.getNode(), subscription ) );
+    }
+
+    /**
+     * Removes the subscription of the user from the DB.
+     *
+     * @param subscription The existing subsription of the user to the node.
+     */
+    private static void removeSubscriptionInDatabase(NodeSubscription subscription) {
         Connection con = null;
         PreparedStatement pstmt = null;
         try {
@@ -1168,14 +1503,16 @@ public class PubSubPersistenceManager {
 		itemCache.put(itemKey, item);
 		log.debug("Added new (inbound) item to cache");
         synchronized (itemsPending) {
-    		LinkedListNode<RetryWrapper> itemToReplace = itemsPending.remove(itemKey);
+    		RetryWrapper itemToReplace = itemsPending.remove(itemKey);
     		if (itemToReplace != null) {
-    			itemToReplace.remove(); // remove duplicate from itemsToAdd linked list
+                itemsToAdd.remove(itemToReplace); // remove duplicate from itemsToAdd linked list
     		}
-    		LinkedListNode<RetryWrapper> listNode = firstPass ? 
-    							itemsToAdd.addLast(wrapper) : 
-    							itemsToAdd.addFirst(wrapper);
-    		itemsPending.put(itemKey, listNode);
+    		if (firstPass) {
+    		    itemsToAdd.addLast(wrapper);
+            } else {
+                itemsToAdd.addFirst(wrapper);
+            }
+    		itemsPending.put(itemKey, wrapper);
         }
         // skip the flush step if this is a retry attempt
 		if (firstPass && itemsPending.size() > MAX_ITEMS_FLUSH) {
@@ -1200,12 +1537,84 @@ public class PubSubPersistenceManager {
     }
 
     /**
+     * Flush the cache(s) of items to be persisted (itemsToAdd) and deleted (itemsToDelete)
+     * for a specific node.
+     */
+    public static void flushPendingItems( String nodeId )
+    {
+        flushPendingItems(nodeId, ClusterManager.isClusteringEnabled());
+    }
+
+    /**
      * Flush the cache(s) of items to be persisted (itemsToAdd) and deleted (itemsToDelete).
      */
 	public static void flushPendingItems()
     {
         flushPendingItems(ClusterManager.isClusteringEnabled());
     }
+
+    /**
+     * Flush the cache(s) of items to be persisted (itemsToAdd) and deleted (itemsToDelete).
+     * @param sendToCluster If true, delegate to cluster members, otherwise local only
+     */
+    public static void flushPendingItems(String nodeId, boolean sendToCluster)
+    {
+        // forward to other cluster members and wait for response
+        if (sendToCluster) {
+            CacheFactory.doSynchronousClusterTask(new FlushTask(nodeId), false);
+        }
+
+        // TODO: figure out if it's required to first flush pending nodes, cluster-wide, synchronously, before flushing items.
+        flushPendingNode(nodeId);
+
+        if (itemsToAdd.isEmpty() && itemsToDelete.isEmpty()) {
+            return;	 // nothing to do for this cluster member
+        }
+
+        List<RetryWrapper> addList;
+        List<PublishedItem> delList;
+
+        // Swap pending items so we can parse and save the contents from this point in time
+        // while not blocking new entries from being cached.
+        synchronized(itemsPending)
+        {
+            // find items for node.
+
+            // Split the to-do list in two parts: one that contains items for the node of interest, and the rest.
+            final Map<Boolean, List<RetryWrapper>> partsToAdd = itemsToAdd.stream().collect(
+                    Collectors.partitioningBy( retryWrapper -> nodeId.equals( retryWrapper.item.getNodeID() ) )
+            );
+            addList = new ArrayList<>( partsToAdd.get( true ) ); // All elements that match must be processed.
+            itemsToAdd.retainAll( partsToAdd.get(false) ); // Non-matching elements remain on the to-do list.
+
+            // Split the to-do list in two parts: one that contains items for the node of interest, and the rest.
+            final Map<Boolean, List<PublishedItem>> partsToDelete = itemsToDelete.stream().collect(
+                    Collectors.partitioningBy( publishedItem -> nodeId.equals( publishedItem.getNodeID() ) )
+            );
+            delList = new ArrayList<>( partsToDelete.get( true ) ); // All elements that match must be processed.
+            itemsToDelete.retainAll( partsToDelete.get(false) ); // Non-matching elements remain on the to-do list.
+
+            // Ensure pending items are available via the item read cache;
+            // this allows the item(s) to be fetched by other request threads
+            // while being written to the DB from this thread
+            // TODO Determine if this works as intended when items are being queued for adding as well as removal.
+            int copied = 0;
+            for (final RetryWrapper itemToAdd : itemsToAdd) {
+                final String key = itemToAdd.get().getItemKey();
+                if (!itemCache.containsKey(key)) {
+                    itemsPending.remove( key );
+                    itemCache.put(key, itemToAdd.item);
+                    copied++;
+                }
+            }
+            if (log.isDebugEnabled() && copied > 0) {
+                log.debug("Added " + copied + " pending items to published item cache");
+            }
+        }
+
+        flushPendingItemsToDatabase( addList, delList );
+    }
+
 
     /**
      * Flush the cache(s) of items to be persisted (itemsToAdd) and deleted (itemsToDelete).
@@ -1218,32 +1627,34 @@ public class PubSubPersistenceManager {
             CacheFactory.doSynchronousClusterTask(new FlushTask(), false);
         }
 
-		if (itemsToAdd.getFirst() == null && itemsToDelete.getFirst() == null) {
+		// TODO: figure out if it's required to first flush pending nodes, cluster-wide, synchronously, before flushing items.
+		flushPendingNodes();
+
+		if (itemsToAdd.isEmpty() && itemsToDelete.isEmpty() ) {
         	return;	 // nothing to do for this cluster member
         }
-        
-		Connection con = null;
-		boolean rollback = false;
-    	LinkedList<RetryWrapper> addList = null;
-    	LinkedList<PublishedItem> delList = null;
+
+        List<RetryWrapper> addList;
+        List<PublishedItem> delList;
 
     	// Swap pending items so we can parse and save the contents from this point in time
     	// while not blocking new entries from being cached.
     	synchronized(itemsPending) 
     	{
-    		addList = itemsToAdd;
-    		delList = itemsToDelete;
+    		addList = new ArrayList<>( itemsToAdd );
+    		delList = new ArrayList<>( itemsToDelete );
 
-    		itemsToAdd = new LinkedList<>();
-    		itemsToDelete = new LinkedList<>();
-    		
+    		itemsToAdd = new ConcurrentLinkedDeque<>();
+    		itemsToDelete = new ConcurrentLinkedDeque<>();
+
     		// Ensure pending items are available via the item read cache;
     		// this allows the item(s) to be fetched by other request threads
     		// while being written to the DB from this thread
+            // TODO Determine if this works as intended when items are being queued for adding as well as removal.
     		int copied = 0;
     		for (String key : itemsPending.keySet()) {
     			if (!itemCache.containsKey(key)) {
-    				itemCache.put(key, (((RetryWrapper)itemsPending.get(key).object)).get());
+    				itemCache.put(key, (itemsPending.get(key)).get());
     				copied++;
     			}
     		}
@@ -1253,31 +1664,34 @@ public class PubSubPersistenceManager {
     		itemsPending.clear();
     	}
 
-    	// Note that we now make multiple attempts to write cached items to the DB:
-    	//   1) insert all pending items in a single batch
-    	//   2) if the batch insert fails, retry by inserting each item separately
-    	//   3) if a given item cannot be written, return it to the pending write cache
-    	// By default step 3 will be tried once per item, but this can be configured
-    	// (or disabled) using the "xmpp.pubsub.item.retry" property. In the event of
-    	// a transaction rollback, items that could not be written to the database
-    	// will be returned to the pending item write cache.
-    	try {
-			con = DbConnectionManager.getTransactionConnection();
-			writePendingItems(con, addList, delList);
-		} catch (SQLException se) {
-			log.error("Failed to flush pending items; initiating rollback", se);
-			// return new items to the write cache
-	        LinkedListNode<RetryWrapper> node = addList.getLast();
-	        while (node != null) {
-	            savePublishedItem(node.object);
-	            node.remove();
-	            node = addList.getLast();
-	        }
-			rollback = true;
-		} finally {
-			DbConnectionManager.closeTransactionConnection(con, rollback);
-		}
+        flushPendingItemsToDatabase( addList, delList );
 	}
+
+	private static void flushPendingItemsToDatabase( final List<RetryWrapper> addList, final List<PublishedItem> delList )
+    {
+        // Note that we now make multiple attempts to write cached items to the DB:
+        //   1) insert all pending items in a single batch
+        //   2) if the batch insert fails, retry by inserting each item separately
+        //   3) if a given item cannot be written, return it to the pending write cache
+        // By default step 3 will be tried once per item, but this can be configured
+        // (or disabled) using the "xmpp.pubsub.item.retry" property. In the event of
+        // a transaction rollback, items that could not be written to the database
+        // will be returned to the pending item write cache.
+        Connection con = null;
+        boolean rollback = false;
+        try {
+            con = DbConnectionManager.getTransactionConnection();
+            writePendingItems(con, addList, delList);
+        } catch (SQLException se) {
+            // TODO it's suspiscous that the delList isn't rolled back. Determine if this is a bug!
+            log.error("Failed to flush pending items; initiating rollback", se);
+            // return new items to the write cache
+            addList.forEach( PubSubPersistenceManager::savePublishedItem );
+            rollback = true;
+        } finally {
+            DbConnectionManager.closeTransactionConnection(con, rollback);
+        }
+    }
 
     /**
      * Loop through the lists of added and deleted items and write to the database
@@ -1286,86 +1700,66 @@ public class PubSubPersistenceManager {
      * @param delList
      * @throws SQLException
      */
-	private static void writePendingItems(Connection con, LinkedList<RetryWrapper> addList, LinkedList<PublishedItem> delList) throws SQLException
+	private static void writePendingItems(Connection con, List<RetryWrapper> addList, List<PublishedItem> delList) throws SQLException
 	{
-        LinkedListNode<RetryWrapper> addItem = addList.getFirst();
-        LinkedListNode<PublishedItem> delItem = delList.getFirst();
-        
         // is there anything to do?
-        if ((addItem == null) && (delItem == null)) { return; }
-        
+        if (addList.isEmpty() && delList.isEmpty() ) { return; }
+
     	if (log.isDebugEnabled()) {
-    		log.debug("Flush " + itemsPending.size() + " pending items to database");
+    		log.debug("Flush pending items to database");
     	}
 
         // ensure there are no duplicates by deleting before adding
-        if (addItem != null) {
-        	LinkedListNode<RetryWrapper> addHead = addItem.previous;
-        	while (addItem != addHead) {
-        		delList.addLast(addItem.object.get());
-        		addItem = addItem.next;
-        	}
-        }
+    	delList.addAll( addList.stream().map( RetryWrapper::get ).collect( Collectors.toList()) );
 
         // delete first (to remove possible duplicates), then add new items
-        delItem = delList.getFirst();
-        if (delItem != null) {
-            PreparedStatement pstmt = null;
-			try {
-                LinkedListNode<PublishedItem> delHead = delItem.previous;
-				pstmt = con.prepareStatement(DELETE_ITEM);
-                Boolean hasBatchItems = false;
-                while (delItem != delHead)
-                {
-                    hasBatchItems = true;
-                	PublishedItem item = delItem.object;
-                    pstmt.setString(1, item.getNode().getService().getServiceID());
-                    pstmt.setString(2, encodeNodeID(item.getNode().getNodeID()));
-                    pstmt.setString(3, item.getID());
-                    pstmt.addBatch();
-
-                    delItem = delItem.next;
-                }
-				if (hasBatchItems) pstmt.executeBatch();
-			} catch (SQLException ex) {
-				log.error("Failed to delete published item(s) from DB", ex);
-				// do not re-throw here; continue with insert operation if possible
-			} finally {
-				DbConnectionManager.closeStatement(pstmt);
-	        }
+        PreparedStatement pstmt = null;
+        try {
+            pstmt = con.prepareStatement(DELETE_ITEM);
+            boolean hasBatchItems = false;
+            for ( final PublishedItem item : delList )
+            {
+                hasBatchItems = true;
+                pstmt.setString(1, item.getNode().getService().getServiceID());
+                pstmt.setString(2, encodeNodeID(item.getNode().getNodeID()));
+                pstmt.setString(3, item.getID());
+                pstmt.addBatch();
+            }
+            if (hasBatchItems) pstmt.executeBatch();
+        } catch (SQLException ex) {
+            log.error("Failed to delete published item(s) from DB", ex);
+            // do not re-throw here; continue with insert operation if possible
+        } finally {
+            DbConnectionManager.closeStatement(pstmt);
         }
-		
-        try { 
+
+        try {
             // first try to add the pending items as a batch
-        	writePendingItems(con, addList.getFirst(), true);
+        	writePendingItems(con, addList, true);
         } catch (SQLException ex) {
         	// retry each item individually rather than rolling back
-        	writePendingItems(con, addList.getFirst(), false);       	
+        	writePendingItems(con, addList, false);
         }
     }
-	
+
 	/**
 	 * Execute JDBC calls (optionally via batch) to persist the given published items
 	 * @param con
-	 * @param addItem
+	 * @param addItems
 	 * @param batch
 	 * @throws SQLException
 	 */
-	private static void writePendingItems(Connection con, LinkedListNode<RetryWrapper> addItem, boolean batch)  throws SQLException 
-	{	
-		if (addItem == null) { return; }
-        LinkedListNode<RetryWrapper> addHead = addItem.previous;
+	private static void writePendingItems(Connection con, List<RetryWrapper> addItems, boolean batch)  throws SQLException
+	{
+		if (addItems == null || addItems.isEmpty()) { return; }
         PreparedStatement pstmt = null;
-        RetryWrapper wrappedItem = null;
-        PublishedItem item = null;       
     	try {
 			pstmt = con.prepareStatement(ADD_ITEM);
-            Boolean hasBatchItems = false;
-            while (addItem != addHead)
+            boolean hasBatchItems = false;
+            for ( final RetryWrapper wrappedItem : addItems)
             {
                 hasBatchItems = true;
-            	wrappedItem = addItem.object;
-            	item = wrappedItem.get();
+                final PublishedItem item = wrappedItem.get();
                 pstmt.setString(1, item.getNode().getService().getServiceID());
                 pstmt.setString(2, encodeNodeID(item.getNodeID()));
                 pstmt.setString(3, item.getID());
@@ -1387,7 +1781,6 @@ public class PubSubPersistenceManager {
         	    		}
                 	}
                 }
-                addItem = addItem.next;
             }
             if (batch && hasBatchItems) { pstmt.executeBatch(); }			
     	} catch (SQLException se) {
@@ -1410,10 +1803,13 @@ public class PubSubPersistenceManager {
         synchronized (itemsPending)
     	{
     		itemsToDelete.addLast(item);
-			LinkedListNode<RetryWrapper> itemToAdd = itemsPending.remove(itemKey);
-			if (itemToAdd != null)
-				itemToAdd.remove();  // drop from itemsToAdd linked list
+    		itemsPending.remove(itemKey);
 		}
+    }
+
+    private static String getDefaultNodeConfigurationCacheKey( PubSubService service, boolean isLeafType )
+    {
+        return service.getServiceID() + "|" + Boolean.toString( isLeafType );
     }
 
     /**
@@ -1427,48 +1823,69 @@ public class PubSubPersistenceManager {
      */
     public static DefaultNodeConfiguration loadDefaultConfiguration(PubSubService service,
             boolean isLeafType) {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        DefaultNodeConfiguration config = null;
-        try {
-            con = DbConnectionManager.getConnection();
-            // Get default node configuration for the specified service
-            pstmt = con.prepareStatement(LOAD_DEFAULT_CONF);
-            pstmt.setString(1, service.getServiceID());
-            pstmt.setInt(2, (isLeafType ? 1 : 0));
-            rs = pstmt.executeQuery();
-            if (rs.next()) {
-                config = new DefaultNodeConfiguration(isLeafType);
-                // Rebuild loaded default node configuration
-                config.setDeliverPayloads(rs.getInt(1) == 1);
-                config.setMaxPayloadSize(rs.getInt(2));
-                config.setPersistPublishedItems(rs.getInt(3) == 1);
-                config.setMaxPublishedItems(rs.getInt(4));
-                config.setNotifyConfigChanges(rs.getInt(5) == 1);
-                config.setNotifyDelete(rs.getInt(6) == 1);
-                config.setNotifyRetract(rs.getInt(7) == 1);
-                config.setPresenceBasedDelivery(rs.getInt(8) == 1);
-                config.setSendItemSubscribe(rs.getInt(9) == 1);
-                config.setPublisherModel(PublisherModel.valueOf(rs.getString(10)));
-                config.setSubscriptionEnabled(rs.getInt(11) == 1);
-                config.setAccessModel(AccessModel.valueOf(rs.getString(12)));
-                config.setLanguage(rs.getString(13));
-                if (rs.getString(14) != null) {
-                    config.setReplyPolicy(Node.ItemReplyPolicy.valueOf(rs.getString(14)));
+
+        final String key = getDefaultNodeConfigurationCacheKey( service, isLeafType );
+        DefaultNodeConfiguration result = defaultNodeConfigurationCache.get( key );
+        if ( result == null )
+        {
+            final Lock lock = CacheFactory.getLock( DEFAULT_CONF_CACHE, defaultNodeConfigurationCache );
+            try
+            {
+                lock.lock();
+                result = defaultNodeConfigurationCache.get( key );
+                if ( result == null )
+                {
+                    Connection con = null;
+                    PreparedStatement pstmt = null;
+                    ResultSet rs = null;
+                    DefaultNodeConfiguration config = null;
+                    try {
+                        con = DbConnectionManager.getConnection();
+                        // Get default node configuration for the specified service
+                        pstmt = con.prepareStatement(LOAD_DEFAULT_CONF);
+                        pstmt.setString(1, service.getServiceID());
+                        pstmt.setInt(2, (isLeafType ? 1 : 0));
+                        rs = pstmt.executeQuery();
+                        if (rs.next()) {
+                            config = new DefaultNodeConfiguration(isLeafType);
+                            // Rebuild loaded default node configuration
+                            config.setDeliverPayloads(rs.getInt(1) == 1);
+                            config.setMaxPayloadSize(rs.getInt(2));
+                            config.setPersistPublishedItems(rs.getInt(3) == 1);
+                            config.setMaxPublishedItems(rs.getInt(4));
+                            config.setNotifyConfigChanges(rs.getInt(5) == 1);
+                            config.setNotifyDelete(rs.getInt(6) == 1);
+                            config.setNotifyRetract(rs.getInt(7) == 1);
+                            config.setPresenceBasedDelivery(rs.getInt(8) == 1);
+                            config.setSendItemSubscribe(rs.getInt(9) == 1);
+                            config.setPublisherModel(PublisherModel.valueOf(rs.getString(10)));
+                            config.setSubscriptionEnabled(rs.getInt(11) == 1);
+                            config.setAccessModel(AccessModel.valueOf(rs.getString(12)));
+                            config.setLanguage(rs.getString(13));
+                            if (rs.getString(14) != null) {
+                                config.setReplyPolicy(Node.ItemReplyPolicy.valueOf(rs.getString(14)));
+                            }
+                            config.setAssociationPolicy(
+                                    CollectionNode.LeafNodeAssociationPolicy.valueOf(rs.getString(15)));
+                            config.setMaxLeafNodes(rs.getInt(16));
+                        }
+                        defaultNodeConfigurationCache.put( key, config );
+                        result = config;
+                    }
+                    catch (Exception sqle) {
+                        log.error(sqle.getMessage(), sqle);
+                    }
+                    finally {
+                        DbConnectionManager.closeConnection(rs, pstmt, con);
+                    }
                 }
-                config.setAssociationPolicy(
-                        CollectionNode.LeafNodeAssociationPolicy.valueOf(rs.getString(15)));
-                config.setMaxLeafNodes(rs.getInt(16));
+            }
+            finally
+            {
+                lock.unlock();
             }
         }
-        catch (Exception sqle) {
-            log.error(sqle.getMessage(), sqle);
-        }
-        finally {
-            DbConnectionManager.closeConnection(rs, pstmt, con);
-        }
-        return config;
+        return result;
     }
 
     /**
@@ -1479,41 +1896,56 @@ public class PubSubPersistenceManager {
      */
     public static void createDefaultConfiguration(PubSubService service,
             DefaultNodeConfiguration config) {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        try {
-            con = DbConnectionManager.getConnection();
-            pstmt = con.prepareStatement(ADD_DEFAULT_CONF);
-            pstmt.setString(1, service.getServiceID());
-            pstmt.setInt(2, (config.isLeaf() ? 1 : 0));
-            pstmt.setInt(3, (config.isDeliverPayloads() ? 1 : 0));
-            pstmt.setInt(4, config.getMaxPayloadSize());
-            pstmt.setInt(5, (config.isPersistPublishedItems() ? 1 : 0));
-            pstmt.setInt(6, config.getMaxPublishedItems());
-            pstmt.setInt(7, (config.isNotifyConfigChanges() ? 1 : 0));
-            pstmt.setInt(8, (config.isNotifyDelete() ? 1 : 0));
-            pstmt.setInt(9, (config.isNotifyRetract() ? 1 : 0));
-            pstmt.setInt(10, (config.isPresenceBasedDelivery() ? 1 : 0));
-            pstmt.setInt(11, (config.isSendItemSubscribe() ? 1 : 0));
-            pstmt.setString(12, config.getPublisherModel().getName());
-            pstmt.setInt(13, (config.isSubscriptionEnabled() ? 1 : 0));
-            pstmt.setString(14, config.getAccessModel().getName());
-            pstmt.setString(15, config.getLanguage());
-            if (config.getReplyPolicy() != null) {
-                pstmt.setString(16, config.getReplyPolicy().name());
+
+        final String key = getDefaultNodeConfigurationCacheKey( service, config.isLeaf() );
+
+        final Lock lock = CacheFactory.getLock( DEFAULT_CONF_CACHE, defaultNodeConfigurationCache );
+        try
+        {
+            lock.lock();
+
+            Connection con = null;
+            PreparedStatement pstmt = null;
+            try {
+                con = DbConnectionManager.getConnection();
+                pstmt = con.prepareStatement(ADD_DEFAULT_CONF);
+                pstmt.setString(1, service.getServiceID());
+                pstmt.setInt(2, (config.isLeaf() ? 1 : 0));
+                pstmt.setInt(3, (config.isDeliverPayloads() ? 1 : 0));
+                pstmt.setInt(4, config.getMaxPayloadSize());
+                pstmt.setInt(5, (config.isPersistPublishedItems() ? 1 : 0));
+                pstmt.setInt(6, config.getMaxPublishedItems());
+                pstmt.setInt(7, (config.isNotifyConfigChanges() ? 1 : 0));
+                pstmt.setInt(8, (config.isNotifyDelete() ? 1 : 0));
+                pstmt.setInt(9, (config.isNotifyRetract() ? 1 : 0));
+                pstmt.setInt(10, (config.isPresenceBasedDelivery() ? 1 : 0));
+                pstmt.setInt(11, (config.isSendItemSubscribe() ? 1 : 0));
+                pstmt.setString(12, config.getPublisherModel().getName());
+                pstmt.setInt(13, (config.isSubscriptionEnabled() ? 1 : 0));
+                pstmt.setString(14, config.getAccessModel().getName());
+                pstmt.setString(15, config.getLanguage());
+                if (config.getReplyPolicy() != null) {
+                    pstmt.setString(16, config.getReplyPolicy().name());
+                }
+                else {
+                    pstmt.setString(16, null);
+                }
+                pstmt.setString(17, config.getAssociationPolicy().name());
+                pstmt.setInt(18, config.getMaxLeafNodes());
+                pstmt.executeUpdate();
+
+                defaultNodeConfigurationCache.put( key, config );
             }
-            else {
-                pstmt.setString(16, null);
+            catch (SQLException sqle) {
+                log.error(sqle.getMessage(), sqle);
             }
-            pstmt.setString(17, config.getAssociationPolicy().name());
-            pstmt.setInt(18, config.getMaxLeafNodes());
-            pstmt.executeUpdate();
+            finally {
+                DbConnectionManager.closeConnection(pstmt, con);
+            }
         }
-        catch (SQLException sqle) {
-            log.error(sqle.getMessage(), sqle);
-        }
-        finally {
-            DbConnectionManager.closeConnection(pstmt, con);
+        finally
+        {
+            lock.unlock();
         }
     }
 
@@ -1525,41 +1957,56 @@ public class PubSubPersistenceManager {
      */
     public static void updateDefaultConfiguration(PubSubService service,
             DefaultNodeConfiguration config) {
-        Connection con = null;
-        PreparedStatement pstmt = null;
+
+        final Lock lock = CacheFactory.getLock( DEFAULT_CONF_CACHE, defaultNodeConfigurationCache );
         try {
-            con = DbConnectionManager.getConnection();
-            pstmt = con.prepareStatement(UPDATE_DEFAULT_CONF);
-            pstmt.setInt(1, (config.isDeliverPayloads() ? 1 : 0));
-            pstmt.setInt(2, config.getMaxPayloadSize());
-            pstmt.setInt(3, (config.isPersistPublishedItems() ? 1 : 0));
-            pstmt.setInt(4, config.getMaxPublishedItems());
-            pstmt.setInt(5, (config.isNotifyConfigChanges() ? 1 : 0));
-            pstmt.setInt(6, (config.isNotifyDelete() ? 1 : 0));
-            pstmt.setInt(7, (config.isNotifyRetract() ? 1 : 0));
-            pstmt.setInt(8, (config.isPresenceBasedDelivery() ? 1 : 0));
-            pstmt.setInt(9, (config.isSendItemSubscribe() ? 1 : 0));
-            pstmt.setString(10, config.getPublisherModel().getName());
-            pstmt.setInt(11, (config.isSubscriptionEnabled() ? 1 : 0));
-            pstmt.setString(12, config.getAccessModel().getName());
-            pstmt.setString(13, config.getLanguage());
-            if (config.getReplyPolicy() != null) {
-                pstmt.setString(14, config.getReplyPolicy().name());
+            Connection con = null;
+            PreparedStatement pstmt = null;
+            try {
+                con = DbConnectionManager.getConnection();
+                pstmt = con.prepareStatement(UPDATE_DEFAULT_CONF);
+                pstmt.setInt(1, (config.isDeliverPayloads() ? 1 : 0));
+                pstmt.setInt(2, config.getMaxPayloadSize());
+                pstmt.setInt(3, (config.isPersistPublishedItems() ? 1 : 0));
+                pstmt.setInt(4, config.getMaxPublishedItems());
+                pstmt.setInt(5, (config.isNotifyConfigChanges() ? 1 : 0));
+                pstmt.setInt(6, (config.isNotifyDelete() ? 1 : 0));
+                pstmt.setInt(7, (config.isNotifyRetract() ? 1 : 0));
+                pstmt.setInt(8, (config.isPresenceBasedDelivery() ? 1 : 0));
+                pstmt.setInt(9, (config.isSendItemSubscribe() ? 1 : 0));
+                pstmt.setString(10, config.getPublisherModel().getName());
+                pstmt.setInt(11, (config.isSubscriptionEnabled() ? 1 : 0));
+                pstmt.setString(12, config.getAccessModel().getName());
+                pstmt.setString(13, config.getLanguage());
+                if (config.getReplyPolicy() != null) {
+                    pstmt.setString(14, config.getReplyPolicy().name());
+                }
+                else {
+                    pstmt.setString(14, null);
+                }
+                pstmt.setString(15, config.getAssociationPolicy().name());
+                pstmt.setInt(16, config.getMaxLeafNodes());
+                pstmt.setString(17, service.getServiceID());
+                pstmt.setInt(18, (config.isLeaf() ? 1 : 0));
+                pstmt.executeUpdate();
+
+
+                getDefaultNodeConfigurationCacheKey( service, false );
+
+                // Note that 'isLeaf' might have changed.
+                defaultNodeConfigurationCache.remove( getDefaultNodeConfigurationCacheKey( service, true ) );
+                defaultNodeConfigurationCache.remove( getDefaultNodeConfigurationCacheKey( service, false ) );
+                defaultNodeConfigurationCache.put( getDefaultNodeConfigurationCacheKey( service, config.isLeaf() ), config );
             }
-            else {
-                pstmt.setString(14, null);
+            catch (SQLException sqle) {
+                log.error(sqle.getMessage(), sqle);
             }
-            pstmt.setString(15, config.getAssociationPolicy().name());
-            pstmt.setInt(16, config.getMaxLeafNodes());
-            pstmt.setString(17, service.getServiceID());
-            pstmt.setInt(18, (config.isLeaf() ? 1 : 0));
-            pstmt.executeUpdate();
-        }
-        catch (SQLException sqle) {
-            log.error(sqle.getMessage(), sqle);
+            finally {
+                DbConnectionManager.closeConnection(pstmt, con);
+            }
         }
         finally {
-            DbConnectionManager.closeConnection(pstmt, con);
+            lock.unlock();
         }
     }
 
@@ -1765,15 +2212,14 @@ public class PubSubPersistenceManager {
 			// that match this node.
 			synchronized (itemsPending)
 			{
-				Iterator<Map.Entry<String, LinkedListNode<RetryWrapper>>> pendingIt = itemsPending.entrySet().iterator();
+                Iterator<Map.Entry<String, RetryWrapper>> pendingIt = itemsPending.entrySet().iterator();
 
 				while (pendingIt.hasNext())
 				{
-					LinkedListNode<RetryWrapper> itemNode = pendingIt.next().getValue();
+					RetryWrapper itemNode = pendingIt.next().getValue();
 
-					if (itemNode.object.get().getNodeID().equals(leafNode.getNodeID()))
+					if (itemNode.get().getNodeID().equals(leafNode.getNodeID()))
 					{
-						itemNode.remove();
 						pendingIt.remove();
 					}
 				}

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProvider.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProvider.java
@@ -15,7 +15,7 @@
  */
 package org.jivesoftware.openfire.pubsub;
 
-import org.jivesoftware.openfire.cluster.ClusterManager;
+import org.jivesoftware.openfire.pep.PEPService;
 
 import java.util.List;
 
@@ -209,4 +209,13 @@ public interface PubSubPersistenceProvider
     PublishedItem getPublishedItem(LeafNode node, String itemID);
 
     void purgeNode(LeafNode leafNode);
+
+    /**
+     * Loads a PEP service from the database, if it exists.
+     *
+     * @param jid
+     *            the JID of the owner of the PEP service.
+     * @return the loaded PEP service, or null if not found.
+     */
+    PEPService loadPEPServiceFromDB( String jid);
 }

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProviderManager.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProviderManager.java
@@ -52,7 +52,7 @@ public class PubSubPersistenceProviderManager
 
     private void initProvider()
     {
-        String className = JiveGlobals.getProperty( "provider.pubsub-persistence.className", PubSubPersistenceManager.class.getName() );
+        String className = JiveGlobals.getProperty( "provider.pubsub-persistence.className", DefaultPubSubPersistenceProvider.class.getName() );
 
         // Check if we need to reset the provider class
         if (provider == null || !className.equals(provider.getClass().getName())) {
@@ -68,7 +68,7 @@ public class PubSubPersistenceProviderManager
             }
             catch (Exception e) {
                 Log.error("Error loading PubSub persistence provider: {}. Using default provider instead.", className, e);
-                provider = new PubSubPersistenceManager();
+                provider = new DefaultPubSubPersistenceProvider();
                 provider.initialize();
             }
         }

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProviderManager.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProviderManager.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.pubsub;
+
+import org.jivesoftware.util.ClassUtils;
+import org.jivesoftware.util.JiveGlobals;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages the persistence provider used to manage pubsub data in persistent storage.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class PubSubPersistenceProviderManager
+{
+    private static final Logger Log = LoggerFactory.getLogger( PubSubPersistenceProviderManager.class );
+
+    private static PubSubPersistenceProviderManager instance;
+
+    private PubSubPersistenceProvider provider;
+
+    public synchronized static PubSubPersistenceProviderManager getInstance()
+    {
+        if ( instance == null ) {
+            instance = new PubSubPersistenceProviderManager();
+        }
+
+        return instance;
+    }
+
+    private PubSubPersistenceProviderManager() {
+        initProvider();
+    }
+
+    public PubSubPersistenceProvider getProvider() {
+        return this.provider;
+    }
+
+    private void initProvider()
+    {
+        String className = JiveGlobals.getProperty( "provider.pubsub-persistence.className", PubSubPersistenceManager.class.getName() );
+
+        // Check if we need to reset the provider class
+        if (provider == null || !className.equals(provider.getClass().getName())) {
+            if ( provider != null ) {
+                provider.shutdown();
+                provider = null;
+            }
+            try {
+                Log.info("Loading PubSub persistence provider: {}.", className);
+                Class c = ClassUtils.forName( className );
+                provider = (PubSubPersistenceProvider) c.newInstance();
+                provider.initialize();
+            }
+            catch (Exception e) {
+                Log.error("Error loading PubSub persistence provider: {}. Using default provider instead.", className, e);
+                provider = new PubSubPersistenceManager();
+                provider.initialize();
+            }
+        }
+    }
+
+    public void shutdown()
+    {
+        if ( provider != null )
+        {
+            provider.shutdown();
+            provider = null;
+        }
+    }
+}

--- a/src/java/org/jivesoftware/openfire/pubsub/PubSubService.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PubSubService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * $RCSfile: $
  * $Revision: $
  * $Date: $
@@ -25,10 +25,8 @@ import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 import org.xmpp.packet.Packet;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Timer;
+import java.io.Serializable;
+import java.util.*;
 
 /**
  * A PubSubService is responsible for keeping the hosted nodes by the service, the default
@@ -245,4 +243,55 @@ public interface PubSubService {
      * @return the ad-hoc commands manager used for this service.
      */
     AdHocCommandManager getManager();
+
+    /**
+     * Returns a value that uniquely identifies this service in the XMPP domain.
+     *
+     * @return Unique identifier for this service
+     */
+    default UniqueIdentifier getUniqueIdentifier() {
+        return new UniqueIdentifier( getServiceID() );
+    }
+
+    /**
+     * A unique identifier for an item, in context of all nodes of all services in the system.
+     *
+     * The property that uniquely identifies a service within the system is its serviceId.
+     */
+    class UniqueIdentifier implements Serializable
+    {
+        private final String serviceId;
+
+        public UniqueIdentifier( final String serviceId ) {
+            if ( serviceId == null ) {
+                throw new IllegalArgumentException( "Argument 'serviceId' cannot be null." );
+            }
+            this.serviceId = serviceId;
+        }
+
+        public String getServiceId() { return serviceId; }
+
+        @Override
+        public boolean equals( final Object o )
+        {
+            if ( this == o ) { return true; }
+            if ( o == null || getClass() != o.getClass() ) { return false; }
+            final UniqueIdentifier that = (UniqueIdentifier) o;
+            return serviceId.equals( that.serviceId );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash( serviceId );
+        }
+
+        @Override
+        public String toString()
+        {
+            return "PubSubService.UniqueIdentifier{" +
+                    "serviceId='" + getServiceId() + '\'' +
+                    '}';
+        }
+    }
 }

--- a/src/java/org/jivesoftware/openfire/pubsub/PublishedItem.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/PublishedItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * $RCSfile: $
  * $Revision: $
  * $Date: $
@@ -23,6 +23,7 @@ package org.jivesoftware.openfire.pubsub;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.util.Date;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -104,10 +105,11 @@ public class PublishedItem implements Serializable {
     
     /**
      * Creates a published item
-     * @param node
-     * @param publisher
-     * @param id
-     * @param creationDate
+     *
+     * @param node The node on which the item is published.
+     * @param publisher The address of the entity that is publishing the item.
+     * @param id The (unique) ID of the published item.
+     * @param creationDate The creation date of the published item.
      */
     PublishedItem(LeafNode node, JID publisher, String id, Date creationDate) {
         this.node = node;
@@ -280,21 +282,33 @@ public class PublishedItem implements Serializable {
     }
 
     /**
-     * Returns a string that uniquely identifies this published item
-     * in the following format: <i>nodeId:itemId</i>
+     * Returns a string that uniquely identifies this published item in the following format: <i>nodeId:itemId</i>
+     *
+     * Note that this method generates a value that's unique only in context of the node. This allows for different
+     * services to have items with identical keys. Use {@link #getItemUniqueKey()} to obtain an identifier that is
+     * unique for the entire XMPP domain.
+     *
      * @return Unique identifier for this item
+     * @deprecated Replaced by {@link #getItemUniqueKey()} which generates more unique values.
      */
+    @Deprecated
     public String getItemKey() {
     	return getItemKey(nodeId,id);
     }
 
 	/**
-     * Returns a string that uniquely identifies this published item
-     * in the following format: <i>nodeId:itemId</i>
+     * Returns a string that uniquely identifies this published item in the following format: <i>nodeId:itemId</i>
+     *
+     * Note that this method generates a value that's unique only in context of the node. This allows for different
+     * services to have items with identical keys. Use {@link #getItemUniqueKey(LeafNode, String)} to obtain an
+     * identifier that is unique for the entire XMPP domain.
+     *
      * @param node Node for the published item
      * @param itemId Id for the published item (unique within the node)
      * @return Unique identifier for this item
+     * @deprecated Replaced by {@link #getItemUniqueKey(LeafNode, String)} which generates more unique values.
      */
+    @Deprecated
     public static String getItemKey(LeafNode node, String itemId) {
     	return getItemKey(node.getNodeID(), itemId);
     }
@@ -305,9 +319,91 @@ public class PublishedItem implements Serializable {
      * @param nodeId Node id for the published item
      * @param itemId Id for the published item (unique within the node)
      * @return Unique identifier for this item
+     * @deprecated Replaced by {@link #getItemUniqueKey(String, String, String)} which generates more unique values.
      */
+    @Deprecated
     public static String getItemKey(String nodeId, String itemId) {
     	return new StringBuilder(nodeId)
     		.append(':').append(itemId).toString();
+    }
+
+    /**
+     * Returns a value that uniquely identifies this published item in the XMPP domain.
+     *
+     * @return Unique identifier for this item
+     */
+    public UniqueIdentifier getUniqueIdentifier() {
+        return getUniqueIdentifier( getNode(), id );
+    }
+
+    /**
+     * Returns a value that uniquely identifies this published item in the XMPP domain.
+     *
+     * @param node Node for the published item
+     * @param itemId Id for the published item (unique within the node)
+     * @return Unique identifier for this item
+     */
+    public static UniqueIdentifier getUniqueIdentifier(LeafNode node, String itemId)
+    {
+        return getUniqueIdentifier( node.getService().getServiceID(), node.getNodeID(), itemId );
+    }
+
+    /**
+     * Returns a value that uniquely identifies this published item in the XMPP domain.
+     *
+     * @param serviceId Id of the service that contains the node.
+     * @param nodeId Node id for the published item
+     * @param itemId Id for the published item (unique within the node)
+     * @return Unique identifier for this item
+     */
+    public static UniqueIdentifier getUniqueIdentifier(String serviceId, String nodeId, String itemId)
+    {
+        return new UniqueIdentifier( serviceId, nodeId, itemId );
+    }
+
+    /**
+     * A unique identifier for an item, in context of all nodes of all services in the system.
+     *
+     * The properties that uniquely identify an item are its node, and its itemId.
+     */
+    public static class UniqueIdentifier extends Node.UniqueIdentifier implements Serializable
+    {
+        private final String itemId;
+
+        public UniqueIdentifier( final String serviceId, final String nodeId, final String itemId ) {
+            super( serviceId, nodeId );
+            if ( itemId == null ) {
+                throw new IllegalArgumentException( "Argument 'itemId' cannot be null." );
+            }
+            this.itemId = itemId;
+        }
+
+        public String getItemId() { return itemId; };
+
+        @Override
+        public boolean equals( final Object o )
+        {
+            if ( this == o ) { return true; }
+            if ( o == null || getClass() != o.getClass() ) { return false; }
+            if ( !super.equals( o ) ) { return false; }
+            final UniqueIdentifier that = (UniqueIdentifier) o;
+            return itemId.equals( that.itemId );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash( super.hashCode(), itemId );
+        }
+
+        @Override
+        public String toString()
+        {
+            return "PublishedItem.UniqueIdentifier{" +
+                    "serviceId='" + getServiceId() + '\'' +
+                    ", nodeId='" + getNodeId() + '\'' +
+                    ", itemId='" + itemId + '\'' +
+                    '}';
+        }
     }
 }

--- a/src/java/org/jivesoftware/openfire/pubsub/cluster/FlushTask.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/cluster/FlushTask.java
@@ -4,32 +4,33 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
-import org.jivesoftware.openfire.pubsub.PubSubPersistenceManager;
+import org.jivesoftware.openfire.pubsub.Node;
+import org.jivesoftware.openfire.pubsub.PubSubPersistenceProviderManager;
 import org.jivesoftware.util.cache.ClusterTask;
 import org.jivesoftware.util.cache.ExternalizableUtil;
 
 
 public class FlushTask implements ClusterTask<Void>
 {
-	private String nodeId;
+	private Node.UniqueIdentifier uniqueIdentifier;
 
-	public FlushTask( String nodeId )
+	public FlushTask( Node.UniqueIdentifier uniqueIdentifier )
 	{
-		this.nodeId = nodeId;
+		this.uniqueIdentifier = uniqueIdentifier;
 	}
 
 	public FlushTask()
 	{
-		this.nodeId = null;
+		this.uniqueIdentifier = null;
 	}
 
 	@Override
 	public void run()
 	{
-		if ( nodeId != null ) {
-			PubSubPersistenceManager.flushPendingItems(nodeId, false); // just this member
+		if ( uniqueIdentifier != null ) {
+			PubSubPersistenceProviderManager.getInstance().getProvider().flushPendingItems( uniqueIdentifier, false); // just this member
 		} else {
-			PubSubPersistenceManager.flushPendingItems(false); // just this member
+			PubSubPersistenceProviderManager.getInstance().getProvider().flushPendingItems(false); // just this member
 		}
 	}
 
@@ -42,17 +43,23 @@ public class FlushTask implements ClusterTask<Void>
 	@Override
 	public void writeExternal(ObjectOutput out) throws IOException
 	{
-		ExternalizableUtil.getInstance().writeBoolean( out, nodeId != null);
-		ExternalizableUtil.getInstance().writeSafeUTF( out, nodeId );
+		ExternalizableUtil.getInstance().writeBoolean( out, uniqueIdentifier != null);
+		if ( uniqueIdentifier != null )
+		{
+			ExternalizableUtil.getInstance().writeSafeUTF( out, uniqueIdentifier.getServiceId() );
+			ExternalizableUtil.getInstance().writeSafeUTF( out, uniqueIdentifier.getNodeId() );
+		}
 	}
 
 	@Override
 	public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException
 	{
 		if ( ExternalizableUtil.getInstance().readBoolean( in ) ) {
-			this.nodeId = ExternalizableUtil.getInstance().readSafeUTF( in );
+			String serviceId = ExternalizableUtil.getInstance().readSafeUTF( in );
+			String nodeId = ExternalizableUtil.getInstance().readSafeUTF( in );
+			uniqueIdentifier = new Node.UniqueIdentifier( serviceId, nodeId );
 		} else {
-			this.nodeId = null;
+			this.uniqueIdentifier = null;
 		}
 	}
 }

--- a/src/java/org/jivesoftware/openfire/pubsub/cluster/FlushTask.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/cluster/FlushTask.java
@@ -6,18 +6,31 @@ import java.io.ObjectOutput;
 
 import org.jivesoftware.openfire.pubsub.PubSubPersistenceManager;
 import org.jivesoftware.util.cache.ClusterTask;
+import org.jivesoftware.util.cache.ExternalizableUtil;
 
 
 public class FlushTask implements ClusterTask<Void>
 {
+	private String nodeId;
+
+	public FlushTask( String nodeId )
+	{
+		this.nodeId = nodeId;
+	}
+
 	public FlushTask()
 	{
+		this.nodeId = null;
 	}
 
 	@Override
 	public void run()
 	{
-        PubSubPersistenceManager.flushPendingItems(false); // just this member
+		if ( nodeId != null ) {
+			PubSubPersistenceManager.flushPendingItems(nodeId, false); // just this member
+		} else {
+			PubSubPersistenceManager.flushPendingItems(false); // just this member
+		}
 	}
 
 	@Override
@@ -29,11 +42,17 @@ public class FlushTask implements ClusterTask<Void>
 	@Override
 	public void writeExternal(ObjectOutput out) throws IOException
 	{
+		ExternalizableUtil.getInstance().writeBoolean( out, nodeId != null);
+		ExternalizableUtil.getInstance().writeSafeUTF( out, nodeId );
 	}
 
 	@Override
 	public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException
 	{
+		if ( ExternalizableUtil.getInstance().readBoolean( in ) ) {
+			this.nodeId = ExternalizableUtil.getInstance().readSafeUTF( in );
+		} else {
+			this.nodeId = null;
+		}
 	}
-
 }

--- a/src/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
@@ -1,7 +1,7 @@
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import org.jivesoftware.openfire.pubsub.NodeSubscription;
-import org.jivesoftware.openfire.pubsub.PubSubPersistenceManager;
+import org.jivesoftware.openfire.pubsub.PubSubPersistenceProviderManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +23,6 @@ public class ModifySubscriptionTask extends SubscriptionTask
 	public void run()
 	{
 		log.debug("[TASK] Modify subscription : {}", toString());
-		PubSubPersistenceManager.loadSubscription(getService(), getNode(), getSubscriptionId());
+		PubSubPersistenceProviderManager.getInstance().getProvider().loadSubscription( getService(), getNode(), getSubscriptionId());
 	}
 }

--- a/src/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
+++ b/src/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
@@ -1,7 +1,7 @@
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import org.jivesoftware.openfire.pubsub.Node;
-import org.jivesoftware.openfire.pubsub.PubSubPersistenceManager;
+import org.jivesoftware.openfire.pubsub.PubSubPersistenceProviderManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +30,7 @@ public class RefreshNodeTask extends NodeTask
 	public void run()
 	{
 		log.debug("[TASK] Refreshing node - nodeID: {}", getNodeId());
-		PubSubPersistenceManager.loadNode(getService(), getNodeId());
+		PubSubPersistenceProviderManager.getInstance().getProvider().loadNode( getService(), getNodeId());
 	}
 
 }

--- a/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/src/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -320,7 +320,8 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 		    }
 		    if (clientRoute != null) {
 		        if (!clientRoute.isAvailable() && routeOnlyAvailable(packet, fromServer) &&
-		                !presenceUpdateHandler.hasDirectPresence(packet.getTo(), packet.getFrom())) {
+		                !presenceUpdateHandler.hasDirectPresence(packet.getTo(), packet.getFrom())
+                        && !PresenceUpdateHandler.isPresenceUpdateReflection( packet )) {
 		        	Log.debug("Unable to route packet. Packet should only be sent to available sessions and the route is not available. {} ", packet.toXML());
 		            routed = false;
 		        } else {

--- a/src/java/org/jivesoftware/util/cache/CacheUtil.java
+++ b/src/java/org/jivesoftware/util/cache/CacheUtil.java
@@ -1,0 +1,519 @@
+/*
+ * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.util.cache;
+
+import java.io.Serializable;
+import java.util.*;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Utility methods for working with caches.
+ *
+ * Different implementations of {@link Cache} have idiosyncrasies, which this implementation takes into
+ * account.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class CacheUtil
+{
+    /**
+     * Adds the specified element to a cache, in a collection that is mapped by the provided key.
+     *
+     * When the cache does not contain an entry for the provided key, a cache entry is added, which will have a new collection
+     * created using the provided Supplier, to which the specified element is added.
+     *
+     * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
+     *
+     * @param cache    The cache from which to remove the element (cannot be null).
+     * @param element  The element to be added (can be null only if the value-Collection supports null values).
+     * @param key      The cache entry identifier (cannot be null)
+     * @param <K> the type of key contained by the cache
+     * @param <V> the type of value contained by the cache
+     * @param <C> the type of collection contained by the cache
+     * @param supplier A provider of empty instances of the collection used as a value of the cache (in which elements are placed).
+     */
+    public static <K extends Serializable, V, C extends Collection<V> & Serializable> void addValueToMultiValuedCache( Cache<K, C> cache, K key, V element, Supplier<C> supplier )
+    {
+        final Lock lock = CacheFactory.getLock( key, cache );
+        try
+        {
+            lock.lock();
+
+            final C elements = cache.getOrDefault( key, supplier.get() );
+            elements.add( element );
+            cache.put( key, elements ); // Explicitly adding the value is required for the change to propagate through Hazelcast.
+        }
+        finally
+        {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Removes all entries of a cache that map to the provided value.
+     *
+     * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
+     *
+     * @param cache   The cache from which to remove the element (cannot be null).
+     * @param element The element to be removed (can not be null ).
+     * @param <K> the type of key contained by the cache
+     * @param <V> the type of value contained by the cache
+     * @return a Set containing the keys of all affected cache entries (never null)
+     */
+    public static <K extends Serializable, V extends Serializable> Set<K> removeValueFromCache( Cache<K, V> cache, V element )
+    {
+        // In some cache implementations, the entry-set is unmodifiable. To guard against potential
+        // future changes of this implementation (that would make the implementation incompatible with
+        // these cache implementations), the entry-set that's operated on in this implementation is
+        // explicitly wrapped in an unmodifiable collection. That forces this implementation to be
+        // compatible with the 'lowest common denominator'.
+        final Set<Map.Entry<K, V>> entries = Collections.unmodifiableSet( cache.entrySet() );
+
+        // contains all entries that were somehow changed.
+        final Set<K> result = new HashSet<>();
+
+        for ( final Map.Entry<K, V> entry : entries )
+        {
+            final K key = entry.getKey();
+
+            final Lock lock = CacheFactory.getLock( key, cache );
+            try
+            {
+                lock.lock();
+
+                if ( entry.getValue().equals( element ) )
+                {
+                    cache.remove( entry.getKey() );
+                    result.add( entry.getKey() );
+                }
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Removes all instances of the specified element from the collection that is mapped by the provided key.
+     *
+     * When the element removed from the set leaves that set empty, the cache entry is removed completely.
+     *
+     * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
+     *
+     * @param cache   The cache from which to remove the element (cannot be null).
+     * @param key     The cache entry identifier (cannot be null)
+     * @param <K> the type of key contained by the cache
+     * @param <V> the type of value contained by the cache
+     * @param <C> the type of collection contained by the cache
+     * @param element The element to be removed (can be null only if the value-Collection supports null values).
+     */
+    public static <K extends Serializable, V, C extends Collection<V> & Serializable> void removeValueFromMultiValuedCache( Cache<K, C> cache, K key, V element )
+    {
+        final Lock lock = CacheFactory.getLock( key, cache );
+        try
+        {
+            lock.lock();
+
+            final C elements = cache.get( key );
+
+            if ( elements == null ) {
+                return;
+            }
+
+            // Remove all instances of the element from the entry value.
+            boolean changed = false;
+            while ( elements.remove( element ) )
+            {
+                changed = true;
+            }
+
+            if ( changed )
+            {
+                if ( elements.isEmpty() )
+                {
+                    // When after removal, the value is empty, remove the cache entry completely.
+                    cache.remove( key );
+                }
+                else
+                {
+                    // The cluster-based cache needs an explicit 'put' to cause the change to propagate.
+                    cache.put( key, elements );
+                }
+            }
+        }
+        finally
+        {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Removes all instances of the specified element from every collection that is a value of the cache.
+     *
+     * When the element removed from the collection leaves that collection empty, the cache entry is removed completely.
+     *
+     * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
+     *
+     * The return value is a Map that contains all entries that were affected by the call. The returned has exactly two
+     * keys, that each have a Map for its value.
+     * - the Map that is the value of the 'false' key contains all entries that have been removed from the cache.
+     * - the Map that is the value of the 'true' key contains all entries that have been modified.
+     *
+     * @param cache   The cache from which to remove the element (cannot be null).
+     * @param element The element to be removed (can be null only if the value-Collection supports null values).
+     * @param <K> the type of key contained by the cache
+     * @param <V> the type of value contained by the cache
+     * @param <C> the type of collection contained by the cache
+     * @return a map containing all affected cache entries (never null)
+     */
+    public static <K extends Serializable, V, C extends Collection<V> & Serializable> Map<Boolean,Map<K, C>> removeValueFromMultiValuedCache( Cache<K, C> cache, V element )
+    {
+        // In some cache implementations, the entry-set is unmodifiable. To guard against potential
+        // future changes of this implementation (that would make the implementation incompatible with
+        // these cache implementations), the entry-set that's operated on in this implementation is
+        // explicitly wrapped in an unmodifiable collection. That forces this implementation to be
+        // compatible with the 'lowest common denominator'.
+        final Set<Map.Entry<K, C>> entries = Collections.unmodifiableSet( cache.entrySet() );
+
+        // contains all entries that were somehow changed.
+        final Map<Boolean, Map<K, C>> result = new HashMap<>();
+        result.put( false, new HashMap<>());
+        result.put( true, new HashMap<>());
+
+        for ( final Map.Entry<K, C> entry : entries )
+        {
+            final K key = entry.getKey();
+
+            final Lock lock = CacheFactory.getLock( key, cache );
+            try
+            {
+                lock.lock();
+
+                final C elements = entry.getValue();
+
+                // Remove all instances of the element from the entry value.
+                boolean changed = false;
+                while ( elements.remove( element ) )
+                {
+                    changed = true;
+                }
+
+                if ( changed )
+                {
+                    if ( elements.isEmpty() )
+                    {
+                        // When after removal, the value is empty, remove the cache entry completely.
+                        cache.remove( entry.getKey() );
+                        result.get(false).put( entry.getKey(), elements );
+                    }
+                    else
+                    {
+                        // The cluster-based cache needs an explicit 'put' to cause the change to propagate.
+                        cache.put( entry.getKey(), elements );
+                        result.get(true).put( entry.getKey(), elements );
+                    }
+                }
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Remove elements from every collection that is a value of the cache, except for the specified element.
+     *
+     * When removal leaves a collection empty, the cache entry is removed completely.
+     *
+     * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
+     *
+     * The return value is a Map that contains all entries that were affected by the call. The returned has exactly two
+     * keys, that each have a Map for its value.
+     * - the Map that is the value of the 'false' key contains all entries that have been removed from the cache.
+     * - the Map that is the value of the 'true' key contains all entries that have been modified.
+     *
+     * @param cache   The cache in which to retain the element (cannot be null).
+     * @param element The element to be retained (can be null only if the value-Collection supports null values).
+     * @param <K> the type of key contained by the cache
+     * @param <V> the type of value contained by the cache
+     * @param <C> the type of collection contained by the cache
+     * @return a map containing all affected cache entries (never null)
+     */
+    public static <K extends Serializable, V, C extends Collection<V> & Serializable> Map<Boolean,Map<K, C>> retainValueInMultiValuedCache( Cache<K, C> cache, V element )
+    {
+        // In some cache implementations, the entry-set is unmodifiable. To guard against potential
+        // future changes of this implementation (that would make the implementation incompatible with
+        // these cache implementations), the entry-set that's operated on in this implementation is
+        // explicitly wrapped in an unmodifiable collection. That forces this implementation to be
+        // compatible with the 'lowest common denominator'.
+        final Set<Map.Entry<K, C>> entries = Collections.unmodifiableSet( cache.entrySet() );
+
+        // contains all entries that were somehow changed.
+        final Map<Boolean, Map<K, C>> result = new HashMap<>();
+        result.put( false, new HashMap<>());
+        result.put( true, new HashMap<>());
+
+        for ( final Map.Entry<K, C> entry : entries )
+        {
+            final K key = entry.getKey();
+
+            final Lock lock = CacheFactory.getLock( key, cache );
+            try
+            {
+                lock.lock();
+
+                final C elements = entry.getValue();
+
+                // Remove all instances of the element from the entry value.
+                boolean changed = false;
+                while ( elements.retainAll( Collections.singleton( element ) ) )
+                {
+                    changed = true;
+                }
+
+                if ( changed )
+                {
+                    if ( elements.isEmpty() )
+                    {
+                        // When after removal, the value is empty, remove the cache entry completely.
+                        cache.remove( entry.getKey() );
+                        result.get(false).put( entry.getKey(), elements );
+                    }
+                    else
+                    {
+                        // The cluster-based cache needs an explicit 'put' to cause the change to propagate.
+                        cache.put( entry.getKey(), elements );
+                        result.get(true).put( entry.getKey(), elements );
+                    }
+                }
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Remove elements from every collection that is a value of the cache, except for the specified element.
+     *
+     * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
+     **
+     * @param cache   The cache in which to retain the element (cannot be null).
+     * @param element The element to be retained (cannot be null).
+     * @param <K> the type of key contained by the cache
+     * @param <V> the type of value contained by the cache
+     * @return a Set containing the keys of all affected cache entries (never null)
+     */
+    public static <K extends Serializable, V extends Serializable> Set<K> retainValueInCache( Cache<K, V> cache, V element )
+    {
+        // In some cache implementations, the entry-set is unmodifiable. To guard against potential
+        // future changes of this implementation (that would make the implementation incompatible with
+        // these cache implementations), the entry-set that's operated on in this implementation is
+        // explicitly wrapped in an unmodifiable collection. That forces this implementation to be
+        // compatible with the 'lowest common denominator'.
+        final Set<Map.Entry<K, V>> entries = Collections.unmodifiableSet( cache.entrySet() );
+
+        // contains all entries that were somehow changed.
+        final Set<K> result = new HashSet<>();
+
+        for ( final Map.Entry<K, V> entry : entries )
+        {
+            final K key = entry.getKey();
+
+            final Lock lock = CacheFactory.getLock( key, cache );
+            try
+            {
+                lock.lock();
+
+                if ( !entry.getValue().equals( element ) )
+                {
+                    cache.remove( entry.getKey() );
+                    result.add( entry.getKey() );
+                }
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Replaces all instances of a particular value in a cache.
+     *
+     * Every instance of the old value that is found in a cache value is replaced by the new value.
+     *
+     * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
+     *
+     * @param cache    The cache from which to remove the element (cannot be null).
+     * @param oldValue The element to be replaced (cannot be null).
+     * @param newValue The replacement element (cannot be null).
+     * @param <K> the type of key contained by the cache
+     * @param <V> the type of value contained by the cache
+     */
+    public static <K extends Serializable, V extends Serializable> void replaceValueInCache( Cache<K, V> cache, V oldValue, V newValue )
+    {
+        if ( newValue.equals( oldValue ) )
+        {
+            return;
+        }
+
+        // In some cache implementations, the entry-set is unmodifiable. To guard against potential
+        // future changes of this implementation (that would make the implementation incompatible with
+        // these cache implementations), the entry-set that's operated on in this implementation is
+        // explicitly wrapped in an unmodifiable collection. That forces this implementation to be
+        // compatible with the 'lowest common denominator'.
+        final Set<Map.Entry<K, V>> entries = Collections.unmodifiableSet( cache.entrySet() );
+
+        for ( final Map.Entry<K, V> entry : entries )
+        {
+            final K key = entry.getKey();
+
+            final Lock lock = CacheFactory.getLock( key, cache );
+            try
+            {
+                lock.lock();
+
+                if ( entry.getValue().equals( oldValue ) )
+                {
+                    // The cluster-based cache needs an explicit 'put' to cause the change to propagate.
+                    cache.put( entry.getKey(), newValue );
+                }
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Applies a mapping function to all values in a cache.
+     *
+     * The provided mapping function is applied to all values in the cache. A cache modification is made only when the
+     * mapping function returns a value that is not equal to the original value.
+     *
+     * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
+     *
+     * @param cache  The cache from which to remove the element (cannot be null).
+     * @param mapper The mapping function (cannot be null).
+     * @param <K> the type of key contained by the cache
+     * @param <V> the type of value contained by the cache
+     */
+    public static <K extends Serializable, V extends Serializable> void replaceValueInCacheByMapping( Cache<K, V> cache, Function<V, V> mapper )
+    {
+        // In some cache implementations, the entry-set is unmodifiable. To guard against potential
+        // future changes of this implementation (that would make the implementation incompatible with
+        // these cache implementations), the entry-set that's operated on in this implementation is
+        // explicitly wrapped in an unmodifiable collection. That forces this implementation to be
+        // compatible with the 'lowest common denominator'.
+        final Set<Map.Entry<K, V>> entries = Collections.unmodifiableSet( cache.entrySet() );
+
+        for ( final Map.Entry<K, V> entry : entries )
+        {
+            final K key = entry.getKey();
+
+            final Lock lock = CacheFactory.getLock( key, cache );
+            try
+            {
+                lock.lock();
+
+                final V modifiedValue = mapper.apply( entry.getValue() );
+                if ( !modifiedValue.equals( entry.getValue() ) )
+                {
+                    // The cluster-based cache needs an explicit 'put' to cause the change to propagate.
+                    cache.put( entry.getKey(), modifiedValue );
+                }
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Replaces an element in a cache that has collection-based values.
+     *
+     * Every instance of the old value that is found in a collection-based value is removed, and for each such removal,
+     * the new value is added to the cache. Note that no guarantees regarding collection order are given.
+     *
+     * Cache entries for which the value-collection does contain the old value are left unchanged.
+     *
+     * The implementation of this method is designed to be compatible with both clustered as well as non-clustered caches.
+     *
+     * @param cache    The cache from which to remove the element (cannot be null).
+     * @param oldValue The element to be replaced (can be null only if the value-Collection supports null values).
+     * @param newValue The replacement element (can be null only if the value-Collection supports null values).
+     * @param <K> the type of key contained by the cache
+     * @param <V> the type of value contained by the cache
+     * @param <C> the type of collection contained by the cache
+     */
+    public static <K extends Serializable, V, C extends Collection<V> & Serializable> void replaceValueInMultivaluedCache( Cache<K, C> cache, V oldValue, V newValue )
+    {
+        if ( newValue.equals( oldValue ) )
+        {
+            return;
+        }
+
+        // In some cache implementations, the entry-set is unmodifiable. To guard against potential
+        // future changes of this implementation (that would make the implementation incompatible with
+        // these cache implementations), the entry-set that's operated on in this implementation is
+        // explicitly wrapped in an unmodifiable collection. That forces this implementation to be
+        // compatible with the 'lowest common denominator'.
+        final Set<Map.Entry<K, C>> entries = Collections.unmodifiableSet( cache.entrySet() );
+
+        for ( final Map.Entry<K, C> entry : entries )
+        {
+            final K key = entry.getKey();
+
+            final Lock lock = CacheFactory.getLock( key, cache );
+            try
+            {
+                lock.lock();
+
+                final C elements = entry.getValue();
+
+                // Replace all instances of the element from the entry value.
+                boolean changed = false;
+                while ( elements.remove( oldValue ) )
+                {
+                    elements.add( newValue );
+                    changed = true;
+                }
+
+                if ( changed )
+                {
+                    // The cluster-based cache needs an explicit 'put' to cause the change to propagate.
+                    cache.put( entry.getKey(), elements );
+                }
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR should probably not be merged.

This includes improvements to the pubsub implementation, that was originally developed against v4.1.5 of Openfire (I'm providing this PR to compare the original changes with the code base it was originally based on).

The primary result of this PR is to introduce a pubsub implementation that does not use the database, but is in-memory only.