### PR TITLE
OF-1895: Unload properties that belong to a plugin

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -916,6 +916,9 @@ public class PluginManager
         // Anyway, for a few seconds admins may not see the plugin in the admin console
         // and in a subsequent refresh it will appear if failed to be removed
         pluginsLoaded.remove( canonicalName );
+        final String pluginName = getMetadata(canonicalName).getName();
+        Log.info("Removing all System Properties for the plugin '{}'", pluginName);
+        SystemProperty.removePropertiesForPlugin(pluginName);
         Path pluginFile = pluginDirs.remove( canonicalName );
         PluginClassLoader pluginLoader = classloaders.remove( plugin );
         PluginMetadata metadata = pluginMetadata.remove( canonicalName );


### PR DESCRIPTION
This PR unloads any SystemProperty whose "plugin" property matches that of the plugin name (as defined in plugin.xml) when the plugin is removed. 

I did look at scanning a plugin to ensure all properties are correctly loaded with the plugin (as opposed to the first time that a class containing the property is referenced - cf. `scanForSystemPropertyClasses()` in XMPPServer.java) - however, there seems to be an incompatibility hat I couldn't resolve between the Openfire specific PluginClassLoader and the Guava utility to find classes.