### PR TITLE
OF-1974 :lock: Don't send Jetty server name & version in websockets response

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -291,6 +291,7 @@ public final class HttpBindManager implements CertificateEventListener, Property
         final int port = getHttpBindUnsecurePort();
         if (port > 0) {
             HttpConfiguration httpConfig = new HttpConfiguration();
+            httpConfig.setSendServerVersion( false );
             configureProxiedConnector(httpConfig);
             ServerConnector connector = new ServerConnector(httpBindServer, new HttpConnectionFactory(httpConfig));
 
@@ -324,6 +325,7 @@ public final class HttpBindManager implements CertificateEventListener, Property
                 httpsConfig.setSecurePort(securePort);
                 configureProxiedConnector(httpsConfig);
                 httpsConfig.addCustomizer(new SecureRequestCustomizer());
+                httpsConfig.setSendServerVersion( false );
 
                 final ServerConnector sslConnector = new ServerConnector(httpBindServer, new SslConnectionFactory(sslContextFactory, "http/1.1"), new HttpConnectionFactory(httpsConfig));
                 sslConnector.setHost(getBindInterface());


### PR DESCRIPTION
Currently Openfire send Jetty server name and version in response header :

![image](https://user-images.githubusercontent.com/48515764/77056286-81cd8580-69d2-11ea-9586-8be820265c92.png)


This is a bad practice security-wise. Note that in the other connexions (like the admin panel) this option is already set to false.

This commit is for the 4.6 branch.

