### PR TITLE
OF-532: Fixed by including sessions with non-negative priority=0

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
@@ -252,7 +252,7 @@ public class MessageRouter extends BasicModule {
             for (JID address : routingTable.getRoutes(recipient.asBareJID(), packet.getFrom())) {
                 ClientSession session = routingTable.getClientRoute(address);
                 if (session != null && session.isInitialized()) {
-                    if (session.getPresence().getPriority() >= 1) {
+                    if (session.getPresence().getPriority() >= 0) {
                         // If message was sent to an unavailable full JID of a user then retry using the bare JID.
                         routingTable.routePacket( recipient.asBareJID(), packet, false );
                         return;


### PR DESCRIPTION
To be compliant with https://tools.ietf.org/html/rfc6121#section-8.5.3.2.1,
for private messages(type="chat"), in case of no resource match,
server MUST deliver this message to any of available resource with non-negative priority