### PR TITLE
OF-1977: Various pubsub fixes

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
@@ -258,6 +258,19 @@ public class CollectionNode extends Node {
     }
 
     /**
+     * Notification that a child node configuration was modified. Trigger notifications
+     * to node subscribers whose subscription type is {@link NodeSubscription.Type#nodes} and
+     * have the proper depth.
+     *
+     * @param child the deleted node that was removed from this node.
+     * @param notification message which will be sent to subscribers.
+     */
+    void childNodeModified(Node child, Message notification){
+        // Broadcast event notification to subscribers
+        broadcastCollectionNodeEvent(child, notification);
+    }
+
+    /**
      * Notification that a child node was deleted from this node. Trigger notifications
      * to node subscribers whose subscription type is {@link NodeSubscription.Type#nodes} and
      * have the proper depth.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -757,7 +757,7 @@ public abstract class Node {
         // Send notification that the node configuration has changed
         broadcastNodeEvent(message, false);
 
-        // And also to the subscribers of descendant nodes with proper subscription depth
+        // And also to the subscribers of parent nodes with proper subscription depth
         if (parent != null){
             parent.childNodeModified(this, message);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -756,6 +756,11 @@ public abstract class Node {
         }
         // Send notification that the node configuration has changed
         broadcastNodeEvent(message, false);
+
+        // And also to the subscribers of descendant nodes with proper subscription depth
+        if (parent != null){
+            parent.childNodeModified(this, message);
+        }
     }
 
     /**
@@ -1823,6 +1828,10 @@ public abstract class Node {
         if (PubSubPersistenceManager.removeNode(this)) {
             // Remove this node from the parent node (if any)
             if (parent != null) {
+                // Notify the parent that the node has been removed from the parent node
+                if (isNotifiedOfDelete()){
+                    parent.childNodeDeleted(this);
+                }
                 parent.removeChildNode(this);
             }
             deletingNode();
@@ -1835,10 +1844,6 @@ public abstract class Node {
                 items.addAttribute("node", nodeID);
                 // Send notification that the node was deleted
                 broadcastNodeEvent(message, true);
-            }
-            // Notify the parent (if any) that the node has been removed from the parent node
-            if (parent != null) {
-                parent.childNodeDeleted(this);
             }
             // Remove presence subscription when node was deleted.
             cancelPresenceSubscriptions();


### PR DESCRIPTION
- pubsub fixes to notification sent to subscribers upon node configuration change and upon node deletion

1. "Node configuration change" message was not sent to subscribers("nodes") of any parent nodes even when the depth was proper. Only if subscription was made directly to node which configuration was changed
2. "Node configuration change" message was not sent to subscribers ("nodes") of any parent nodes even when the depth was proper, because the node was deleted 1st from collection and therefore not found as descendant node later when the notification messages were sent.