### PR TITLE
OF-1858: Ensure that adding/deleting MUC services is cluster aware

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceAddedEvent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceAddedEvent.java
@@ -62,7 +62,7 @@ public class ServiceAddedEvent implements ClusterTask<Void> {
         // should really never occur.
         if (!XMPPServer.getInstance().getMultiUserChatManager().isServiceRegistered(subdomain)) {
             MultiUserChatService service = new MultiUserChatServiceImpl(subdomain, description, isHidden);
-            XMPPServer.getInstance().getMultiUserChatManager().registerMultiUserChatService(service);
+            XMPPServer.getInstance().getMultiUserChatManager().registerMultiUserChatService(service, false);
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceRemovedEvent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceRemovedEvent.java
@@ -47,7 +47,7 @@ public class ServiceRemovedEvent implements ClusterTask<Void> {
 
     @Override
     public void run() {
-        XMPPServer.getInstance().getMultiUserChatManager().unregisterMultiUserChatService(subdomain);
+        XMPPServer.getInstance().getMultiUserChatManager().unregisterMultiUserChatService(subdomain, false);
     }
 
     @Override


### PR DESCRIPTION
This is an odd one; 
* Updating MUC services seems to be OK - handled by the ServiceUpdatedEvent cluster task.
* Cluster tasks exist for ServiceAddedEvent, ServiceRemovedEvent, but were never used.
* There was also a bug in the above two which meant that updating a MUC on node 1 would update the MUC on node 2 which would update the MUC on node 1 which would ... well, you get the idea. Perhaps this is why they were never used?

**NOTE:** I have been unable to test this in a cluster (!). I think it's OK, but it would probably be a useful exercise to do so.