### PR TITLE
Add coverage reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,9 +207,6 @@
 
         <profile>
             <id>coverage</id>
-            <properties>
-                <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -239,6 +236,18 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M3</version>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
+                            </systemPropertyVariables>
+                            <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,7 @@
                 </plugins>
             </build>
         </profile>
+
     </profiles>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -139,9 +139,6 @@
 
         <profile>
             <id>release</id>
-            <properties>
-                <argLine>-Duser.language=us -Duser.country=US</argLine>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -164,9 +161,6 @@
 
         <profile>
             <id>ci</id>
-            <properties>
-                <argLine>-Duser.language=us -Duser.country=US</argLine>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -188,58 +188,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <profile>
-            <id>coverage</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.5</version>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/*_jsp.class</exclude>
-                            </excludes>
-
-                            <destFile>${project.build.directory}/coverage-reports/jacoco-unit.exec</destFile>
-                            <dataFile>${project.build.directory}/coverage-reports/jacoco-unit.exec</dataFile>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>default-prepare-agent</id>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                                <configuration>
-                                    <destFile>${project.build.directory}/coverage-reports/jacoco-unit.exec</destFile>
-                                    <propertyName>argLine</propertyName>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>report</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M3</version>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
-                            </systemPropertyVariables>
-                            <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,54 @@
             </build>
         </profile>
 
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.5</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*_jsp.class</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>default-prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>argLine</propertyName>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M3</version>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
+                            </systemPropertyVariables>
+                            <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,20 @@
 
     <profiles>
         <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <argLine>-Duser.language=us -Duser.country=US</argLine>
+            </properties>
+        </profile>
+
+        <profile>
             <id>release</id>
+            <properties>
+                <argLine>-Duser.language=us -Duser.country=US</argLine>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -151,6 +164,9 @@
 
         <profile>
             <id>ci</id>
+            <properties>
+                <argLine>-Duser.language=us -Duser.country=US</argLine>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -191,6 +207,9 @@
 
         <profile>
             <id>coverage</id>
+            <properties>
+                <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -221,22 +240,9 @@
                             </execution>
                         </executions>
                     </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M3</version>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
-                            </systemPropertyVariables>
-                            <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
-                        </configuration>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
-
     </profiles>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -128,16 +128,6 @@
 
     <profiles>
         <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <argLine>-Duser.language=us -Duser.country=US</argLine>
-            </properties>
-        </profile>
-
-        <profile>
             <id>release</id>
             <build>
                 <plugins>
@@ -211,6 +201,9 @@
                             <excludes>
                                 <exclude>**/*_jsp.class</exclude>
                             </excludes>
+
+                            <destFile>${project.build.directory}/coverage-reports/jacoco-unit.exec</destFile>
+                            <dataFile>${project.build.directory}/coverage-reports/jacoco-unit.exec</dataFile>
                         </configuration>
                         <executions>
                             <execution>
@@ -219,6 +212,7 @@
                                     <goal>prepare-agent</goal>
                                 </goals>
                                 <configuration>
+                                    <destFile>${project.build.directory}/coverage-reports/jacoco-unit.exec</destFile>
                                     <propertyName>argLine</propertyName>
                                 </configuration>
                             </execution>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -12,135 +12,81 @@
     <properties>
         <warSourceDirectory>${basedir}/src/main/webapp</warSourceDirectory>
     </properties>
-    <profiles>
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-jar-plugin</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                        </manifest>
+                    </archive>
+                    <excludes>
+                        <exclude>**/*_jsp.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <!-- Create the admin console web archive. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <!-- Exclude JSP files, they will be compiled -->
+                    <warSourceExcludes>**/*.jsp,**/*.jspf,WEB-INF/lib/*.*</warSourceExcludes>
+                    <warSourceDirectory>${warSourceDirectory}</warSourceDirectory>
+                    <!-- Use the web.xml, which contains the generated servlet declarations from the jetty-jspc-maven-plugin -->
+                    <webXml>${project.build.directory}/web.xml</webXml>
+                </configuration>
+            </plugin>
+
+            <!-- Compile the JSP pages -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-jspc-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <executions>
+                    <execution>
+                        <id>jspc</id>
+                        <goals>
+                            <goal>jspc</goal>
+                        </goals>
                         <configuration>
-                            <archive>
-                                <manifest>
-                                    <addClasspath>true</addClasspath>
-                                </manifest>
-                            </archive>
-                            <excludes>
-                                <exclude>**/*_jsp.java</exclude>
-                            </excludes>
+                            <sourceVersion>1.8</sourceVersion>
+                            <targetVersion>1.8</targetVersion>
+                            <webAppSourceDirectory>${warSourceDirectory}</webAppSourceDirectory>
+                            <!-- Merge this web.xml with the generated servlet declarations -->
+                            <webXml>${warSourceDirectory}/WEB-INF/web.xml</webXml>
+                            <jspc>
+                                <package>org.jivesoftware.openfire.admin</package>
+                            </jspc>
+                            <sourceVersion>1.8</sourceVersion>
+                            <targetVersion>1.8</targetVersion>
+                            <keepSources>true</keepSources>
                         </configuration>
-                    </plugin>
+                    </execution>
+                </executions>
+            </plugin>
 
-                    <!-- Create the admin console web archive. -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-war-plugin</artifactId>
-                        <version>3.2.2</version>
-                        <configuration>
-                            <!-- Exclude JSP files, they will be compiled -->
-                            <warSourceExcludes>**/*.jsp,**/*.jspf,WEB-INF/lib/*.*</warSourceExcludes>
-                            <warSourceDirectory>${warSourceDirectory}</warSourceDirectory>
-                            <!-- Use the web.xml, which contains the generated servlet declarations from the jetty-jspc-maven-plugin -->
-                            <webXml>${project.build.directory}/web.xml</webXml>
-                        </configuration>
-                    </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
+                    </systemPropertyVariables>
+                    <argLine>-Duser.language=us -Duser.country=US</argLine>
+                </configuration>
+            </plugin>
 
-                    <!-- Compile the JSP pages -->
-                    <plugin>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-jspc-maven-plugin</artifactId>
-                        <version>${jetty.version}</version>
-                        <executions>
-                            <execution>
-                                <id>jspc</id>
-                                <goals>
-                                    <goal>jspc</goal>
-                                </goals>
-                                <configuration>
-                                    <sourceVersion>1.8</sourceVersion>
-                                    <targetVersion>1.8</targetVersion>
-                                    <webAppSourceDirectory>${warSourceDirectory}</webAppSourceDirectory>
-                                    <!-- Merge this web.xml with the generated servlet declarations -->
-                                    <webXml>${warSourceDirectory}/WEB-INF/web.xml</webXml>
-                                    <jspc>
-                                        <package>org.jivesoftware.openfire.admin</package>
-                                    </jspc>
-                                    <sourceVersion>1.8</sourceVersion>
-                                    <targetVersion>1.8</targetVersion>
-                                    <keepSources>true</keepSources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
+        </plugins>
+    </build>
 
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M3</version>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
-                            </systemPropertyVariables>
-                            <argLine>-Duser.language=us -Duser.country=US</argLine>
-                        </configuration>
-                    </plugin>
-
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>coverage</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.5</version>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/*_jsp.class</exclude>
-                            </excludes>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>default-prepare-agent</id>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                                <configuration>
-                                    <propertyName>argLine</propertyName>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>report</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M3</version>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
-                            </systemPropertyVariables>
-                            <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
     <dependencies>
         <!-- Ignite Realtime -->
         <dependency>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -12,81 +12,135 @@
     <properties>
         <warSourceDirectory>${basedir}/src/main/webapp</warSourceDirectory>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                        </manifest>
-                    </archive>
-                    <excludes>
-                        <exclude>**/*_jsp.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-
-            <!-- Create the admin console web archive. -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>3.2.2</version>
-                <configuration>
-                    <!-- Exclude JSP files, they will be compiled -->
-                    <warSourceExcludes>**/*.jsp,**/*.jspf,WEB-INF/lib/*.*</warSourceExcludes>
-                    <warSourceDirectory>${warSourceDirectory}</warSourceDirectory>
-                    <!-- Use the web.xml, which contains the generated servlet declarations from the jetty-jspc-maven-plugin -->
-                    <webXml>${project.build.directory}/web.xml</webXml>
-                </configuration>
-            </plugin>
-
-            <!-- Compile the JSP pages -->
-            <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jspc-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
-                <executions>
-                    <execution>
-                        <id>jspc</id>
-                        <goals>
-                            <goal>jspc</goal>
-                        </goals>
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
                         <configuration>
-                            <sourceVersion>1.8</sourceVersion>
-                            <targetVersion>1.8</targetVersion>
-                            <webAppSourceDirectory>${warSourceDirectory}</webAppSourceDirectory>
-                            <!-- Merge this web.xml with the generated servlet declarations -->
-                            <webXml>${warSourceDirectory}/WEB-INF/web.xml</webXml>
-                            <jspc>
-                                <package>org.jivesoftware.openfire.admin</package>
-                            </jspc>
-                            <sourceVersion>1.8</sourceVersion>
-                            <targetVersion>1.8</targetVersion>
-                            <keepSources>true</keepSources>
+                            <archive>
+                                <manifest>
+                                    <addClasspath>true</addClasspath>
+                                </manifest>
+                            </archive>
+                            <excludes>
+                                <exclude>**/*_jsp.java</exclude>
+                            </excludes>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+                    </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M3</version>
-                <configuration>
-                    <systemPropertyVariables>
-                        <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
-                    </systemPropertyVariables>
-                    <argLine>-Duser.language=us -Duser.country=US</argLine>
-                </configuration>
-            </plugin>
+                    <!-- Create the admin console web archive. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>3.2.2</version>
+                        <configuration>
+                            <!-- Exclude JSP files, they will be compiled -->
+                            <warSourceExcludes>**/*.jsp,**/*.jspf,WEB-INF/lib/*.*</warSourceExcludes>
+                            <warSourceDirectory>${warSourceDirectory}</warSourceDirectory>
+                            <!-- Use the web.xml, which contains the generated servlet declarations from the jetty-jspc-maven-plugin -->
+                            <webXml>${project.build.directory}/web.xml</webXml>
+                        </configuration>
+                    </plugin>
 
-        </plugins>
-    </build>
+                    <!-- Compile the JSP pages -->
+                    <plugin>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-jspc-maven-plugin</artifactId>
+                        <version>${jetty.version}</version>
+                        <executions>
+                            <execution>
+                                <id>jspc</id>
+                                <goals>
+                                    <goal>jspc</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceVersion>1.8</sourceVersion>
+                                    <targetVersion>1.8</targetVersion>
+                                    <webAppSourceDirectory>${warSourceDirectory}</webAppSourceDirectory>
+                                    <!-- Merge this web.xml with the generated servlet declarations -->
+                                    <webXml>${warSourceDirectory}/WEB-INF/web.xml</webXml>
+                                    <jspc>
+                                        <package>org.jivesoftware.openfire.admin</package>
+                                    </jspc>
+                                    <sourceVersion>1.8</sourceVersion>
+                                    <targetVersion>1.8</targetVersion>
+                                    <keepSources>true</keepSources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
 
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M3</version>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
+                            </systemPropertyVariables>
+                            <argLine>-Duser.language=us -Duser.country=US</argLine>
+                        </configuration>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.5</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*_jsp.class</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>default-prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>argLine</propertyName>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M3</version>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
+                            </systemPropertyVariables>
+                            <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     <dependencies>
         <!-- Ignite Realtime -->
         <dependency>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -80,6 +80,7 @@
                     <systemPropertyVariables>
                         <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
                     </systemPropertyVariables>
+                    <argLine>-Duser.language=us -Duser.country=US</argLine>
                 </configuration>
             </plugin>
 

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -80,7 +80,6 @@
                     <systemPropertyVariables>
                         <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
                     </systemPropertyVariables>
-                    <argLine>-Duser.language=us -Duser.country=US</argLine>
                 </configuration>
             </plugin>
 

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -13,6 +13,52 @@
         <warSourceDirectory>${basedir}/src/main/webapp</warSourceDirectory>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.5</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*_jsp.class</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M3</version>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
+                            </systemPropertyVariables>
+                            <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -71,30 +117,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*_jsp.class</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -104,7 +126,7 @@
                     <systemPropertyVariables>
                         <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
                     </systemPropertyVariables>
-                    <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
+                    <argLine>-Duser.language=us -Duser.country=US</argLine>
                 </configuration>
             </plugin>
 

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -71,6 +71,30 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*_jsp.class</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -80,7 +104,7 @@
                     <systemPropertyVariables>
                         <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
                     </systemPropertyVariables>
-                    <argLine>-Duser.language=us -Duser.country=US</argLine>
+                    <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
After build (like mvn verify) code coverage report is generated in xmppserver/target/site/jacoco/index.html (there are also xml and csv versions). It should be useful during planing which tests to write first and you will be able to see which lines are not covered yet.

![Screenshot from 2019-11-11 15-19-39](https://user-images.githubusercontent.com/18727810/68594978-ea42ae00-0498-11ea-84a2-d22947839658.png)
