### PR TITLE
OF-1978 (feature) Added xmpp.muc.join.presence

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1626,6 +1626,7 @@ system_property.xmpp.auth.sasl.external.client.suppress-matching-realmname=Ignor
 system_property.adminConsole.servlet-request-authenticator=The class to use to authenticate requests made to the admin console. If not supplied, normal username/password authentication will be used.
 system_property.adminConsole.siteMinderHeader=The name of the HTTP header that will contain the CA SiteMinder/Single Sign-On authenticated user, if available.
 system_property.xmpp.muc.muclumbus.v1-0.enabled=Determine is the multi-user chat "muclumbus" (v1.0) search feature is enabled.
+system_property.xmpp.muc.join.presence=Setting the presence send of participants joining in MUC rooms.
 system_property.ldap.pagedResultsSize=The maximum number of records to retrieve from LDAP in a single page. \
    The default value of -1 means rely on the paging of the LDAP server itself. \
    Note that if using ActiveDirectory, this should not be left at the default, and should not be set to more than the value of the ActiveDirectory MaxPageSize; 1,000 by default.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -74,6 +74,7 @@ import org.jivesoftware.util.JiveConstants;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.LocaleUtils;
 import org.jivesoftware.util.NotFoundException;
+import org.jivesoftware.util.SystemProperty;
 import org.jivesoftware.util.cache.CacheFactory;
 import org.jivesoftware.util.cache.ExternalizableUtil;
 import org.slf4j.Logger;
@@ -100,6 +101,12 @@ import org.xmpp.packet.Presence;
 public class LocalMUCRoom implements MUCRoom, GroupEventListener {
 
     private static final Logger Log = LoggerFactory.getLogger(LocalMUCRoom.class);
+
+    private static final SystemProperty<Boolean> JOIN_PRESENCE_ENABLE = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("xmpp.muc.join.presence")
+        .setDynamic(true)
+        .setDefaultValue(true)
+        .build();
 
     /**
      * The service hosting the room.
@@ -689,7 +696,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         boolean isRoomNew = isLocked() && creationDate.getTime() == lockedTime;
         try {
             // Send the presence of this new occupant to existing occupants
-            if (JiveGlobals.getBooleanProperty("xmpp.muc.join.presence", true)) {
+            if (JOIN_PRESENCE_ENABLE.getValue()) {
                 Presence joinPresence = joinRole.getPresence().createCopy();
                 broadcastPresence(joinPresence, true);
             }
@@ -765,7 +772,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
      * @param joinRole the role of the new occupant in the room.
      */
     private void sendInitialPresences(MUCRole joinRole) {
-        if (!JiveGlobals.getBooleanProperty("xmpp.muc.join.presence", true)) {
+        if (!JOIN_PRESENCE_ENABLE.getValue()) {
             return;
         }
 
@@ -872,7 +879,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             else {
                 if (getOccupantsByNickname(leaveRole.getNickname()).size() <= 1) {
                     // Inform the rest of the room occupants that the user has left the room
-                    if (JiveGlobals.getBooleanProperty("xmpp.muc.join.presence", true)) {
+                    if (JOIN_PRESENCE_ENABLE.getValue()) {
                         broadcastPresence(presence, false);
                     }
                 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -689,8 +689,10 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         boolean isRoomNew = isLocked() && creationDate.getTime() == lockedTime;
         try {
             // Send the presence of this new occupant to existing occupants
-            Presence joinPresence = joinRole.getPresence().createCopy();
-            broadcastPresence(joinPresence, true);
+            if (JiveGlobals.getBooleanProperty("xmpp.muc.join.presence", true)) {
+                Presence joinPresence = joinRole.getPresence().createCopy();
+                broadcastPresence(joinPresence, true);
+            }
         }
         catch (Exception e) {
             Log.error(LocaleUtils.getLocalizedString("admin.error"), e);
@@ -763,6 +765,10 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
      * @param joinRole the role of the new occupant in the room.
      */
     private void sendInitialPresences(MUCRole joinRole) {
+        if (!JiveGlobals.getBooleanProperty("xmpp.muc.join.presence", true)) {
+            return;
+        }
+
         for (MUCRole occupant : occupantsByFullJID.values()) {
             if (occupant == joinRole) {
                 continue;
@@ -866,7 +872,9 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             else {
                 if (getOccupantsByNickname(leaveRole.getNickname()).size() <= 1) {
                     // Inform the rest of the room occupants that the user has left the room
-                    broadcastPresence(presence, false);
+                    if (JiveGlobals.getBooleanProperty("xmpp.muc.join.presence", true)) {
+                        broadcastPresence(presence, false);
+                    }
                 }
             }
         }


### PR DESCRIPTION
With this feature, "join presence" of participating users cannot be sent. It is very useful if you don't want to send join presence in all groups. This will be preparation for [MUC lite](https://xmpp.org/extensions/inbox/muc-light.html)