### PR TITLE
OF-1984: Replace DummyExternalizableUtil

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultExternalizableUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultExternalizableUtil.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright (C) 2020 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.util.cache;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Default serialization strategy.
+ *
+ * @author Tom Evans
+ * @author Gaston Dombiak
+ */
+// Note that this implementation is heavily based on the implementation provided by the 'clustering' plugin in
+// org.jivesoftware.openfire.plugin.util.cache.ClusterExternalizableUtil - if changes are made to either implementation,
+// it's likely that the other implementation needs a similar change. See https://issues.igniterealtime.org/browse/OF-1984
+public class DefaultExternalizableUtil implements ExternalizableUtilStrategy {
+
+    /**
+     * Writes a Map of String key and value pairs. This method handles the
+     * case when the Map is <tt>null</tt>.
+     *
+     * @param out       the output stream.
+     * @param stringMap the Map of String key/value pairs.
+     * @throws java.io.IOException if an error occurs.
+     */
+    public void writeStringMap(DataOutput out, Map<String, String> stringMap) throws IOException {
+        writeObject(out, stringMap);
+    }
+
+    /**
+     * Reads a Map of String key and value pairs. This method will return
+     * <tt>null</tt> if the Map written to the stream was <tt>null</tt>.
+     *
+     * @param in the input stream.
+     * @return a Map of String key/value pairs.
+     * @throws IOException if an error occurs.
+     */
+    public Map<String, String> readStringMap(DataInput in) throws IOException {
+        return (Map<String, String>) readObject(in);
+    }
+
+    /**
+     * Writes a Map of String key and Set of Strings value pairs. This method DOES NOT handle the
+     * case when the Map is <tt>null</tt>.
+     *
+     * @param out       the output stream.
+     * @param map       the Map of String key and Set of Strings value pairs.
+     * @throws java.io.IOException if an error occurs.
+     */
+    public void writeStringsMap(DataOutput out, Map<String, Set<String>> map) throws IOException {
+        writeObject(out, map);
+    }
+
+    /**
+     * Reads a Map of String key and Set of Strings value pairs.
+     *
+     * @param in the input stream.
+     * @param map a Map of String key and Set of Strings value pairs.
+     * @return number of elements added to the collection.
+     * @throws IOException if an error occurs.
+     */
+    public int readStringsMap(DataInput in, Map<String, Set<String>> map) throws IOException {
+        Map<String, Set<String>> result = (Map<String, Set<String>>) readObject(in);
+        if (result == null) return 0;
+        map.putAll(result);
+        return result.size();
+    }
+
+    /**
+     * Writes a Map of Long key and Integer value pairs. This method handles
+     * the case when the Map is <tt>null</tt>.
+     *
+     * @param out the output stream.
+     * @param map the Map of Long key/Integer value pairs.
+     * @throws IOException if an error occurs.
+     */
+    public void writeLongIntMap(DataOutput out, Map<Long, Integer> map) throws IOException {
+        writeObject(out, map);
+    }
+
+    /**
+     * Reads a Map of Long key and Integer value pairs. This method will return
+     * <tt>null</tt> if the Map written to the stream was <tt>null</tt>.
+     *
+     * @param in the input stream.
+     * @return a Map of Long key/Integer value pairs.
+     * @throws IOException if an error occurs.
+     */
+    public Map<Long, Integer> readLongIntMap(DataInput in) throws IOException {
+        return (Map<Long, Integer>) readObject(in);
+    }
+
+    /**
+     * Writes a List of Strings. This method handles the case when the List is
+     * <tt>null</tt>.
+     *
+     * @param out        the output stream.
+     * @param stringList the List of Strings.
+     * @throws IOException if an error occurs.
+     */
+    public void writeStringList(DataOutput out, List<String> stringList) throws IOException {
+        writeObject(out, stringList);
+    }
+
+    /**
+     * Reads a List of Strings. This method will return <tt>null</tt> if the List
+     * written to the stream was <tt>null</tt>.
+     *
+     * @param in the input stream.
+     * @return a List of Strings.
+     * @throws IOException if an error occurs.
+     */
+    public List<String> readStringList(DataInput in) throws IOException {
+        return (List<String>) readObject(in);
+    }
+
+    /**
+     * Writes an array of long values. This method handles the case when the
+     * array is <tt>null</tt>.
+     *
+     * @param out   the output stream.
+     * @param array the array of long values.
+     * @throws IOException if an error occurs.
+     */
+    public void writeLongArray(DataOutput out, long [] array) throws IOException {
+        writeObject(out, array);
+    }
+
+    /**
+     * Reads an array of long values. This method will return <tt>null</tt> if
+     * the array written to the stream was <tt>null</tt>.
+     *
+     * @param in the input stream.
+     * @return an array of long values.
+     * @throws IOException if an error occurs.
+     */
+    public long [] readLongArray(DataInput in) throws IOException {
+        return (long []) readObject(in);
+    }
+
+    public void writeLong(DataOutput out, long value) throws IOException {
+        writeObject(out, value);
+    }
+
+    public long readLong(DataInput in) throws IOException {
+        return (Long) readObject(in);
+    }
+
+    public void writeByteArray(DataOutput out, byte[] value) throws IOException {
+        writeObject(out, value);
+    }
+
+    public byte[] readByteArray(DataInput in) throws IOException {
+        return (byte []) readObject(in);
+    }
+
+    public void writeInt(DataOutput out, int value) throws IOException {
+        writeObject(out, value);
+    }
+
+    public int readInt(DataInput in) throws IOException {
+        return (Integer) readObject(in);
+    }
+
+    public void writeBoolean(DataOutput out, boolean value) throws IOException {
+        writeObject(out, value);
+    }
+
+    public boolean readBoolean(DataInput in) throws IOException {
+        return (Boolean) readObject(in);
+    }
+
+    public void writeSerializable(DataOutput out, Serializable value) throws IOException {
+        writeObject(out, value);
+    }
+
+    public Serializable readSerializable(DataInput in) throws IOException {
+        return (Serializable) readObject(in);
+    }
+
+    public void writeSafeUTF(DataOutput out, String value) throws IOException {
+        writeObject(out, value);
+    }
+
+    public String readSafeUTF(DataInput in) throws IOException {
+        return (String) readObject(in);
+    }
+
+    /**
+     * Writes a collection of Externalizable objects. The collection passed as a parameter
+     * must be a collection and not a <tt>null</null> value.
+     *
+     * @param out   the output stream.
+     * @param value the collection of Externalizable objects. This value must not be null.
+     * @throws IOException if an error occurs.
+     */
+    public void writeExternalizableCollection(DataOutput out, Collection<? extends Externalizable> value) throws IOException {
+        writeObject(out, value);
+    }
+
+    /**
+     * Writes a collection of Serializable objects. The collection passed as a parameter
+     * must be a collection and not a <tt>null</null> value.
+     *
+     * @param out   the output stream.
+     * @param value the collection of Serializable objects. This value must not be null.
+     * @throws IOException if an error occurs.
+     */
+    public void writeSerializableCollection(DataOutput out, Collection<? extends Serializable> value) throws IOException {
+        writeObject(out, value);
+    }
+
+    /**
+     * Reads a collection of Externalizable objects and adds them to the collection passed as a parameter. The
+     * collection passed as a parameter must be a collection and not a <tt>null</null> value.
+     *
+     * @param in the input stream.
+     * @param value the collection of Externalizable objects. This value must not be null.
+     * @param loader class loader to use to build elements inside of the serialized collection.
+     * @throws IOException if an error occurs.
+     * @return the number of elements added to the collection.
+     */
+    public int readExternalizableCollection(DataInput in, Collection<? extends Externalizable> value, ClassLoader loader) throws IOException {
+        Collection<Externalizable> result = (Collection<Externalizable>) readObject(in);
+        if (result == null) return 0;
+        ((Collection<Externalizable>)value).addAll(result);
+        return result.size();
+    }
+
+    /**
+     * Reads a collection of Serializable objects and adds them to the collection passed as a parameter. The
+     * collection passed as a parameter must be a collection and not a <tt>null</null> value.
+     *
+     * @param in the input stream.
+     * @param value the collection of Serializable objects. This value must not be null.
+     * @param loader class loader to use to build elements inside of the serialized collection.
+     * @throws IOException if an error occurs.
+     * @return the number of elements added to the collection.
+     */
+    public int readSerializableCollection(DataInput in, Collection<? extends Serializable> value, ClassLoader loader) throws IOException {
+        Collection<Serializable> result = (Collection<Serializable>) readObject(in);
+        if (result == null) return 0;
+        ((Collection<Serializable>)value).addAll(result);
+        return result.size();
+    }
+
+    /**
+     * Writes a Map of String key and value pairs. This method handles the
+     * case when the Map is <tt>null</tt>.
+     *
+     * @param out       the output stream.
+     * @param map       the Map of String key and Externalizable value pairs.
+     * @throws java.io.IOException if an error occurs.
+     */
+    public void writeExternalizableMap(DataOutput out, Map<String, ? extends Externalizable> map) throws IOException {
+        writeObject(out, map);
+    }
+
+    /**
+     * Writes a Map of Serializable key and value pairs. This method handles the
+     * case when the Map is <tt>null</tt>.
+     *
+     * @param out       the output stream.
+     * @param map       the Map of Serializable key and value pairs.
+     * @throws java.io.IOException if an error occurs.
+     */
+    public void writeSerializableMap(DataOutput out, Map<? extends Serializable, ? extends Serializable> map) throws IOException {
+        writeObject(out, map);
+    }
+
+    /**
+     * Reads a Map of String key and value pairs. This method will return
+     * <tt>null</tt> if the Map written to the stream was <tt>null</tt>.
+     *
+     * @param in the input stream.
+     * @param map a Map of String key and Externalizable value pairs.
+     * @param loader class loader to use to build elements inside of the serialized collection.
+     * @throws IOException if an error occurs.
+     * @return the number of elements added to the collection.
+     */
+    public int readExternalizableMap(DataInput in, Map<String, ? extends Externalizable> map, ClassLoader loader) throws IOException {
+        Map<String, Externalizable> result = (Map<String, Externalizable>) readObject(in);
+        if (result == null) return 0;
+        ((Map<String, Externalizable>)map).putAll(result);
+        return result.size();
+    }
+
+    /**
+     * Reads a Map of Serializable key and value pairs. This method will return
+     * <tt>null</tt> if the Map written to the stream was <tt>null</tt>.
+     *
+     * @param in the input stream.
+     * @param map a Map of Serializable key and value pairs.
+     * @param loader class loader to use to build elements inside of the serialized collection.
+     * @throws IOException if an error occurs.
+     * @return the number of elements added to the collection.
+     */
+    public int readSerializableMap(DataInput in, Map<? extends Serializable, ? extends Serializable> map, ClassLoader loader) throws IOException {
+        Map<String, Serializable> result = (Map<String, Serializable>) readObject(in);
+        if (result == null) return 0;
+        ((Map<String, Serializable>)map).putAll(result);
+        return result.size();
+    }
+
+    public void writeStrings(DataOutput out, Collection<String> collection) throws IOException {
+        writeObject(out, collection);
+    }
+
+    public int readStrings(DataInput in, Collection<String> collection) throws IOException {
+        Collection<String> result = (Collection<String>) readObject(in);
+        if (result == null) return 0;
+        collection.addAll(result);
+        return result.size();
+    }
+
+    // serialization helpers
+
+    public static void writeObject(DataOutput out, Object obj) throws IOException {
+        if (obj == null) {
+            out.writeByte(0);
+        } else if (obj instanceof Long) {
+            out.writeByte(1);
+            out.writeLong((Long) obj);
+        } else if (obj instanceof Integer) {
+            out.writeByte(2);
+            out.writeInt((Integer) obj);
+        } else if (obj instanceof String) {
+            out.writeByte(3);
+            out.writeUTF((String) obj);
+        } else if (obj instanceof Double) {
+            out.writeByte(4);
+            out.writeDouble((Double) obj);
+        } else if (obj instanceof Float) {
+            out.writeByte(5);
+            out.writeFloat((Float) obj);
+        } else if (obj instanceof Boolean) {
+            out.writeByte(6);
+            out.writeBoolean((Boolean) obj);
+        } else if (obj instanceof Date) {
+            out.writeByte(8);
+            out.writeLong(((Date) obj).getTime());
+        } else if(obj instanceof byte[]){
+            out.writeByte(9);
+            // write length
+            out.writeInt(((byte[]) obj).length);
+            // write byte array
+            out.write((byte[]) obj);
+        } else {
+            out.writeByte(10);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(bos);
+            oos.writeObject(obj);
+            oos.close();
+            byte[] buf = bos.toByteArray();
+            out.writeInt(buf.length);
+            out.write(buf);
+        }
+    }
+
+    public static Object readObject(DataInput in) throws IOException {
+        byte type = in.readByte();
+        if (type == 0) {
+            return null;
+        } else if (type == 1) {
+            return in.readLong();
+        } else if (type == 2) {
+            return in.readInt();
+        } else if (type == 3) {
+            return in.readUTF();
+        } else if (type == 4) {
+            return in.readDouble();
+        } else if (type == 5) {
+            return in.readFloat();
+        } else if (type == 6) {
+            return in.readBoolean();
+        } else if (type == 8) {
+            return new Date(in.readLong());
+        } else if (type == 9) {
+            byte[] buf = new byte[in.readInt()];
+            in.readFully(buf);
+            return buf;
+        } else if (type == 10) {
+            int len = in.readInt();
+            byte[] buf = new byte[len];
+            in.readFully(buf);
+            ObjectInputStream oin = newObjectInputStream(new ByteArrayInputStream(buf));
+            try {
+                return oin.readObject();
+            } catch (ClassNotFoundException e) {
+                throw new IOException(e);
+            } finally {
+                oin.close();
+            }
+        } else {
+            throw new IOException("Unknown object type=" + type);
+        }
+    }
+
+    public static ObjectInputStream newObjectInputStream(final InputStream in) throws IOException {
+        return new ObjectInputStream(in) {
+            @Override
+            protected Class<?> resolveClass(final ObjectStreamClass desc) throws ClassNotFoundException {
+                return loadClass(desc.getName());
+            }
+        };
+    }
+
+    public static Class<?> loadClass(final String className) throws ClassNotFoundException {
+        return loadClass(null, className);
+    }
+
+    public static Class<?> loadClass(final ClassLoader classLoader, final String className) throws ClassNotFoundException {
+        if (className == null) {
+            throw new IllegalArgumentException("ClassName cannot be null!");
+        }
+        if (className.length() <= MAX_PRIM_CLASSNAME_LENGTH && Character.isLowerCase(className.charAt(0))) {
+            for (int i = 0; i < PRIMITIVE_CLASSES_ARRAY.length; i++) {
+                if (className.equals(PRIMITIVE_CLASSES_ARRAY[i].getName())) {
+                    return PRIMITIVE_CLASSES_ARRAY[i];
+                }
+            }
+        }
+        ClassLoader theClassLoader = classLoader;
+
+        if (theClassLoader == null) {
+            theClassLoader = Thread.currentThread().getContextClassLoader();
+        }
+        if (theClassLoader != null) {
+            if (className.startsWith("[")) {
+                return Class.forName(className, true, theClassLoader);
+            } else {
+                return theClassLoader.loadClass(className);
+            }
+        }
+        return Class.forName(className);
+    }
+
+    private static final Class[] PRIMITIVE_CLASSES_ARRAY = {int.class, long.class, boolean.class, byte.class,
+        float.class, double.class, byte.class, char.class, short.class, void.class};
+    private static final int MAX_PRIM_CLASSNAME_LENGTH = 7; // boolean.class.getName().length();
+
+
+}

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/DummyExternalizableUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/DummyExternalizableUtil.java
@@ -23,7 +23,9 @@ import java.util.*;
  * strategy.
  *
  * @author Gaston Dombiak
+ * @deprecated Use {@link DefaultExternalizableUtil} which, unlike this implementation, provides actual serialization functionality.
  */
+@Deprecated
 public class DummyExternalizableUtil implements ExternalizableUtilStrategy {
     /**
      * Writes a Map of String key and value pairs. This method handles the

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ExternalizableUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ExternalizableUtil.java
@@ -37,7 +37,7 @@ public class ExternalizableUtil {
 
     private static ExternalizableUtil instance = new ExternalizableUtil();
 
-    private ExternalizableUtilStrategy strategy = new DummyExternalizableUtil();
+    private ExternalizableUtilStrategy strategy = new DefaultExternalizableUtil();
 
     static {
         instance = new ExternalizableUtil();

--- a/xmppserver/src/test/java/org/jivesoftware/util/cache/DefaultExternalizableUtilTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/cache/DefaultExternalizableUtilTest.java
@@ -1,0 +1,622 @@
+/*
+ * Copyright (C) 2020 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.util.cache;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.*;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Verifies functionality as implemented by {@link DefaultExternalizableUtil}
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class DefaultExternalizableUtilTest
+{
+    private Bus bus;
+
+    @Before
+    public void setupBus() {
+        bus = new Bus();
+    }
+
+    /**
+     * Asserts that the process of writing and reading a map of Strings through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    @Test
+    public void testWriteReadStringMap() throws Exception
+    {
+        // Setup fixture.
+        final Map<String, String> input = new HashMap<>();
+        input.put("foo", "\uD834\uDD1E");
+        input.put("\uD834\uDD1E", "bar");
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeStringMap(bus.getDataOutput(), input);
+        final Map<String, String> result = new DefaultExternalizableUtil().readStringMap(bus.getDataInput());
+
+        // Verify result.
+        assertTrue(areEqualString(input, result ));
+    }
+
+    /**
+     * Asserts that the process of writing and reading a map of Strings through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the map contains a null value.
+     */
+    @Test
+    public void testWriteReadStringMapNullValue() throws Exception
+    {
+        // Setup fixture.
+        final Map<String, String> input = new HashMap<>();
+        input.put("foo", null);
+        input.put("\uD834\uDD1E", "bar");
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeStringMap(bus.getDataOutput(), input);
+        final Map<String, String> result = new DefaultExternalizableUtil().readStringMap(bus.getDataInput());
+
+        // Verify result.
+        assertTrue(areEqualString(input, result ));
+    }
+
+    /**
+     * Asserts that the process of writing and reading a map of Strings through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the map is empty.
+     */
+    @Test
+    public void testWriteReadStringMapEmpty() throws Exception
+    {
+        // Setup fixture.
+        final Map<String, String> input = new HashMap<>();
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeStringMap(bus.getDataOutput(), input);
+        final Map<String, String> result = new DefaultExternalizableUtil().readStringMap(bus.getDataInput());
+
+        // Verify result.
+        assertTrue(areEqualString(input, result ));
+    }
+
+    /**
+     * Asserts that the process of writing and reading a map of a Set of Strings through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    @Test
+    public void testWriteReadStringsMap() throws Exception
+    {
+        // Setup fixture.
+        final Map<String, Set<String>> input = new HashMap<>();
+        final Set<String> firstSet = new HashSet<>();
+        firstSet.add("\uD834\uDD1E");
+        firstSet.add("foo bar");
+        input.put("bar", firstSet);
+
+        final Set<String> secondSet = new HashSet<>();
+        secondSet.add("bar");
+        secondSet.add("foo");
+        input.put("\uD834\uDD1E", secondSet);
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeStringsMap(bus.getDataOutput(), input);
+        final Map<String, Set<String>> result = new HashMap<>();
+        final int reportedCount = new DefaultExternalizableUtil().readStringsMap(bus.getDataInput(), result);
+
+        // Verify result.
+        assertEquals(2, reportedCount);
+        assertTrue(areEqualStrings(input, result));
+    }
+
+    /**
+     * Asserts that the process of writing and reading a map of a Set of Strings through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the map contains a null value.
+     */
+    @Test
+    public void testWriteReadStringsMapNullValue() throws Exception
+    {
+        // Setup fixture.
+        final Map<String, Set<String>> input = new HashMap<>();
+        final Set<String> firstSet = new HashSet<>();
+        firstSet.add("\uD834\uDD1E");
+        firstSet.add("foo bar");
+        input.put("bar", firstSet);
+
+        input.put("\uD834\uDD1E", null);
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeStringsMap(bus.getDataOutput(), input);
+        final Map<String, Set<String>> result = new HashMap<>();
+        final int reportedCount = new DefaultExternalizableUtil().readStringsMap(bus.getDataInput(), result);
+
+        // Verify result.
+        assertEquals(2, reportedCount);
+        assertTrue(areEqualStrings(input, result));
+    }
+
+    /**
+     * Asserts that the process of writing and reading a map of a Set of Strings through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the map contains a set that contains
+     * a null value.
+     */
+    @Test
+    public void testWriteReadStringsMapEmptyValueInValue() throws Exception
+    {
+        // Setup fixture.
+        final Map<String, Set<String>> input = new HashMap<>();
+        final Set<String> firstSet = new HashSet<>();
+        firstSet.add(null);
+        firstSet.add("foo bar");
+        input.put("bar", firstSet);
+
+        final Set<String> secondSet = new HashSet<>();
+        secondSet.add("bar");
+        secondSet.add("foo");
+        input.put("\uD834\uDD1E", secondSet);
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeStringsMap(bus.getDataOutput(), input);
+        final Map<String, Set<String>> result = new HashMap<>();
+        final int reportedCount = new DefaultExternalizableUtil().readStringsMap(bus.getDataInput(), result);
+
+        // Verify result.
+        assertEquals(2, reportedCount);
+        assertTrue(areEqualStrings(input, result));
+    }
+
+    /**
+     * Asserts that the process of writing and reading a map of a Set of Strings through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the map is empty.
+     */
+    @Test
+    public void testWriteReadStringsMapEmpty() throws Exception
+    {
+        // Setup fixture.
+        final Map<String, Set<String>> input = new HashMap<>();
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeStringsMap(bus.getDataOutput(), input);
+        final Map<String, Set<String>> result = new HashMap<>();
+        final int reportedCount = new DefaultExternalizableUtil().readStringsMap(bus.getDataInput(), result);
+
+        // Verify result.
+        assertEquals(0, reportedCount);
+        assertTrue(areEqualStrings(input, result));
+    }
+
+    /**
+     * Asserts that the process of writing and reading a map of Long-to-Integer through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    @Test
+    public void testWriteReadLongIntMap() throws Exception
+    {
+        // Setup fixture.
+        final Map<Long, Integer> input = new HashMap<>();
+        input.put( Long.MIN_VALUE, Integer.MAX_VALUE );
+        input.put( Long.MAX_VALUE, Integer.MIN_VALUE );
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeLongIntMap(bus.getDataOutput(), input);
+        final Map<Long, Integer> result = new DefaultExternalizableUtil().readLongIntMap(bus.getDataInput());
+
+        // Verify result.
+        assertTrue(areEqualLongInt(input, result ));
+    }
+
+    /**
+     * Asserts that the process of writing and reading a map of Long-to-Integer through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the map contains a null value.
+     */
+    @Test
+    public void testWriteReadLongToIntMapNullValue() throws Exception
+    {
+        // Setup fixture.
+        final Map<Long, Integer> input = new HashMap<>();
+        input.put( Long.MIN_VALUE, Integer.MAX_VALUE );
+        input.put( Long.MAX_VALUE, null );
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeLongIntMap(bus.getDataOutput(), input);
+        final Map<Long, Integer> result = new DefaultExternalizableUtil().readLongIntMap(bus.getDataInput());
+
+        // Verify result.
+        assertTrue(areEqualLongInt(input, result ));
+    }
+
+    /**
+     * Asserts that the process of writing and reading a map of Long-to-Integer through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the map is empty.
+     */
+    @Test
+    public void testWriteReadLongToIntMapEmpty() throws Exception
+    {
+        // Setup fixture.
+        final Map<Long, Integer> input = new HashMap<>();
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeLongIntMap(bus.getDataOutput(), input);
+        final Map<Long, Integer> result = new DefaultExternalizableUtil().readLongIntMap(bus.getDataInput());
+
+        // Verify result.
+        assertTrue(areEqualLongInt(input, result ));
+    }
+
+    /**
+     * Asserts that the process of writing and reading a List of Strings through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    @Test
+    public void testWriteReadStringList() throws Exception
+    {
+        // Setup fixture.
+        final List<String> input = new ArrayList<>();
+        input.add("foo");
+        input.add("\uD834\uDD1E");
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeStringList(bus.getDataOutput(), input);
+        final List<String> result = new DefaultExternalizableUtil().readStringList(bus.getDataInput());
+
+        // Verify result.
+        assertEquals(input, result);
+    }
+
+    /**
+     * Asserts that the process of writing and reading a List of Strings through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the list contains a null value.
+     */
+    @Test
+    public void testWriteReadStringListNullValue() throws Exception
+    {
+        // Setup fixture.
+        final List<String> input = new ArrayList<>();
+        input.add(null);
+        input.add("\uD834\uDD1E");
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeStringList(bus.getDataOutput(), input);
+        final List<String> result = new DefaultExternalizableUtil().readStringList(bus.getDataInput());
+
+        // Verify result.
+        assertEquals(input, result);
+    }
+
+    /**
+     * Asserts that the process of writing and reading a List of Strings through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the list is empty.
+     */
+    @Test
+    public void testWriteReadStringListEmpty() throws Exception
+    {
+        // Setup fixture.
+        final List<String> input = new ArrayList<>();
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeStringList(bus.getDataOutput(), input);
+        final List<String> result = new DefaultExternalizableUtil().readStringList(bus.getDataInput());
+
+        // Verify result.
+        assertEquals(input, result);
+    }
+
+    /**
+     * Asserts that the process of writing and reading a Array of Long through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    @Test
+    public void testWriteReadLongArray() throws Exception
+    {
+        // Setup fixture.
+        final long[] input = new long[] { Long.MAX_VALUE, Long.MIN_VALUE };
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeLongArray(bus.getDataOutput(), input);
+        final long[] result = new DefaultExternalizableUtil().readLongArray(bus.getDataInput());
+
+        // Verify result.
+        assertArrayEquals( input, result );
+    }
+
+    /**
+     * Asserts that the process of writing and reading a Array of Long through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the array is empty
+     */
+    @Test
+    public void testWriteReadLongArrayEmpty() throws Exception
+    {
+        // Setup fixture.
+        final long[] input = new long[0];
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeLongArray(bus.getDataOutput(), input);
+        final long[] result = new DefaultExternalizableUtil().readLongArray(bus.getDataInput());
+
+        // Verify result.
+        assertArrayEquals( input, result );
+    }
+
+
+    /**
+     * Asserts that the process of writing and reading a long value through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    @Test
+    public void testWriteReadLong() throws Exception
+    {
+        // Setup fixture.
+        final long input = Long.MIN_VALUE;
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeLong(bus.getDataOutput(), input);
+        final long result = new DefaultExternalizableUtil().readLong(bus.getDataInput());
+
+        // Verify result.
+        assertEquals( input, result );
+    }
+
+    /**
+     * Asserts that the process of writing and reading a byte array value through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    @Test
+    public void testWriteReadByteArray() throws Exception
+    {
+        // Setup fixture.
+        final byte[] input = new byte[] { (byte)0xe0, 0x4d, (byte)0xd0, 0x20, (byte)0xfa, 0x3d, 0x29, 0x13, (byte)0xa2, (byte)0xd8, 0x08, 0x00, 0x2b, (byte) 0x90, 0x39, (byte)0x9d };
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeByteArray(bus.getDataOutput(), input);
+        final byte[] result = new DefaultExternalizableUtil().readByteArray(bus.getDataInput());
+
+        // Verify result.
+        assertArrayEquals( input, result );
+    }
+
+    /**
+     * Asserts that the process of writing and reading a byte array value through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the array is empty.
+     */
+    @Test
+    public void testWriteReadByteArrayEmpty() throws Exception
+    {
+        // Setup fixture.
+        final byte[] input = new byte[0];
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeByteArray(bus.getDataOutput(), input);
+        final byte[] result = new DefaultExternalizableUtil().readByteArray(bus.getDataInput());
+
+        // Verify result.
+        assertArrayEquals( input, result );
+    }
+
+    /**
+     * Asserts that the process of writing and reading an int value through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    @Test
+    public void testWriteReadInt() throws Exception
+    {
+        // Setup fixture.
+        final int input = 42;
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeInt(bus.getDataOutput(), input);
+        final int result = new DefaultExternalizableUtil().readInt(bus.getDataInput());
+
+        // Verify result.
+        assertEquals( input, result );
+    }
+
+    /**
+     * Asserts that the process of writing and reading a boolean value through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    @Test
+    public void testWriteReadBoolean() throws Exception
+    {
+        // Setup fixture.
+        final boolean input = true;
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeBoolean(bus.getDataOutput(), input);
+        final boolean result = new DefaultExternalizableUtil().readBoolean(bus.getDataInput());
+
+        // Verify result.
+        assertEquals( input, result );
+    }
+
+    /**
+     * Asserts that the process of writing and reading a Serializable value through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    @Test
+    public void testWriteReadSerializable() throws Exception
+    {
+        // Setup fixture.
+        final Serializable input = UUID.randomUUID();
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeSerializable(bus.getDataOutput(), input);
+        final Serializable result = new DefaultExternalizableUtil().readSerializable(bus.getDataInput());
+
+        // Verify result.
+        assertEquals( input, result );
+    }
+
+    /**
+     * Asserts that the process of writing and reading a UTF value through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     *
+     * Values taken from https://rosettacode.org/wiki/UTF-8_encode_and_decode#Java
+     */
+    @Test
+    public void testWriteReadSafeUTF() throws Exception
+    {
+        // Setup fixture.
+        final String input = "Test String With Unicode characters: \u0041 \u00f6 \u0416 \u20ac \uD834\uDD1E";
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeSafeUTF(bus.getDataOutput(), input);
+        final String result = new DefaultExternalizableUtil().readSafeUTF(bus.getDataInput());
+
+        // Verify result.
+        assertEquals( input, result );
+    }
+
+    /**
+     * Asserts that the process of writing and reading a UTF value through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input, when the String is empty.
+     */
+    @Test
+    public void testWriteReadSafeUTFEmpty() throws Exception
+    {
+        // Setup fixture.
+        final String input = "";
+
+        // Execute system under test.
+        new DefaultExternalizableUtil().writeSafeUTF(bus.getDataOutput(), input);
+        final String result = new DefaultExternalizableUtil().readSafeUTF(bus.getDataInput());
+
+        // Verify result.
+        assertEquals( input, result );
+    }
+
+    /**
+     * Asserts that the process of writing and reading a collection of Externalizable objects through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    // TODO @Test
+    public void testWriteReadExternalizableCollection() throws Exception
+    {
+        // TODO implement me (and variants for collections that are empty or contain null values).
+    }
+
+    /**
+     * Asserts that the process of writing and reading a collection of Serializable objects through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    // TODO @Test
+    public void testWriteReadSerializableCollection() throws Exception
+    {
+        // TODO implement me (and variants for collections that are empty or contain null values).
+    }
+
+    /**
+     * Asserts that the process of writing and reading a Map of String to Externalizable objects through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    // TODO @Test
+    public void testWriteReadExternalizableMap() throws Exception
+    {
+        // TODO implement me (and variants for collections that are empty or contain null values).
+    }
+
+    /**
+     * Asserts that the process of writing and reading a Map of Serializable to Serializable objects through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    // TODO @Test
+    public void testWriteReadSerializableMap() throws Exception
+    {
+        // TODO implement me (and variants for collections that are empty or contain null values).
+    }
+
+    /**
+     * Asserts that the process of writing and reading a Collection of Strings through the {@link DefaultExternalizableUtil}
+     * implementation results in a value that is equal to the original input.
+     */
+    @Test
+    public void testWriteReadStringCollection() throws Exception
+    {
+        // TODO implement me (and variants for collections that are empty or contain null values).
+    }
+
+    /**
+     * Checks if two maps are equal.
+     *
+     * @param first A map
+     * @param second Another map
+     * @return if both maps are equal, otherwise false.
+     */
+    private static boolean areEqualString(Map<String, String> first, Map<String, String> second) {
+        if (first.size() != second.size()) {
+            return false;
+        }
+
+        return first.entrySet().stream()
+            .allMatch(e -> (e.getValue() == null && second.get(e.getKey()) == null)
+                        || (e.getValue().equals(second.get(e.getKey()))) );
+    }
+
+    /**
+     * Checks if two maps are equal.
+     *
+     * @param first A map
+     * @param second Another map
+     * @return if both maps are equal, otherwise false.
+     */
+    private static boolean areEqualStrings(Map<String, Set<String>> first, Map<String, Set<String>> second) {
+        if (first.size() != second.size()) {
+            return false;
+        }
+
+        return first.entrySet().stream()
+            .allMatch(e -> (e.getValue() == null && second.get(e.getKey()) == null)
+                || (e.getValue().equals(second.get(e.getKey()))) );
+    }
+
+    /**
+     * Checks if two maps are equal.
+     *
+     * @param first A map
+     * @param second Another map
+     * @return if both maps are equal, otherwise false.
+     */
+    private static boolean areEqualLongInt(Map<Long, Integer> first, Map<Long, Integer> second) {
+        if (first.size() != second.size()) {
+            return false;
+        }
+
+        return first.entrySet().stream()
+            .allMatch(e -> (e.getValue() == null && second.get(e.getKey()) == null)
+                || (e.getValue().equals(second.get(e.getKey()))) );
+    }
+
+    /**
+     * Utility class that generates a DataOutput and DataInput that share a common resource, meaning that what is
+     * written to the DataOutput becomes available for reading on the DataInput.
+     *
+     * Instances are single-use. DataOutput should be written to before DataInput is obtained (this implementation was
+     * designed for unit testing only, not for re-use elsewhere).
+     */
+    public static class Bus
+    {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        public DataOutput getDataOutput() {
+            return new DataOutputStream( baos );
+        }
+
+        public DataInput getDataInput() {
+            return new DataInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
+        }
+    }
+}


### PR DESCRIPTION
This introduces a new ExternalizableUtilStrategy that, unlike the existing DummyExternalizableUtil, is fully functional.

The new implementation is named DefaultExternalizableUtil. It's implementation is a near copy of ClusterExternalizableUtil from the Hazelcast plugin.