### PR TITLE
Fix docker logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5-jdk-8
+FROM maven:3.6.2-jdk-8 as packager
 WORKDIR /usr/src
 
 COPY ./pom.xml .
@@ -15,8 +15,8 @@ COPY . .
 RUN mvn package
 
 FROM openjdk:8-jre
-COPY --from=0 /usr/src/distribution/target/distribution-base /usr/local/openfire
-COPY --from=0 /usr/src/build/docker/entrypoint.sh /sbin/entrypoint.sh
+COPY --from=packager /usr/src/distribution/target/distribution-base /usr/local/openfire
+COPY --from=packager /usr/src/build/docker/entrypoint.sh /sbin/entrypoint.sh
 WORKDIR /usr/local/openfire
 
 ENV OPENFIRE_USER=openfire \

--- a/build/docker/entrypoint.sh
+++ b/build/docker/entrypoint.sh
@@ -59,6 +59,7 @@ if [[ -z ${1} ]]; then
     -server \
     -DopenfireHome="${OPENFIRE_DIR}" \
     -Dopenfire.lib.dir=${OPENFIRE_DIR}/lib \
+    -Dlog4j.configurationFile=${OPENFIRE_DIR}/lib/log4j2.xml \
     -classpath ${OPENFIRE_DIR}/lib/startup.jar \
     -jar ${OPENFIRE_DIR}/lib/startup.jar ${EXTRA_ARGS}
 else


### PR DESCRIPTION
Current docker builds don't have working logging infrastructure due to missing log4j config.
I've pointed to the config file in the entrypoint script (and done a little housekeeping on the Dockerfile)