### PR TITLE
OF-1946: Correct cache size causing incorrect values display on admin UI

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultCache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultCache.java
@@ -398,7 +398,7 @@ public class DefaultCache<K extends Serializable, V extends Serializable> implem
      */
     @Override
     public int getCacheSize() {
-        return (int) Math.max(Integer.MAX_VALUE,cacheSize);
+        return (int) Math.min(Integer.MAX_VALUE, cacheSize);
     }
 
     /**

--- a/xmppserver/src/main/webapp/system-cache.jsp
+++ b/xmppserver/src/main/webapp/system-cache.jsp
@@ -195,7 +195,7 @@
             overallTotal += (double)cache.getMaxCacheSize();
         }
         int entries = cache.size();
-        memUsed = (double)cache.getCacheSize()/(1024*1024);
+        memUsed = (double)cache.getLongCacheSize()/(1024*1024);
         totalMem = (double)cache.getMaxCacheSize()/(1024*1024);
         usedMem = 100*memUsed/totalMem;
         hits = cache.getCacheHits();


### PR DESCRIPTION
Replace a Math.max with a Math.min