### PR TITLE
remove demoboot.xml from RPM distribution

### DIFF
--- a/build/rpm/openfire.spec
+++ b/build/rpm/openfire.spec
@@ -74,6 +74,7 @@ rm -f $RPM_BUILD_ROOT%{homedir}/bin/*.bat
 rm -rf $RPM_BUILD_ROOT%{homedir}/resources/nativeAuth/osx-ppc
 rm -rf $RPM_BUILD_ROOT%{homedir}/resources/nativeAuth/win32-x86
 rm -f $RPM_BUILD_ROOT%{homedir}/lib/*.dll
+rm -f $RPM_BUILD_ROOT%{homedir}/conf/openfire-demoboot.xml
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
removes a newly included demoboot.xml #1539 from being included in the RPM distribution