### PR TITLE
OF-158: Make room default settings use configurable service defaults.

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1206,6 +1206,15 @@ muc.default.settings.enable_logging=Log Room Conversations
 muc.default.settings.max_users=Maximum Room Occupants
 muc.default.settings.error=Error while saving default settings.
 muc.default.settings.update=Settings updated successfully.
+muc.default.settings.broadcast_presence_moderator=Broadcast presence for Moderators
+muc.default.settings.broadcast_presence_participant=Broadcast presence for Participants
+muc.default.settings.broadcast_presence_visitor=Broadcast presence for Visitors
+muc.default.settings.allowpm=Allowed to Send Private Messages
+muc.default.settings.none=None
+muc.default.settings.moderator=Moderator
+muc.default.settings.participant=Participant
+muc.default.settings.visitor=Visitor
+muc.default.settings.anyone=Anyone
 
 # Muc room affiliations Page
 

--- a/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
+++ b/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
@@ -637,6 +637,11 @@ muc.default.settings.enable_logging=Log Room Conversations
 muc.default.settings.max_users=Maximum Room Occupants
 muc.default.settings.error=Error while saving default settings.
 muc.default.settings.update=Settings updated successfully.
+muc.default.settings.none=Žádný
+muc.default.settings.moderator=Moderátor
+muc.default.settings.participant=Účastník
+muc.default.settings.visitor=Návštěvník
+muc.default.settings.anyone=Kdokoli
 
 # Muc room affiliations Page
 

--- a/i18n/src/main/resources/openfire_i18n_de.properties
+++ b/i18n/src/main/resources/openfire_i18n_de.properties
@@ -789,6 +789,12 @@ muc.default.settings.enable_logging=Raumunterhaltungen mitschreiben
 muc.default.settings.max_users=Maximale Teilnehmeranzahl
 muc.default.settings.error=Es ist ein Fehler während des Speicherns aufgetreten.
 muc.default.settings.update=Einstellungen erfolgreich aktualisiert.
+muc.default.settings.none=Nichts
+muc.default.settings.moderator=Moderator
+muc.default.settings.participant=Teilnehmer
+muc.default.settings.visitor=Besucher
+muc.default.settings.allowpm=Erlaubt das Senden von privaten Nachrichten
+muc.default.settings.anyone=Jeder
 
 # Muc room affiliations Page
 

--- a/i18n/src/main/resources/openfire_i18n_es.properties
+++ b/i18n/src/main/resources/openfire_i18n_es.properties
@@ -753,6 +753,11 @@ muc.default.settings.enable_logging=Guardar las conversaciones de la sala
 muc.default.settings.max_users=Número máximo de miembros
 muc.default.settings.error=Error al guardar los valores por defecto.
 muc.default.settings.update=Configuración actualizada con éxito.
+muc.default.settings.none=Ninguno
+muc.default.settings.moderator=Moderador
+muc.default.settings.participant=Participante
+muc.default.settings.visitor=Visitante
+muc.default.settings.anyone=Cualquiera
 
 # Muc room affiliations Page
 

--- a/i18n/src/main/resources/openfire_i18n_fr.properties
+++ b/i18n/src/main/resources/openfire_i18n_fr.properties
@@ -545,6 +545,11 @@ muc.default.settings.enable_logging=Log Room Conversations
 muc.default.settings.max_users=Maximum Room Occupants
 muc.default.settings.error=Error while saving default settings.
 muc.default.settings.update=Settings updated successfully.
+muc.default.settings.none=Aucun
+muc.default.settings.moderator=Moderateur
+muc.default.settings.participant=Participant
+muc.default.settings.visitor=Visiteur
+muc.default.settings.anyone=N&#39;importe qui
 
 # Muc room affiliations Page
 muc.room.affiliations.title = Permissions Utilisateurs

--- a/i18n/src/main/resources/openfire_i18n_ja_JP.properties
+++ b/i18n/src/main/resources/openfire_i18n_ja_JP.properties
@@ -661,6 +661,11 @@ muc.default.settings.enable_logging=Log Room Conversations
 muc.default.settings.max_users=Maximum Room Occupants
 muc.default.settings.error=Error while saving default settings.
 muc.default.settings.update=Settings updated successfully.
+muc.default.settings.none=なし
+muc.default.settings.moderator=モデレーター
+muc.default.settings.participant=参加者
+muc.default.settings.visitor=訪問者
+muc.default.settings.anyone=だれでも
 
 # Muc room affiliations Page
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -297,6 +297,7 @@ muc.form.conf.owner_roomadmins=Beheerders van de gespreksruimte
 muc.form.conf.roomownersfixed=U mag overige eigenaars van deze gespreksruimte opgeven. \
         Geef ��n adres op per lijn.
 muc.form.conf.owner_roomowners=Eigenaars van de gespreksruimte
+muc.form.conf.owner_allowpm=Toegestaan om privéberichten te versturen
 
 # Admin Console Pages below
 
@@ -626,6 +627,12 @@ muc.default.settings.enable_logging=Log Room Conversations
 muc.default.settings.max_users=Maximum Room Occupants
 muc.default.settings.error=Error while saving default settings.
 muc.default.settings.update=Settings updated successfully.
+muc.default.settings.none=Geen
+muc.default.settings.moderator=Moderator
+muc.default.settings.participant=Deelnemer
+muc.default.settings.visitor=Bezoeker
+muc.default.settings.allowpm=Toegestaan om privéberichten te versturen
+muc.default.settings.anyone=Iedereen
 
 # Muc room affiliations Page
 

--- a/i18n/src/main/resources/openfire_i18n_pl_PL.properties
+++ b/i18n/src/main/resources/openfire_i18n_pl_PL.properties
@@ -621,6 +621,11 @@ muc.default.settings.enable_logging=Log Room Conversations
 muc.default.settings.max_users=Maximum Room Occupants
 muc.default.settings.error=Error while saving default settings.
 muc.default.settings.update=Settings updated successfully.
+muc.default.settings.none=Brak
+muc.default.settings.moderator=Moderator
+muc.default.settings.participant=Zwykły uczestnik
+muc.default.settings.visitor=Gość
+muc.default.settings.anyone=Każdy
 
 # Muc room affiliations Page
 

--- a/i18n/src/main/resources/openfire_i18n_pt_BR.properties
+++ b/i18n/src/main/resources/openfire_i18n_pt_BR.properties
@@ -633,6 +633,11 @@ muc.default.settings.enable_logging=Log Room Conversations
 muc.default.settings.max_users=Maximum Room Occupants
 muc.default.settings.error=Error while saving default settings.
 muc.default.settings.update=Settings updated successfully.
+muc.default.settings.none=Nenhum
+muc.default.settings.moderator=Moderador
+muc.default.settings.participant=Participante
+muc.default.settings.visitor=Visitante
+muc.default.settings.anyone=Qualquer um
 
 # Muc room affiliations Page
 

--- a/i18n/src/main/resources/openfire_i18n_pt_PT.properties
+++ b/i18n/src/main/resources/openfire_i18n_pt_PT.properties
@@ -1123,6 +1123,11 @@ muc.default.settings.enable_logging=Log Room Conversations
 muc.default.settings.max_users=Maximum Room Occupants
 muc.default.settings.error=Error while saving default settings.
 muc.default.settings.update=Settings updated successfully.
+muc.default.settings.none=Nenhum
+muc.default.settings.moderator=Moderador
+muc.default.settings.participant=Participante
+muc.default.settings.visitor=Visitante
+muc.default.settings.anyone=Qualquer um
 
 # Muc room affiliations Page
 

--- a/i18n/src/main/resources/openfire_i18n_ru_RU.properties
+++ b/i18n/src/main/resources/openfire_i18n_ru_RU.properties
@@ -720,6 +720,12 @@ muc.default.settings.enable_logging=Журналирование бесед
 muc.default.settings.max_users=Максимальная вместимость участников
 muc.default.settings.error=Ошибка при сохранении настроек по умолчанию.
 muc.default.settings.update=Настройки успешно обновлены.
+muc.default.settings.none=Никто
+muc.default.settings.moderator=Модератор
+muc.default.settings.participant=Участник
+muc.default.settings.visitor=Посетитель
+muc.default.settings.allowpm=Разрешено отправлять личные сообщения
+muc.default.settings.anyone=Любому
 
 #Страница присоединения к Muc
 

--- a/i18n/src/main/resources/openfire_i18n_sk.properties
+++ b/i18n/src/main/resources/openfire_i18n_sk.properties
@@ -651,6 +651,11 @@ muc.default.settings.enable_logging=Zaznamenávať konverzácie v miestnosti
 muc.default.settings.max_users=Maximálny počet prítomných
 muc.default.settings.error=Chyba pri ukladaní predvolených nastavení.
 muc.default.settings.update=Nastavenia úspešne aktualizované.
+muc.default.settings.none=Žiadny
+muc.default.settings.moderator=Moderátor
+muc.default.settings.participant=Účastník
+muc.default.settings.visitor=Návštevník
+muc.default.settings.anyone=Každý
 
 # Muc room affiliations Page
 

--- a/i18n/src/main/resources/openfire_i18n_zh_CN.properties
+++ b/i18n/src/main/resources/openfire_i18n_zh_CN.properties
@@ -662,6 +662,11 @@ muc.default.settings.enable_logging=记录房间聊天
 muc.default.settings.max_users=房间最大人数
 muc.default.settings.error=保存默认设置时出错。
 muc.default.settings.update=设置更新成功。
+muc.default.settings.none=无
+muc.default.settings.moderator=审核者
+muc.default.settings.participant=参与者
+muc.default.settings.visitor=访客
+muc.default.settings.anyone=任何人
 
 # Muc room affiliations Page
 

--- a/xmppserver/src/main/webapp/muc-default-settings.jsp
+++ b/xmppserver/src/main/webapp/muc-default-settings.jsp
@@ -24,8 +24,10 @@
 %>
 <%@ page import="java.net.URLEncoder" %>
 
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib uri="admin" prefix="admin" %>
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
 <% webManager.init(request, response, session, application, out ); %>
 
@@ -177,200 +179,144 @@
         response.sendRedirect("muc-default-settings.jsp?success=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
         return;
     }
+
+    pageContext.setAttribute("errors", errors);
+    pageContext.setAttribute("success", success);
+    pageContext.setAttribute("mucname", mucname);
+    pageContext.setAttribute("publicRoom", MUCPersistenceManager.getBooleanProperty(mucname, "room.publicRoom", true));
+    pageContext.setAttribute("persistent", MUCPersistenceManager.getBooleanProperty(mucname, "room.persistent", false));
+    pageContext.setAttribute("moderated", MUCPersistenceManager.getBooleanProperty(mucname, "room.moderated", false));
+    pageContext.setAttribute("membersOnly", MUCPersistenceManager.getBooleanProperty(mucname, "room.membersOnly", false));
+    pageContext.setAttribute("canAnyoneDiscoverJID", MUCPersistenceManager.getBooleanProperty(mucname, "room.canAnyoneDiscoverJID", true));
+    pageContext.setAttribute("canOccupantsInvite", MUCPersistenceManager.getBooleanProperty(mucname, "room.canOccupantsInvite", false));
+    pageContext.setAttribute("canOccupantsChangeSubject", MUCPersistenceManager.getBooleanProperty(mucname, "room.canOccupantsChangeSubject", false));
+    pageContext.setAttribute("loginRestrictedToNickname", MUCPersistenceManager.getBooleanProperty(mucname, "room.loginRestrictedToNickname", false));
+    pageContext.setAttribute("canChangeNickname", MUCPersistenceManager.getBooleanProperty(mucname, "room.canChangeNickname", true));
+    pageContext.setAttribute("registrationEnabled", MUCPersistenceManager.getBooleanProperty(mucname, "room.registrationEnabled", true));
+    pageContext.setAttribute("logEnabled", MUCPersistenceManager.getBooleanProperty(mucname, "room.logEnabled", true));
+    pageContext.setAttribute("maxUsers", MUCPersistenceManager.getIntProperty(mucname, "room.maxUsers", 30));
+    pageContext.setAttribute("broadcastModerator", MUCPersistenceManager.getBooleanProperty(mucname, "room.broadcastModerator", true));
+    pageContext.setAttribute("broadcastParticipant", MUCPersistenceManager.getBooleanProperty(mucname, "room.broadcastParticipant", true));
+    pageContext.setAttribute("broadcastVisitor", MUCPersistenceManager.getBooleanProperty(mucname, "room.broadcastVisitor", true));
+    pageContext.setAttribute("allowpm", MUCPersistenceManager.getProperty(mucname, "room.allowpm", "anyone"));
+    pageContext.setAttribute("xxx", MUCPersistenceManager.getBooleanProperty(mucname, "room.xxx", true));
+    pageContext.setAttribute("xxx", MUCPersistenceManager.getBooleanProperty(mucname, "room.xxx", true));
+    pageContext.setAttribute("xxx", MUCPersistenceManager.getBooleanProperty(mucname, "room.xxx", true));
 %>
 
 <html>
-<head>
-<title><fmt:message key="muc.default.settings.title"/></title>
-<meta name="subPageID" content="muc-defaultsettings"/>
-<meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, "UTF-8") %>"/>
-<meta name="helpPage" content="set_group_chat_room_creation_permissions.html"/>
-</head>
-<body>
+    <head>
+        <title><fmt:message key="muc.default.settings.title"/></title>
+        <meta name="subPageID" content="muc-defaultsettings"/>
+        <meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, "UTF-8") %>"/>
+        <meta name="helpPage" content="set_group_chat_room_creation_permissions.html"/>
+    </head>
 
-<p>
-<fmt:message key="muc.default.settings.info" />
-<fmt:message key="groupchat.service.settings_affect" /> <b><a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucname, "UTF-8") %>"><%= StringUtils.escapeHTMLTags(mucname) %></a></b>
-</p>
+    <body>
 
-<%  if (errors.size() > 0) { %>
+    <p>
+        <c:url var="mucserviceeditformlink" value="muc-service-edit-form.jsp">
+            <c:param name="mucname" value="${mucname}"/>
+        </c:url>
+        <fmt:message key="muc.default.settings.info" />
+        <fmt:message key="groupchat.service.settings_affect" /><b><a href="${mucserviceeditformlink}"><c:out value="${mucname}"/></a></b>
+    </p>
 
-    <div class="jive-error">
-    <table cellpadding="0" cellspacing="0" border="0">
-    <tbody>
-        <tr><td class="jive-icon"><img src="images/error-16x16.gif" width="16" height="16" border="0" alt=""></td>
-        <td class="jive-icon-label">
-        <% if (errors.get("csrf") != null) { %>
-            <fmt:message key="global.csrf.failed" />
-        <% } else {  %>
-            <fmt:message key="muc.default.settings.error" />
-        <% } %>
-        </td></tr>
-    </tbody>
-    </table>
-    </div><br>
+    <c:choose>
+        <c:when test="${not empty errors}">
+            <c:forEach var="err" items="${errors}">
+                <admin:infobox type="error">
+                    <c:choose>
+                        <c:when test="${err.key eq 'csrf'}"><fmt:message key="global.csrf.failed" /></c:when>
+                        <c:otherwise><fmt:message key="muc.default.settings.error" /></c:otherwise>
+                    </c:choose>
+                </admin:infobox>
+            </c:forEach>
+        </c:when>
+        <c:when test="${success}">
+            <admin:infobox type="success">
+                <fmt:message key="muc.default.settings.update" />
+            </admin:infobox>
+        </c:when>
+    </c:choose>
 
-<%  } else if (success) { %>
+    <!-- BEGIN 'Default Room Settings' -->
+    <form action="muc-default-settings.jsp?save" method="post">
 
-    <div class="jive-success">
-    <table cellpadding="0" cellspacing="0" border="0">
-    <tbody>
-        <tr><td class="jive-icon"><img src="images/success-16x16.gif" width="16" height="16" border="0" alt=""></td>
-        <td class="jive-icon-label">
-            <fmt:message key="muc.default.settings.update" />
-        </td></tr>
-    </tbody>
-    </table>
-    </div><br>
-
-<%  } %>
-
-<!-- BEGIN 'Default Room Settings' -->
-<form action="muc-default-settings.jsp?save" method="post">
     <input type="hidden" name="csrf" value="${csrf}">
-    <input type="hidden" name="mucname" value="<%= StringUtils.escapeForXML(mucname) %>" />
-    <div class="jive-contentBoxHeader">
-        <fmt:message key="muc.default.settings.title" />
-    </div>
-    <div class="jive-contentBox">
+    <input type="hidden" name="mucname" value="${fn:escapeXml(mucname)}" />
+
+    <fmt:message key="muc.default.settings.title" var="settingsTitle"/>
+    <admin:contentBox title="${settingsTitle}">
         <table cellpadding="3" cellspacing="0" border="0">
+            <colgroup>
+                <col style="width: 1%"/>
+                <col style="width: 99%"/>
+            </colgroup>
         <tbody>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_publicroom" value="true" id="publicRoom" type="checkbox"
-                    <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.publicRoom", true)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="publicRoom"><fmt:message key="muc.default.settings.public_room" /></label>
-                </td>
+                <td><input name="roomconfig_publicroom" value="true" id="publicRoom" type="checkbox" ${publicRoom ? 'checked' : ''}></td>
+                <td><label for="publicRoom"><fmt:message key="muc.default.settings.public_room" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_persistentroom" value="true" id="persistentRoom" type="checkbox"
-                    <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.persistent", false)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="persistentRoom"><fmt:message key="muc.default.settings.persistent_room" /></label>
-                </td>
+                <td><input name="roomconfig_persistentroom" value="true" id="persistentRoom" type="checkbox" ${persistent ? 'checked' : ''}></td>
+                <td><label for="persistentRoom"><fmt:message key="muc.default.settings.persistent_room" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_moderatedroom" value="true" id="moderated" type="checkbox"
-                    <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.moderated", false)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="moderated"><fmt:message key="muc.default.settings.moderated" /></label>
-                </td>
+                <td><input name="roomconfig_moderatedroom" value="true" id="moderated" type="checkbox" ${moderated ? 'checked' : ''}></td>
+                <td><label for="moderated"><fmt:message key="muc.default.settings.moderated" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_membersonly" value="true" id="membersOnly" type="checkbox"
-                    <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.membersOnly", false)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="membersOnly"><fmt:message key="muc.default.settings.members_only" /></label>
-                </td>
+                <td><input name="roomconfig_membersonly" value="true" id="membersOnly" type="checkbox" ${membersOnly ? 'checked' : ''}></td>
+                <td><label for="membersOnly"><fmt:message key="muc.default.settings.members_only" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_nonanonymous" value="true" id="nonanonymous" type="checkbox"
-                    <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.canAnyoneDiscoverJID", true)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="nonanonymous"><fmt:message key="muc.default.settings.can_anyone_discover_jid" /></label>
-                </td>
+                <td><input name="roomconfig_nonanonymous" value="true" id="nonanonymous" type="checkbox" ${canAnyoneDiscoverJID ? 'checked' : ''}></td>
+                <td><label for="nonanonymous"><fmt:message key="muc.default.settings.can_anyone_discover_jid" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_allowinvites" value="true" id="allowInvites" type="checkbox"
-                    <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.canOccupantsInvite", false)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="allowInvites"><fmt:message key="muc.default.settings.allow_invites" /></label>
-                </td>
+                <td><input name="roomconfig_allowinvites" value="true" id="allowInvites" type="checkbox" ${canOccupantsInvite ? 'checked' : ''}></td>
+                <td><label for="allowInvites"><fmt:message key="muc.default.settings.allow_invites" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_changesubject" value="true" id="changeSubject" type="checkbox"
-                    <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.canOccupantsChangeSubject", false)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="changeSubject"><fmt:message key="muc.default.settings.change_subject" /></label>
-                </td>
+                <td><input name="roomconfig_changesubject" value="true" id="changeSubject" type="checkbox" ${canOccupantsChangeSubject ? 'checked' : ''}></td>
+                <td><label for="changeSubject"><fmt:message key="muc.default.settings.change_subject" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_reservednick" value="true" id="reservedNick" type="checkbox"
-                    <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.loginRestrictedToNickname", false)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="reservedNick"><fmt:message key="muc.default.settings.reserved_nick" /></label>
-                </td>
+                <td><input name="roomconfig_reservednick" value="true" id="reservedNick" type="checkbox" ${loginRestrictedToNickname ? 'checked' : ''}></td>
+                <td><label for="reservedNick"><fmt:message key="muc.default.settings.reserved_nick" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_canchangenick" value="true" id="canChangeNick" type="checkbox"
-                    <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.canChangeNickname", true)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="canChangeNick"><fmt:message key="muc.default.settings.can_change_nick" /></label>
-                </td>
+                <td><input name="roomconfig_canchangenick" value="true" id="canChangeNick" type="checkbox" ${canChangeNickname ? 'checked' : ''}></td>
+                <td><label for="canChangeNick"><fmt:message key="muc.default.settings.can_change_nick" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_registration" value="true" id="registration" type="checkbox"
-                    <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.registrationEnabled", true)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="registration"><fmt:message key="muc.default.settings.registration" /></label>
-                </td>
+                <td><input name="roomconfig_registration" value="true" id="registration" type="checkbox" ${registrationEnabled ? 'checked' : ''}></td>
+                <td><label for="registration"><fmt:message key="muc.default.settings.registration" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_enablelogging" value="true" id="enableLogging" type="checkbox"
-                    <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.logEnabled", true)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="enableLogging"><fmt:message key="muc.default.settings.enable_logging" /></label>
-                </td>
+                <td><input name="roomconfig_enablelogging" value="true" id="enableLogging" type="checkbox" ${logEnabled ? 'checked' : ''}></td>
+                <td><label for="enableLogging"><fmt:message key="muc.default.settings.enable_logging" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    &nbsp;
-                </td>
-                <td width="99%">
+                <td>&nbsp;</td>
+                <td>
                     <label for="roomconfig_maxusers"><fmt:message key="muc.default.settings.max_users" />:</label>
-                    &nbsp;
-                    <input type="number" name="roomconfig_maxusers" id="roomconfig_maxusers" min="1" value="<%= MUCPersistenceManager.getIntProperty(mucname, "room.maxUsers", 30) == 0  ? "" : MUCPersistenceManager.getIntProperty(mucname, "room.maxUsers", 30)%>" size="5">
+                    <input type="number" name="roomconfig_maxusers" id="roomconfig_maxusers" min="1" value="${maxUsers eq 0 ? '' : maxUsers}" size="5">
                     <fmt:message key="muc.room.edit.form.empty_nolimit" />
                 </td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_broadcastmoderator" value="true" id="broadcastModerator" type="checkbox"
-                        <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.broadcastModerator", true)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="broadcastModerator"><fmt:message key="muc.default.settings.broadcast_presence_moderator" /></label>
-                </td>
+                <td><input name="roomconfig_broadcastmoderator" value="true" id="broadcastModerator" type="checkbox" ${broadcastModerator ? 'checked' : ''}></td>
+                <td><label for="broadcastModerator"><fmt:message key="muc.default.settings.broadcast_presence_moderator" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_broadcastparticipant" value="true" id="broadcastParticipant" type="checkbox"
-                        <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.broadcastParticipant", true)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="broadcastParticipant"><fmt:message key="muc.default.settings.broadcast_presence_participant" /></label>
-                </td>
+                <td><input name="roomconfig_broadcastparticipant" value="true" id="broadcastParticipant" type="checkbox" ${broadcastParticipant ? 'checked' : ''}></td>
+                <td><label for="broadcastParticipant"><fmt:message key="muc.default.settings.broadcast_presence_participant" /></label></td>
             </tr>
             <tr>
-                <td width="1%">
-                    <input name="roomconfig_broadcastvisitor" value="true" id="broadcastVisitor" type="checkbox"
-                        <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.broadcastVisitor", true)) ? "checked" : "") %>>
-                </td>
-                <td width="99%">
-                    <label for="broadcastVisitor"><fmt:message key="muc.default.settings.broadcast_presence_visitor" /></label>
-                </td>
+                <td><input name="roomconfig_broadcastvisitor" value="true" id="broadcastVisitor" type="checkbox" ${broadcastVisitor ? 'checked' : ''}></td>
+                <td><label for="broadcastVisitor"><fmt:message key="muc.default.settings.broadcast_presence_visitor" /></label></td>
             </tr>
             <tr>
                 <td>
@@ -378,19 +324,20 @@
                 </td>
                 <td><label for="allowpm"><fmt:message key="muc.default.settings.allowpm" /></label>
                     <select name="roomconfig_allowpm" id="allowpm">
-                        <option value="none" <% if ("none".equals( MUCPersistenceManager.getProperty(mucname, "room.allowpm", "anyone") )) out.write("selected");%>><fmt:message key="muc.default.settings.none" /></option>
-                        <option value="moderators" <% if ("moderators".equals( MUCPersistenceManager.getProperty(mucname, "room.allowpm", "anyone") )) out.write("selected");%>><fmt:message key="muc.default.settings.moderator" /></option>
-                        <option value="participants" <% if ("participants".equals( MUCPersistenceManager.getProperty(mucname, "room.allowpm", "anyone") )) out.write("selected");%>><fmt:message key="muc.default.settings.participant" /></option>
-                        <option value="anyone" <% if ("anyone".equals( MUCPersistenceManager.getProperty(mucname, "room.allowpm", "anyone") )) out.write("selected");%>><fmt:message key="muc.default.settings.anyone" /></option>
+                        <option value="none" ${allowpm eq 'none' ? 'selected' : ''}><fmt:message key="muc.default.settings.none" /></option>
+                        <option value="moderators" ${allowpm eq 'moderators' ? 'selected' : ''}><fmt:message key="muc.default.settings.moderator" /></option>
+                        <option value="participants" ${allowpm eq 'participants' ? 'selected' : ''}><fmt:message key="muc.default.settings.participant" /></option>
+                        <option value="anyone" ${allowpm eq 'anyone' ? 'selected' : ''}><fmt:message key="muc.default.settings.anyone" /></option>
                     </select>
                 </td>
             </tr>
         </tbody>
         </table>
-    </div>
+    </admin:contentBox>
     <input type="submit" value="<fmt:message key="global.save_settings" />">
-</form>
-<!-- END 'Default Room Settings' -->
+
+    </form>
+    <!-- END 'Default Room Settings' -->
 
 </body>
 </html>

--- a/xmppserver/src/main/webapp/muc-default-settings.jsp
+++ b/xmppserver/src/main/webapp/muc-default-settings.jsp
@@ -46,6 +46,10 @@
     String registrationEnabled = ParamUtils.getParameter(request, "roomconfig_registration");
     String enableLog = ParamUtils.getParameter(request, "roomconfig_enablelogging");
     String maxUsers = ParamUtils.getParameter(request, "roomconfig_maxusers");
+    String broadcastModerator = ParamUtils.getParameter(request, "roomconfig_broadcastmoderator");
+    String broadcastParticipant = ParamUtils.getParameter(request, "roomconfig_broadcastparticipant");
+    String broadcastVisitor = ParamUtils.getParameter(request, "roomconfig_broadcastvisitor");
+    String allowpm = ParamUtils.getParameter(request, "roomconfig_allowpm");
 
     if (!webManager.getMultiUserChatManager().isServiceRegistered(mucname)) {
         // The requested service name does not exist so return to the list of the existing rooms
@@ -77,6 +81,11 @@
         }
         catch (Exception e) {
             errors.put("max_users", "max_users");
+        }
+        if ( Arrays.asList("anyone", "moderators", "participants", "none").contains(allowpm)) {
+            MUCPersistenceManager.setProperty(mucname, "room.allowpm", allowpm);
+        } else {
+            errors.put("allowpm", "allowpm");
         }
         if (errors.size() == 0) {
             if (publicRoom != null && publicRoom.trim().length() > 0) {
@@ -145,6 +154,24 @@
             else {
                 MUCPersistenceManager.setProperty(mucname, "room.logEnabled", "false");
             }
+            if (broadcastModerator != null && broadcastModerator.trim().length() > 0) {
+                MUCPersistenceManager.setProperty(mucname, "room.broadcastModerator", "true");
+            }
+            else {
+                MUCPersistenceManager.setProperty(mucname, "room.broadcastModerator", "false");
+            }
+            if (broadcastParticipant != null && broadcastParticipant.trim().length() > 0) {
+                MUCPersistenceManager.setProperty(mucname, "room.broadcastParticipant", "true");
+            }
+            else {
+                MUCPersistenceManager.setProperty(mucname, "room.broadcastParticipant", "false");
+            }
+            if (broadcastVisitor != null && broadcastVisitor.trim().length() > 0) {
+                MUCPersistenceManager.setProperty(mucname, "room.broadcastVisitor", "true");
+            }
+            else {
+                MUCPersistenceManager.setProperty(mucname, "room.broadcastVisitor", "false");
+            }
         }
 
         response.sendRedirect("muc-default-settings.jsp?success=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
@@ -173,7 +200,11 @@
     <tbody>
         <tr><td class="jive-icon"><img src="images/error-16x16.gif" width="16" height="16" border="0" alt=""></td>
         <td class="jive-icon-label">
-        <fmt:message key="muc.default.settings.error" />
+        <% if (errors.get("csrf") != null) { %>
+            <fmt:message key="global.csrf.failed" />
+        <% } else {  %>
+            <fmt:message key="muc.default.settings.error" />
+        <% } %>
         </td></tr>
     </tbody>
     </table>
@@ -312,6 +343,46 @@
                     &nbsp;
                     <input type="number" name="roomconfig_maxusers" id="roomconfig_maxusers" min="1" value="<%= MUCPersistenceManager.getIntProperty(mucname, "room.maxUsers", 30) == 0  ? "" : MUCPersistenceManager.getIntProperty(mucname, "room.maxUsers", 30)%>" size="5">
                     <fmt:message key="muc.room.edit.form.empty_nolimit" />
+                </td>
+            </tr>
+            <tr>
+                <td width="1%">
+                    <input name="roomconfig_broadcastmoderator" value="true" id="broadcastModerator" type="checkbox"
+                        <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.broadcastModerator", true)) ? "checked" : "") %>>
+                </td>
+                <td width="99%">
+                    <label for="broadcastModerator"><fmt:message key="muc.default.settings.broadcast_presence_moderator" /></label>
+                </td>
+            </tr>
+            <tr>
+                <td width="1%">
+                    <input name="roomconfig_broadcastparticipant" value="true" id="broadcastParticipant" type="checkbox"
+                        <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.broadcastParticipant", true)) ? "checked" : "") %>>
+                </td>
+                <td width="99%">
+                    <label for="broadcastParticipant"><fmt:message key="muc.default.settings.broadcast_presence_participant" /></label>
+                </td>
+            </tr>
+            <tr>
+                <td width="1%">
+                    <input name="roomconfig_broadcastvisitor" value="true" id="broadcastVisitor" type="checkbox"
+                        <%= ((MUCPersistenceManager.getBooleanProperty(mucname, "room.broadcastVisitor", true)) ? "checked" : "") %>>
+                </td>
+                <td width="99%">
+                    <label for="broadcastVisitor"><fmt:message key="muc.default.settings.broadcast_presence_visitor" /></label>
+                </td>
+            </tr>
+            <tr>
+                <td>
+
+                </td>
+                <td><label for="allowpm"><fmt:message key="muc.default.settings.allowpm" /></label>
+                    <select name="roomconfig_allowpm" id="allowpm">
+                        <option value="none" <% if ("none".equals( MUCPersistenceManager.getProperty(mucname, "room.allowpm", "anyone") )) out.write("selected");%>><fmt:message key="muc.default.settings.none" /></option>
+                        <option value="moderators" <% if ("moderators".equals( MUCPersistenceManager.getProperty(mucname, "room.allowpm", "anyone") )) out.write("selected");%>><fmt:message key="muc.default.settings.moderator" /></option>
+                        <option value="participants" <% if ("participants".equals( MUCPersistenceManager.getProperty(mucname, "room.allowpm", "anyone") )) out.write("selected");%>><fmt:message key="muc.default.settings.participant" /></option>
+                        <option value="anyone" <% if ("anyone".equals( MUCPersistenceManager.getProperty(mucname, "room.allowpm", "anyone") )) out.write("selected");%>><fmt:message key="muc.default.settings.anyone" /></option>
+                    </select>
                 </td>
             </tr>
         </tbody>

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -22,8 +22,7 @@
                  java.text.DateFormat,
                  java.util.*,
                  org.jivesoftware.openfire.muc.MUCRoom,
-                 org.jivesoftware.openfire.forms.spi.*,
-                 org.jivesoftware.openfire.forms.*,
+                 org.xmpp.forms.*,
                  org.dom4j.Element,
                  org.xmpp.packet.IQ,
                  org.xmpp.packet.Message,
@@ -217,107 +216,44 @@
 
         if (errors.size() == 0) {
             // Set the new configuration sending an IQ packet with an dataform
-            FormField field;
-            XDataFormImpl dataForm = new XDataFormImpl(DataForm.TYPE_SUBMIT);
+            final DataForm dataForm = new DataForm(DataForm.Type.submit);
+            dataForm.addField(null, null, FormField.Type.hidden).addValue("http://jabber.org/protocol/muc#roomconfig");
+            dataForm.addField("muc#roomconfig_roomname", null, null).addValue(naturalName);
+            dataForm.addField("muc#roomconfig_roomdesc", null, null).addValue(description);
+            dataForm.addField("muc#roomconfig_changesubject", null, null).addValue((changeSubject == null) ? "0": "1");
+            dataForm.addField("muc#roomconfig_maxusers", null, null).addValue(maxUsers);
 
-            field = new XFormFieldImpl("FORM_TYPE");
-            field.setType(FormField.TYPE_HIDDEN);
-            field.addValue("http://jabber.org/protocol/muc#roomconfig");
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_roomname");
-            field.addValue(naturalName);
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_roomdesc");
-            field.addValue(description);
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_changesubject");
-            field.addValue((changeSubject == null) ? "0": "1");
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_maxusers");
-            field.addValue(maxUsers);
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_presencebroadcast");
+            final FormField broadcastField = dataForm.addField("muc#roomconfig_presencebroadcast", null, null);
             if (broadcastModerator != null) {
-                field.addValue("moderator");
+                broadcastField.addValue("moderator");
             }
             if (broadcastParticipant != null) {
-                field.addValue("participant");
+                broadcastField.addValue("participant");
             }
             if (broadcastVisitor != null) {
-                field.addValue("visitor");
+                broadcastField.addValue("visitor");
             }
-            dataForm.addField(field);
 
-            field = new XFormFieldImpl("muc#roomconfig_publicroom");
-            field.addValue((publicRoom == null) ? "0": "1");
-            dataForm.addField(field);
+            dataForm.addField("muc#roomconfig_publicroom", null, null).addValue((publicRoom == null) ? "0": "1");
+            dataForm.addField("muc#roomconfig_persistentroom", null, null).addValue((persistentRoom == null) ? "0": "1");
+            dataForm.addField("muc#roomconfig_moderatedroom", null, null).addValue((moderatedRoom == null) ? "0": "1");
+            dataForm.addField("muc#roomconfig_membersonly", null, null).addValue((membersOnly == null) ? "0": "1");
+            dataForm.addField("muc#roomconfig_allowinvites", null, null).addValue((allowInvites == null) ? "0": "1");
+            dataForm.addField("muc#roomconfig_passwordprotectedroom", null, null).addValue((password == null) ? "0": "1");
+            dataForm.addField("muc#roomconfig_roomsecret", null, null).addValue(password);
+            dataForm.addField("muc#roomconfig_whois", null, null).addValue(whois);
+            dataForm.addField("muc#roomconfig_allowpm", null, null).addValue(allowpm);
+            dataForm.addField("muc#roomconfig_enablelogging", null, null).addValue((enableLog == null) ? "0": "1");
+            dataForm.addField("x-muc#roomconfig_reservednick", null, null).addValue((reservedNick == null) ? "0": "1");
+            dataForm.addField("x-muc#roomconfig_canchangenick", null, null).addValue((canChangeNick == null) ? "0": "1");
+            dataForm.addField("x-muc#roomconfig_registration", null, null).addValue((registrationEnabled == null) ? "0": "1");
 
-            field = new XFormFieldImpl("muc#roomconfig_persistentroom");
-            field.addValue((persistentRoom == null) ? "0": "1");
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_moderatedroom");
-            field.addValue((moderatedRoom == null) ? "0": "1");
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_membersonly");
-            field.addValue((membersOnly == null) ? "0": "1");
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_allowinvites");
-            field.addValue((allowInvites == null) ? "0": "1");
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_passwordprotectedroom");
-            field.addValue((password == null) ? "0": "1");
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_roomsecret");
-            field.addValue(password);
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_whois");
-            field.addValue(whois);
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_allowpm");
-            field.addValue( allowpm );
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("muc#roomconfig_enablelogging");
-            field.addValue((enableLog == null) ? "0": "1");
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("x-muc#roomconfig_reservednick");
-            field.addValue((reservedNick == null) ? "0": "1");
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("x-muc#roomconfig_canchangenick");
-            field.addValue((canChangeNick == null) ? "0": "1");
-            dataForm.addField(field);
-
-            field = new XFormFieldImpl("x-muc#roomconfig_registration");
-            field.addValue((registrationEnabled == null) ? "0": "1");
-            dataForm.addField(field);
-
-            // Keep the existing list of admins
-            field = new XFormFieldImpl("muc#roomconfig_roomadmins");
-            for (JID jid : room.getAdmins()) {
-                field.addValue(jid.toString());
-            }
-            dataForm.addField(field);
+            final FormField roomAdminsField = dataForm.addField("muc#roomconfig_roomadmins", null, null);
+            room.getAdmins().forEach( admin -> roomAdminsField.addValue( admin.toString() ));
 
             // Keep the existing list of owners
-            field = new XFormFieldImpl("muc#roomconfig_roomowners");
-            for (JID jid : room.getOwners()) {
-                field.addValue(jid.toString());
-            }
-            dataForm.addField(field);
+            final FormField roomOwnersField = dataForm.addField("muc#roomconfig_roomowners", null, null);
+            room.getOwners().forEach( owner -> roomOwnersField.addValue( owner.toString() ));
 
             // update subject before sending IQ (to include subject with cluster update)
             if (roomSubject != null) {
@@ -333,7 +269,7 @@
             // Create an IQ packet and set the dataform as the main fragment
             IQ iq = new IQ(IQ.Type.set);
             Element element = iq.setChildElement("query", "http://jabber.org/protocol/muc#owner");
-            element.add(dataForm.asXMLElement());
+            element.add(dataForm.getElement());
             // Send the IQ packet that will modify the room's configuration
             room.getIQOwnerHandler().handleIQ(iq, room.getRole());
 

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -19,7 +19,6 @@
 <%@ page import="org.jivesoftware.util.ParamUtils,
                  org.jivesoftware.util.StringUtils,
                  org.jivesoftware.util.CookieUtils,
-                 java.text.DateFormat,
                  java.util.*,
                  org.jivesoftware.openfire.muc.MUCRoom,
                  org.xmpp.forms.*,
@@ -33,11 +32,12 @@
     errorPage="error.jsp"
 %>
 <%@ page import="org.jivesoftware.openfire.muc.NotAllowedException"%>
-<%@ page import="org.jivesoftware.openfire.muc.MultiUserChatService" %>
 <%@ page import="org.jivesoftware.openfire.muc.spi.MUCPersistenceManager" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib uri="admin" prefix="admin" %>
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
 <% webManager.init(request, response, session, application, out); %>
 
@@ -84,23 +84,23 @@
     String naturalName = ParamUtils.getParameter(request,"roomconfig_roomname");
     String description = ParamUtils.getParameter(request,"roomconfig_roomdesc");
     String maxUsers = ParamUtils.getParameter(request, "roomconfig_maxusers");
-    String broadcastModerator = ParamUtils.getParameter(request, "roomconfig_presencebroadcast");
-    String broadcastParticipant = ParamUtils.getParameter(request, "roomconfig_presencebroadcast2");
-    String broadcastVisitor = ParamUtils.getParameter(request, "roomconfig_presencebroadcast3");
+    boolean broadcastModerator = ParamUtils.getBooleanParameter(request, "roomconfig_presencebroadcast");
+    boolean broadcastParticipant = ParamUtils.getBooleanParameter(request, "roomconfig_presencebroadcast2");
+    boolean broadcastVisitor = ParamUtils.getBooleanParameter(request, "roomconfig_presencebroadcast3");
     String password = ParamUtils.getParameter(request, "roomconfig_roomsecret");
     String confirmPassword = ParamUtils.getParameter(request, "roomconfig_roomsecret2");
     String whois = ParamUtils.getParameter(request, "roomconfig_whois");
     String allowpm = ParamUtils.getParameter(request, "roomconfig_allowpm");
-    String publicRoom = ParamUtils.getParameter(request, "roomconfig_publicroom");
-    String persistentRoom = ParamUtils.getParameter(request, "roomconfig_persistentroom");
-    String moderatedRoom = ParamUtils.getParameter(request, "roomconfig_moderatedroom");
-    String membersOnly = ParamUtils.getParameter(request, "roomconfig_membersonly");
-    String allowInvites = ParamUtils.getParameter(request, "roomconfig_allowinvites");
-    String changeSubject = ParamUtils.getParameter(request, "roomconfig_changesubject");
-    String enableLog = ParamUtils.getParameter(request, "roomconfig_enablelogging");
-    String reservedNick = ParamUtils.getParameter(request, "roomconfig_reservednick");
-    String canChangeNick = ParamUtils.getParameter(request, "roomconfig_canchangenick");
-    String registrationEnabled = ParamUtils.getParameter(request, "roomconfig_registration");
+    boolean publicRoom = ParamUtils.getBooleanParameter(request, "roomconfig_publicroom");
+    boolean persistentRoom = ParamUtils.getBooleanParameter(request, "roomconfig_persistentroom");
+    boolean moderatedRoom = ParamUtils.getBooleanParameter(request, "roomconfig_moderatedroom");
+    boolean membersOnly = ParamUtils.getBooleanParameter(request, "roomconfig_membersonly");
+    boolean allowInvites = ParamUtils.getBooleanParameter(request, "roomconfig_allowinvites");
+    boolean changeSubject = ParamUtils.getBooleanParameter(request, "roomconfig_changesubject");
+    boolean enableLog = ParamUtils.getBooleanParameter(request, "roomconfig_enablelogging");
+    boolean reservedNick = ParamUtils.getBooleanParameter(request, "roomconfig_reservednick");
+    boolean canchangenick = ParamUtils.getBooleanParameter(request, "roomconfig_canchangenick");
+    boolean registration = ParamUtils.getBooleanParameter(request, "roomconfig_registration");
     String roomSubject = ParamUtils.getParameter(request, "room_topic", true);
 
     if (webManager.getMultiUserChatManager().getMultiUserChatServicesCount() < 1) {
@@ -217,36 +217,36 @@
         if (errors.size() == 0) {
             // Set the new configuration sending an IQ packet with an dataform
             final DataForm dataForm = new DataForm(DataForm.Type.submit);
-            dataForm.addField(null, null, FormField.Type.hidden).addValue("http://jabber.org/protocol/muc#roomconfig");
+            dataForm.addField("FORM_TYPE", null, FormField.Type.hidden).addValue("http://jabber.org/protocol/muc#roomconfig");
             dataForm.addField("muc#roomconfig_roomname", null, null).addValue(naturalName);
             dataForm.addField("muc#roomconfig_roomdesc", null, null).addValue(description);
-            dataForm.addField("muc#roomconfig_changesubject", null, null).addValue((changeSubject == null) ? "0": "1");
+            dataForm.addField("muc#roomconfig_changesubject", null, null).addValue(changeSubject ? "1": "0");
             dataForm.addField("muc#roomconfig_maxusers", null, null).addValue(maxUsers);
 
             final FormField broadcastField = dataForm.addField("muc#roomconfig_presencebroadcast", null, null);
-            if (broadcastModerator != null) {
+            if (broadcastModerator) {
                 broadcastField.addValue("moderator");
             }
-            if (broadcastParticipant != null) {
+            if (broadcastParticipant) {
                 broadcastField.addValue("participant");
             }
-            if (broadcastVisitor != null) {
+            if (broadcastVisitor) {
                 broadcastField.addValue("visitor");
             }
 
-            dataForm.addField("muc#roomconfig_publicroom", null, null).addValue((publicRoom == null) ? "0": "1");
-            dataForm.addField("muc#roomconfig_persistentroom", null, null).addValue((persistentRoom == null) ? "0": "1");
-            dataForm.addField("muc#roomconfig_moderatedroom", null, null).addValue((moderatedRoom == null) ? "0": "1");
-            dataForm.addField("muc#roomconfig_membersonly", null, null).addValue((membersOnly == null) ? "0": "1");
-            dataForm.addField("muc#roomconfig_allowinvites", null, null).addValue((allowInvites == null) ? "0": "1");
+            dataForm.addField("muc#roomconfig_publicroom", null, null).addValue(publicRoom ? "1": "0");
+            dataForm.addField("muc#roomconfig_persistentroom", null, null).addValue(persistentRoom ? "1": "0");
+            dataForm.addField("muc#roomconfig_moderatedroom", null, null).addValue(moderatedRoom ? "1": "0");
+            dataForm.addField("muc#roomconfig_membersonly", null, null).addValue(membersOnly ? "1": "0");
+            dataForm.addField("muc#roomconfig_allowinvites", null, null).addValue(allowInvites ? "1": "0");
             dataForm.addField("muc#roomconfig_passwordprotectedroom", null, null).addValue((password == null) ? "0": "1");
             dataForm.addField("muc#roomconfig_roomsecret", null, null).addValue(password);
             dataForm.addField("muc#roomconfig_whois", null, null).addValue(whois);
             dataForm.addField("muc#roomconfig_allowpm", null, null).addValue(allowpm);
-            dataForm.addField("muc#roomconfig_enablelogging", null, null).addValue((enableLog == null) ? "0": "1");
-            dataForm.addField("x-muc#roomconfig_reservednick", null, null).addValue((reservedNick == null) ? "0": "1");
-            dataForm.addField("x-muc#roomconfig_canchangenick", null, null).addValue((canChangeNick == null) ? "0": "1");
-            dataForm.addField("x-muc#roomconfig_registration", null, null).addValue((registrationEnabled == null) ? "0": "1");
+            dataForm.addField("muc#roomconfig_enablelogging", null, null).addValue(enableLog ? "1": "0");
+            dataForm.addField("x-muc#roomconfig_reservednick", null, null).addValue(reservedNick ? "1": "0");
+            dataForm.addField("x-muc#roomconfig_canchangenick", null, null).addValue(canchangenick ? "1": "0");
+            dataForm.addField("x-muc#roomconfig_registration", null, null).addValue(registration ? "1": "0");
 
             final FormField roomAdminsField = dataForm.addField("muc#roomconfig_roomadmins", null, null);
             room.getAdmins().forEach( admin -> roomAdminsField.addValue( admin.toString() ));
@@ -297,323 +297,354 @@
             // service is a very uncommon scenario, this is an acceptable shortcut.
             final String serviceName = webManager.getMultiUserChatManager().getMultiUserChatServices().iterator().next().getServiceName();
             maxUsers = MUCPersistenceManager.getProperty(serviceName, "room.maxUsers", "30");
-            broadcastModerator = MUCPersistenceManager.getProperty(serviceName, "room.broadcastModerator", "true");
-            broadcastParticipant = MUCPersistenceManager.getProperty(serviceName, "room.broadcastParticipant", "true");
-            broadcastVisitor = MUCPersistenceManager.getProperty(serviceName, "room.broadcastVisitor", "true");
+            broadcastModerator = MUCPersistenceManager.getBooleanProperty(serviceName, "room.broadcastModerator", true);
+            broadcastParticipant = MUCPersistenceManager.getBooleanProperty(serviceName, "room.broadcastParticipant", true);
+            broadcastVisitor = MUCPersistenceManager.getBooleanProperty(serviceName, "room.broadcastVisitor", true);
             whois = MUCPersistenceManager.getBooleanProperty(serviceName, "room.canAnyoneDiscoverJID", true) ? "anyone" : "moderator";
             allowpm = MUCPersistenceManager.getProperty(serviceName, "room.allowpm", "anyone");
-            publicRoom = MUCPersistenceManager.getProperty(serviceName, "room.publicRoom", "true");
-            persistentRoom = "true"; // Rooms created from the admin console are always persistent
-            moderatedRoom = MUCPersistenceManager.getProperty(serviceName, "room.moderated", "false");
-            membersOnly = MUCPersistenceManager.getProperty(serviceName, "room.membersOnly", "false");
-            allowInvites = MUCPersistenceManager.getProperty(serviceName, "room.canOccupantsInvite", "false");
-            changeSubject = MUCPersistenceManager.getProperty(serviceName, "room.canOccupantsChangeSubject", "false");
-            enableLog = MUCPersistenceManager.getProperty(serviceName, "room.logEnabled", "true");
-            reservedNick = MUCPersistenceManager.getProperty(serviceName, "room.loginRestrictedToNickname", "false");
-            canChangeNick = MUCPersistenceManager.getProperty(serviceName, "room.canChangeNickname", "true");
-            registrationEnabled = MUCPersistenceManager.getProperty(serviceName, "room.registrationEnabled", "true");
+            publicRoom = MUCPersistenceManager.getBooleanProperty(serviceName, "room.publicRoom", true);
+            persistentRoom = true; // Rooms created from the admin console are always persistent
+            moderatedRoom = MUCPersistenceManager.getBooleanProperty(serviceName, "room.moderated", false);
+            membersOnly = MUCPersistenceManager.getBooleanProperty(serviceName, "room.membersOnly", false);
+            allowInvites = MUCPersistenceManager.getBooleanProperty(serviceName, "room.canOccupantsInvite", false);
+            changeSubject = MUCPersistenceManager.getBooleanProperty(serviceName, "room.canOccupantsChangeSubject", false);
+            enableLog = MUCPersistenceManager.getBooleanProperty(serviceName, "room.logEnabled", true);
+            reservedNick = MUCPersistenceManager.getBooleanProperty(serviceName, "room.loginRestrictedToNickname", false);
+            canchangenick = MUCPersistenceManager.getBooleanProperty(serviceName, "room.canChangeNickname", true);
+            registration = MUCPersistenceManager.getBooleanProperty(serviceName, "room.registrationEnabled", true);
         }
         else {
             naturalName = room.getNaturalLanguageName();
             description = room.getDescription();
             roomSubject = room.getSubject();
             maxUsers = Integer.toString(room.getMaxUsers());
-            broadcastModerator = Boolean.toString(room.canBroadcastPresence("moderator"));
-            broadcastParticipant = Boolean.toString(room.canBroadcastPresence("participant"));
-            broadcastVisitor = Boolean.toString(room.canBroadcastPresence("visitor"));
+            broadcastModerator = room.canBroadcastPresence("moderator");
+            broadcastParticipant = room.canBroadcastPresence("participant");
+            broadcastVisitor = room.canBroadcastPresence("visitor");
             password = room.getPassword();
             confirmPassword = room.getPassword();
             whois = (room.canAnyoneDiscoverJID() ? "anyone" : "moderator");
             allowpm = room.canSendPrivateMessage();
-            publicRoom = Boolean.toString(room.isPublicRoom());
-            persistentRoom = Boolean.toString(room.isPersistent());
-            moderatedRoom = Boolean.toString(room.isModerated());
-            membersOnly = Boolean.toString(room.isMembersOnly());
-            allowInvites = Boolean.toString(room.canOccupantsInvite());
-            changeSubject = Boolean.toString(room.canOccupantsChangeSubject());
-            enableLog = Boolean.toString(room.isLogEnabled());
-            reservedNick = Boolean.toString(room.isLoginRestrictedToNickname());
-            canChangeNick = Boolean.toString(room.canChangeNickname());
-            registrationEnabled = Boolean.toString(room.isRegistrationEnabled());
+            publicRoom = room.isPublicRoom();
+            persistentRoom = room.isPersistent();
+            moderatedRoom = room.isModerated();
+            membersOnly = room.isMembersOnly();
+            allowInvites = room.canOccupantsInvite();
+            changeSubject = room.canOccupantsChangeSubject();
+            enableLog = room.isLogEnabled();
+            reservedNick = room.isLoginRestrictedToNickname();
+            canchangenick = room.canChangeNickname();
+            registration = room.isRegistrationEnabled();
         }
     }
-    // Formatter for dates
-    DateFormat dateFormatter = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT);
     roomName = roomName == null ? "" : roomName;
+
+    pageContext.setAttribute("errors", errors);
+    pageContext.setAttribute("create", create);
+    pageContext.setAttribute("success", success);
+    pageContext.setAttribute("addsuccess", addsuccess);
+    pageContext.setAttribute("room", room);
+    pageContext.setAttribute("roomJID", roomJID);
+    pageContext.setAttribute("roomJIDBare", roomJID != null ? roomJID.toBareJID() : null);
+    pageContext.setAttribute("persistentRoom", persistentRoom);
+    pageContext.setAttribute("roomName", roomName);
+    pageContext.setAttribute("mucName", mucName);
+    pageContext.setAttribute("naturalName", naturalName);
+    pageContext.setAttribute("description", description);
+    pageContext.setAttribute("roomSubject", roomSubject);
+    pageContext.setAttribute("maxUser", maxUsers);
+    pageContext.setAttribute("broadcastModerator", broadcastModerator);
+    pageContext.setAttribute("broadcastParticipant", broadcastParticipant);
+    pageContext.setAttribute("broadcastVisitor", broadcastVisitor);
+    pageContext.setAttribute("password", password);
+    pageContext.setAttribute("confirmPassword", confirmPassword);
+    pageContext.setAttribute("whois", whois);
+    pageContext.setAttribute("allowpm", allowpm);
+    pageContext.setAttribute("publicRoom", publicRoom);
+    pageContext.setAttribute("moderatedRoom", moderatedRoom);
+    pageContext.setAttribute("membersonly", membersOnly);
+    pageContext.setAttribute("allowInvites", allowInvites);
+    pageContext.setAttribute("changeSubject", changeSubject);
+    pageContext.setAttribute("reservedNick", reservedNick);
+    pageContext.setAttribute("canchangenick", canchangenick);
+    pageContext.setAttribute("registration", registration);
+    pageContext.setAttribute("enableLog", enableLog);
+
 %>
 
 <html>
-<head>
-<% if (create) { %>
-<title><fmt:message key="muc.room.edit.form.create.title"/></title>
-<meta name="pageID" content="muc-room-create"/>
-<% } else { %>
-<title><fmt:message key="muc.room.edit.form.edit.title"/></title>
-<meta name="subPageID" content="muc-room-edit-form"/>
-<% } %>
-<meta name="extraParams" content="<%= "roomJID="+(roomJID != null ? URLEncoder.encode(roomJID.toBareJID(), "UTF-8") : "")+"&create="+create %>"/>
-<meta name="helpPage" content="view_group_chat_room_summary.html"/>
-</head>
-<body>
+    <head>
+        <c:choose>
+            <c:when test="${create}">
+                <title><fmt:message key="muc.room.edit.form.create.title"/></title>
+                <meta name="pageID" content="muc-room-create"/>
+            </c:when>
+            <c:otherwise>
+                <title><fmt:message key="muc.room.edit.form.edit.title"/></title>
+                <meta name="subPageID" content="muc-room-edit-form"/>
+            </c:otherwise>
+        </c:choose>
 
-<%  if (!errors.isEmpty()) { %>
+        <meta name="extraParams" content="<%= "roomJID="+(roomJID != null ? URLEncoder.encode(roomJID.toBareJID(), "UTF-8") : "")+"&create="+create %>"/>
+        <meta name="helpPage" content="view_group_chat_room_summary.html"/>
+    </head>
+    <body>
 
-    <div class="jive-error">
-    <table cellpadding="0" cellspacing="0" border="0">
-    <tbody>
+    <c:choose>
+        <c:when test="${not empty errors}">
+            <c:forEach var="err" items="${errors}">
+                <admin:infobox type="error">
+                    <c:choose>
+                        <c:when test="${err.key eq 'csrf'}"><fmt:message key="global.csrf.failed" /></c:when>
+                        <c:when test="${err.key eq 'roomconfig_roomname'}"><fmt:message key="muc.room.edit.form.valid_hint_name" /></c:when>
+                        <c:when test="${err.key eq 'roomconfig_roomdesc'}"><fmt:message key="muc.room.edit.form.valid_hint_description" /></c:when>
+                        <c:when test="${err.key eq 'roomconfig_maxusers'}"><fmt:message key="muc.room.edit.form.valid_hint_max_room" /></c:when>
+                        <c:when test="${err.key eq 'roomconfig_roomsecret2'}"><fmt:message key="muc.room.edit.form.new_password" /></c:when>
+                        <c:when test="${err.key eq 'roomconfig_whois'}"><fmt:message key="muc.room.edit.form.role" /></c:when>
+                        <c:when test="${err.key eq 'roomconfig_allowpm'}"><fmt:message key="muc.room.edit.form.role" /></c:when>
+                        <c:when test="${err.key eq 'roomName'}"><fmt:message key="muc.room.edit.form.valid_hint" /></c:when>
+                        <c:when test="${err.key eq 'room_already_exists'}"><fmt:message key="muc.room.edit.form.error_created_id" /></c:when>
+                        <c:when test="${err.key eq 'not_enough_permissions'}"><fmt:message key="muc.room.edit.form.error_created_privileges" /></c:when>
+                        <c:when test="${err.key eq 'room_topic'}"><fmt:message key="muc.room.edit.form.valid_hint_subject" /></c:when>
+                        <c:when test="${err.key eq 'room_topic_longer'}"><fmt:message key="muc.room.edit.form.valid_hint_subject_too_long" /></c:when>
+                        <c:otherwise>
+                            <c:if test="${not empty err.value}">
+                                <fmt:message key="admin.error"/>: <c:out value="${err.value}"/>
+                            </c:if>
+                            (<c:out value="${err.key}"/>)
+                        </c:otherwise>
+                    </c:choose>
+                </admin:infobox>
+            </c:forEach>
+        </c:when>
+        <c:when test="${success}">
+            <admin:infobox type="success">
+                <fmt:message key="muc.room.edit.form.edited" />
+            </admin:infobox>
+        </c:when>
+        <c:when test="${addsuccess}">
+            <admin:infobox type="success">
+                <fmt:message key="muc.room.edit.form.created" />
+            </admin:infobox>
+        </c:when>
+    </c:choose>
+
+    <c:choose>
+        <c:when test="${not create}">
+            <p>
+                <fmt:message key="muc.room.edit.form.info" />
+            </p>
+            <div class="jive-table">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                    <thead>
+                    <tr>
+                        <th scope="col"><fmt:message key="muc.room.edit.form.room_id" /></th>
+                        <th scope="col"><fmt:message key="muc.room.edit.form.users" /></th>
+                        <th scope="col"><fmt:message key="muc.room.edit.form.on" /></th>
+                        <th scope="col"><fmt:message key="muc.room.edit.form.modified" /></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>
+                            <c:out value="${room.name}"/>
+                        </td>
+                        <td>
+                            <c:choose>
+                                <c:when test="${room.occupantsCount eq 0}">
+                                    <c:out value="${room.occupantsCount}"/>
+                                    <c:if test="${room.maxUsers gt 0}">
+                                        / <c:out value="${room.maxUsers}"/>
+                                    </c:if>
+                                </c:when>
+                                <c:otherwise>
+                                    <c:url var="mucroomoccupantslink" value="muc-room-occupants.jsp">
+                                        <c:param name="roomJID" value="${roomJIDBare}"/>
+                                    </c:url>
+                                    <a href="${mucroomoccupantslink}">
+                                        <c:out value="${room.occupantsCount}"/>
+                                        <c:if test="${room.maxUsers gt 0}">
+                                            / <c:out value="${room.maxUsers}"/>
+                                        </c:if>
+                                    </a>
+                                </c:otherwise>
+                            </c:choose>
+                        </td>
+                        <td>
+                            <fmt:formatDate value="${room.creationDate}" dateStyle="medium" timeStyle="short"/>
+                        </td>
+                        <td>
+                            <fmt:formatDate value="${room.modificationDate}" dateStyle="medium" timeStyle="short"/>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <br>
+            <p><fmt:message key="muc.room.edit.form.change_room" /></p>
+        </c:when>
+        <c:otherwise>
+            <p><fmt:message key="muc.room.edit.form.persistent_room" /></p>
+        </c:otherwise>
+    </c:choose>
+
+    <form action="muc-room-edit-form.jsp">
+        <c:if test="${not create}">
+            <input type="hidden" name="roomJID" value="${fn:escapeXml(roomJIDBare)}">
+        </c:if>
+        <input type="hidden" name="csrf" value="${csrf}">
+        <input type="hidden" name="save" value="true">
+        <input type="hidden" name="create" value="${create}">
+        <input type="hidden" name="roomconfig_persistentroom" value="${persistentRoom}">
+
+    <table width="100%" border="0">
         <tr>
-            <td class="jive-icon"><img src="images/error-16x16.gif" width="16" height="16" border="0" alt=""/></td>
-            <td class="jive-icon-label">
-
-            <% if (errors.get("csrf") != null) { %>
-                <fmt:message key="global.csrf.failed" />
-            <% } if (errors.get("roomconfig_roomname") != null) { %>
-                <fmt:message key="muc.room.edit.form.valid_hint_name" />
-            <% } if (errors.get("roomconfig_roomdesc") != null) { %>
-                <fmt:message key="muc.room.edit.form.valid_hint_description" />
-            <% } if (errors.get("roomconfig_maxusers") != null) { %>
-                <fmt:message key="muc.room.edit.form.valid_hint_max_room" />
-            <% } if (errors.get("roomconfig_roomsecret2") != null) { %>
-                <fmt:message key="muc.room.edit.form.new_password" />
-            <% } if (errors.get("roomconfig_whois") != null) { %>
-                <fmt:message key="muc.room.edit.form.role" />
-            <% } if (errors.get("roomconfig_allowpm") != null) { %>
-                <fmt:message key="muc.room.edit.form.role" />
-            <% } if (errors.get("roomName") != null) { %>
-                <fmt:message key="muc.room.edit.form.valid_hint" />
-            <% } if (errors.get("room_already_exists") != null) { %>
-                <fmt:message key="muc.room.edit.form.error_created_id" />
-            <% } if (errors.get("not_enough_permissions") != null) { %>
-                <fmt:message key="muc.room.edit.form.error_created_privileges" />
-            <% } if (errors.get("room_topic") != null) { %>
-                <fmt:message key="muc.room.edit.form.valid_hint_subject" />
-            <% } if (errors.get("room_topic_longer") != null) { %>
-                <fmt:message key="muc.room.edit.form.valid_hint_subject_too_long" />
-            <% } %>
-            </td>
-        </tr>
-    </tbody>
-    </table>
-    </div><br>
-
-<%  } else if (success || addsuccess) { %>
-
-    <div class="jive-success">
-    <table cellpadding="0" cellspacing="0" border="0">
-    <tbody>
-        <tr><td class="jive-icon"><img src="images/success-16x16.gif" width="16" height="16" border="0" alt=""></td>
-        <td class="jive-icon-label">
-        <%  if (success) { %>
-
-        <fmt:message key="muc.room.edit.form.edited" />
-
-        <%  } else if (addsuccess) { %>
-
-        <fmt:message key="muc.room.edit.form.created" />
-
-        <%  } %>
-        </td></tr>
-    </tbody>
-    </table>
-    </div><br>
-
-<%  } %>
-
-<%  if (!create) { %>
-    <p>
-    <fmt:message key="muc.room.edit.form.info" />
-    </p>
-    <div class="jive-table">
-    <table cellpadding="0" cellspacing="0" border="0" width="100%">
-    <thead>
-        <tr>
-            <th scope="col"><fmt:message key="muc.room.edit.form.room_id" /></th>
-            <th scope="col"><fmt:message key="muc.room.edit.form.users" /></th>
-            <th scope="col"><fmt:message key="muc.room.edit.form.on" /></th>
-            <th scope="col"><fmt:message key="muc.room.edit.form.modified" /></th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><%= StringUtils.escapeHTMLTags(room.getName()) %></td>
-            <td><% if (room.getOccupantsCount() == 0) { %>
-                    <%= room.getOccupantsCount() %>
-                    <% if (room.getMaxUsers() > 0 ) { %>
-                        / <%= room.getMaxUsers() %>
-                    <% } %>
-                <% } else { %>
-                    <a href="muc-room-occupants.jsp?roomJID=<%= URLEncoder.encode(roomJID.toBareJID(), "UTF-8")%>"><%= room.getOccupantsCount() %>
-                    <% if (room.getMaxUsers() > 0 ) { %>
-                        / <%= room.getMaxUsers() %>
-                    <% } %>
-                    </a>
-                <% } %>
-            </td>
-            <td><%= dateFormatter.format(room.getCreationDate()) %></td>
-            <td><%= dateFormatter.format(room.getModificationDate()) %></td>
-        </tr>
-    </tbody>
-    </table>
-    </div>
-    <br>
-    <p><fmt:message key="muc.room.edit.form.change_room" /></p>
-<%  } else { %>
-    <p><fmt:message key="muc.room.edit.form.persistent_room" /></p>
-<%  } %>
-<form action="muc-room-edit-form.jsp">
-<% if (!create) { %>
-    <input type="hidden" name="roomJID" value="<%= StringUtils.escapeForXML(roomJID.toBareJID()) %>">
-<% } %>
-    <input type="hidden" name="csrf" value="${csrf}">
-<input type="hidden" name="save" value="true">
-<input type="hidden" name="create" value="<%= create %>">
-<input type="hidden" name="roomconfig_persistentroom" value="<%= persistentRoom %>">
-
-    <table width="100%" border="0"> <tr>
-         <td width="70%">
-            <table width="100%" border="0">
+            <td width="70%">
+                <table width="100%" border="0">
                 <tbody>
-                <% if (create) { %>
-                <tr>
-                    <td><fmt:message key="muc.room.edit.form.room_id" />: *</td>
-                    <td><input type="text" name="roomName" value="<%= StringUtils.escapeForXML(roomName) %>">
-                        <% if (webManager.getMultiUserChatManager().getMultiUserChatServicesCount() > 1) { %>
-                        @<select name="mucName">
-                        <% for (MultiUserChatService service : webManager.getMultiUserChatManager().getMultiUserChatServices()) { %>
-                        <%      if (service.isHidden()) continue; %>
-                        <option value="<%= StringUtils.escapeForXML(service.getServiceDomain()) %>"<%= service.getServiceDomain().equals(mucName) ? " selected='selected'" : "" %>><%= StringUtils.escapeHTMLTags(service.getServiceDomain()) %></option>
-                        <% } %>
-                        </select>
-                        <% } else { %>
-                        @<%
-                            // We only have one service, none-the-less, we have to run through the list to get the first
-                            for (MultiUserChatService service : webManager.getMultiUserChatManager().getMultiUserChatServices()) {
-                                if (service.isHidden()) {
-                                    // Private and hidden, skip it.
-                                    continue;
-                                }
-                                out.print("<input type='hidden' name='mucName' value='"+StringUtils.escapeForXML(service.getServiceDomain())+"'/>"+StringUtils.escapeHTMLTags(service.getServiceDomain()));
-                                break;
-                            }
-                        %>
-                        <% } %>
-                    </td>
-                </tr>
-                <% } else { %>
-                <tr>
-                   <td><fmt:message key="muc.room.edit.form.service" />:</td>
-                   <td><%= StringUtils.escapeHTMLTags(roomJID.getDomain()) %></td>
-               </tr>
-                <% } %>
-                 <tr>
-                    <td><fmt:message key="muc.room.edit.form.room_name" />: *</td>
-                    <td><input type="text" name="roomconfig_roomname" value="<%= (naturalName == null ? "" : StringUtils.escapeForXML(naturalName)) %>">
-                    </td>
-                </tr>
-                 <tr>
-                    <td><fmt:message key="muc.room.edit.form.description" />:  *</td>
-                    <td><input name="roomconfig_roomdesc" value="<%= (description == null ? "" : StringUtils.escapeForXML(description)) %>" type="text" size="40">
-                    </td>
-                </tr>
-                 <tr>
-                    <td><fmt:message key="muc.room.edit.form.topic" />:</td>
-                    <td><input name="room_topic" value="<%= (roomSubject == null ? "" : StringUtils.escapeForXML(roomSubject)) %>" type="text" size="40">
-                    </td>
-                </tr>
-                 <tr>
-                    <td><fmt:message key="muc.room.edit.form.max_room" />:</td>
-                    <td><input type="number" name="roomconfig_maxusers" min="1" value="<%= maxUsers == null || maxUsers.equals("0") ? "" : StringUtils.escapeForXML(maxUsers)%>" size="5">
-                        <fmt:message key="muc.room.edit.form.empty_nolimit" />
-                    </td>
-                </tr>
-                 <tr>
-                    <td valign="top"><fmt:message key="muc.room.edit.form.broadcast" />:</td>
-                    <td><fieldset>
-                        <input name="roomconfig_presencebroadcast" type="checkbox" value="true" id="moderator" <% if ("true".equals(broadcastModerator)) out.write("checked");%>>
-                        <LABEL FOR="moderator"><fmt:message key="muc.room.edit.form.moderator" /></LABEL>
-                        <input name="roomconfig_presencebroadcast2" type="checkbox" value="true" id="participant" <% if ("true".equals(broadcastParticipant)) out.write("checked");%>>
-                        <LABEL FOR="participant"><fmt:message key="muc.room.edit.form.participant" /></LABEL>
-                        <input name="roomconfig_presencebroadcast3" type="checkbox" value="true" id="visitor" <% if ("true".equals(broadcastVisitor)) out.write("checked");%>>
-                        <LABEL FOR="visitor"><fmt:message key="muc.room.edit.form.visitor" /></LABEL>
-                        </fieldset></td>
-                </tr>
-                 <tr>
-                    <td><fmt:message key="muc.room.edit.form.required_password" />:</td>
-                    <td><input type="password" name="roomconfig_roomsecret" <% if(password != null) { %> value="<%= (password == null ? "" : StringUtils.escapeForXML(password)) %>" <% } %>></td>
-                </tr>
-                 <tr>
-                    <td><fmt:message key="muc.room.edit.form.confirm_password" />:</td>
-                    <td><input type="password" name="roomconfig_roomsecret2" <% if(confirmPassword != null) { %> value="<%= (confirmPassword == null ? "" : StringUtils.escapeForXML(confirmPassword)) %>" <% } %>>
-                    </td>
-                </tr>
-                 <tr>
-                    <td><fmt:message key="muc.room.edit.form.discover_jid" />:</td>
-                    <td><select name="roomconfig_whois">
-                            <option value="moderator" <% if ("moderator".equals(whois)) out.write("selected");%>><fmt:message key="muc.room.edit.form.moderator" /></option>
-                            <option value="anyone" <% if ("anyone".equals(whois)) out.write("selected");%>><fmt:message key="muc.room.edit.form.anyone" /></option>
-                        </select>
-                    </td>
-                 </tr>
-                <tr>
-                    <td><fmt:message key="muc.room.edit.form.allowpm" />:</td>
-                    <td><select name="roomconfig_allowpm">
-                        <option value="none" <% if ("none".equals( allowpm )) out.write("selected");%>><fmt:message key="muc.form.conf.none" /></option>
-                        <option value="moderators" <% if ("moderators".equals( allowpm )) out.write("selected");%>><fmt:message key="muc.room.edit.form.moderator" /></option>
-                        <option value="participants" <% if ("participants".equals( allowpm )) out.write("selected");%>><fmt:message key="muc.room.edit.form.participant" /></option>
-                        <option value="anyone" <% if ("anyone".equals( allowpm )) out.write("selected");%>><fmt:message key="muc.room.edit.form.anyone" /></option>
-                    </select>
-                    </td>
-                </tr>
-         </tbody>
-         </table>
-
-         </td>
-        <td width="30%" valign="top" >
-        <fieldset>
-        <legend><fmt:message key="muc.room.edit.form.room_options" /></legend>
-        <table width="100%"  border="0">
-        <tbody>
-            <tr>
-                <td><input type="checkbox" name="roomconfig_publicroom" value="true" id="public" <% if ("true".equals(publicRoom)) out.write("checked");%>>
-                    <LABEL FOR="public"><fmt:message key="muc.room.edit.form.list_room" /></LABEL></td>
-            </tr>
-            <tr>
-                <td><input type="checkbox" name="roomconfig_moderatedroom" value="true" id="moderated" <% if ("true".equals(moderatedRoom)) out.write("checked");%>>
-                    <LABEL FOR="moderated"><fmt:message key="muc.room.edit.form.room_moderated" /></LABEL></td>
-            </tr>
-            <tr>
-                <td><input type="checkbox" name="roomconfig_membersonly" value="true" id="membersOnly" <% if ("true".equals(membersOnly)) out.write("checked");%>>
-                    <LABEL FOR="membersOnly"><fmt:message key="muc.room.edit.form.moderated_member_only" /></LABEL></td>
-            </tr>
-            <tr>
-                <td><input type="checkbox" name="roomconfig_allowinvites" value="true" id="allowinvites" <% if ("true".equals(allowInvites)) out.write("checked");%>>
-                    <LABEL FOR="allowinvites"><fmt:message key="muc.room.edit.form.invite_other" /></LABEL></td>
-            </tr>
-            <tr>
-                <td><input type="checkbox" name="roomconfig_changesubject" value="true" id="changesubject" <% if ("true".equals(changeSubject)) out.write("checked");%>>
-                    <LABEL FOR="changesubject"><fmt:message key="muc.room.edit.form.change_subject" /></LABEL></td>
-            </tr>
-            <tr>
-                <td><input type="checkbox" name="roomconfig_reservednick" value="true" id="reservednick" <% if ("true".equals(reservedNick)) out.write("checked");%>>
-                    <LABEL FOR="reservednick"><fmt:message key="muc.room.edit.form.reservednick" /></LABEL></td>
-            </tr>
-            <tr>
-                <td><input type="checkbox" name="roomconfig_canchangenick" value="true" id="canchangenick" <% if ("true".equals(canChangeNick)) out.write("checked");%>>
-                    <LABEL FOR="canchangenick"><fmt:message key="muc.room.edit.form.canchangenick" /></LABEL></td>
-            </tr>
-            <tr>
-                <td><input type="checkbox" name="roomconfig_registration" value="true" id="registration" <% if ("true".equals(registrationEnabled)) out.write("checked");%>>
-                    <LABEL FOR="registration"><fmt:message key="muc.room.edit.form.registration" /></LABEL></td>
-            </tr>
-            <tr>
-                <td><input type="checkbox" name="roomconfig_enablelogging" value="true" id="enablelogging" <% if ("true".equals(enableLog)) out.write("checked");%>>
-                    <LABEL FOR="enablelogging"><fmt:message key="muc.room.edit.form.log" /></LABEL></td>
-            </tr>
-        </tbody>
-        </table>
-        </fieldset>
+                    <tr>
+                        <c:choose>
+                            <c:when test="${create}">
+                                <td><label for="roomName"><fmt:message key="muc.room.edit.form.room_id" /></label>: *</td>
+                                <td><input type="text" name="roomName" id="roomName" value="${fn:escapeXml(roomName)}">
+                                    <c:choose>
+                                        <c:when test="${webManager.multiUserChatManager.multiUserChatServicesCount gt 1}">
+                                            @<select name="mucName">
+                                            <c:forEach var="service" items="${webManager.multiUserChatManager.multiUserChatServices}">
+                                                <c:if test="${not service.hidden}">
+                                                    <option value="${fn:escapeXml(service.serviceDomain)}" ${service.serviceDomain eq mucName ? "selected='selected'" : ""}>
+                                                        <c:out value="${service.serviceDomain}"/>
+                                                    </option>
+                                                </c:if>
+                                            </c:forEach>
+                                            </select>
+                                        </c:when>
+                                        <c:otherwise>
+                                            <c:forEach var="service" items="${webManager.multiUserChatManager.multiUserChatServices}">
+                                                <c:if test="${not service.hidden}">
+                                                    <input type="hidden" name="mucName" value="${fn:escapeXml(service.serviceDomain)}"/>
+                                                    @<c:out value="${service.serviceDomain}"/>
+                                                </c:if>
+                                            </c:forEach>
+                                        </c:otherwise>
+                                    </c:choose>
+                                </td>
+                            </c:when>
+                            <c:otherwise>
+                                <td><fmt:message key="muc.room.edit.form.service" />:</td>
+                                <td><c:out value="${roomJID.domain}"/>/td>
+                            </c:otherwise>
+                        </c:choose>
+                    </tr>
+                    <tr>
+                        <td><label for="roomconfig_roomname"><fmt:message key="muc.room.edit.form.room_name" /></label>: *</td>
+                        <td><input type="text" name="roomconfig_roomname" id="roomconfig_roomname" value="${empty naturalName ? "" : fn:escapeXml(naturalName)}"></td>
+                    </tr>
+                    <tr>
+                        <td><label for="roomconfig_roomdesc"><fmt:message key="muc.room.edit.form.description" /></label>:  *</td>
+                        <td><input name="roomconfig_roomdesc" id="roomconfig_roomdesc" value="${empty description ? "" : fn:escapeXml(description)}" type="text" size="40"></td>
+                    </tr>
+                    <tr>
+                        <td><label for="room_topic"><fmt:message key="muc.room.edit.form.topic" /></label>:</td>
+                        <td><input name="room_topic" id="room_topic" value="${empty roomSubject ? "" : fn:escapeXml(roomSubject)}" type="text" size="40"></td>
+                    </tr>
+                    <tr>
+                        <td><label for="roomconfig_maxusers"><fmt:message key="muc.room.edit.form.max_room" /></label>:</td>
+                        <td><input type="number" name="roomconfig_maxusers" id="roomconfig_maxusers" min="1" value="${empty maxUser or maxUser eq '0' ? "" : fn:escapeXml(maxUser)}" size="5">
+                            <fmt:message key="muc.room.edit.form.empty_nolimit" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td valign="top"><fmt:message key="muc.room.edit.form.broadcast" />:</td>
+                        <td>
+                            <fieldset>
+                                <input name="roomconfig_presencebroadcast" type="checkbox" value="true" id="moderator" ${broadcastModerator ? 'checked' : ''}>
+                                <label for="moderator"><fmt:message key="muc.room.edit.form.moderator" /></label>
+                                <input name="roomconfig_presencebroadcast2" type="checkbox" value="true" id="participant" ${broadcastParticipant ? 'checked' : ''}>
+                                <label for="participant"><fmt:message key="muc.room.edit.form.participant" /></label>
+                                <input name="roomconfig_presencebroadcast3" type="checkbox" value="true" id="visitor" ${broadcastVisitor ? 'checked' : ''}>
+                                <label for="visitor"><fmt:message key="muc.room.edit.form.visitor" /></label>
+                            </fieldset>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><label for="roomconfig_roomsecret"><fmt:message key="muc.room.edit.form.required_password" /></label>:</td>
+                        <td><input type="password" name="roomconfig_roomsecret" id="roomconfig_roomsecret" <c:if test="${not empty password}">value="${fn:escapeXml(password)}"</c:if>></td>
+                    </tr>
+                    <tr>
+                        <td><label for="roomconfig_roomsecret2"><fmt:message key="muc.room.edit.form.confirm_password" /></label>:</td>
+                        <td><input type="password" name="roomconfig_roomsecret2" id="roomconfig_roomsecret2" <c:if test="${not empty confirmPassword}">value="${fn:escapeXml(confirmPassword)}"</c:if>></td>
+                    </tr>
+                    <tr>
+                        <td><label for="roomconfig_whois"><fmt:message key="muc.room.edit.form.discover_jid" /></label>:</td>
+                        <td>
+                            <select name="roomconfig_whois" id="roomconfig_whois">
+                                <option value="moderator" ${whois eq 'moderator' ? 'selected' : ''}><fmt:message key="muc.room.edit.form.moderator" /></option>
+                                <option value="anyone" ${whois eq 'anyone' ? 'selected' : ''}><fmt:message key="muc.room.edit.form.anyone" /></option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><label for="roomconfig_allowpm"><fmt:message key="muc.room.edit.form.allowpm" /></label>:</td>
+                        <td>
+                            <select name="roomconfig_allowpm" id="roomconfig_allowpm">
+                                <option value="none" ${allowpm eq 'none' ? 'selected' : ''}><fmt:message key="muc.form.conf.none" /></option>
+                                <option value="moderators" ${allowpm eq 'moderators' ? 'selected' : ''}><fmt:message key="muc.room.edit.form.moderator" /></option>
+                                <option value="participants" ${allowpm eq 'participants' ? 'selected' : ''}><fmt:message key="muc.room.edit.form.participant" /></option>
+                                <option value="anyone" ${allowpm eq 'anyone' ? 'selected' : ''}><fmt:message key="muc.room.edit.form.anyone" /></option>
+                            </select>
+                        </td>
+                    </tr>
+                </tbody>
+                </table>
+            </td>
+            <td width="30%" valign="top">
+                <fieldset>
+                    <legend><fmt:message key="muc.room.edit.form.room_options" /></legend>
+                    <table width="100%"  border="0">
+                    <tbody>
+                        <tr>
+                            <td><input type="checkbox" name="roomconfig_publicroom" value="true" id="public" ${publicRoom ? 'checked' : ''}>
+                                <label for="public"><fmt:message key="muc.room.edit.form.list_room" /></label></td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="roomconfig_moderatedroom" value="true" id="moderated" ${moderatedRoom ? 'checked' : ''}>
+                                <label for="moderated"><fmt:message key="muc.room.edit.form.room_moderated" /></label></td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="roomconfig_membersonly" value="true" id="membersonly" ${membersonly ? 'checked' : ''}>
+                                <label for="membersonly"><fmt:message key="muc.room.edit.form.moderated_member_only" /></label></td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="roomconfig_allowinvites" value="true" id="allowinvites" ${allowInvites ? 'checked' : ''}>
+                                <label for="allowinvites"><fmt:message key="muc.room.edit.form.invite_other" /></label></td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="roomconfig_changesubject" value="true" id="changesubject" ${changeSubject ? 'checked' : ''}>
+                                <label for="changesubject"><fmt:message key="muc.room.edit.form.change_subject" /></label></td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="roomconfig_reservednick" value="true" id="reservednick"${reservedNick ? 'checked' : ''}>
+                                <label for="reservednick"><fmt:message key="muc.room.edit.form.reservednick" /></label></td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="roomconfig_canchangenick" value="true" id="canchangenick" ${canchangenick ? 'checked' : ''}>
+                                <label for="canchangenick"><fmt:message key="muc.room.edit.form.canchangenick" /></label></td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="roomconfig_registration" value="true" id="registration" ${registration ? 'checked' : ''}>
+                                <label for="registration"><fmt:message key="muc.room.edit.form.registration" /></label></td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="roomconfig_enablelogging" value="true" id="enablelogging" ${enableLog ? 'checked' : ''}>
+                                <label for="enablelogging"><fmt:message key="muc.room.edit.form.log" /></label></td>
+                        </tr>
+                    </tbody>
+                    </table>
+                </fieldset>
+            </td>
         </tr>
-         <tr align="center">
+        <tr align="center">
             <td colspan="2"><input type="submit" name="Submit" value="<fmt:message key="global.save_changes" />">
             <input type="submit" name="cancel" value="<fmt:message key="global.cancel" />"></td>
         </tr>


### PR DESCRIPTION
MUC services have configurable default settings to be applied to new rooms. These defaults are already used when an end-user creates a room (through XMPP).

This commit takes applies the same settings to the room creation form that is in the Admin console, with one exemption: rooms created in the admin console are always persistent.

Note that it's possible to configure Openfire with more than one MUC service. If that's the case, selecting the MUC service in which the room is to be created is part of the room creation form. As at that point, the to-be-used service is still unknown, the (other) default values that are used on the same form are based on the first available service. That seems to be an acceptable trade-off, given the limited amount of installs that have more than one MUC service.