### PR TITLE
Smack Integration Tests: use later version of Smack and Gradle.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 - gem install travis
 script:
   - mvn verify -P ci
-  - TERM="dumb" ./runIntegrationTests -g
+#  - TERM="dumb" ./runIntegrationTests -g
 install: true
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 - gem install travis
 script:
   - mvn verify -P ci
-#  - TERM="dumb" ./runIntegrationTests -g
+  - TERM="dumb" ./runIntegrationTests -g
 install: true
 deploy:
   provider: script

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -124,7 +124,7 @@ SINTTEST_DISABLED_TESTS_ARGUMENT="${SINTTEST_DISABLED_TESTS_ARGUMENT::-1}"
 pushd "${SMACKDIR}"
 sed -i '/-Werror/d' build.gradle
 sed -i 's/if (config.testPackages == null) {/if (config.testPackages == null || config.testPackages.isEmpty()) {/' smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
-$GRADLE integrationTest \
+$GRADLE --stacktrace integrationTest \
 		-Dsinttest.service=example.org \
 		-Dsinttest.securityMode=disabled \
 		-Dsinttest.replyTimeout=60000 \

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SMACK_COMMIT_ID="8831961afeda11e9055ff105da3352d3bd0e91e5" # release 4.3.4
+SMACK_COMMIT_ID="9d626bf" # master 22 Nov 2019
 GRADLE_VERSION="6.0.1"
 FORCE_CUSTOM_GRADLE=false
 CURL_ARGS="--location --silent"

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SMACK_COMMIT_ID="ae208d6a2f608a69c54aae7cb2b22dc52524e9ff"
-GRADLE_VERSION="5.2.1"
+SMACK_COMMIT_ID="8831961afeda11e9055ff105da3352d3bd0e91e5" # release 4.3.4
+GRADLE_VERSION="6.0.1"
 FORCE_CUSTOM_GRADLE=false
 CURL_ARGS="--location --silent"
 


### PR DESCRIPTION
Recently, the integration tests have been failing a lot. Flow suggested improving the version of Gradle that's used to run them. While at it, I'm also bumping the version of Smack that we use to the latest release (4.3.4).