### PR TITLE
OF-1923 (and OF-1925, OF-1926, and trivial OF-1924) Fix for Stream Management 

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1630,6 +1630,7 @@ plugins.servlet.allowLocalFileReading=Determines if the plugin servlets can be u
 system_property.cert.storewatcher.enabled=Automatically reloads certificate stores when they're modified on disk.
 system_property.stream.management.active=Offer Stream Management (XEP-0198) functionality to clients.
 system_property.stream.management.location.enabled=Tell clients that request Stream Management (XEP-0198) to be enabled on what server to resume streams.
+system_property.stream.management.max-server.enabled=Announce how long streams are allowed to linger in 'detached' mode before being terminated.
 
 # Server properties Page
 

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1628,6 +1628,8 @@ system_property.ldap.pagedResultsSize=The maximum number of records to retrieve 
    Note that if using ActiveDirectory, this should not be left at the default, and should not be set to more than the value of the ActiveDirectory MaxPageSize; 1,000 by default.
 plugins.servlet.allowLocalFileReading=Determines if the plugin servlets can be used to access files outside of Openfire's home directory.
 system_property.cert.storewatcher.enabled=Automatically reloads certificate stores when they're modified on disk.
+system_property.stream.management.active=Offer Stream Management (XEP-0198) functionality to clients.
+system_property.stream.management.location.enabled=Tell clients that request Stream Management (XEP-0198) to be enabled on what server to resume streams.
 
 # Server properties Page
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -854,6 +854,9 @@ server.db.multiple_connect=Ondersteuning voor meerdere verbindingen
 server.db.multiple_connect2=tegelijktijdig geopend:
 server.db.read_only_mode=Als enkel-lezen:
 
+system_property.stream.management.active=Bied clienten Stream Management (XEP-0198) functionaliteit.
+system_property.stream.management.location.enabled=Vertel clienten die Stream Management (XEP-0198) functionaliteit gebruiken, op welke server streams te hervatten.
+
 # Server properties Page
 
 server.properties.title=Systeemeigenschappen

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -856,6 +856,7 @@ server.db.read_only_mode=Als enkel-lezen:
 
 system_property.stream.management.active=Bied clienten Stream Management (XEP-0198) functionaliteit.
 system_property.stream.management.location.enabled=Vertel clienten die Stream Management (XEP-0198) functionaliteit gebruiken, op welke server streams te hervatten.
+system_property.stream.management.max-server.enabled=Vertel clienten hoe lang streams in 'detached' mode mogen bestaan, voordat ze afgesloten worden.
 
 # Server properties Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -200,6 +200,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
      * @param localSession the LocalSession (this) to mark as detached.
      */
     public void addDetached(LocalSession localSession) {
+        Log.trace( "Marking session '{}' ({}) as detached.", localSession.getAddress(), localSession.getStreamID() );
         this.detachedSessions.put(localSession.getStreamID(), localSession);
     }
 
@@ -213,6 +214,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
     public synchronized void removeDetached(LocalSession localSession) {
         LocalSession other = this.detachedSessions.get(localSession.getStreamID());
         if (other == localSession) {
+            Log.trace( "Removing detached session '{}'", localSession.getAddress(), localSession.getStreamID() );
             this.detachedSessions.remove(localSession.getStreamID());
         }
     }
@@ -1707,10 +1709,16 @@ public class SessionManager extends BasicModule implements ClusterEventListener
             final long deadline = System.currentTimeMillis() - idleTime;
             for (LocalSession session : detachedSessions.values()) {
                 try {
+                    Log.trace("Iterating over detached session '{}' ({}) to determine if it needs to be cleaned up.", session.getAddress(), session.getStreamID());
                     if (session.getLastActiveDate().getTime() < deadline) {
+                        Log.debug("Detached session '{}' ({}) has been detached for longer than {} and will be cleaned up.", session.getAddress(), session.getStreamID(), Duration.ofMillis(idleTime));
                         removeDetached(session);
                         LocalClientSession clientSession = (LocalClientSession)session;
-                        if (clientSession != null) {
+
+                        // OF-1923: Only close the session if it has not been replaced by another session (if the session
+                        // has been replaced, then the condition below will compare to distinct instances). This *should* not
+                        // occur (but has been observed, prior to the fix of OF-1923). This check is left in as a safeguard.
+                        if (session == routingTable.getClientRoute(session.getAddress())) {
                             try {
                                 if ((clientSession.getPresence().isAvailable() || !clientSession.wasAvailable()) &&
                                     routingTable.hasClientRoute(session.getAddress())) {
@@ -1728,11 +1736,15 @@ public class SessionManager extends BasicModule implements ClusterEventListener
                                 // Remove the session
                                 removeSession(clientSession);
                             }
+                        } else {
+                            Log.warn("Not removing detached session '{}' ({}) that appears to have been replaced by another session.", session.getAddress(), session.getStreamID());
                         }
+                    } else {
+                        Log.trace("Detached session '{}' ({}) has been detached for {}, which is not longer than the configured maximum of {}. It will not (yet) be cleaned up.", session.getAddress(), session.getStreamID(), Duration.ofMillis(System.currentTimeMillis()-session.getLastActiveDate().getTime()), Duration.ofMillis(idleTime));
                     }
                 }
                 catch (Throwable e) {
-                    Log.error(LocaleUtils.getLocalizedString("admin.error"), e);
+                    Log.error("An exception occurred while trying processing detached session '{}' ({}).", session.getAddress(), session.getStreamID(), e);
                 }
             }
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -214,7 +214,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
     public synchronized void removeDetached(LocalSession localSession) {
         LocalSession other = this.detachedSessions.get(localSession.getStreamID());
         if (other == localSession) {
-            Log.trace( "Removing detached session '{}'", localSession.getAddress(), localSession.getStreamID() );
+            Log.trace( "Removing detached session '{}' ({}).", localSession.getAddress(), localSession.getStreamID() );
             this.detachedSessions.remove(localSession.getStreamID());
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
@@ -131,6 +131,14 @@ public class IQBindHandler extends IQHandler {
                         StreamError error = new StreamError(StreamError.Condition.conflict);
                         oldSession.deliverRawText(error.toXML());
                         oldSession.close();
+
+                        // OF-1923: As the session is now replaced, the old session will never be resumed.
+                        // TODO remove detached session if it lives on a remote cluster node. Not doing this should not have functional consequences (but could lead to these warnings in the logs: "Not removing detached session 'foo@example.org/bar' that appears to have been replaced by another session.")
+                        if ( oldSession instanceof LocalClientSession ) {
+                            // As the new session has already replaced the old session, we're not explicitly closing
+                            // the old session again, as that would cause the state of the new session to be affected.
+                            sessionManager.removeDetached((LocalClientSession) oldSession);
+                        }
                     }
                     else {
                         reply.setChildElement(packet.getChildElement().createCopy());


### PR DESCRIPTION
The changes in this PR intend to resolve an issue where a connection that reconnects and binds using the same resource (full JID) gets disconnected.

The original problem is caused by the cleanup task for stream management cleaning up sessions by full JID, even if the original session has been replaced by a new session (that uses the same full JID).