### PR TITLE
OF-1956: Introduce a configurable pause when restarting connection listeners

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -62,6 +62,13 @@ public final class ConnectionSettings {
         public static final String MAX_THREADS_SSL = "xmpp.client_ssl.processing.threads";
         public static final String MAX_READ_BUFFER_SSL = "xmpp.client_ssl.maxReadBufferSize";
         public static final String TLS_ALGORITHM = "xmpp.socket.ssl.algorithm";
+        public static final SystemProperty<Duration> RESTART_PAUSE = SystemProperty.Builder.ofType(Duration.class)
+            .setKey("xmpp.client.restart.pause")
+            .setDefaultValue(Duration.ofMillis(0))
+            .setMinValue(Duration.ofMillis(-1))
+            .setChronoUnit(ChronoUnit.MILLIS)
+            .setDynamic(Boolean.TRUE)
+            .build();
     }
 
     public static final class Server {
@@ -97,6 +104,13 @@ public final class ConnectionSettings {
         public static final String PERMISSION_SETTINGS = "xmpp.server.permission";
         public static final String AUTH_PER_CLIENTCERT_POLICY = "xmpp.server.cert.policy";
         public static final String ALLOW_ANONYMOUS_OUTBOUND_DATA = "xmpp.server.allow-anonymous-outbound-data";
+        public static final SystemProperty<Duration> RESTART_PAUSE = SystemProperty.Builder.ofType(Duration.class)
+            .setKey("xmpp.server.restart.pause")
+            .setDefaultValue(Duration.ofMillis(500))
+            .setMinValue(Duration.ofMillis(-1))
+            .setChronoUnit(ChronoUnit.MILLIS)
+            .setDynamic(Boolean.TRUE)
+            .build();
     }
 
     public static final class Multiplex {
@@ -110,7 +124,14 @@ public final class ConnectionSettings {
         public static final String ENABLE_OLD_SSLPORT = "xmpp.multiplex.ssl.active";
         public static final String MAX_THREADS ="xmpp.multiplex.processing.threads";
         public static final String MAX_THREADS_SSL = "xmpp.multiplex.ssl.processing.threads";
-        public static final String AUTH_PER_CLIENTCERT_POLICY = "xmpp.multiplex.cert.policy" ;
+        public static final String AUTH_PER_CLIENTCERT_POLICY = "xmpp.multiplex.cert.policy";
+        public static final SystemProperty<Duration> RESTART_PAUSE = SystemProperty.Builder.ofType(Duration.class)
+            .setKey("xmpp.multiplex.restart.pause")
+            .setDefaultValue(Duration.ofMillis(500))
+            .setMinValue(Duration.ofMillis(-1))
+            .setChronoUnit(ChronoUnit.MILLIS)
+            .setDynamic(Boolean.TRUE)
+            .build();
     }
 
     public static final class Component {
@@ -132,5 +153,12 @@ public final class ConnectionSettings {
         public static final String AUTH_PER_CLIENTCERT_POLICY = "xmpp.component.cert.policy";
         public static final String TLS_POLICY = "xmpp.component.tls.policy";
         public static final String COMPRESSION_SETTINGS = "xmpp.component.compression.policy";
+        public static final SystemProperty<Duration> RESTART_PAUSE = SystemProperty.Builder.ofType(Duration.class)
+            .setKey("xmpp.component.restart.pause")
+            .setDefaultValue(Duration.ofMillis(500))
+            .setMinValue(Duration.ofMillis(-1))
+            .setChronoUnit(ChronoUnit.MILLIS)
+            .setDynamic(Boolean.TRUE)
+            .build();
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
@@ -114,7 +114,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 bindAddress,
                 certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.SOCKET_C2S ),
                 certificateStoreManager.getTrustStoreConfiguration( ConnectionType.SOCKET_C2S ),
-                ConnectionSettings.Client.COMPRESSION_SETTINGS
+                ConnectionSettings.Client.COMPRESSION_SETTINGS,
+                ConnectionSettings.Client.RESTART_PAUSE
         );
         clientSslListener = new ConnectionListener(
                 ConnectionType.SOCKET_C2S,
@@ -128,7 +129,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 bindAddress,
                 certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.SOCKET_C2S ),
                 certificateStoreManager.getTrustStoreConfiguration( ConnectionType.SOCKET_C2S ),
-                ConnectionSettings.Client.COMPRESSION_SETTINGS
+                ConnectionSettings.Client.COMPRESSION_SETTINGS,
+                ConnectionSettings.Client.RESTART_PAUSE
         );
         // BOSH / HTTP-bind
         boshListener = new ConnectionListener(
@@ -143,7 +145,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 bindAddress,
                 certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.BOSH_C2S ),
                 certificateStoreManager.getTrustStoreConfiguration( ConnectionType.BOSH_C2S ),
-                ConnectionSettings.Client.COMPRESSION_SETTINGS // Existing code re-used the generic client compression property. Should we have a BOSH-specific one?
+                ConnectionSettings.Client.COMPRESSION_SETTINGS, // Existing code re-used the generic client compression property. Should we have a BOSH-specific one?
+                ConnectionSettings.Client.RESTART_PAUSE
         );
         boshSslListener = new ConnectionListener(
                 ConnectionType.BOSH_C2S,
@@ -157,7 +160,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 bindAddress,
                 certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.BOSH_C2S ),
                 certificateStoreManager.getTrustStoreConfiguration( ConnectionType.BOSH_C2S ),
-                ConnectionSettings.Client.COMPRESSION_SETTINGS // Existing code re-used the generic client compression property. Should we have a BOSH-specific one?
+                ConnectionSettings.Client.COMPRESSION_SETTINGS, // Existing code re-used the generic client compression property. Should we have a BOSH-specific one?
+                ConnectionSettings.Client.RESTART_PAUSE
         );
         // server-to-server (federation)
         serverListener = new ConnectionListener(
@@ -172,7 +176,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 bindAddress,
                 certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.SOCKET_S2S ),
                 certificateStoreManager.getTrustStoreConfiguration( ConnectionType.SOCKET_S2S ),
-                ConnectionSettings.Server.COMPRESSION_SETTINGS
+                ConnectionSettings.Server.COMPRESSION_SETTINGS,
+                ConnectionSettings.Server.RESTART_PAUSE
         );
         serverSslListener = new ConnectionListener(
             ConnectionType.SOCKET_S2S,
@@ -186,7 +191,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
             bindAddress,
             certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.SOCKET_S2S ),
             certificateStoreManager.getTrustStoreConfiguration( ConnectionType.SOCKET_S2S ),
-            ConnectionSettings.Server.COMPRESSION_SETTINGS
+            ConnectionSettings.Server.COMPRESSION_SETTINGS,
+            ConnectionSettings.Server.RESTART_PAUSE
         );
 
         // external components (XEP 0114)
@@ -202,7 +208,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 bindAddress,
                 certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.COMPONENT ),
                 certificateStoreManager.getTrustStoreConfiguration( ConnectionType.COMPONENT ),
-                ConnectionSettings.Component.COMPRESSION_SETTINGS
+                ConnectionSettings.Component.COMPRESSION_SETTINGS,
+                ConnectionSettings.Component.RESTART_PAUSE
         );
         componentSslListener = new ConnectionListener(
                 ConnectionType.COMPONENT,
@@ -216,7 +223,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 bindAddress,
                 certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.COMPONENT ),
                 certificateStoreManager.getTrustStoreConfiguration( ConnectionType.COMPONENT ),
-                ConnectionSettings.Component.COMPRESSION_SETTINGS
+                ConnectionSettings.Component.COMPRESSION_SETTINGS,
+                ConnectionSettings.Component.RESTART_PAUSE
         );
 
         // Multiplexers (our propertietary connection manager implementation)
@@ -232,7 +240,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 bindAddress,
                 certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.CONNECTION_MANAGER ),
                 certificateStoreManager.getTrustStoreConfiguration( ConnectionType.CONNECTION_MANAGER ),
-                ConnectionSettings.Multiplex.COMPRESSION_SETTINGS
+                ConnectionSettings.Multiplex.COMPRESSION_SETTINGS,
+                ConnectionSettings.Multiplex.RESTART_PAUSE
         );
         connectionManagerSslListener = new ConnectionListener(
                 ConnectionType.CONNECTION_MANAGER,
@@ -246,7 +255,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 bindAddress,
                 certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.CONNECTION_MANAGER ),
                 certificateStoreManager.getTrustStoreConfiguration( ConnectionType.CONNECTION_MANAGER ),
-                ConnectionSettings.Multiplex.COMPRESSION_SETTINGS
+                ConnectionSettings.Multiplex.COMPRESSION_SETTINGS,
+                ConnectionSettings.Multiplex.RESTART_PAUSE
         );
 
         // Admin console (the Openfire web-admin) // TODO these use the XML properties instead of normal properties!
@@ -262,7 +272,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 adminConsoleBindAddress,
                 certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.WEBADMIN ),
                 certificateStoreManager.getTrustStoreConfiguration( ConnectionType.WEBADMIN ),
-                null // Should we have compression on the admin console?
+                null, // Should we have compression on the admin console?
+                null
         );
 
         webAdminSslListener = new ConnectionListener(
@@ -277,7 +288,8 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 adminConsoleBindAddress,
                 certificateStoreManager.getIdentityStoreConfiguration( ConnectionType.WEBADMIN ),
                 certificateStoreManager.getTrustStoreConfiguration( ConnectionType.WEBADMIN ),
-                null // Should we have compression on the admin console?
+                null, // Should we have compression on the admin console?
+                null
         );
 
     }


### PR DESCRIPTION
To combat race conditions when restarting a (socket) listener, this commit introduces a configurable pause that occurs when restarting a listener (after 'stop', before 'start').

As the race condition is more likely to affect the older s2s code, a non-zero default has been configured for that listener. Client listeners have a default of zero.