### PR TITLE
Better cross-platform integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ nbbuild/
 # build temp folders
 rpmbuild/
 debian/
+
+.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 - gem install travis
 script:
   - mvn verify -P ci
-  - TERM="dumb" ./runIntegrationTests -g
+  - TERM="dumb" ./runIntegrationTests -gl
 install: true
 deploy:
   provider: script

--- a/distribution/src/conf/openfire-demoboot.xml
+++ b/distribution/src/conf/openfire-demoboot.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jive>
+  <adminConsole>
+      <port>9090</port>
+      <securePort>9091</securePort>
+  </adminConsole>
+  <connectionProvider>
+    <className>org.jivesoftware.database.EmbeddedConnectionProvider</className>
+  </connectionProvider>
+  <autosetup>
+      <run>true</run>
+      <locale>en</locale>
+      <xmpp>
+          <domain>example.org</domain>
+          <fqdn>example.org</fqdn>
+      </xmpp>
+      <database>
+          <mode>embedded</mode>
+      </database>
+      <admin>
+          <email>admin@example.com</email>
+          <password>admin</password>
+      </admin>
+  </autosetup>
+</jive>

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -52,6 +52,8 @@ function cleanup {
 		echo "Resetting hosts file after local running. This may prompt for sudo."
 		sudo sed -i'.original' "/example.org/d" /etc/hosts
 	fi
+	echo "Stopping Openfire"
+	pkill -f openfire.lib #TODO: Can this be made more future-proof against changes in the start script?
 }
 trap cleanup EXIT
 

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -5,11 +5,17 @@ SMACK_COMMIT_ID="9d626bf" # master 22 Nov 2019
 GRADLE_VERSION="6.0.1"
 FORCE_CUSTOM_GRADLE=false
 CURL_ARGS="--location --silent"
+DEBUG=false
+LOCAL_RUN=false
 
-while getopts dgs: OPTION "$@"; do
+while getopts dlgs: OPTION "$@"; do
 	case $OPTION in
 		d)
+			DEBUG=true
 			set -x
+			;;
+		l)
+			LOCAL_RUN=true
 			;;
 		g)
 			FORCE_CUSTOM_GRADLE=true
@@ -38,7 +44,16 @@ declare -r BASEDIR="${SCRIPTDIR}"
 cd "${BASEDIR}"
 
 TMPDIR=$(mktemp -d)
-trap "rm -rf ${TMPDIR}" EXIT
+function cleanup {
+	if [[ $DEBUG == false ]]; then
+		rm -rf ${TMPDIR}
+	fi
+	if [[ $LOCAL_RUN == true ]]; then
+		echo "Resetting hosts file after local running. This may prompt for sudo."
+		sudo sed -i'.original' "/example.org/d" /etc/hosts
+	fi
+}
+trap cleanup EXIT
 
 SMACKDIR="${TMPDIR}/smack"
 GRADLEDIR="${TMPDIR}/gradle"
@@ -91,6 +106,10 @@ curl ${CURL_ARGS} \
 	-o distribution/target/distribution-base/conf/openfire.xml \
 	https://raw.github.com/igniterealtime/ci-tooling/master/openfire-demoboot.xml
 
+if [[ $LOCAL_RUN == true ]]; then
+	echo "Setting hosts file for local running. This may prompt for sudo."
+	sudo /bin/sh -c 'echo "127.0.0.1 example.org" >> /etc/hosts'
+fi
 echo "Starting Openfire…"
 
 "${OPENFIRE_SHELL_SCRIPT}" &

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -25,7 +25,7 @@ usage()
 	exit 2
 }
 
-while getopts dlgs:h:u:p: OPTION "$@"; do
+while getopts dlgs:h:i:u:p: OPTION "$@"; do
 	case $OPTION in
 		d)
 			DEBUG=true
@@ -42,6 +42,9 @@ while getopts dlgs:h:u:p: OPTION "$@"; do
 			;;
 		h)
 			HOST="${OPTARG}"
+			;;
+		i)
+			IPADDRESS="${OPTARG}"
 			;;
 		u)
 			ADMINUSER="${OPTARG}"
@@ -81,9 +84,11 @@ function cleanup {
 	if [[ $DEBUG == false ]]; then
 		rm -rf ${TMPDIR}
 	fi
-	if [[ $LOCAL_RUN == true ]]; then
+	if [[ -n "$IPADDRESS" ]]; then
 		echo "Resetting hosts file after local running. This may prompt for sudo."
-		sudo sed -i'.original' "/example.org/d" /etc/hosts
+		sudo sed -i'.original' "/$IPADDRESS $HOST/d" /etc/hosts
+	fi
+	if [[ $LOCAL_RUN == true ]]; then
 		echo "Stopping Openfire"
 		pkill -f openfire.lib #TODO: Can this be made more future-proof against changes in the start script?
 	fi
@@ -126,6 +131,12 @@ fi
 git reset --hard "${SMACK_COMMIT_ID}"
 popd
 
+if [[ -n "$IPADDRESS" ]]; then
+	echo "Setting hosts file for local running. This may prompt for sudo."
+	sudo /bin/sh -c "echo \"$IPADDRESS $HOST\" >> /etc/hosts"
+	echo "Starting Openfire…"
+fi
+
 if [[ $LOCAL_RUN == true ]]; then
 
 	declare -r OPENFIRE_SHELL_SCRIPT="${BASEDIR}/distribution/target/distribution-base/bin/openfire.sh"
@@ -142,10 +153,6 @@ if [[ $LOCAL_RUN == true ]]; then
 	curl ${CURL_ARGS} \
 		-o distribution/target/distribution-base/conf/openfire.xml \
 		https://raw.github.com/igniterealtime/ci-tooling/master/openfire-demoboot.xml
-
-	echo "Setting hosts file for local running. This may prompt for sudo."
-	sudo /bin/sh -c 'echo "127.0.0.1 example.org" >> /etc/hosts'
-	echo "Starting Openfire…"
 
 	"${OPENFIRE_SHELL_SCRIPT}" &
 

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -12,6 +12,19 @@ HOST='example.org'
 ADMINUSER='admin'
 ADMINPASS='admin'
 
+usage()
+{
+	echo "Usage: $0 [-d] [-l] [-g] [-s GITREF] [-h HOST] [-u USERNAME] [-p PASSWORD]"
+	echo "    -d: Enable debug mode. Preserves temp directories once complete (default: off)"
+	echo "    -l: Launch a local Openfire. Sets a hosts file before and unsets it afterwards (default: off)"
+	echo "    -g: Download and use a known-good Gradle, rather than use the system in-built (default: off)"
+	echo "    -s: Set Smack to the given label or SHA (default: 9d626bf787dc3e0e0a4399cef429285b22744d73)"
+	echo "    -h: The hostname for the Openfire under test (default: example.org)"
+	echo "    -u: Admin username for Openfire (default: admin)"
+	echo "    -p: Admin password for Openfire (default: password)"
+	exit 2
+}
+
 while getopts dlgs:h:u:p: OPTION "$@"; do
 	case $OPTION in
 		d)
@@ -36,9 +49,9 @@ while getopts dlgs:h:u:p: OPTION "$@"; do
 		p)
 			ADMINPASS="${OPTARG}"
 			;;
-		\? ) echo "Unknown option: -$OPTARG" >&2; exit 1;;
-        :  ) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
-        *  ) echo "Unimplemented option: -$OPTARG" >&2; exit 1;;
+		\? ) usage;;
+        :  ) usage;;
+        *  ) usage;;
 	esac
 done
 
@@ -52,12 +65,12 @@ fi
 # stackoverflow: http://stackoverflow.com/a/12197518/194894
 pushd . > /dev/null
 SCRIPTDIR="${BASH_SOURCE[0]}";
-while([ -h "${SCRIPTDIR}" ]); do
-    cd "`dirname "${SCRIPTDIR}"`"
-    SCRIPTDIR="$(readlink "`basename "${SCRIPTDIR}"`")";
+while [ -h "${SCRIPTDIR}" ]; do
+    cd "$(dirname "${SCRIPTDIR}")"
+    SCRIPTDIR="$(readlink "$(basename "${SCRIPTDIR}")")";
 done
-cd "`dirname "${SCRIPTDIR}"`" > /dev/null
-SCRIPTDIR="`pwd`";
+cd "$(dirname "${SCRIPTDIR}")" > /dev/null
+SCRIPTDIR="$(pwd)";
 popd  > /dev/null
 declare -r BASEDIR="${SCRIPTDIR}"
 cd "${BASEDIR}"

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -155,14 +155,15 @@ function runTestsInGradle {
 	echo "Starting Integration Tests (using Smack ${SMACK_VERSION})…"
 
 	DISABLED_INTEGRATION_TESTS=()
-	#DISABLED_INTEGRATION_TESTS+=(MoodIntegrationTest)
+	#Fails only in Java8, only on Travis
+	DISABLED_INTEGRATION_TESTS+=(MoodIntegrationTest)
 	#DISABLED_INTEGRATION_TESTS+=(MultiUserChatIntegrationTest)
 	DISABLED_INTEGRATION_TESTS+=(StreamManagementTest)
 	#DISABLED_INTEGRATION_TESTS+=(MultiUserChatLowLevelIntegrationTest)
 	# Flaps sometimes (possibly a Openfire issue)
 	#DISABLED_INTEGRATION_TESTS+=(PubSubIntegrationTest)
-	# Does sometimes not succeed (possibly a Smack issue)
-	#DISABLED_INTEGRATION_TESTS+=(XmppConnectionIntegrationTest)
+	# Does sometimes not succeed in Travis (stress test is too much?)
+	DISABLED_INTEGRATION_TESTS+=(XmppConnectionIntegrationTest)
 	# EntityCapsTest#testEntityCaps fails regularly. Reason unknown.
 	#DISABLED_INTEGRATION_TESTS+=(EntityCapsTest)
 	#FileTransferIntegrationTest doesn't progress at all on 4.4.0a2

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SMACK_COMMIT_ID="9d626bf" # master 22 Nov 2019
+SMACK_VERSION="4.3.4-SNAPSHOT" # master 22 Nov 2019
 GRADLE_VERSION="6.0.1"
 FORCE_CUSTOM_GRADLE=false
 CURL_ARGS="--location --silent"
@@ -14,11 +14,12 @@ ADMINPASS='admin'
 
 usage()
 {
-	echo "Usage: $0 [-d] [-l] [-g] [-s GITREF] [-h HOST] [-u USERNAME] [-p PASSWORD]"
-	echo "    -d: Enable debug mode. Preserves temp directories once complete (default: off)"
-	echo "    -l: Launch a local Openfire. Sets a hosts file before and unsets it afterwards (default: off)"
+	echo "Usage: $0 [-d] [-l] [-g] [-i IPADDRESS] [-s GITREF] [-h HOST] [-u USERNAME] [-p PASSWORD]"
+	echo "    -d: Enable debug mode. Prints commands, and preserves temp directories if used (default: off)"
+	echo "    -l: Launch a local Openfire. (default: off)"
+	echo "    -i: Set a hosts file for the given IP and host (or for example.com if running locally). Reverted at exit."
 	echo "    -g: Download and use a known-good Gradle, rather than use the system in-built (default: off)"
-	echo "    -s: Set Smack to the given label or SHA (default: 9d626bf787dc3e0e0a4399cef429285b22744d73)"
+	echo "    -s: Set Smack to the given version (default: 4.3.4-SNAPSHOT)"
 	echo "    -h: The hostname for the Openfire under test (default: example.org)"
 	echo "    -u: Admin username for Openfire (default: admin)"
 	echo "    -p: Admin password for Openfire (default: password)"
@@ -38,7 +39,7 @@ while getopts dlgs:h:i:u:p: OPTION "$@"; do
 			FORCE_CUSTOM_GRADLE=true
 			;;
 		s)
-			SMACK_COMMIT_ID="${OPTARG}"
+			SMACK_VERSION="${OPTARG}"
 			;;
 		h)
 			HOST="${OPTARG}"
@@ -59,32 +60,37 @@ while getopts dlgs:h:i:u:p: OPTION "$@"; do
 done
 
 if [[ $LOCAL_RUN == true ]] && [[ $HOST != "example.org" ]]; then
-	echo "Cannot specify custom host if launching a local instance. If you have an already-running local instance to test against, omit the -l flag."
+	echo "Host is fixed if launching a local instance. If you have an already-running instance to test against, omit the -l flag (and provide -i 127.0.0.1 if necessary)."
 	exit 1
 fi
 
-# Pretty fancy method to get reliable the absolute path of a shell
-# script, *even if it is sourced*. Credits go to GreenFox on
-# stackoverflow: http://stackoverflow.com/a/12197518/194894
-pushd . > /dev/null
-SCRIPTDIR="${BASH_SOURCE[0]}";
-while [ -h "${SCRIPTDIR}" ]; do
-    cd "$(dirname "${SCRIPTDIR}")"
-    SCRIPTDIR="$(readlink "$(basename "${SCRIPTDIR}")")";
-done
-cd "$(dirname "${SCRIPTDIR}")" > /dev/null
-SCRIPTDIR="$(pwd)";
-popd  > /dev/null
-declare -r BASEDIR="${SCRIPTDIR}"
-cd "${BASEDIR}"
+function setBaseDirectory {
+	# Pretty fancy method to get reliable the absolute path of a shell
+	# script, *even if it is sourced*. Credits go to GreenFox on
+	# stackoverflow: http://stackoverflow.com/a/12197518/194894
+	pushd . > /dev/null
+	SCRIPTDIR="${BASH_SOURCE[0]}";
+	while [ -h "${SCRIPTDIR}" ]; do
+		cd "$(dirname "${SCRIPTDIR}")"
+		SCRIPTDIR="$(readlink "$(basename "${SCRIPTDIR}")")";
+	done
+	cd "$(dirname "${SCRIPTDIR}")" > /dev/null
+	SCRIPTDIR="$(pwd)";
+	popd  > /dev/null
+	BASEDIR="${SCRIPTDIR}"
+	cd "${BASEDIR}"
+}
 
-TMPDIR=$(mktemp -d)
+function createTempDirectory {
+	OFTEMPDIR=$(mktemp -d)
+}
 
 function cleanup {
-	if [[ $DEBUG == false ]]; then
-		rm -rf ${TMPDIR}
+	if [[ $DEBUG == false && -n "${OFTEMPDIR-}" ]]; then
+		echo "Removing temp directories"
+		rm -rf "${OFTEMPDIR}"
 	fi
-	if [[ -n "$IPADDRESS" ]]; then
+	if [[ -n "${IPADDRESS-}" ]]; then
 		echo "Resetting hosts file after local running. This may prompt for sudo."
 		sudo sed -i'.original' "/$IPADDRESS $HOST/d" /etc/hosts
 	fi
@@ -93,52 +99,38 @@ function cleanup {
 		pkill -f openfire.lib #TODO: Can this be made more future-proof against changes in the start script?
 	fi
 }
-trap cleanup EXIT
 
-SMACKDIR="${TMPDIR}/smack"
-GRADLEDIR="${TMPDIR}/gradle"
+function setUpGradleEnvironment {
 
-if command -v gradle &> /dev/null; then
-	GRADLE_IN_PATH=true
-else
-	GRADLE_IN_PATH=false
-fi
+	if command -v gradle &> /dev/null; then
+		GRADLE_IN_PATH=true
+	else
+		GRADLE_IN_PATH=false
+	fi
 
-if [[ $GRADLE_IN_PATH == false ]] || $FORCE_CUSTOM_GRADLE; then
-	mkdir "${GRADLEDIR}"
-	pushd "${GRADLEDIR}"
-	declare -r GRADLE_ZIP="gradle-${GRADLE_VERSION}-bin.zip"
-	curl ${CURL_ARGS} --output ${GRADLE_ZIP} "https://services.gradle.org/distributions/${GRADLE_ZIP}"
-	unzip "${GRADLE_ZIP}"
-	GRADLE="${GRADLEDIR}/gradle-${GRADLE_VERSION}/bin/gradle"
-	popd
-else
-	GRADLE="gradle"
-fi
+	if [[ $GRADLE_IN_PATH == false ]] || $FORCE_CUSTOM_GRADLE; then
+		createTempDirectory
+		GRADLEDIR="${OFTEMPDIR}/gradle"
+		mkdir "${GRADLEDIR}"
+		pushd "${GRADLEDIR}"
+		declare -r GRADLE_ZIP="gradle-${GRADLE_VERSION}-bin.zip"
+		curl ${CURL_ARGS} --output ${GRADLE_ZIP} "https://services.gradle.org/distributions/${GRADLE_ZIP}"
+		unzip "${GRADLE_ZIP}"
+		GRADLE="${GRADLEDIR}/gradle-${GRADLE_VERSION}/bin/gradle"
+		popd
+	else
+		GRADLE="gradle"
+	fi
+}
 
-mkdir "${SMACKDIR}"
-pushd "${SMACKDIR}"
-git init
-git remote add origin git://github.com/igniterealtime/Smack.git
-set +e
-git fetch --depth=1 origin "${SMACK_COMMIT_ID}"
-GIT_FETCH_EXIT_CODE=$?
-set -e
-if [[ $GIT_FETCH_EXIT_CODE -ne 0 ]]; then
-	echo "Git shallow fetch failed, falling back to full fetch"
-	git fetch origin
-fi
-git reset --hard "${SMACK_COMMIT_ID}"
-popd
+function setHostsFile {
+	if [[ -n "${IPADDRESS-}" ]]; then
+		echo "Setting hosts file for local running. This may prompt for sudo."
+		sudo /bin/sh -c "echo \"$IPADDRESS $HOST\" >> /etc/hosts"
+	fi
+}
 
-if [[ -n "$IPADDRESS" ]]; then
-	echo "Setting hosts file for local running. This may prompt for sudo."
-	sudo /bin/sh -c "echo \"$IPADDRESS $HOST\" >> /etc/hosts"
-	echo "Starting Openfire…"
-fi
-
-if [[ $LOCAL_RUN == true ]]; then
-
+function launchOpenfire {
 	declare -r OPENFIRE_SHELL_SCRIPT="${BASEDIR}/distribution/target/distribution-base/bin/openfire.sh"
 
 	if [[ ! -f "${OPENFIRE_SHELL_SCRIPT}" ]]; then
@@ -154,41 +146,57 @@ if [[ $LOCAL_RUN == true ]]; then
 		-o distribution/target/distribution-base/conf/openfire.xml \
 		https://raw.github.com/igniterealtime/ci-tooling/master/openfire-demoboot.xml
 
+	echo "Starting Openfire…"
 	"${OPENFIRE_SHELL_SCRIPT}" &
 
 	# Wait 120 seconds for Openfire to open up the web interface and
 	# assume Openfire is fully operational once that happens (not sure if
 	# this assumption is correct).
+	echo "Waiting for Openfire…"
 	timeout 120 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 0.3; done' localhost 7070
+}
 
+function runTestsInGradle {
+	echo "Starting Integration Tests (using Smack ${SMACK_VERSION})…"
+
+	DISABLED_INTEGRATION_TESTS=()
+	DISABLED_INTEGRATION_TESTS+=(MoodIntegrationTest)
+	DISABLED_INTEGRATION_TESTS+=(MultiUserChatIntegrationTest)
+	DISABLED_INTEGRATION_TESTS+=(StreamManagementTest)
+	DISABLED_INTEGRATION_TESTS+=(MultiUserChatLowLevelIntegrationTest)
+	# Flaps sometimes (possibly a Openfire issue)
+	DISABLED_INTEGRATION_TESTS+=(PubSubIntegrationTest)
+	# Does sometimes not succeed (possibly a Smack issue)
+	DISABLED_INTEGRATION_TESTS+=(XmppConnectionIntegrationTest)
+	# EntityCapsTest#testEntityCaps fails regularly. Reason unknown.
+	DISABLED_INTEGRATION_TESTS+=(EntityCapsTest)
+
+	SINTTEST_DISABLED_TESTS_ARGUMENT="-Dsinttest.disabledTests="
+	for disabledTest in "${DISABLED_INTEGRATION_TESTS[@]}"; do
+		SINTTEST_DISABLED_TESTS_ARGUMENT+="${disabledTest},"
+	done
+	# Remove last ',' from the argument. Can't use ${SINTTEST_DISABLED_TESTS_ARGUMENT::-1} because bash on MacOS is infuriatingly incompatible.
+	SINTTEST_DISABLED_TESTS_ARGUMENT="${SINTTEST_DISABLED_TESTS_ARGUMENT:0:$((${#SINTTEST_DISABLED_TESTS_ARGUMENT}-1))}"
+
+	$GRADLE --stacktrace run \
+			-b test.gradle \
+			-PsmackVersion="${SMACK_VERSION}" \
+			-Dsinttest.service="${HOST}" \
+			-Dsinttest.securityMode=disabled \
+			-Dsinttest.replyTimeout=60000 \
+			-Dsinttest.adminAccountUsername="${ADMINUSER}" \
+			-Dsinttest.adminAccountPassword="${ADMINPASS}" \
+			${SINTTEST_DISABLED_TESTS_ARGUMENT}
+}
+
+
+setBaseDirectory
+trap cleanup EXIT
+setUpGradleEnvironment
+if [[ -n "${IPADDRESS-}" ]]; then
+	setHostsFile
 fi
-
-echo "Starting Integration Tests (using Smack ${SMACK_COMMIT_ID})…"
-
-DISABLED_INTEGRATION_TESTS=()
-DISABLED_INTEGRATION_TESTS+=(MoodIntegrationTest)
-DISABLED_INTEGRATION_TESTS+=(MultiUserChatIntegrationTest)
-DISABLED_INTEGRATION_TESTS+=(StreamManagementTest)
-DISABLED_INTEGRATION_TESTS+=(MultiUserChatLowLevelIntegrationTest)
-# Flaps sometimes (possibly a Openfire issue)
-DISABLED_INTEGRATION_TESTS+=(PubSubIntegrationTest)
-# Does sometimes not succeed (possibly a Smack issue)
-DISABLED_INTEGRATION_TESTS+=(XmppConnectionIntegrationTest)
-# EntityCapsTest#testEntityCaps fails regularly. Reason unknown.
-DISABLED_INTEGRATION_TESTS+=(EntityCapsTest)
-
-SINTTEST_DISABLED_TESTS_ARGUMENT="-Dsinttest.disabledTests="
-for disabledTest in "${DISABLED_INTEGRATION_TESTS[@]}"; do
-	SINTTEST_DISABLED_TESTS_ARGUMENT+="${disabledTest},"
-done
-# Remove last ',' from the argument.
-SINTTEST_DISABLED_TESTS_ARGUMENT="${SINTTEST_DISABLED_TESTS_ARGUMENT::-1}"
-
-pushd "${SMACKDIR}"
-$GRADLE --stacktrace integrationTest \
-		-Dsinttest.service=${HOST} \
-		-Dsinttest.securityMode=disabled \
-		-Dsinttest.replyTimeout=60000 \
-		-Dsinttest.adminAccountUsername="${ADMINUSER}" \
-		-Dsinttest.adminAccountPassword="${ADMINPASS}" \
-		${SINTTEST_DISABLED_TESTS_ARGUMENT}
+if [[ $LOCAL_RUN == true ]]; then
+	launchOpenfire
+fi
+runTestsInGradle

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -137,14 +137,9 @@ function launchOpenfire {
 		mvn verify -P ci
 	fi
 
-	rm distribution/target/distribution-base/conf/openfire.xml
-
-	# TODO: This file should probably be part of Openfire's git and be
-	# selectable by openfire.sh (.e.g "openfire.sh -c
-	# openfire-demoboot.xml").
-	curl ${CURL_ARGS} \
-		-o distribution/target/distribution-base/conf/openfire.xml \
-		https://raw.github.com/igniterealtime/ci-tooling/master/openfire-demoboot.xml
+	rm -f distribution/target/distribution-base/conf/openfire.xml
+	cp distribution/src/conf/openfire-demoboot.xml \
+		distribution/target/distribution-base/conf/openfire.xml
 
 	echo "Starting Openfire…"
 	"${OPENFIRE_SHELL_SCRIPT}" &

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -8,7 +8,11 @@ CURL_ARGS="--location --silent"
 DEBUG=false
 LOCAL_RUN=false
 
-while getopts dlgs: OPTION "$@"; do
+HOST='example.org'
+ADMINUSER='admin'
+ADMINPASS='admin'
+
+while getopts dlgs:h:u:p: OPTION "$@"; do
 	case $OPTION in
 		d)
 			DEBUG=true
@@ -23,8 +27,25 @@ while getopts dlgs: OPTION "$@"; do
 		s)
 			SMACK_COMMIT_ID="${OPTARG}"
 			;;
+		h)
+			HOST="${OPTARG}"
+			;;
+		u)
+			ADMINUSER="${OPTARG}"
+			;;
+		p)
+			ADMINPASS="${OPTARG}"
+			;;
+		\? ) echo "Unknown option: -$OPTARG" >&2; exit 1;;
+        :  ) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
+        *  ) echo "Unimplemented option: -$OPTARG" >&2; exit 1;;
 	esac
 done
+
+if [[ $LOCAL_RUN == true ]] && [[ $HOST != "example.org" ]]; then
+	echo "Cannot specify custom host if launching a local instance. If you have an already-running local instance to test against, omit the -l flag."
+	exit 1
+fi
 
 # Pretty fancy method to get reliable the absolute path of a shell
 # script, *even if it is sourced*. Credits go to GreenFox on
@@ -38,12 +59,11 @@ done
 cd "`dirname "${SCRIPTDIR}"`" > /dev/null
 SCRIPTDIR="`pwd`";
 popd  > /dev/null
-
 declare -r BASEDIR="${SCRIPTDIR}"
-
 cd "${BASEDIR}"
 
 TMPDIR=$(mktemp -d)
+
 function cleanup {
 	if [[ $DEBUG == false ]]; then
 		rm -rf ${TMPDIR}
@@ -51,9 +71,9 @@ function cleanup {
 	if [[ $LOCAL_RUN == true ]]; then
 		echo "Resetting hosts file after local running. This may prompt for sudo."
 		sudo sed -i'.original' "/example.org/d" /etc/hosts
+		echo "Stopping Openfire"
+		pkill -f openfire.lib #TODO: Can this be made more future-proof against changes in the start script?
 	fi
-	echo "Stopping Openfire"
-	pkill -f openfire.lib #TODO: Can this be made more future-proof against changes in the start script?
 }
 trap cleanup EXIT
 
@@ -93,33 +113,35 @@ fi
 git reset --hard "${SMACK_COMMIT_ID}"
 popd
 
-declare -r OPENFIRE_SHELL_SCRIPT="${BASEDIR}/distribution/target/distribution-base/bin/openfire.sh"
-
-if [[ ! -f "${OPENFIRE_SHELL_SCRIPT}" ]]; then
-	mvn verify -P ci
-fi
-
-rm distribution/target/distribution-base/conf/openfire.xml
-
-# TODO: This file should probably be part of Openfire's git and be
-# selectable by openfire.sh (.e.g "openfire.sh -c
-# openfire-demoboot.xml").
-curl ${CURL_ARGS} \
-	-o distribution/target/distribution-base/conf/openfire.xml \
-	https://raw.github.com/igniterealtime/ci-tooling/master/openfire-demoboot.xml
-
 if [[ $LOCAL_RUN == true ]]; then
+
+	declare -r OPENFIRE_SHELL_SCRIPT="${BASEDIR}/distribution/target/distribution-base/bin/openfire.sh"
+
+	if [[ ! -f "${OPENFIRE_SHELL_SCRIPT}" ]]; then
+		mvn verify -P ci
+	fi
+
+	rm distribution/target/distribution-base/conf/openfire.xml
+
+	# TODO: This file should probably be part of Openfire's git and be
+	# selectable by openfire.sh (.e.g "openfire.sh -c
+	# openfire-demoboot.xml").
+	curl ${CURL_ARGS} \
+		-o distribution/target/distribution-base/conf/openfire.xml \
+		https://raw.github.com/igniterealtime/ci-tooling/master/openfire-demoboot.xml
+
 	echo "Setting hosts file for local running. This may prompt for sudo."
 	sudo /bin/sh -c 'echo "127.0.0.1 example.org" >> /etc/hosts'
+	echo "Starting Openfire…"
+
+	"${OPENFIRE_SHELL_SCRIPT}" &
+
+	# Wait 120 seconds for Openfire to open up the web interface and
+	# assume Openfire is fully operational once that happens (not sure if
+	# this assumption is correct).
+	timeout 120 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 0.3; done' localhost 7070
+
 fi
-echo "Starting Openfire…"
-
-"${OPENFIRE_SHELL_SCRIPT}" &
-
-# Wait 120 seconds for Openfire to open up the web interface and
-# assume Openfire is fully operational once that happens (not sure if
-# this assumption is correct).
-timeout 120 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 0.3; done' localhost 7070
 
 echo "Starting Integration Tests (using Smack ${SMACK_COMMIT_ID})…"
 
@@ -143,12 +165,10 @@ done
 SINTTEST_DISABLED_TESTS_ARGUMENT="${SINTTEST_DISABLED_TESTS_ARGUMENT::-1}"
 
 pushd "${SMACKDIR}"
-sed -i '/-Werror/d' build.gradle
-sed -i 's/if (config.testPackages == null) {/if (config.testPackages == null || config.testPackages.isEmpty()) {/' smack-integration-test/src/main/java/org/igniterealtime/smack/inttest/SmackIntegrationTestFramework.java
 $GRADLE --stacktrace integrationTest \
-		-Dsinttest.service=example.org \
+		-Dsinttest.service=${HOST} \
 		-Dsinttest.securityMode=disabled \
 		-Dsinttest.replyTimeout=60000 \
-		-Dsinttest.adminAccountUsername=admin \
-		-Dsinttest.adminAccountPassword=admin \
+		-Dsinttest.adminAccountUsername="${ADMINUSER}" \
+		-Dsinttest.adminAccountPassword="${ADMINPASS}" \
 		${SINTTEST_DISABLED_TESTS_ARGUMENT}

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SMACK_VERSION="4.3.4-SNAPSHOT" # master 22 Nov 2019
+SMACK_VERSION="4.4.0-alpha2" # master 22 Nov 2019
 GRADLE_VERSION="6.0.1"
 FORCE_CUSTOM_GRADLE=false
 CURL_ARGS="--location --silent"
@@ -165,6 +165,11 @@ function runTestsInGradle {
 	DISABLED_INTEGRATION_TESTS+=(XmppConnectionIntegrationTest)
 	# EntityCapsTest#testEntityCaps fails regularly. Reason unknown.
 	DISABLED_INTEGRATION_TESTS+=(EntityCapsTest)
+	#FileTransferIntegrationTest doesn't progress at all on 4.4.0a2
+	DISABLED_INTEGRATION_TESTS+=(FileTransferIntegrationTest)
+	#OX tests use a removed dependency, and so don't compile on 4.4.0a2
+	DISABLED_INTEGRATION_TESTS+=(OXInstantMessagingIntegrationTest)
+	DISABLED_INTEGRATION_TESTS+=(OXSecretKeyBackupIntegrationTest)
 
 	SINTTEST_DISABLED_TESTS_ARGUMENT="-Dsinttest.disabledTests="
 	for disabledTest in "${DISABLED_INTEGRATION_TESTS[@]}"; do

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -155,16 +155,16 @@ function runTestsInGradle {
 	echo "Starting Integration Tests (using Smack ${SMACK_VERSION})…"
 
 	DISABLED_INTEGRATION_TESTS=()
-	DISABLED_INTEGRATION_TESTS+=(MoodIntegrationTest)
-	DISABLED_INTEGRATION_TESTS+=(MultiUserChatIntegrationTest)
+	#DISABLED_INTEGRATION_TESTS+=(MoodIntegrationTest)
+	#DISABLED_INTEGRATION_TESTS+=(MultiUserChatIntegrationTest)
 	DISABLED_INTEGRATION_TESTS+=(StreamManagementTest)
-	DISABLED_INTEGRATION_TESTS+=(MultiUserChatLowLevelIntegrationTest)
+	#DISABLED_INTEGRATION_TESTS+=(MultiUserChatLowLevelIntegrationTest)
 	# Flaps sometimes (possibly a Openfire issue)
-	DISABLED_INTEGRATION_TESTS+=(PubSubIntegrationTest)
+	#DISABLED_INTEGRATION_TESTS+=(PubSubIntegrationTest)
 	# Does sometimes not succeed (possibly a Smack issue)
-	DISABLED_INTEGRATION_TESTS+=(XmppConnectionIntegrationTest)
+	#DISABLED_INTEGRATION_TESTS+=(XmppConnectionIntegrationTest)
 	# EntityCapsTest#testEntityCaps fails regularly. Reason unknown.
-	DISABLED_INTEGRATION_TESTS+=(EntityCapsTest)
+	#DISABLED_INTEGRATION_TESTS+=(EntityCapsTest)
 	#FileTransferIntegrationTest doesn't progress at all on 4.4.0a2
 	DISABLED_INTEGRATION_TESTS+=(FileTransferIntegrationTest)
 	#OX tests use a removed dependency, and so don't compile on 4.4.0a2
@@ -177,7 +177,8 @@ function runTestsInGradle {
 	done
 	# Remove last ',' from the argument. Can't use ${SINTTEST_DISABLED_TESTS_ARGUMENT::-1} because bash on MacOS is infuriatingly incompatible.
 	SINTTEST_DISABLED_TESTS_ARGUMENT="${SINTTEST_DISABLED_TESTS_ARGUMENT:0:$((${#SINTTEST_DISABLED_TESTS_ARGUMENT}-1))}"
-
+	
+	#SINTTEST_DISABLED_TESTS_ARGUMENT="-Dsinttest.enabledTests=EntityCapsTest"
 	$GRADLE --stacktrace run \
 			-b test.gradle \
 			-PsmackVersion="${SMACK_VERSION}" \

--- a/test.gradle
+++ b/test.gradle
@@ -11,6 +11,11 @@ repositories {
 }
 
 dependencies {
+	compile group: 'org.igniterealtime.smack', name: 'smack-java7', version: smackVersion
+	if (smackVersion.matches("(5|4.[45]).*")) {
+		compile group: 'org.igniterealtime.smack', name: 'smack-xmlparser-xpp3', version: smackVersion
+		compile group: 'org.igniterealtime.smack', name: 'smack-xmlparser-stax', version: smackVersion
+	}
 	compile group: 'org.igniterealtime.smack', name: 'smack-integration-test', version: smackVersion
 }
 

--- a/test.gradle
+++ b/test.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'application'
+
+mainClassName = 'org.igniterealtime.smack.inttest.SmackIntegrationTestFramework'
+applicationDefaultJvmArgs = ["-enableassertions"]
+
+repositories {
+	mavenCentral()
+    maven {
+        url 'https://oss.sonatype.org/content/repositories/snapshots'
+    }
+}
+
+dependencies {
+	compile group: 'org.igniterealtime.smack', name: 'smack-integration-test', version: smackVersion
+}
+
+run {
+	// Pass all system properties down to the "application" run
+	systemProperties System.getProperties()
+}

--- a/test.gradle
+++ b/test.gradle
@@ -12,6 +12,7 @@ repositories {
 
 dependencies {
 	compile group: 'org.igniterealtime.smack', name: 'smack-java7', version: smackVersion
+	compile group: 'org.igniterealtime.smack', name: 'smack-legacy', version: smackVersion
 	if (smackVersion.matches("(5|4.[45]).*")) {
 		compile group: 'org.igniterealtime.smack', name: 'smack-xmlparser-xpp3', version: smackVersion
 		compile group: 'org.igniterealtime.smack', name: 'smack-xmlparser-stax', version: smackVersion


### PR DESCRIPTION
This started as "I'll fix that sed statement, then these will run on my Mac", but snowballed.

Improved the running script for readability
Added options for running tests against an already running host, even if it isn't local
Added ability to run tests in a local Docker container (because the Smack tests won't run on case-insensitive file systems)
Added option to set hosts file whilst the script is running

I believe this to be complete, but concede that in coping with lots more scenarios there are some combinations I haven't spotted or tested.

Feedback so very welcome!