### PR TITLE
OF-1901: Pubsub unsubscribe permissions

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
@@ -829,7 +829,7 @@ public class NodeSubscription {
      * @return true if the specified user is allowed to modify or cancel the subscription.
      */
     boolean canModify(JID user) {
-        return user.equals(getJID()) || user.equals(getOwner()) || node.getService().isServiceAdmin(user);
+        return user.equals(getJID()) || user.toBareJID().equals(getOwner().toBareJID()) || node.getService().isServiceAdmin(user);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -843,7 +843,7 @@ public class PubSubEngine {
         }
 
         // A subscription was found so check if the user is allowed to cancel the subscription
-        if (!subscription.canModify(from) && !subscription.canModify(owner)) {
+        if (!subscription.canModify(from)) {
             // Requestor is prohibited from unsubscribing entity
             sendErrorPacket(iq, PacketError.Condition.forbidden, null);
             return;


### PR DESCRIPTION
This fixes two problems that occur while determining if a particular JID is allowed to unsubscribe a (potentially different) JID from a pubsub node.