### PR TITLE
OF-2000: Stop using intern'ed strings as locks

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutManager.java
@@ -16,6 +16,9 @@
 package org.jivesoftware.openfire.lockout;
 
 import java.util.Date;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import org.jivesoftware.util.SystemProperty;
 import org.jivesoftware.util.cache.Cache;
 import org.jivesoftware.util.cache.CacheFactory;
@@ -36,6 +39,8 @@ import org.slf4j.LoggerFactory;
  * @author Daniel Henninger
  */
 public class LockOutManager {
+
+    private static final Interner<String> userBaseMutex = Interners.newWeakInterner();
 
     public static final SystemProperty<Class> LOCKOUT_PROVIDER = SystemProperty.Builder.ofType(Class.class)
         .setKey("provider.lockout.className")
@@ -214,7 +219,7 @@ public class LockOutManager {
         LockOutFlag flag = lockOutCache.get(username);
         // If ID wan't found in cache, load it up and put it there.
         if (flag == null) {
-            synchronized ((username+ MUTEX_SUFFIX).intern()) {
+            synchronized (userBaseMutex.intern(username)) {
                 flag = lockOutCache.get(username);
                 // If group wan't found in cache, load it up and put it there.
                 if (flag == null) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -20,6 +20,8 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.Lock;
 
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import org.jivesoftware.openfire.RoutableChannelHandler;
 import org.jivesoftware.openfire.RoutingTable;
 import org.jivesoftware.openfire.SessionManager;
@@ -60,6 +62,8 @@ import org.xmpp.packet.Presence;
 public class OutgoingSessionPromise implements RoutableChannelHandler {
 
     private static final Logger Log = LoggerFactory.getLogger(OutgoingSessionPromise.class);
+
+    private static final Interner<String> domainBasedMutex = Interners.newWeakInterner();
 
     private static OutgoingSessionPromise instance = new OutgoingSessionPromise();
 
@@ -123,7 +127,7 @@ public class OutgoingSessionPromise implements RoutableChannelHandler {
                             boolean newProcessor = false;
                             PacketsProcessor packetsProcessor;
                             String domain = packet.getTo().getDomain();
-                            synchronized (domain.intern()) {
+                            synchronized (domainBasedMutex.intern(domain)) {
                                 packetsProcessor = packetsProcessors.get(domain);
                                 if (packetsProcessor == null) {
                                     packetsProcessor =
@@ -184,7 +188,7 @@ public class OutgoingSessionPromise implements RoutableChannelHandler {
     }
 
     private void processorDone(PacketsProcessor packetsProcessor) {
-        synchronized(packetsProcessor.getDomain().intern()) {
+        synchronized(domainBasedMutex.intern(packetsProcessor.getDomain())) {
             if (packetsProcessor.isDone()) {
                 packetsProcessors.remove(packetsProcessor.getDomain());
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -26,6 +26,8 @@ import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import org.dom4j.Element;
 import org.jivesoftware.openfire.IQRouter;
 import org.jivesoftware.openfire.XMPPServer;
@@ -54,6 +56,8 @@ import gnu.inet.encoding.StringprepException;
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
 public final class UserManager {
+
+    private static final Interner<String> userBaseMutex = Interners.newWeakInterner();
 
     public static final SystemProperty<Class> USER_PROVIDER = SystemProperty.Builder.ofType(Class.class)
         .setKey("provider.user.className")
@@ -265,7 +269,7 @@ public final class UserManager {
         username = username.trim().toLowerCase();
         User user = userCache.get(username);
         if (user == null) {
-            synchronized ((username + MUTEX_SUFFIX).intern()) {
+            synchronized (userBaseMutex.intern(username)) {
                 user = userCache.get(username);
                 if (user == null) {
                     user = provider.loadUser(username);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
@@ -24,6 +24,8 @@ import java.sql.SQLException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import org.dom4j.Element;
 import org.dom4j.io.SAXReader;
 import org.jivesoftware.database.DbConnectionManager;
@@ -43,7 +45,7 @@ public class DefaultVCardProvider implements VCardProvider {
 
     private static final Logger Log = LoggerFactory.getLogger(DefaultVCardProvider.class);
 
-    private static final String MUTEX_SUFFIX = " dvcp";
+    private static final Interner<String> userBaseMutex = Interners.newWeakInterner();
     
     private static final String LOAD_PROPERTIES =
         "SELECT vcard FROM ofVCard WHERE username=?";
@@ -73,7 +75,7 @@ public class DefaultVCardProvider implements VCardProvider {
 
     @Override
     public Element loadVCard(String username) {
-        synchronized ((username + MUTEX_SUFFIX).intern()) {
+        synchronized (userBaseMutex.intern(username)) {
             Connection con = null;
             PreparedStatement pstmt = null;
             ResultSet rs = null;


### PR DESCRIPTION
This replaces the (often namespaced) interned strings used to synchronize on (which introduces a risk of deadlock) with a dedicated map of locks that mimics String interning for any other object type (that should be immutable).

Drawbacks of this solution:
- provided by Google Guava that is marked as 'Beta'
- probably more resource intensive than the native, String-based mutex.