### PR TITLE
OF-1856: Fix isAnonymous detection

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -825,7 +825,13 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
     @Override
     public boolean isAnonymousRoute(JID jid) {
-        return anonymousUsersCache.containsKey(jid.toString());
+        if ( jid.getResource() != null ) {
+            // Check if there's a anonymous route for the JID.
+            return anonymousUsersCache.containsKey( jid.toString() );
+        } else {
+            // Anonymous routes are mapped by full JID. if there's no full JID, check for any route for the node-part.
+            return anonymousUsersCache.keySet().stream().anyMatch( key -> key.startsWith( jid.toString() ) );
+        }
     }
 
     @Override


### PR DESCRIPTION
The isAnonymous check should not depend on the fact that the provided JID is a full JID. This will give incorrect results ('not anonymous') if the provided JID is bare.

This commit checks for any anonymous session that matches the bare JID - if there's one then that's enough (a user cannot be both anonymous and not anonymous).