### PR TITLE
OF-1983: Add flags to skip setup

### DIFF
--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -111,11 +111,19 @@ if [ ! -x "$JAVACMD" ] ; then
   	exit 1
 fi
 
+# Note: you can combine options, eg: -devboot -debug
 for arguments in "$@"
 do
 case $arguments in
     -debug)
     JAVACMD="$JAVACMD -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+    ;;
+    -demoboot)
+    cp $OPENFIRE_HOME/conf/openfire-demoboot.xml $OPENFIRE_HOME/conf/openfire.xml
+    ;;
+    -devboot)
+    HOSTNAME=$(hostname)
+    sed "s/example.org/$HOSTNAME/g" $OPENFIRE_HOME/conf/openfire-demoboot.xml > $OPENFIRE_HOME/conf/openfire.xml
     ;;
     *)
 	# unknown option


### PR DESCRIPTION
Adding arguments to openfire.sh that allows Openfire to be started, without a need to go through the web-based setup.
- demoboot: starts with fqdn and xmpp domain set to 'example.org', admin account: admin/admin
- devboot: same, but replaces 'example.org' with the hostname of the computer running Openfire.

hattip @Fishbowler 