### PR TITLE
OF-1886: Plugin Servlet shouldn't provide access to any file on the host

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1626,6 +1626,7 @@ system_property.xmpp.muc.muclumbus.v1-0.enabled=Determine is the multi-user chat
 system_property.ldap.pagedResultsSize=The maximum number of records to retrieve from LDAP in a single page. \
    The default value of -1 means rely on the paging of the LDAP server itself. \
    Note that if using ActiveDirectory, this should not be left at the default, and should not be set to more than the value of the ActiveDirectory MaxPageSize; 1,000 by default.
+plugins.servlet.allowLocalFileReading=Determines if the plugin servlets can be used to access files outside of Openfire's home directory.
 system_property.cert.storewatcher.enabled=Automatically reloads certificate stores when they're modified on disk.
 
 # Server properties Page


### PR DESCRIPTION
This commit limits what files can be accessed through the plugin servlet to those that are under the Openfire home directory.

A property has been provided to disable this new restriction.