### PR TITLE
Add aioxmpp-based tests to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ dist: trusty
 sudo: false
 language: java
 addons:
-  apt:
-    packages:
-      - "python3"
-      - "python3-pip"
   hostname: example.org
   hosts:
     - example.org
@@ -16,6 +12,9 @@ cache:
   directories:
   - $HOME/.m2/repository/
 before_install:
+# Need newer python than provided by trusty
+- sudo add-apt-repository -y ppa:deadsnakes/ppa
+- sudo apt install python3.7 python3.7-pip
 - git clone --depth 1 https://github.com/igniterealtime/ci-tooling.git target/ci-tooling
 - cp target/ci-tooling/maven-settings-for-openfire-plugins.xml $HOME/.m2/settings.xml
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 - sudo add-apt-repository -y ppa:deadsnakes/ppa
 - sudo apt-get update
 - sudo apt install python3.7
-- curl https://bootstrap.pypa.io/get-pip.py | python3.7 --user
+- curl https://bootstrap.pypa.io/get-pip.py | python3.7
 - git clone --depth 1 https://github.com/igniterealtime/ci-tooling.git target/ci-tooling
 - cp target/ci-tooling/maven-settings-for-openfire-plugins.xml $HOME/.m2/settings.xml
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 - sudo add-apt-repository -y ppa:deadsnakes/ppa
 - sudo apt-get update
 - sudo apt install python3.6
-- curl https://bootstrap.pypa.io/get-pip.py | python3.6
+- curl https://bootstrap.pypa.io/get-pip.py | sudo python3.6
 - git clone --depth 1 https://github.com/igniterealtime/ci-tooling.git target/ci-tooling
 - cp target/ci-tooling/maven-settings-for-openfire-plugins.xml $HOME/.m2/settings.xml
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ dist: trusty
 sudo: false
 language: java
 addons:
+  apt:
+    packages:
+      - "python3"
+      - "python3-pip"
   hostname: example.org
   hosts:
     - example.org
@@ -20,6 +24,7 @@ script:
   - mvn verify -P ci
 # Disabled Smack Integration Tests until we can get them to run reliably again.
 # - TERM="dumb" ./runIntegrationTests -gl
+  - TERM="dumb" ./runAioxmppIntegrationTests -l
 install: true
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_install:
 # Need newer python than provided by trusty
 - sudo add-apt-repository -y ppa:deadsnakes/ppa
 - sudo apt-get update
-- sudo apt install python3.7
-- curl https://bootstrap.pypa.io/get-pip.py | python3.7
+- sudo apt install python3.6
+- curl https://bootstrap.pypa.io/get-pip.py | python3.6
 - git clone --depth 1 https://github.com/igniterealtime/ci-tooling.git target/ci-tooling
 - cp target/ci-tooling/maven-settings-for-openfire-plugins.xml $HOME/.m2/settings.xml
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_install:
 # Need newer python than provided by trusty
 - sudo add-apt-repository -y ppa:deadsnakes/ppa
 - sudo apt-get update
-- sudo apt install python3.7 python3.7-pip
+- sudo apt install python3.7
+- curl https://bootstrap.pypa.io/get-pip.py | python3.7 --user
 - git clone --depth 1 https://github.com/igniterealtime/ci-tooling.git target/ci-tooling
 - cp target/ci-tooling/maven-settings-for-openfire-plugins.xml $HOME/.m2/settings.xml
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
 before_install:
 # Need newer python than provided by trusty
 - sudo add-apt-repository -y ppa:deadsnakes/ppa
+- sudo apt-get update
 - sudo apt install python3.7 python3.7-pip
 - git clone --depth 1 https://github.com/igniterealtime/ci-tooling.git target/ci-tooling
 - cp target/ci-tooling/maven-settings-for-openfire-plugins.xml $HOME/.m2/settings.xml

--- a/distribution/src/conf/openfire-demoboot.xml
+++ b/distribution/src/conf/openfire-demoboot.xml
@@ -11,6 +11,9 @@
       <run>true</run>
       <locale>en</locale>
       <xmpp>
+          <auth>
+              <anonymous>true</anonymous>
+          </auth>
           <domain>example.org</domain>
           <fqdn>example.org</fqdn>
       </xmpp>

--- a/runAioxmppIntegrationTests
+++ b/runAioxmppIntegrationTests
@@ -120,7 +120,7 @@ function runTests {
 	echo "Starting Integration Tests (using aioxmpp)…"
     pushd "${AIOXMPPDIR}"
     which python3.6
-    python3.6 -m aioxmpp.e2etest --e2etest-config="${AIOXMPPCONFIG}" test
+    python3.6 -m aioxmpp.e2etest --e2etest-config="${AIOXMPPCONFIG}" tests
     popd
 }
 

--- a/runAioxmppIntegrationTests
+++ b/runAioxmppIntegrationTests
@@ -80,7 +80,7 @@ function setUpAioxmppEnvironment {
     AIOXMPPCONFIG="${AIOXMPPDIR}/openfire-config.ini"
     git clone https://github.com/horazont/aioxmpp "${AIOXMPPDIR}"
     pushd "${AIOXMPPDIR}"
-    pip3 install -e .
+    sudo pip3 install -e .
     cat >"${AIOXMPPCONFIG}" <<EOL
 [global]
 provisioner=aioxmpp.e2etest.provision.AnonymousProvisioner

--- a/runAioxmppIntegrationTests
+++ b/runAioxmppIntegrationTests
@@ -81,6 +81,7 @@ function setUpAioxmppEnvironment {
     git clone https://github.com/horazont/aioxmpp "${AIOXMPPDIR}"
     pushd "${AIOXMPPDIR}"
     which pip3
+    sudo pip3 install nose
     sudo pip3 install -e .
     cat >"${AIOXMPPCONFIG}" <<EOL
 [global]

--- a/runAioxmppIntegrationTests
+++ b/runAioxmppIntegrationTests
@@ -80,7 +80,7 @@ function setUpAioxmppEnvironment {
     AIOXMPPCONFIG="${AIOXMPPDIR}/openfire-config.ini"
     git clone https://github.com/horazont/aioxmpp "${AIOXMPPDIR}"
     pushd "${AIOXMPPDIR}"
-    python3 -m pip install -e .
+    pip3 install -e .
     cat >"${AIOXMPPCONFIG}" <<EOL
 [global]
 provisioner=aioxmpp.e2etest.provision.AnonymousProvisioner

--- a/runAioxmppIntegrationTests
+++ b/runAioxmppIntegrationTests
@@ -80,8 +80,8 @@ function setUpAioxmppEnvironment {
     AIOXMPPCONFIG="${AIOXMPPDIR}/openfire-config.ini"
     git clone https://github.com/horazont/aioxmpp "${AIOXMPPDIR}"
     pushd "${AIOXMPPDIR}"
-    pip3 install -U setuptools
-    pip3 install -e .
+    python3 -m pip install -U setuptools
+    python3 -m pip install -e .
     cat >"${AIOXMPPCONFIG}" <<EOL
 [global]
 provisioner=aioxmpp.e2etest.provision.AnonymousProvisioner

--- a/runAioxmppIntegrationTests
+++ b/runAioxmppIntegrationTests
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEBUG=false
+LOCAL_RUN=false
+
+DOMAIN='example.org'
+HOST='localhost'
+
+usage()
+{
+	echo "Usage: $0 [-d] [-l] [-h HOST] [-s DOMAIN]"
+	echo "    -d: Enable debug mode. Prints commands, and preserves temp directories if used (default: off)"
+	echo "    -l: Launch a local Openfire. (default: off)"
+	echo "    -h: The hostname for the Openfire under test (default: localhost)"
+	echo "    -s: The XMPP domain name for the Openfire under test (default: example.org)"
+	exit 2
+}
+
+while getopts dlh:s: OPTION "$@"; do
+	case $OPTION in
+		d)
+			DEBUG=true
+			set -x
+			;;
+		l)
+			LOCAL_RUN=true
+			;;
+		h)
+			HOST="${OPTARG}"
+			;;
+		s)
+			DOMAIN="${OPTARG}"
+			;;
+		\? ) usage;;
+        :  ) usage;;
+        *  ) usage;;
+	esac
+done
+
+if [[ $LOCAL_RUN == true ]] && [[ $DOMAIN != "example.org" ]]; then
+	echo "Domain is fixed if launching a local instance. If you have an already-running instance to test against, omit the -l flag (and provide -h 127.0.0.1 if necessary)."
+	exit 1
+fi
+
+function setBaseDirectory {
+	# Pretty fancy method to get reliable the absolute path of a shell
+	# script, *even if it is sourced*. Credits go to GreenFox on
+	# stackoverflow: http://stackoverflow.com/a/12197518/194894
+	pushd . > /dev/null
+	SCRIPTDIR="${BASH_SOURCE[0]}";
+	while [ -h "${SCRIPTDIR}" ]; do
+		cd "$(dirname "${SCRIPTDIR}")"
+		SCRIPTDIR="$(readlink "$(basename "${SCRIPTDIR}")")";
+	done
+	cd "$(dirname "${SCRIPTDIR}")" > /dev/null
+	SCRIPTDIR="$(pwd)";
+	popd  > /dev/null
+	BASEDIR="${SCRIPTDIR}"
+	cd "${BASEDIR}"
+}
+
+function createTempDirectory {
+	OFTEMPDIR=$(mktemp -d)
+}
+
+function cleanup {
+	if [[ $DEBUG == false && -n "${OFTEMPDIR-}" ]]; then
+		echo "Removing temp directories"
+		rm -rf "${OFTEMPDIR}"
+	fi
+	if [[ $LOCAL_RUN == true ]]; then
+		echo "Stopping Openfire"
+		pkill -f openfire.lib #TODO: Can this be made more future-proof against changes in the start script?
+	fi
+}
+
+function setUpAioxmppEnvironment {
+    AIOXMPPDIR="${BASEDIR}/aioxmpp"
+    AIOXMPPCONFIG="${AIOXMPPDIR}/openfire-config.ini"
+    git clone https://github.com/horazont/aioxmpp "${AIOXMPPDIR}"
+    pushd "${AIOXMPPDIR}"
+    pip3 install -U setuptools
+    pip3 install -e .
+    cat >"${AIOXMPPCONFIG}" <<EOL
+[global]
+provisioner=aioxmpp.e2etest.provision.AnonymousProvisioner
+
+[aioxmpp.e2etest.provision.AnonymousProvisioner]
+domain=$DOMAIN
+host=$HOST
+no_verify=true
+EOL
+    popd
+}
+
+function launchOpenfire {
+	declare -r OPENFIRE_SHELL_SCRIPT="${BASEDIR}/distribution/target/distribution-base/bin/openfire.sh"
+
+	if [[ ! -f "${OPENFIRE_SHELL_SCRIPT}" ]]; then
+		mvn verify -P ci
+	fi
+
+	rm -f distribution/target/distribution-base/conf/openfire.xml
+	cp distribution/src/conf/openfire-demoboot.xml \
+		distribution/target/distribution-base/conf/openfire.xml
+
+	echo "Starting Openfire…"
+	"${OPENFIRE_SHELL_SCRIPT}" &
+
+	# Wait 120 seconds for Openfire to open up the web interface and
+	# assume Openfire is fully operational once that happens (not sure if
+	# this assumption is correct).
+	echo "Waiting for Openfire…"
+	timeout 120 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 0.3; done' localhost 7070
+}
+
+function runTests {
+	echo "Starting Integration Tests (using aioxmpp)…"
+    pushd "${AIOXMPPDIR}"
+    python3 -m aioxmpp.e2etest --e2etest-config="${AIOXMPPCONFIG}" test
+    popd
+}
+
+setBaseDirectory
+trap cleanup EXIT
+setUpAioxmppEnvironment
+if [[ $LOCAL_RUN == true ]]; then
+	launchOpenfire
+fi
+runTests

--- a/runAioxmppIntegrationTests
+++ b/runAioxmppIntegrationTests
@@ -80,7 +80,6 @@ function setUpAioxmppEnvironment {
     AIOXMPPCONFIG="${AIOXMPPDIR}/openfire-config.ini"
     git clone https://github.com/horazont/aioxmpp "${AIOXMPPDIR}"
     pushd "${AIOXMPPDIR}"
-    python3 -m pip install -U setuptools
     python3 -m pip install -e .
     cat >"${AIOXMPPCONFIG}" <<EOL
 [global]

--- a/runAioxmppIntegrationTests
+++ b/runAioxmppIntegrationTests
@@ -80,6 +80,7 @@ function setUpAioxmppEnvironment {
     AIOXMPPCONFIG="${AIOXMPPDIR}/openfire-config.ini"
     git clone https://github.com/horazont/aioxmpp "${AIOXMPPDIR}"
     pushd "${AIOXMPPDIR}"
+    which pip3
     sudo pip3 install -e .
     cat >"${AIOXMPPCONFIG}" <<EOL
 [global]
@@ -117,7 +118,8 @@ function launchOpenfire {
 function runTests {
 	echo "Starting Integration Tests (using aioxmpp)…"
     pushd "${AIOXMPPDIR}"
-    python3 -m aioxmpp.e2etest --e2etest-config="${AIOXMPPCONFIG}" test
+    which python3.6
+    python3.6 -m aioxmpp.e2etest --e2etest-config="${AIOXMPPCONFIG}" test
     popd
 }
 


### PR DESCRIPTION
This commit adds a script, similar to the one for the Smack-based integration tests, that downloads and excutes the tests that are part of aioxmpp (https://github.com/horazont/aioxmpp)

aioxmpp requires anonymous authentication to be enabled. This commit achieves that by adding a corresponding autosetup configuration option to the demoboot config file.