### PR TITLE
OF-1976: Admin console: allow any positive number for max muc room occupants

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1286,6 +1286,7 @@ muc.room.edit.form.valid_hint_subject=Please enter a valid topic.
 muc.room.edit.form.valid_hint_subject_too_long=Topic is too long. Maximum 100 characters.
 muc.room.edit.form.max_room=Maximum Room Occupants
 muc.room.edit.form.none=Unlimited
+muc.room.edit.form.empty_nolimit=(for unlimited, leave empty)
 muc.room.edit.form.valid_hint_max_room=Please select the maximum room occupants.
 muc.room.edit.form.broadcast=Broadcast Presence for
 muc.room.edit.form.moderator=Moderator

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -694,6 +694,7 @@ muc.room.edit.form.topic=Onderwerp
 muc.room.edit.form.valid_hint_subject=Vul een geldig onderwerp in.
 muc.room.edit.form.max_room=Maximum aantal aanwezigen
 muc.room.edit.form.none=Geen
+muc.room.edit.form.empty_nolimit=(laat leeg voor geen limiet)
 muc.room.edit.form.valid_hint_max_room=Kies het maximum aantal aanwezigen voor de gespreksruimte.
 muc.room.edit.form.broadcast=Rollen waarvoor de status informatie wordt getoond
 muc.room.edit.form.moderator=Moderator

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -155,8 +155,13 @@
         if (description == null) {
             errors.put("roomconfig_roomdesc","roomconfig_roomdesc");
         }
-        if (maxUsers == null) {
-            errors.put("roomconfig_maxusers","roomconfig_maxusers");
+        if (maxUsers == null || maxUsers.isEmpty()) {
+            maxUsers = "0"; // 0 indicates no limit.
+        }
+        try {
+            Integer.parseInt(maxUsers);
+        } catch ( NumberFormatException e ) {
+            errors.put("roomconfig_maxusers", "roomconfig_maxusers");
         }
         if (password != null && !password.equals(confirmPassword)) {
             errors.put("roomconfig_roomsecret2","roomconfig_roomsecret2");
@@ -484,11 +489,19 @@
     <tbody>
         <tr>
             <td><%= StringUtils.escapeHTMLTags(room.getName()) %></td>
-            <% if (room.getOccupantsCount() == 0) { %>
-            <td><%= room.getOccupantsCount() %> / <%= room.getMaxUsers() %></td>
-            <% } else { %>
-            <td><a href="muc-room-occupants.jsp?roomJID=<%= URLEncoder.encode(roomJID.toBareJID(), "UTF-8")%>"><%= room.getOccupantsCount() %> / <%= room.getMaxUsers() %></a></td>
-            <% } %>
+            <td><% if (room.getOccupantsCount() == 0) { %>
+                    <%= room.getOccupantsCount() %>
+                    <% if (room.getMaxUsers() > 0 ) { %>
+                        / <%= room.getMaxUsers() %>
+                    <% } %>
+                <% } else { %>
+                    <a href="muc-room-occupants.jsp?roomJID=<%= URLEncoder.encode(roomJID.toBareJID(), "UTF-8")%>"><%= room.getOccupantsCount() %>
+                    <% if (room.getMaxUsers() > 0 ) { %>
+                        / <%= room.getMaxUsers() %>
+                    <% } %>
+                    </a>
+                <% } %>
+            </td>
             <td><%= dateFormatter.format(room.getCreationDate()) %></td>
             <td><%= dateFormatter.format(room.getModificationDate()) %></td>
         </tr>
@@ -562,14 +575,8 @@
                 </tr>
                  <tr>
                     <td><fmt:message key="muc.room.edit.form.max_room" />:</td>
-                    <td><select name="roomconfig_maxusers">
-                            <option value="10" <% if ("10".equals(maxUsers)) out.write("selected");%>>10</option>
-                            <option value="20" <% if ("20".equals(maxUsers)) out.write("selected");%>>20</option>
-                            <option value="30" <% if ("30".equals(maxUsers)) out.write("selected");%>>30</option>
-                            <option value="40" <% if ("40".equals(maxUsers)) out.write("selected");%>>40</option>
-                            <option value="50" <% if ("50".equals(maxUsers)) out.write("selected");%>>50</option>
-                            <option value="0" <% if ("0".equals(maxUsers)) out.write("selected");%>><fmt:message key="muc.room.edit.form.none" /></option>
-                        </select>
+                    <td><input type="number" name="roomconfig_maxusers" min="1" value="<%= maxUsers == null || maxUsers.equals("0") ? "" : StringUtils.escapeForXML(maxUsers)%>" size="5">
+                        <fmt:message key="muc.room.edit.form.empty_nolimit" />
                     </td>
                 </tr>
                  <tr>

--- a/xmppserver/src/main/webapp/muc-room-summary.jsp
+++ b/xmppserver/src/main/webapp/muc-room-summary.jsp
@@ -217,7 +217,10 @@
                 <% } %>
         </td>
         <td width="1%" align="center">
-            <nobr><%= room.getOccupantsCount() %> / <%= room.getMaxUsers() %></nobr>
+            <nobr><%= room.getOccupantsCount() %>
+            <% if (room.getMaxUsers() > 0 ) { %>
+                / <%= room.getMaxUsers() %>
+            <% } %></nobr>
         </td>
         <td width="1%" align="center">
             <a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), "UTF-8") %>"


### PR DESCRIPTION
Additionally, room listings no longer show a '0' when listing room occuptant count vs max occupants, when the room max occupant count is unlimited. For those rooms, only the occupant count is shown (eg: "28" instead of "28 / 0").