### PR TITLE
OF-1937: Reduce connection timeout for LDAP.

### DIFF
--- a/documentation/ldap-guide.html
+++ b/documentation/ldap-guide.html
@@ -158,7 +158,7 @@ servers, some of which are detailed below:
         representing the connection timeout in milliseconds. If the LDAP provider doesn't
         connect within the specified period, it aborts the connection attempt. The integer should
         be greater than zero. An integer less than or equal to zero means no connection timeout is specified in which
-        case the default 10 seconds timeout is used. <i>Does not apply to SSL connections.</i></li>
+        case the default 4 seconds timeout is used. <i>Does not apply to SSL connections.</i></li>
     <li>ldap.readTimeout -- The value of this property is the string representation of an integer
         representing the read timeout in milliseconds for LDAP operations. If the LDAP provider doesn't
         get an LDAP response within the specified period, it aborts the read attempt. The integer should

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -638,7 +638,7 @@ public class LdapManager {
         if (connTimeout > 0) {
             env.put("com.sun.jndi.ldap.connect.timeout", String.valueOf(connTimeout));
         } else {
-            env.put("com.sun.jndi.ldap.connect.timeout", "10000");
+            env.put("com.sun.jndi.ldap.connect.timeout", "4000");
         }
 
         if (readTimeout > 0) {
@@ -746,7 +746,7 @@ public class LdapManager {
             if (connTimeout > 0) {
                     env.put("com.sun.jndi.ldap.connect.timeout", String.valueOf(connTimeout));
                 } else {
-                    env.put("com.sun.jndi.ldap.connect.timeout", "10000");
+                    env.put("com.sun.jndi.ldap.connect.timeout", "4000");
                 }
 
             if (readTimeout > 0) {
@@ -832,7 +832,11 @@ public class LdapManager {
                         env.put(Context.SECURITY_CREDENTIALS, password);
                     }
 
-                        env.put("com.sun.jndi.ldap.connect.timeout", "10000");
+                    if (connTimeout > 0) {
+                        env.put("com.sun.jndi.ldap.connect.timeout", String.valueOf(connTimeout));
+                    } else {
+                        env.put("com.sun.jndi.ldap.connect.timeout", "4000");
+                    }
 
                     if (ldapDebugEnabled) {
                         env.put("com.sun.jndi.ldap.trace.ber", System.err);


### PR DESCRIPTION
We've found that with a connection timeout of larger than 4 seconds, Spark fails to authenticate against LDAP, when LDAP integration is making use of more than one LDAP server with the first of the two unavailable.

This commit reduces the connection timeout to a value that allows Spark to authenticate. It does not, however, prevent that Openfire operates with degraded performance.