### PR TITLE
OF-1848: Prevent duplicate S2S session establishment

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
@@ -44,6 +44,7 @@ public class SocketUtil
         Log.debug( "Use DNS to resolve remote hosts for the provided XMPP domain '{}' (default port: {}) ...", xmppDomain, port );
         final List<DNSUtil.HostAddress> remoteHosts = DNSUtil.resolveXMPPDomain( xmppDomain, port );
         Log.debug( "Found {} host(s) for XMPP domain '{}'.", remoteHosts.size(), xmppDomain );
+        remoteHosts.forEach( remoteHost -> Log.debug( "- {} ({})", remoteHost.toString(), (remoteHost.isDirectTLS() ? "direct TLS" : "no direct TLS" ) ) );
 
         Socket socket = null;
         final int socketTimeout = RemoteServerManager.getSocketTimeout();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -267,8 +267,6 @@ public class ServerDialback {
                     // Set the hostname as the address of the session
                     session.setAddress(new JID(null, remoteDomain, null));
                     log.debug( "Successfully created new outgoing session!" );
-                    // After the session has been created, inform all listeners as well.
-                    ServerSessionEventDispatcher.dispatchEvent(session, ServerSessionEventDispatcher.EventType.session_created);
                     return session;
                 }
                 else {
@@ -588,7 +586,7 @@ public class ServerDialback {
                     case valid:
                     case invalid:
                         boolean valid = (result == VerifyResult.valid);
-                        log.debug( "Dialback key is" + (valid? "valid":"invalid") + ". Sending verification result to remote domain." );
+                        log.debug( "Dialback key is " + (valid? "valid":"invalid") + ". Sending verification result to remote domain." );
                         sb = new StringBuilder();
                         sb.append("<db:result");
                         sb.append(" from=\"").append(recipient).append("\"");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -202,8 +202,6 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
 
             // Set the domain or subdomain of the local server targeted by the remote server
             session.setLocalDomain(serverName);
-            // After the session has been created, inform all listeners as well.
-            ServerSessionEventDispatcher.dispatchEvent(session, ServerSessionEventDispatcher.EventType.session_created);
             return session;
         }
         catch (Exception e) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -318,8 +318,6 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                             // Everything went fine so return the secured and
                             // authenticated connection
                             log.debug( "Successfully created new session!" );
-                             //inform all listeners as well.
-                            ServerSessionEventDispatcher.dispatchEvent(answer, ServerSessionEventDispatcher.EventType.session_created);
                             return answer;
                         }
                         log.debug( "Unable to authenticate the connection with SASL." );
@@ -334,8 +332,6 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                                 // Everything went fine so return the secured and
                                 // authenticated connection
                                 log.debug( "Successfully created new session!" );
-                                 //inform all listeners as well.
-                                ServerSessionEventDispatcher.dispatchEvent(answer, ServerSessionEventDispatcher.EventType.session_created);
                                 return answer;
                             }
                             log.debug( "Unable to secure and authenticate the connection with TLS & SASL." );
@@ -358,8 +354,6 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                                 // Set the hostname as the address of the session
                                 session.setAddress(new JID(null, remoteDomain, null));
                                 log.debug( "Successfully created new session!" );
-                                // After the session has been created, inform all listeners as well.
-                                ServerSessionEventDispatcher.dispatchEvent(session, ServerSessionEventDispatcher.EventType.session_created);
                                 return session;
                             }
                             else {
@@ -412,8 +406,6 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
             final LocalOutgoingServerSession outgoingSession = new ServerDialback().createOutgoingSession( localDomain, remoteDomain, port );
             if ( outgoingSession != null) { // TODO this success handler behaves differently from a similar success handler above. Shouldn't those be the same?
                 log.debug( "Successfully created new session (using dialback as a fallback)!" );
-                 //inform all listeners as well.
-                 ServerSessionEventDispatcher.dispatchEvent(outgoingSession, ServerSessionEventDispatcher.EventType.session_created);
                 return outgoingSession;
             } else {
                 log.warn( "Unable to create a new session: Dialback (as a fallback) failed." );


### PR DESCRIPTION
The session creation event must not be triggered before the created session has been fully registered. This prevents an issue where a new session is established by stanzas being sent by the trigger.

Additionally, duplicate events should be prevented.