### PR TITLE
OF-1890 Added support for flatting nested groups in LDAP.

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -384,6 +384,12 @@
             <version>3.1.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.zapodot</groupId>
+            <artifactId>embedded-ldap-junit</artifactId>
+            <version>0.7</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
@@ -27,6 +27,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
+import java.text.MessageFormat;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.naming.Name;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
@@ -36,11 +52,6 @@ import javax.naming.directory.SearchResult;
 import javax.naming.ldap.LdapContext;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
-import java.text.MessageFormat;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * LDAP implementation of the GroupProvider interface.  All data in the directory is treated as
@@ -72,18 +83,48 @@ public class LdapGroupProvider extends AbstractGroupProvider {
 
     @Override
     public Group getGroup(String groupName) throws GroupNotFoundException {
-        LdapContext ctx = null;
         try {
-            Rdn[] groupRDN = manager.findGroupRDN(groupName);
-            // Load record.
-            ctx = manager.getContext(manager.getGroupsBaseDN(groupName));
-            Attributes attrs = ctx.getAttributes(LdapManager.escapeForJNDI(groupRDN), standardAttributes);
-
-            return processGroup(ctx, attrs);
+            LdapName groupDN = manager.findGroupAbsoluteDN(groupName);
+            return getGroupByDN(groupDN, new HashSet<>(Collections.singleton(groupDN.toString())));
         }
         catch (Exception e) {
             Log.error("Unable to load group: {}", groupName, e);
             throw new GroupNotFoundException("Group with name " + groupName + " not found.", e);
+        }
+    }
+
+    /**
+     * Reads the group with the given DN
+     *
+     * @param groupDN         the absolute DN of the group
+     * @param membersToIgnore A mutable set of DNs and/or UIDs (for Posix mode) to ignore. This set will be
+     *                        filled with visited DNs. If flatten of hierarchies of groups is active
+     *                        ({@link LdapManager#isFlattenNestedGroups()}, this will prevent endless loops
+     *                        for cyclic hierarchies.
+     * @return
+     * @throws NamingException
+     */
+    private Group getGroupByDN(LdapName groupDN, Set<String> membersToIgnore) throws NamingException {
+        LdapContext ctx = null;
+        try {
+            LdapName baseDN;
+            Name relativeDN;
+            if (manager.getAlternateBaseDN() != null
+                && groupDN.startsWith(manager.getAlternateBaseDN())) {
+                baseDN = manager.getAlternateBaseDN();
+            } else if (groupDN.startsWith(manager.getBaseDN())) {
+                baseDN = manager.getBaseDN();
+            }
+            else {
+                throw new IllegalArgumentException("GroupDN does not match any baseDN");
+            }
+            relativeDN = groupDN.getSuffix(baseDN.size());
+            membersToIgnore.add(groupDN.toString());
+            // Load record.
+            ctx = manager.getContext(baseDN);
+            Attributes attrs = ctx.getAttributes(relativeDN, standardAttributes);
+
+            return processGroup(ctx, attrs, membersToIgnore);
         }
         finally {
             try {
@@ -162,7 +203,46 @@ public class LdapGroupProvider extends AbstractGroupProvider {
         if (username == null || "".equals(username)) {
             return Collections.emptyList();
         }
-        return search(manager.getGroupMemberField(), username);
+
+        Set<String> groupNames = new LinkedHashSet<>(search(manager.getGroupMemberField(), username));
+
+        if (manager.isFlattenNestedGroups()) {
+            // search groups that contain the given groups
+
+            Set<String> checkedGroups = new HashSet<>();
+            Deque<String> todo = new ArrayDeque<>(groupNames);
+            String group;
+            while (null != (group = todo.pollFirst())) {
+                if (checkedGroups.contains(group)) {
+                    continue;
+                }
+                checkedGroups.add(group);
+                try {
+                    // get the DN of the group
+                    LdapName groupDN = manager.findGroupAbsoluteDN(group);
+                    if(manager.isPosixMode()){
+                        // in posix mode we need to search for the "uid" of the group.
+                        List<String> uids = manager.retrieveAttributeOf(manager.getUsernameField(), groupDN);
+                        if(uids.isEmpty()) {
+                            // group not there or has not the "uid" attribute
+                            continue;
+                        }
+                        group = uids.get(0);
+                    } else {
+                        group = groupDN.toString();
+                    }
+                    // search for groups that have the given group (DN normal, UID posix) as member
+                    Collection<String> containingGroupNames = search(manager.getGroupMemberField(), group);
+                    // add the found groups to the result and to the groups to be checked transitively
+                    todo.addAll(containingGroupNames);
+                    groupNames.addAll(containingGroupNames);
+                }
+                catch (Exception e) {
+                    Log.warn("Error looking up group: {}", group);
+                }
+            }
+        }
+        return groupNames;
     }
 
     @Override
@@ -215,7 +295,7 @@ public class LdapGroupProvider extends AbstractGroupProvider {
         return true;
     }
 
-    private Group processGroup(LdapContext ctx, Attributes a) throws NamingException {
+    private Group processGroup(LdapContext ctx, Attributes a, Set<String> membersToIgnore) throws NamingException {
         XMPPServer server = XMPPServer.getInstance();
         String serverName = server.getServerInfo().getXMPPDomain();
         // Build `3 groups.
@@ -228,7 +308,7 @@ public class LdapGroupProvider extends AbstractGroupProvider {
         // We have to process Active Directory differently.
         boolean isAD = manager.getUsernameField().equals("sAMAccountName");
         String[] returningAttributes = isAD ? new String[] { "distinguishedName", manager.getUsernameField() } : new String[] { manager.getUsernameField() };
-        
+
         SearchControls searchControls = new SearchControls();
         searchControls.setReturningAttributes(returningAttributes);
         // See if recursive searching is enabled. Otherwise, only search one level.
@@ -255,10 +335,14 @@ public class LdapGroupProvider extends AbstractGroupProvider {
         }
         Set<JID> members = new TreeSet<>();
         Attribute memberField = a.get(manager.getGroupMemberField());
+
+        Log.debug("Loading members of group: {}", name);
+
         if (memberField != null) {
             NamingEnumeration ne = memberField.getAll();
             while (ne.hasMore()) {
                 String username = (String) ne.next();
+                LdapName userDN = null;
                 // If not posix mode, each group member is stored as a full DN.
                 if (!manager.isPosixMode()) {
                     try {
@@ -274,18 +358,18 @@ public class LdapGroupProvider extends AbstractGroupProvider {
                         // sAMAccountName, but stores group members as "CN=...".
                         else {
                             // Create an LDAP name with the full DN.
-                            LdapName ldapName = new LdapName(username);
+                            userDN = new LdapName(username);
                             // Turn the LDAP name into something we can use in a
                             // search by stripping off the comma.
                             StringBuilder userFilter = new StringBuilder();
                             userFilter.append("(&(");
-                            userFilter.append(ldapName.get(ldapName.size() - 1));
+                            userFilter.append(userDN.get(userDN.size() - 1));
                             userFilter.append(')');
                             userFilter.append(MessageFormat.format(manager.getSearchFilter(), "*"));
                             userFilter.append(')');
                             NamingEnumeration usrAnswer = ctx.search("",
                                     userFilter.toString(), searchControls);
-                            if (usrAnswer != null && usrAnswer.hasMoreElements()) {
+                            if (usrAnswer.hasMoreElements()) {
                                 SearchResult searchResult = null;
                                 // We may get multiple search results for the same user CN.
                                 // Iterate through the entire set to find a matching distinguished name.
@@ -320,35 +404,67 @@ public class LdapGroupProvider extends AbstractGroupProvider {
                 // Therefore, we have to try to load each user we found to see if
                 // it passes the filter.
                 try {
-                    JID userJID;
-                    int position = username.indexOf("@" + serverName);
-                    // Create JID of local user if JID does not match a component's JID
-                    if (position == -1) {
-                        // In order to lookup a username from the manager, the username
-                        // must be a properly escaped JID node.
-                        String escapedUsername = JID.escapeNode(username);
-                        if (!escapedUsername.equals(username)) {
+                    if (!membersToIgnore.contains(username)) {
+                        JID userJID;
+                        int position = username.indexOf("@" + serverName);
+                        // Create JID of local user if JID does not match a component's JID
+                        if (position == -1) {
+                            // In order to lookup a username from the manager, the username
+                            // must be a properly escaped JID node.
+                            String escapedUsername = JID.escapeNode(username);
                             // Check if escaped username is valid
                             userManager.getUser(escapedUsername);
+                            // No exception, so the user must exist. Add the user as a group
+                            // member using the escaped username.
+                            userJID = server.createJID(escapedUsername, null);
                         }
-                        // No exception, so the user must exist. Add the user as a group
-                        // member using the escaped username.
-                        userJID = server.createJID(escapedUsername, null);
+                        else {
+                            // This is a JID of a component or node of a server's component
+                            String node = username.substring(0, position);
+                            String escapedUsername = JID.escapeNode(node);
+                            userJID = new JID(escapedUsername + "@" + serverName);
+                        }
+                        members.add(userJID);
                     }
-                    else {
-                        // This is a JID of a component or node of a server's component
-                        String node = username.substring(0, position);
-                        String escapedUsername = JID.escapeNode(node);
-                        userJID = new JID(escapedUsername + "@" + serverName);
-                    }
-                    members.add(userJID);
                 }
                 catch (UserNotFoundException e) {
-                    // We can safely ignore this error. It likely means that
-                    // the user didn't pass the search filter that's defined.
-                    // So, we want to simply ignore the user as a group member.
-                    if (manager.isDebugEnabled()) {
-                        Log.debug("LdapGroupProvider: User not found: " + username);
+                    // not a user!
+                    // maybe it is a group?
+                    boolean isGroup = false;
+                    if (manager.isFlattenNestedGroups()) {
+                        if (manager.isPosixMode()) { // in posix mode, the DN has not been set...
+                            // Look up the userDN using the UID
+                            String userDNStr = manager.retrieveSingle(null,
+                                "(" + manager.getUsernameField()
+                                    + "=" + LdapManager.sanitizeSearchFilter(username) + ")",
+                                true);
+                            if (userDNStr != null)
+                                userDN = new LdapName(userDNStr);
+                        } else if (userDN == null) {
+                            // Create an LDAP name with the full DN.
+                            userDN = new LdapName(username);
+                        }
+                        if (userDN != null && manager.isGroupDN(userDN)) {
+                            isGroup = true;
+                            if (!membersToIgnore.contains(userDN.toString())
+                                && !membersToIgnore.contains(username)) {
+                                // prevent endless adding of cyclic referenced groups
+                                membersToIgnore.add(username);
+                                membersToIgnore.add(userDN.toString());
+                                // it's a sub group not already added, so add its members
+                                Log.debug("Adding members of sub-group: {}", userDN);
+                                Group subGroup = getGroupByDN(userDN, membersToIgnore);
+                                members.addAll(subGroup.getMembers());
+                            }
+                        }
+                    }
+                    if (!isGroup) {
+                        // We can safely ignore this error. It likely means that
+                        // the user didn't pass the search filter that's defined.
+                        // So, we want to simply ignore the user as a group member.
+                        if (manager.isDebugEnabled()) {
+                            Log.debug("LdapGroupProvider: User not found: " + username);
+                        }
                     }
                 }
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -27,18 +27,43 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
-import javax.naming.*;
-import javax.naming.directory.DirContext;
-import javax.naming.directory.InitialDirContext;
-import javax.naming.directory.SearchControls;
-import javax.naming.directory.SearchResult;
-import javax.naming.ldap.*;
-import javax.net.ssl.SSLSession;
 import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import javax.naming.CompositeName;
+import javax.naming.Context;
+import javax.naming.InvalidNameException;
+import javax.naming.Name;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.PagedResultsControl;
+import javax.naming.ldap.PagedResultsResponseControl;
+import javax.naming.ldap.Rdn;
+import javax.naming.ldap.SortControl;
+import javax.naming.ldap.StartTlsRequest;
+import javax.naming.ldap.StartTlsResponse;
+import javax.net.ssl.SSLSession;
 
 /**
  * Centralized administration of LDAP connections. The {@link #getInstance()} method
@@ -63,6 +88,7 @@ import java.util.*;
  *      <li>ldap.groupDescriptionField</li>
  *      <li>ldap.posixMode</li>
  *      <li>ldap.groupSearchFilter</li>
+ *      <li>ldap.flattenNestedGroups</li>
  *      <li>ldap.debugEnabled</li>
  *      <li>ldap.sslEnabled</li>
  *      <li>ldap.startTlsEnabled</li>
@@ -174,6 +200,10 @@ public class LdapManager {
         instance = new LdapManager(properties);
     }
 
+    /** Exposed for test use only */
+    public static void setInstance(LdapManager instance) {
+        LdapManager.instance = instance;
+    }
 
     private Collection<String> hosts = new ArrayList<>();
     private int port;
@@ -203,6 +233,7 @@ public class LdapManager {
     private String groupDescriptionField;
     private boolean posixMode;
     private String groupSearchFilter;
+    private boolean flattenNestedGroups;
 
     private final Map<String, String> properties;
 
@@ -246,6 +277,7 @@ public class LdapManager {
         JiveGlobals.migrateProperty("ldap.groupDescriptionField");
         JiveGlobals.migrateProperty("ldap.posixMode");
         JiveGlobals.migrateProperty("ldap.groupSearchFilter");
+        JiveGlobals.migrateProperty("ldap.flattenNestedGroups");
         JiveGlobals.migrateProperty("ldap.adminDN");
         JiveGlobals.migrateProperty("ldap.adminPassword");
         JiveGlobals.migrateProperty("ldap.debugEnabled");
@@ -355,6 +387,12 @@ public class LdapManager {
         }
         groupSearchFilter = properties.get("ldap.groupSearchFilter");
 
+        flattenNestedGroups = false;
+        String flattenNestedGroupsStr = properties.get("ldap.flattenNestedGroups");
+        if (flattenNestedGroupsStr != null) {
+            flattenNestedGroups = Boolean.parseBoolean(flattenNestedGroupsStr);
+        }
+
         adminDN = properties.get("ldap.adminDN");
         if (adminDN != null && adminDN.trim().equals("")) {
             adminDN = null;
@@ -430,6 +468,7 @@ public class LdapManager {
         buf.append("\t groupDescriptionField: ").append(groupDescriptionField).append("\n");
         buf.append("\t posixMode: ").append(posixMode).append("\n");
         buf.append("\t groupSearchFilter: ").append(groupSearchFilter).append("\n");
+        buf.append("\t flattenNestedGroups: ").append(flattenNestedGroups).append("\n");
         buf.append("\t findUsersFromGroupsEnabled: ").append(findUsersFromGroupsEnabled).append("\n");
 
         if (Log.isDebugEnabled()) {
@@ -1069,7 +1108,7 @@ public class LdapManager {
             constraints.setReturningAttributes(new String[] { usernameField });
 
             // NOTE: this assumes that the username has already been JID-unescaped
-            NamingEnumeration<SearchResult> answer = ctx.search("", getSearchFilter(), 
+            NamingEnumeration<SearchResult> answer = ctx.search("", getSearchFilter(),
                     new String[] {sanitizeSearchFilter(username)},
                     constraints);
 
@@ -1140,12 +1179,29 @@ public class LdapManager {
             return findGroupRDN(groupname, baseDN);
         }
         catch (Exception e) {
-            if (alternateBaseDN != null) {
-                return findGroupRDN(groupname, alternateBaseDN);
-            }
-            else {
+            if (alternateBaseDN == null) {
                 throw e;
             }
+            return findGroupRDN(groupname, alternateBaseDN);
+        }
+    }
+
+    /**
+     * Like {@link #findGroupRDN(String)} but returns the absolute DN of a group
+     */
+    public LdapName findGroupAbsoluteDN(String groupname) throws Exception {
+        try {
+            LdapName r = LdapManager.escapeForJNDI(findGroupRDN(groupname, baseDN));
+            r.addAll(0, baseDN);
+            return r;
+        }
+        catch (Exception e) {
+            if (alternateBaseDN == null) {
+                throw e;
+            }
+            LdapName r = LdapManager.escapeForJNDI(findGroupRDN(groupname, alternateBaseDN));
+            r.addAll(0, alternateBaseDN);
+            return r;
         }
     }
 
@@ -1232,6 +1288,63 @@ public class LdapManager {
             try { if ( ctx != null ) { ctx.close(); } }
             catch (Exception e) {
                 Log.debug("An unexpected exception occurred while closing the LDAP context after searching for group '{}'.", groupname, e);
+            }
+        }
+    }
+
+    /**
+     * Check if the given DN matches the group search filter
+     *
+     * @param dn the absolute DN of the node to check
+     * @return true if the given DN is matching the group filter. false oterwise.
+     * @throws NamingException if the search for the dn fails.
+     */
+    public boolean isGroupDN(LdapName dn) throws NamingException {
+        Log.debug("LdapManager: Trying to check if DN is a group. DN: {}, Base DN: {} ...", dn, baseDN);
+
+        // is it a sub DN of the base DN?
+        if (!dn.startsWith(baseDN)
+            && (alternateBaseDN == null || !dn.startsWith(alternateBaseDN))) {
+            if (Log.isDebugEnabled()) {
+                Log.debug("LdapManager: DN ({}) does not fit to baseDN ({},{})", dn, baseDN, alternateBaseDN);
+            }
+            return false;
+        }
+
+        DirContext ctx = null;
+        try {
+            Log.debug("LdapManager: Starting LDAP search to check group DN: {}", dn);
+            // Search for the group in the node with the given DN.
+            // should return the group object itself if is matches the group filter
+            ctx = getContext(dn);
+            // only search the object itself.
+            SearchControls constraints = new SearchControls();
+            constraints.setSearchScope(SearchControls.OBJECT_SCOPE);
+            constraints.setReturningAttributes(new String[]{});
+            String filter = MessageFormat.format(getGroupSearchFilter(), "*");
+            NamingEnumeration<SearchResult> answer = ctx.search("", filter, constraints);
+
+            Log.debug("LdapManager: ... group check search finished for DN: {}", dn);
+
+            boolean result = (answer != null && answer.hasMoreElements());
+
+            if (answer != null) {
+                answer.close();
+            }
+            Log.debug("LdapManager: DN is group: {}? {}!", dn, result);
+            return result;
+        }
+        catch (final Exception e) {
+            Log.debug("LdapManager: Exception thrown when checking if DN is a group {}", dn, e);
+            throw e;
+        }
+        finally {
+            try {
+                if (ctx != null)
+                    ctx.close();
+            }
+            catch (Exception ignored) {
+                // Ignore.
             }
         }
     }
@@ -1877,6 +1990,26 @@ public class LdapManager {
     }
 
     /**
+     * Returns true if nested / complex / hierarchic groups should be should be flattened.
+     * <p>
+     * This means: if group A is member of group B, the members of group A will also be members of
+     * group B
+     */
+    public boolean isFlattenNestedGroups() {
+        return flattenNestedGroups;
+    }
+
+    /**
+     * Set whether nested / complex / hierarchic groups should be should be flattened.
+     *
+     * @see #isFlattenNestedGroups()
+     */
+    public void setFlattenNestedGroups(boolean flattenNestedGroups) {
+        this.flattenNestedGroups = flattenNestedGroups;
+        properties.put("ldap.flattenNestedGroups", String.valueOf(posixMode));
+    }
+
+    /**
      * Sets the search filter appended to the default filter when searching for groups.
      *
      * @param groupSearchFilter the search filter appended to the default filter
@@ -2124,6 +2257,145 @@ public class LdapManager {
     }
 
     /**
+     * Generic routine for retrieving a single element from the LDAP server.  It's meant to be very
+     * flexible so that just about any query for a single results can make use of it without having
+     * to reimplement their own calls to LDAP.
+     * <p>
+     * The passed in filter string needs to be pre-prepared! In other words, nothing will be changed
+     * in the string before it is used as a string.
+     *
+     * @param attribute             LDAP attribute to be pulled from each result and placed in the return results.
+     *                              Typically pulled from this manager. Null means the the absolute DN is returned.
+     * @param searchFilter          Filter to use to perform the search.  Typically pulled from this manager.
+     * @param failOnMultipleResults It true, an {@link IllegalStateException} will be thrown, if the
+     *                              search result is not unique. If false, just the first result will be returned.
+     * @return A single string.
+     */
+    public String retrieveSingle(String attribute, String searchFilter, boolean failOnMultipleResults) {
+        try {
+            return retrieveSingle(attribute, searchFilter, failOnMultipleResults, baseDN);
+        }
+        catch (Exception e) {
+            if (alternateBaseDN != null) {
+                return retrieveSingle(attribute, searchFilter, failOnMultipleResults, alternateBaseDN);
+            }
+            else {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Generic routine for retrieving a single element from the LDAP server.  It's meant to be very
+     * flexible so that just about any query for a single results can make use of it without having
+     * to reimplement their own calls to LDAP.
+     * <p>
+     * The passed in filter string needs to be pre-prepared!  In other words, nothing will be changed
+     * in the string before it is used as a string.
+     *
+     * @param attribute             LDAP attribute to be pulled from each result and placed in the return results.
+     *                              Typically pulled from this manager. Null means the the absolute DN is returned.
+     * @param searchFilter          Filter to use to perform the search.  Typically pulled from this manager.
+     * @param failOnMultipleResults It true, an {@link IllegalStateException} will be thrown, if the
+     *                              search result is not unique. If false, just the first result will be returned.
+     * @param baseDN                DN where to start the search. Typically {@link #getBaseDN()} or {@link #getAlternateBaseDN()}.
+     * @return A single string.
+     */
+    public String retrieveSingle(String attribute, String searchFilter, boolean failOnMultipleResults, LdapName baseDN) {
+        LdapContext ctx = null;
+        try {
+            ctx = getContext(baseDN);
+
+            SearchControls searchControls = new SearchControls();
+            // See if recursive searching is enabled. Otherwise, only search one level.
+            if (isSubTreeSearch()) {
+                searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+            }
+            else {
+                searchControls.setSearchScope(SearchControls.ONELEVEL_SCOPE);
+            }
+            searchControls.setReturningAttributes(attribute == null ? new String[0] : new String[]{attribute});
+
+            NamingEnumeration<SearchResult> answer = ctx.search("", searchFilter, searchControls);
+            if (answer == null || !answer.hasMoreElements()) {
+                return null;
+            }
+            SearchResult searchResult = answer.next();
+            String result = attribute == null
+                ? new LdapName(searchResult.getName()).addAll(0, baseDN).toString() :
+                (String) searchResult.getAttributes().get(attribute).get();
+            if (answer.hasMoreElements()) {
+                Log.debug("Search result for '{}' is not unique.", searchFilter);
+                if (failOnMultipleResults)
+                    throw new IllegalStateException("Search result for " + searchFilter + " is not unique.");
+            }
+            answer.close();
+            return result;
+        }
+        catch (Exception e) {
+            Log.error("Error while searching for single result of: {}", searchFilter, e);
+            return null;
+        }
+        finally {
+            try {
+                if (ctx != null) {
+                    ctx.close();
+                }
+            } catch (Exception ignored) {
+                // Ignore.
+            }
+        }
+    }
+
+    /**
+     * Reads the attribute values of an entry with the given DN.
+     *
+     * @param attributeName LDAP attribute to be read.
+     * @param dn            DN of the entry.
+     * @return A list with the values of the attribute.
+     */
+    public List<String> retrieveAttributeOf(String attributeName, LdapName dn) throws NamingException {
+        Log.debug("LdapManager: Reading attribute '{}' of DN '{}' ...", attributeName, dn);
+
+        DirContext ctx = null;
+        NamingEnumeration<?> values = null;
+        try {
+
+            ctx = getContext(dn);
+            Attributes attributes = ctx.getAttributes("", new String[]{attributeName});
+            Attribute attribute = attributes.get(attributeName);
+            if (attribute == null)
+                return Collections.emptyList();
+            List<String> result = new ArrayList<>(attribute.size());
+            values = attribute.getAll();
+            while (values.hasMoreElements()) {
+                result.add(values.next().toString());
+            }
+            return result;
+        }
+        catch (final Exception e) {
+            Log.debug("LdapManager: Exception thrown when reading attribute '{}' of DN '{}' ...", attributeName, dn, e);
+            throw e;
+        }
+        finally {
+            try {
+                if (values != null)
+                    values.close();
+            }
+            catch (Exception ignored) {
+                // Ignore.
+            }
+            try {
+                if (ctx != null)
+                    ctx.close();
+            }
+            catch (Exception ignored) {
+                // Ignore.
+            }
+        }
+    }
+
+    /**
      * Generic routine for retrieving the number of available results from the LDAP server that
      * match the passed search filter.  This routine also accounts for paging settings and
      * alternate DNs.
@@ -2285,7 +2557,7 @@ public class LdapManager {
      * @see https://docs.oracle.com/javase/tutorial/jndi/ldap/jndi.html
      * @see https://docs.oracle.com/javase/jndi/tutorial/beyond/names/syntax.html
      */
-    public static Name escapeForJNDI( Rdn... rdn )
+    public static LdapName escapeForJNDI(Rdn... rdn)
     {
         // Create a clone, to prevent changes to ordering of elements to affect the original array.
         final Rdn[] copy = Arrays.copyOf(rdn, rdn.length);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -518,4 +518,17 @@ public final class UserManager {
             }
         }
     }
+
+    /** Exposed for test use only */
+    public static void setProvider(UserProvider provider) {
+        USER_PROVIDER.setValue(provider.getClass());
+        UserManager.provider = provider;
+    }
+
+    /** Exposed for test use only */
+    public void clearCaches()
+    {
+        userCache.clear();
+        remoteUsersCache.clear();
+    }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/ldap/FlattenNestedGroupsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/ldap/FlattenNestedGroupsTest.java
@@ -1,0 +1,334 @@
+package org.jivesoftware.openfire.ldap;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.XMPPServerInfo;
+import org.jivesoftware.openfire.group.GroupNotFoundException;
+import org.jivesoftware.openfire.user.User;
+import org.jivesoftware.openfire.user.UserManager;
+import org.jivesoftware.util.JiveGlobals;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.xmpp.packet.JID;
+import org.zapodot.junit.ldap.EmbeddedLdapRule;
+import org.zapodot.junit.ldap.EmbeddedLdapRuleBuilder;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+
+/**
+ * Tests the flattenNestedGroups mode of the {@link LdapGroupProvider}
+ *
+ * @author Marcel Heckel, 2019
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FlattenNestedGroupsTest {
+
+    static {
+        // TODO: is there a better place to set this?
+        // When not set, an error is thrown. So set it to an arbitrary value.
+        JiveGlobals.setHomeDirectory(new File(".").getAbsolutePath());
+    }
+
+    private static final String THIS_HOST_NAME = "test-host-name";
+
+    private final int LDAP_SERVER_PORT = 12345;
+
+    @Rule
+    public EmbeddedLdapRule embeddedLdapRule = EmbeddedLdapRuleBuilder
+        .newInstance()
+        .bindingToPort(LDAP_SERVER_PORT)
+        .usingDomainDsn("dc=mobikat,dc=net")
+        .importingLdifs("org/jivesoftware/openfire/ldap/flattenNestedGroups.ldif")
+        .build();
+
+    @Mock
+    private XMPPServer xmppServer;
+    @Mock
+    private XMPPServerInfo xmppServerInfo;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        Fixtures.reconfigureOpenfireHome();
+    }
+
+    @Before
+    public void setUp() {
+        Fixtures.clearExistingProperties();
+
+        //noinspection deprecation
+        XMPPServer.setInstance(xmppServer);
+        //doReturn(THIS_HOST_NAME).when(xmppServerInfo).getHostname();
+        //doReturn(THIS_HOST_NAME).when(xmppServerInfo).getXMPPDomain();
+
+        doReturn(xmppServerInfo).when(xmppServer).getServerInfo();
+
+        doAnswer(invocation -> {
+                Object[] args = invocation.getArguments();
+                return new JID((String) args[0], THIS_HOST_NAME, (String) args[1]);
+            }
+        ).when(xmppServer).createJID(any(), any());
+
+        doAnswer(invocation -> {
+                JID jid = (JID) invocation.getArguments()[0];
+                return jid != null && jid.getDomain().equals(THIS_HOST_NAME);
+            }
+        ).when(xmppServer).isLocal(any());
+
+    }
+
+    private void initLdapManager(boolean posix, boolean flattenNestedGroups) {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("ldap.host", "localhost");
+        properties.put("ldap.port", "" + LDAP_SERVER_PORT);
+        properties.put("ldap.sslEnabled", "false" );
+        properties.put("ldap.startTlsEnabled", "false" );
+        properties.put("ldap.baseDN", "dc=mobikat,dc=net");
+        properties.put("ldap.adminDN", EmbeddedLdapRuleBuilder.DEFAULT_BIND_DSN);
+        properties.put("ldap.adminPassword", EmbeddedLdapRuleBuilder.DEFAULT_BIND_CREDENTIALS);
+        properties.put("ldap.usernameField", "uid");
+        properties.put("ldap.nameField", "cn");
+        properties.put("ldap.searchFilter", "(objectClass=inetOrgPerson)");
+        properties.put("ldap.groupNameField", "cn");
+        properties.put("ldap.groupMemberField", posix ? "memberUid" : "uniqueMember");
+        properties.put("ldap.groupSearchFilter", posix ? "(objectClass=posixGroup)" : "(objectClass=groupOfUniqueNames)");
+
+        if (posix)
+            properties.put("ldap.posixMode", "true");
+        if (flattenNestedGroups)
+            properties.put("ldap.flattenNestedGroups", "true");
+
+        LdapManager.setInstance(new LdapManager(properties));
+        UserManager.setProvider(new LdapUserProvider());
+        UserManager.getInstance().clearCaches();
+    }
+
+
+    @Test
+    public void testConnection() throws Exception {
+        initLdapManager(false, false);
+
+        LdapManager ldapManager = LdapManager.getInstance();
+        assertEquals("cn=admins,ou=groups,dc=mobikat,dc=net", ldapManager.findGroupAbsoluteDN("admins").toString());
+
+        UserManager userManager = UserManager.getInstance();
+
+        User user = userManager.getUser("j.bond");
+        assertNotNull(user);
+        assertEquals("James Bond", user.getName());
+    }
+
+
+    @Test
+    public void testNormalUsersOfGroupsNoPosix() throws GroupNotFoundException {
+        initLdapManager(false, false);
+        testNormalUsersOfGroups();
+    }
+
+    @Test
+    public void testNormalUsersOfGroupsPosix() throws GroupNotFoundException {
+        initLdapManager(true, false);
+        testNormalUsersOfGroups();
+    }
+
+    @Test
+    public void testFlattenUsersOfGroupsNoPosix() throws GroupNotFoundException {
+        initLdapManager(false, true);
+        testFlattenUsersOfGroups();
+    }
+
+    @Test
+    public void testFlattenUsersOfGroupsPosix() throws GroupNotFoundException {
+        initLdapManager(true, true);
+        testFlattenUsersOfGroups();
+    }
+
+    public void testNormalUsersOfGroups() throws GroupNotFoundException {
+        LdapGroupProvider groupProvider = new LdapGroupProvider();
+
+        // admins
+        assertThat(groupProvider.getGroup("admins").getAll(),
+            containsInAnyOrder(
+                new JID("j.bond", THIS_HOST_NAME, null),
+                new JID("j.lopez", THIS_HOST_NAME, null)
+            ));
+        // cycle1
+        assertThat(groupProvider.getGroup("cycle1").getAll(),
+            containsInAnyOrder(
+                new JID("l.densivillja", THIS_HOST_NAME, null),
+                new JID("p.silie", THIS_HOST_NAME, null)
+            ));
+        // cycle2
+        assertThat(groupProvider.getGroup("cycle2").getAll(),
+            containsInAnyOrder(
+                new JID("c.man", THIS_HOST_NAME, null),
+                new JID("h.wurst", THIS_HOST_NAME, null)
+            ));
+        // cycle3
+        assertThat(groupProvider.getGroup("cycle3").getAll(),
+            containsInAnyOrder(
+                new JID("a.schweis", THIS_HOST_NAME, null),
+                new JID("j.lopez", THIS_HOST_NAME, null)
+            ));
+        // group1
+        assertThat(groupProvider.getGroup("group1").getAll(),
+            containsInAnyOrder(
+                new JID("c.man", THIS_HOST_NAME, null),
+                new JID("h.wurst", THIS_HOST_NAME, null)
+            ));
+        // group2
+        assertThat(groupProvider.getGroup("group2").getAll(),
+            containsInAnyOrder(
+                new JID("l.densivillja", THIS_HOST_NAME, null),
+                new JID("p.silie", THIS_HOST_NAME, null)
+            ));
+        // group3
+        assertThat(groupProvider.getGroup("group3").getAll(),
+            containsInAnyOrder(
+                new JID("a.schweis", THIS_HOST_NAME, null)
+            ));
+        // group4
+        assertThat(groupProvider.getGroup("group4").getAll(),
+            containsInAnyOrder(
+                new JID("j.lopez", THIS_HOST_NAME, null)
+            ));
+    }
+
+    public void testFlattenUsersOfGroups() throws GroupNotFoundException {
+        LdapGroupProvider groupProvider = new LdapGroupProvider();
+        // admins
+        assertThat(groupProvider.getGroup("admins").getAll(),
+            containsInAnyOrder(
+                new JID("j.bond", THIS_HOST_NAME, null),
+                new JID("j.lopez", THIS_HOST_NAME, null)
+            ));
+        // cycle1..3
+        for (String cycle : new String[]{"cycle1", "cycle2", "cycle3"}) {
+            assertThat(groupProvider.getGroup(cycle).getAll(),
+                containsInAnyOrder(
+                    new JID("l.densivillja", THIS_HOST_NAME, null),
+                    new JID("p.silie", THIS_HOST_NAME, null),
+                    new JID("c.man", THIS_HOST_NAME, null),
+                    new JID("h.wurst", THIS_HOST_NAME, null),
+                    new JID("a.schweis", THIS_HOST_NAME, null),
+                    new JID("j.lopez", THIS_HOST_NAME, null)
+                ));
+        }
+        // group1
+        assertThat(groupProvider.getGroup("group1").getAll(),
+            containsInAnyOrder(
+                new JID("c.man", THIS_HOST_NAME, null),
+                new JID("h.wurst", THIS_HOST_NAME, null),
+                new JID("l.densivillja", THIS_HOST_NAME, null),
+                new JID("p.silie", THIS_HOST_NAME, null),
+                new JID("a.schweis", THIS_HOST_NAME, null),
+                new JID("j.lopez", THIS_HOST_NAME, null)
+            ));
+        // group2
+        assertThat(groupProvider.getGroup("group2").getAll(),
+            containsInAnyOrder(
+                new JID("l.densivillja", THIS_HOST_NAME, null),
+                new JID("p.silie", THIS_HOST_NAME, null),
+                new JID("a.schweis", THIS_HOST_NAME, null),
+                new JID("j.lopez", THIS_HOST_NAME, null)
+            ));
+        // group3
+        assertThat(groupProvider.getGroup("group3").getAll(),
+            containsInAnyOrder(
+                new JID("a.schweis", THIS_HOST_NAME, null)
+            ));
+        // group4
+        assertThat(groupProvider.getGroup("group4").getAll(),
+            containsInAnyOrder(
+                new JID("j.lopez", THIS_HOST_NAME, null)
+            ));
+    }
+
+    @Test
+    public void testNormalGroupsOfUsersNoPosix() throws GroupNotFoundException {
+        initLdapManager(false, false);
+        testNormalGroupsOfUsers();
+    }
+
+    @Test
+    public void testNormalGroupsOfUsersPosix() throws GroupNotFoundException {
+        initLdapManager(true, false);
+        testNormalGroupsOfUsers();
+    }
+
+    @Test
+    public void testFlattenGroupsOfUsersNoPosix() throws GroupNotFoundException {
+        initLdapManager(false, true);
+        testFlattenGroupsOfUsers();
+    }
+
+    @Test
+    public void testFlattenGroupsOfUsersPosix() throws GroupNotFoundException {
+        initLdapManager(true, true);
+        testFlattenGroupsOfUsers();
+    }
+
+    public void testNormalGroupsOfUsers() throws GroupNotFoundException {
+        LdapGroupProvider groupProvider = new LdapGroupProvider();
+
+        assertThat(groupProvider.getGroupNames(new JID("j.bond", THIS_HOST_NAME, null)),
+            containsInAnyOrder("admins"));
+
+        assertThat(groupProvider.getGroupNames(new JID("a.schweis", THIS_HOST_NAME, null)),
+            containsInAnyOrder("cycle3", "group3"));
+
+        assertThat(groupProvider.getGroupNames(new JID("c.man", THIS_HOST_NAME, null)),
+            containsInAnyOrder("cycle2", "group1"));
+
+        assertThat(groupProvider.getGroupNames(new JID("h.wurst", THIS_HOST_NAME, null)),
+            containsInAnyOrder("cycle2", "group1"));
+
+        assertThat(groupProvider.getGroupNames(new JID("j.lopez", THIS_HOST_NAME, null)),
+            containsInAnyOrder("admins", "cycle3", "group4"));
+
+        assertThat(groupProvider.getGroupNames(new JID("l.densivillja", THIS_HOST_NAME, null)),
+            containsInAnyOrder("cycle1", "group2"));
+
+        assertThat(groupProvider.getGroupNames(new JID("p.silie", THIS_HOST_NAME, null)),
+            containsInAnyOrder("cycle1", "group2"));
+    }
+
+    public void testFlattenGroupsOfUsers() throws GroupNotFoundException {
+        LdapGroupProvider groupProvider = new LdapGroupProvider();
+
+        assertThat(groupProvider.getGroupNames(new JID("j.bond", THIS_HOST_NAME, null)),
+            containsInAnyOrder("admins"));
+
+        assertThat(groupProvider.getGroupNames(new JID("a.schweis", THIS_HOST_NAME, null)),
+            containsInAnyOrder("cycle1", "cycle2", "cycle3", "group1", "group2", "group3"));
+
+        assertThat(groupProvider.getGroupNames(new JID("c.man", THIS_HOST_NAME, null)),
+            containsInAnyOrder("cycle1", "cycle2", "cycle3", "group1"));
+
+        assertThat(groupProvider.getGroupNames(new JID("h.wurst", THIS_HOST_NAME, null)),
+            containsInAnyOrder("cycle1", "cycle2", "cycle3", "group1"));
+
+        assertThat(groupProvider.getGroupNames(new JID("j.lopez", THIS_HOST_NAME, null)),
+            containsInAnyOrder("admins", "cycle1", "cycle2", "group1", "group2", "cycle3", "group4"));
+
+        assertThat(groupProvider.getGroupNames(new JID("l.densivillja", THIS_HOST_NAME, null)),
+            containsInAnyOrder("cycle1", "cycle2", "cycle3", "group1", "group2"));
+
+        assertThat(groupProvider.getGroupNames(new JID("p.silie", THIS_HOST_NAME, null)),
+            containsInAnyOrder("cycle1", "cycle2", "cycle3", "group1", "group2"));
+    }
+}

--- a/xmppserver/src/test/resources/org/jivesoftware/openfire/ldap/flattenNestedGroups.ldif
+++ b/xmppserver/src/test/resources/org/jivesoftware/openfire/ldap/flattenNestedGroups.ldif
@@ -1,0 +1,252 @@
+version: 1
+
+dn: dc=mobikat,dc=net
+objectClass: organization
+objectClass: dcObject
+objectClass: top
+dc: mobikat
+o: Mobikat
+
+dn: ou=users,dc=mobikat,dc=net
+objectClass: top
+objectClass: organizationalUnit
+ou: users
+
+dn: ou=groups,dc=mobikat,dc=net
+objectClass: organizationalUnit
+objectClass: top
+ou: groups
+
+dn: ou=possixGroups,dc=mobikat,dc=net
+objectClass: organizationalUnit
+objectClass: top
+ou: possixGroups
+
+dn: cn=Cool Man,ou=users,dc=mobikat,dc=net
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Cool Man
+sn: Man
+uid: c.man
+userPassword: {CRYPT}$6$rounds=5000$q4CyfzUPkz5jxyLb$h7lnGkEO4RzZOFy.cUPVgXj
+ 9w39G75scyO7jo9aWvr70AoO/Coh3ElfaeC59/rsJWQZNBlrLscRWEqa/3xdTX.
+
+dn: cn=Hans Wurst,ou=users,dc=mobikat,dc=net
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Hans Wurst
+sn: Wurst
+uid: h.wurst
+userPassword: {CRYPT}$6$rounds=5000$Dz/z6Y/woSbUomSK$ZkvdfXqi1.9eNzPnLCWYycq
+ NlBfZGoGIsfTDUra2p9jPM1tCY4mgoZYQ7mp4Tf1BT2t/c59.6pynYpR86.xN41
+
+dn: cn=James Bond,ou=users,dc=mobikat,dc=net
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: James Bond
+sn: Bond
+uid: j.bond
+userPassword: {CRYPT}$6$rounds=5000$q4CyfzUPkz5jxyLb$h7lnGkEO4RzZOFy.cUPVgXj
+ 9w39G75scyO7jo9aWvr70AoO/Coh3ElfaeC59/rsJWQZNBlrLscRWEqa/3xdTX.
+
+dn: cn=Peter Silie,ou=users,dc=mobikat,dc=net
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Peter Silie
+sn: Silie
+uid: p.silie
+userPassword: {CRYPT}$6$rounds=5000$hqg7CcrAvPWuCo0b$uf7.1tSBeLCGRhTysjUqeO2
+ /AOCUB90doRpHB3c//S/hxakOd4BjIZ48vWE0qkhm6YtLyYwHJcOnIaTavIbSA.
+
+dn: cn=Axel Schweis,ou=users,dc=mobikat,dc=net
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Axel Schweis
+sn: Schweis
+uid: a.schweis
+userPassword: {CRYPT}$6$rounds=5000$q4CyfzUPkz5jxyLb$h7lnGkEO4RzZOFy.cUPVgXj
+ 9w39G75scyO7jo9aWvr70AoO/Coh3ElfaeC59/rsJWQZNBlrLscRWEqa/3xdTX.
+
+dn: cn=Jennifer Lopez,ou=users,dc=mobikat,dc=net
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Jennifer Lopez
+sn: Lopez
+uid: j.lopez
+userPassword: {CRYPT}$6$rounds=5000$q4CyfzUPkz5jxyLb$h7lnGkEO4RzZOFy.cUPVgXj
+ 9w39G75scyO7jo9aWvr70AoO/Coh3ElfaeC59/rsJWQZNBlrLscRWEqa/3xdTX.
+
+dn: cn=Lasmiranda Densivillja,ou=users,dc=mobikat,dc=net
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Lasmiranda Densivillja
+sn: Densivillja
+uid: l.densivillja
+userPassword: {CRYPT}$6$rounds=5000$q4CyfzUPkz5jxyLb$h7lnGkEO4RzZOFy.cUPVgXj
+ 9w39G75scyO7jo9aWvr70AoO/Coh3ElfaeC59/rsJWQZNBlrLscRWEqa/3xdTX.
+
+dn: cn=admins,ou=groups,dc=mobikat,dc=net
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: admins
+uniqueMember: cn=James Bond,ou=users,dc=mobikat,dc=net
+uniqueMember: cn=GibtEsNicht
+uniqueMember: cn=Jennifer Lopez,ou=users,dc=mobikat,dc=net
+
+dn: cn=cycle1,ou=groups,dc=mobikat,dc=net
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: cycle1
+uniqueMember: cn=Lasmiranda Densivillja,ou=users,dc=mobikat,dc=net
+uniqueMember: cn=Peter Silie,ou=users,dc=mobikat,dc=net
+uniqueMember: cn=cycle2,ou=groups,dc=mobikat,dc=net
+
+dn: cn=cycle2,ou=groups,dc=mobikat,dc=net
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: cycle2
+uniqueMember: cn=Cool Man,ou=users,dc=mobikat,dc=net
+uniqueMember: cn=Hans Wurst,ou=users,dc=mobikat,dc=net
+uniqueMember: cn=cycle3,ou=groups,dc=mobikat,dc=net
+
+dn: cn=cycle3,ou=groups,dc=mobikat,dc=net
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: cycle3
+uniqueMember: cn=cycle1,ou=groups,dc=mobikat,dc=net
+uniqueMember: cn=Jennifer Lopez,ou=users,dc=mobikat,dc=net
+uniqueMember: cn=Axel Schweis,ou=users,dc=mobikat,dc=net
+
+dn: cn=group1,ou=groups,dc=mobikat,dc=net
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: group1
+uniqueMember: cn=Cool Man,ou=users,dc=mobikat,dc=net
+uniqueMember: cn=Hans Wurst,ou=users,dc=mobikat,dc=net
+uniqueMember: dc=mobikat,dc=net
+uniqueMember: cn=group2,ou=groups,dc=mobikat,dc=net
+
+dn: cn=group2,ou=groups,dc=mobikat,dc=net
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: group2
+uniqueMember: cn=Lasmiranda Densivillja,ou=users,dc=mobikat,dc=net
+uniqueMember: cn=Peter Silie,ou=users,dc=mobikat,dc=net
+uniqueMember: cn=group3,ou=groups,dc=mobikat,dc=net
+uniqueMember: cn=group4,ou=groups,dc=mobikat,dc=net
+
+dn: cn=group3,ou=groups,dc=mobikat,dc=net
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: group3
+uniqueMember: dc=mobikat,dc=net
+uniqueMember: cn=Axel Schweis,ou=users,dc=mobikat,dc=net
+
+dn: cn=group4,ou=groups,dc=mobikat,dc=net
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: group4
+uniqueMember: dc=mobikat,dc=net
+uniqueMember: cn=Jennifer Lopez,ou=users,dc=mobikat,dc=net
+
+dn: cn=admins,ou=possixGroups,dc=mobikat,dc=net
+objectClass: uidObject
+objectClass: top
+objectClass: posixGroup
+cn: admins
+gidNumber: 0
+uid: admins
+memberUid: j.bond
+memberUid: gibtEsNicht
+memberUid: j.lopez
+
+dn: cn=cycle1,ou=possixGroups,dc=mobikat,dc=net
+objectClass: uidObject
+objectClass: top
+objectClass: posixGroup
+cn: cycle1
+gidNumber: 0
+uid: cycle1
+memberUid: cycle2
+memberUid: p.silie
+memberUid: l.densivillja
+
+dn: cn=cycle2,ou=possixGroups,dc=mobikat,dc=net
+objectClass: uidObject
+objectClass: top
+objectClass: posixGroup
+cn: cycle2
+gidNumber: 0
+uid: cycle2
+memberUid: h.wurst
+memberUid: c.man
+memberUid: cycle3
+
+dn: cn=cycle3,ou=possixGroups,dc=mobikat,dc=net
+objectClass: uidObject
+objectClass: top
+objectClass: posixGroup
+cn: cycle3
+gidNumber: 0
+uid: cycle3
+memberUid: cycle1
+memberUid: a.schweis
+memberUid: j.lopez
+
+dn: cn=group1,ou=possixGroups,dc=mobikat,dc=net
+objectClass: uidObject
+objectClass: top
+objectClass: posixGroup
+cn: group1
+gidNumber: 0
+uid: group1
+memberUid: c.man
+memberUid: h.wurst
+memberUid: group2
+
+dn: cn=group2,ou=possixGroups,dc=mobikat,dc=net
+objectClass: uidObject
+objectClass: top
+objectClass: posixGroup
+cn: group2
+gidNumber: 0
+uid: group2
+memberUid: p.silie
+memberUid: l.densivillja
+memberUid: group3
+memberUid: group4
+
+dn: cn=group3,ou=possixGroups,dc=mobikat,dc=net
+objectClass: uidObject
+objectClass: top
+objectClass: posixGroup
+cn: group3
+gidNumber: 0
+uid: group3
+memberUid: a.schweis
+memberUid: mobi
+
+dn: cn=group4,ou=possixGroups,dc=mobikat,dc=net
+objectClass: uidObject
+objectClass: top
+objectClass: posixGroup
+cn: group4
+gidNumber: 0
+uid: group4
+memberUid: mobi
+memberUid: j.lopez
+


### PR DESCRIPTION
Nested / complex / hierarchic groups are flattened. This means: if
group A is member of group B, the members of group A will also be
members of group B.

Cyclic paths are detected and followed only once.

The features is disable by default.
Set property "ldap.flattenNestedGroups" to "true" to enable it.