### PR TITLE
OF-1966: Allow Japanese i18n to be selected.

### DIFF
--- a/xmppserver/src/main/webapp/server-locale.jsp
+++ b/xmppserver/src/main/webapp/server-locale.jsp
@@ -180,6 +180,15 @@
             </tr>
             <tr>
                 <td>
+                    <input type="radio" name="localeCode" value="ja_JP" <%= ("ja_JP".equals(locale.toString()) ? "checked" : "") %>
+                           id="locja" />
+                </td>
+                <td colspan="2">
+                    <label for="locja">日本語 (ja_JP)</label>
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <input type="radio" name="localeCode" value="nl" <%= ("nl".equals(locale.toString()) ? "checked" : "") %>
                      id="loc06" />
                 </td>

--- a/xmppserver/src/main/webapp/setup/index.jsp
+++ b/xmppserver/src/main/webapp/setup/index.jsp
@@ -283,6 +283,11 @@
                                 <b>Fran&ccedil;ais</b> (fr)
                             </label><br>
 
+                            <label for="locJa">
+                                <input type="radio" name="localeCode" value="ja_JP" ${locale eq 'ja_JP' ? 'checked' : ''} id="locJa" />
+                                <b>日本語</b> (ja_JP)
+                            </label><br>
+
                             <label for="loc06">
                                 <input type="radio" name="localeCode" value="nl" ${locale eq 'nl' ? 'checked' : ''} id="loc06" />
                                 <b>Nederlands</b> (nl)


### PR DESCRIPTION
Openfire has Japanese translation, but lacked the option to select that translation. This commit rectifies that.