### PR TITLE
OF-1894: Allow the contents of Cache's to be kept private

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SystemCacheDetailsServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SystemCacheDetailsServlet.java
@@ -46,20 +46,23 @@ public class SystemCacheDetailsServlet extends HttpServlet {
             request.setAttribute("warningMessage", LocaleUtils.getLocalizedString("system.cache-details.cache_not_found", Collections.singletonList(cacheName)));
         }
 
+        final boolean secretKey = optionalCache.map(Cache::isKeySecret).orElse(Boolean.FALSE);
+        final boolean secretValue = optionalCache.map(Cache::isValueSecret).orElse(Boolean.FALSE);
+
         final List<Map.Entry<String, String>> cacheEntries = optionalCache.map(Cache::entrySet)
             .map(Collection::stream)
             .orElseGet(Stream::empty)
-            .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey().toString(), entry.getValue().toString()))
+            .map(entry -> new AbstractMap.SimpleEntry<>(secretKey ? "************" : entry.getKey().toString(), secretValue ? "************" : entry.getValue().toString()))
             .sorted(Comparator.comparing(Map.Entry::getKey))
             .collect(Collectors.toList());
 
         // Find what we're searching for
         final Search search = new Search(request);
         Predicate<Map.Entry<String, String>> predicate = entry -> true;
-        if (!search.key.isEmpty()) {
+        if (!search.key.isEmpty() && !secretKey) {
             predicate = predicate.and(entry -> StringUtils.containsIgnoringCase(entry.getKey(), search.key));
         }
-        if (!search.value.isEmpty()) {
+        if (!search.value.isEmpty() && !secretValue) {
             predicate = predicate.and(entry -> StringUtils.containsIgnoringCase(entry.getValue(), search.value));
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/Cache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/Cache.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 
 /**
@@ -186,4 +187,21 @@ public interface Cache<K extends Serializable, V extends Serializable> extends j
         return CacheFactory.getLock(key, this);
     }
 
+    AtomicBoolean secretKey = new AtomicBoolean(false);
+    AtomicBoolean secretValue = new AtomicBoolean(false);
+    default void setSecretKey() {
+        this.secretKey.set(true);
+    }
+
+    default void setSecretValue() {
+        this.secretValue.set(true);
+    }
+
+    default boolean isKeySecret() {
+        return this.secretKey.get();
+    }
+
+    default boolean isValueSecret() {
+        return this.secretValue.get();
+    }
 }


### PR DESCRIPTION
Note; this PR deliberately does not use system properties to determine if the contents of a cache should be displayed on there admin UI. If the developer does not wish a cache to be displayed on the admin UI, then it should not be possible for an administrator to override their wishes by changing a system property.

An implication of this is that the code must explicitly set the key and/or value to be secret.