### PR TITLE
OF-1883 & OF-1884

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -144,6 +144,7 @@ public abstract class LocalSession implements Session {
      * has been closed.
      */
     public void setDetached() {
+        Log.debug("Setting session with address {} and streamID {} in detached mode.", this.address, this.streamID );
         this.sessionManager.addDetached(this);
         this.conn = null;
     }
@@ -156,6 +157,7 @@ public abstract class LocalSession implements Session {
      * @param h the sequence number of the last handled stanza sent over the former stream
      */
     public void reattach(Connection connection, long h) {
+        Log.debug("Reattaching session with address {} and streamID {}.", this.address, this.streamID);
         Connection temp = this.conn;
         this.conn = null;
         if (temp != null && !temp.isClosed()) {
@@ -203,7 +205,7 @@ public abstract class LocalSession implements Session {
             try {
                 conn.isClosed(); // This generates an NPE deliberately.
             } catch (NullPointerException e) {
-                Log.error("Attempt to read connection of detached session: ", e);
+                Log.error("Attempt to read connection of detached session with address {} and streamID {}: ", this.address, this.streamID, e);
             }
         }
         return conn;
@@ -228,7 +230,7 @@ public abstract class LocalSession implements Session {
      */
     public void setStatus(int status) {
         if (status == STATUS_CLOSED && this.streamManager.getResume()) {
-            Log.debug("Suppressing close.");
+            Log.debug( "Suppressing close for session with address {} and streamID {}.", this.address, this.streamID );
             return;
         }
         this.status = status;
@@ -425,7 +427,7 @@ public abstract class LocalSession implements Session {
     public void deliverRawText(String text) {
         if ( conn == null )
         {
-            Log.debug( "Unable to deliver raw text in session, as its connection is null. Dropping: " + text );
+            Log.debug( "Unable to deliver raw text in session with address {} and streamID {}, as its connection is null. Dropping: {}", this.address, this.streamID, text );
             return;
         }
         conn.deliverRawText(text);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ClientRoute.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ClientRoute.java
@@ -89,4 +89,13 @@ public class ClientRoute implements Cacheable, Externalizable {
         }
         available = ExternalizableUtil.getInstance().readBoolean(in);
     }
+
+    @Override
+    public String toString()
+    {
+        return "ClientRoute{" +
+            "nodeID=" + nodeID +
+            ", available=" + available +
+            '}';
+    }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -253,7 +253,7 @@ public class StreamManager {
         } else {
             fullJid = new JID(authToken.getUsername(), authToken.getDomain(), resource, true);
         }
-        Log.debug("Resuming session for '{}'. Current session: {}", fullJid, session);
+        Log.debug("Resuming session for '{}'. Current session: {}", fullJid, session.getStreamID());
 
         // Locate existing session.
         LocalClientSession otherSession = (LocalClientSession)XMPPServer.getInstance().getRoutingTable().getClientRoute(fullJid);
@@ -288,18 +288,18 @@ public class StreamManager {
             return;
         }
         if (!otherSession.isDetached()) {
-            Log.debug("Existing session {} of '{}' is not detached; detaching.", otherSession, fullJid);
+            Log.debug("Existing session {} of '{}' is not detached; detaching.", otherSession.getStreamID(), fullJid);
             Connection oldConnection = otherSession.getConnection();
             otherSession.setDetached();
             oldConnection.close();
         }
-        Log.debug("Attaching to other session {} of '{}'.", otherSession, fullJid);
+        Log.debug("Attaching to other session '{}' of '{}'.", otherSession.getStreamID(), fullJid);
         // If we're all happy, disconnect this session.
         Connection conn = session.getConnection();
         session.setDetached();
         // Connect new session.
         otherSession.reattach(conn, h);
-        Log.debug( "Perform resumption on session {} for '{}'. Closing session {}", otherSession, fullJid, session );
+        Log.debug( "Perform resumption on session {} for '{}'. Closing session {}", otherSession.getStreamID(), fullJid, session.getStreamID() );
         session.close();
     }
 

--- a/xmppserver/src/main/webapp/session-row.jspf
+++ b/xmppserver/src/main/webapp/session-row.jspf
@@ -8,6 +8,7 @@
                  org.xmpp.packet.JID,
                  org.xmpp.packet.Presence"%>
  <%@ page import="java.net.URLEncoder"%>
+ <%@ page import="org.jivesoftware.openfire.session.LocalSession" %>
 
  <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -48,7 +49,12 @@
     </td>
     <td>
         <%  int _status = sess.getStatus();
-            if (_status == Session.STATUS_CLOSED) {
+            boolean isDetached = sess instanceof LocalSession && ((LocalSession) sess).isDetached();
+            if (isDetached) { %>
+
+            <fmt:message key="session.details.sm-detached" />
+        <%
+            } else if (_status == Session.STATUS_CLOSED) {
         %>
             <fmt:message key="session.details.close" />
 
@@ -67,7 +73,9 @@
         <%  } %>
     </td>
     <td width="1%">
-        <%  if (sess.isSecure()) {
+        <%  if (isDetached) { %>
+                    <img src="images/working-16x16.gif" width="1" height="1" alt="">
+        <%  } else if (sess.isSecure()) {
                 if (sess.getPeerCertificates() != null && sess.getPeerCertificates().length > 0) { %>
                     <img src="images/lock_both.gif" width="16" height="16" border="0" title="<fmt:message key='session.row.cliked_ssl' /> (mutual authentication)" alt="<fmt:message key='session.row.cliked_ssl' /> (mutual authentication)">
         <%      } else { %>
@@ -169,7 +177,7 @@
 
     <td width="1%" nowrap>
         <%
-            if (sess instanceof LocalClientSession && ((LocalClientSession)sess).isDetached()) { %>
+            if (isDetached) { %>
                 <fmt:message key="session.details.sm-detached"/>
             <% } else {
                 try { %>

--- a/xmppserver/src/main/webapp/session-summary.jsp
+++ b/xmppserver/src/main/webapp/session-summary.jsp
@@ -26,11 +26,12 @@
     errorPage="error.jsp"
 %>
 <%@ page import="java.util.Date" %>
-<%@ page import="java.util.List" %>
 <%@ page import="org.jivesoftware.util.ListPager" %>
-<%@ page import="java.util.stream.Collectors" %>
 <%@ page import="java.util.function.Predicate" %>
 <%@ page import="java.net.UnknownHostException" %>
+<%@ page import="java.util.Collection" %>
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.ArrayList" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -95,16 +96,7 @@
     SessionResultFilter sessionResultFilter = SessionResultFilter.createDefaultSessionFilter();
     sessionResultFilter.setSortOrder(order);
     // Filter out the dodgy looking sessions
-    List<ClientSession> sessions = sessionManager.getSessions(sessionResultFilter)
-        .stream()
-        .filter(clientSession -> {
-            try { // skip invalid sessions (OF-590)
-                return clientSession.validate();
-            } catch (Exception ex) {
-                return false;
-            }
-        })
-        .collect(Collectors.toList());
+    List<ClientSession> sessions = new ArrayList<>(sessionManager.getSessions( sessionResultFilter));
 
     // By default, display all nodes
     Predicate<ClientSession> filter = clientSession -> true;
@@ -127,6 +119,9 @@
     final String searchStatus = ParamUtils.getStringParameter(request, "searchStatus", "");
     if(!searchStatus.isEmpty()) {
         filter = filter.and(clientSession -> {
+            if (searchStatus.equals("detached")) {
+                return clientSession instanceof LocalSession && ((LocalSession) clientSession).isDetached();
+            }
             switch (clientSession.getStatus()) {
                 case Session.STATUS_CLOSED:
                     return "closed".equals(searchStatus);
@@ -337,6 +332,7 @@
                 <option <c:if test='${searchStatus eq "closed"}'>selected</c:if> value="closed"><fmt:message key="session.details.close"/></option>
                 <option <c:if test='${searchStatus eq "connected"}'>selected</c:if> value="connected"><fmt:message key="session.details.connect"/></option>
                 <option <c:if test='${searchStatus eq "authenticated"}'>selected</c:if> value="authenticated"><fmt:message key="session.details.authenticated"/></option>
+                <option <c:if test='${searchStatus eq "detached"}'>selected</c:if> value="detached"><fmt:message key="session.details.local"/> & <fmt:message key="session.details.sm-detached"/></option>
                 <option <c:if test='${searchStatus eq "unknown"}'>selected</c:if> value="unknown"><fmt:message key="session.details.unknown"/></option>
             </select>
         </td>


### PR DESCRIPTION
OF-590 introduces a connection validity check to the client sessions that are to be listed on the admin console. This check fails for sessions that are detached, which caused them to go unlisted.

This commit removes the check that was introduced in OF-590. I feel confident that the problems that guarded for are fixed by OF-1700.

Additionally, some (debug) log statements were added / enriched with session data.