### PR TITLE
OF-1997: Bouncy Castle 1.65 instead of 1.64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <jetty.version>9.4.18.v20190429</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <mina.version>2.1.3</mina.version>
-        <bouncycastle.version>1.64</bouncycastle.version>
+        <bouncycastle.version>1.65</bouncycastle.version>
         <slf4j.version>1.7.26</slf4j.version>
         <log4j.version>2.11.2</log4j.version>
     </properties>


### PR DESCRIPTION
Bouncy Castle 1.65 instead of 1.64: https://www.bouncycastle.org/releasenotes.html
- http://www.bouncycastle.org/latest_releases.html