### PR TITLE
OF-872: Properly process IQ and Message without 'to' attribute.

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1608,6 +1608,7 @@ system_property.xmpp.auth.external.client.skip-cert-revalidation=Set to true to 
 system_property.xmpp.auth.ssl.default-trustmanager-impl=The class to use as the default SSL/TLS TrustManager (which checks certificates from peers).
 system_property.xmpp.client.idle=How long, in milliseconds, before idle sessions are dropped. Set to -1 to never drop idle sessions.
 system_property.xmpp.client.idle.ping=Set to true to ping idle clients, otherwise false
+system_property.xmpp.server.rewrite.replace-missing-to=If the server receives a message or IQ stanza with no 'to' attribute, set the 'to' attribute to the bare JID representation of the 'from' attribute value.
 system_property.cluster-monitor.service-enabled=Set to true to send messages to admins on cluster events, otherwise false
 system_property.ldap.override.avatar=Set to true to save avatars in the local database, otherwise false
 system_property.xmpp.domain=The XMPP domain of this server. Do not change this property directly, instead re-run the setup process.

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -860,6 +860,7 @@ system_provider.provider.pubsub-persistence.caching.delegate-className=De klasse
 system_property.stream.management.active=Bied clienten Stream Management (XEP-0198) functionaliteit.
 system_property.stream.management.location.enabled=Vertel clienten die Stream Management (XEP-0198) functionaliteit gebruiken, op welke server streams te hervatten.
 system_property.stream.management.max-server.enabled=Vertel clienten hoe lang streams in 'detached' mode mogen bestaan, voordat ze afgesloten worden.
+system_property.xmpp.server.rewrite.replace-missing-to=Als de server een IQ of message stanza ontvangt zonder 'to' attribuut, zet dan de waarde van het 'to' attribuut op de bare JID representatie van het 'from' attribuut.
 
 # Server properties Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -31,6 +31,7 @@ import org.jivesoftware.openfire.spi.BasicStreamIDFactory;
 import org.jivesoftware.openfire.streammanagement.StreamManager;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.LocaleUtils;
+import org.jivesoftware.util.SystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
@@ -51,6 +52,12 @@ import java.util.Map;
 public abstract class StanzaHandler {
 
     private static final Logger Log = LoggerFactory.getLogger(StanzaHandler.class);
+
+    public static final SystemProperty<Boolean> PROPERTY_OVERWRITE_EMPTY_TO = SystemProperty.Builder.ofType( Boolean.class )
+        .setKey( "xmpp.server.rewrite.replace-missing-to" )
+        .setDefaultValue( true )
+        .setDynamic( true )
+        .build();
 
     /**
      * A factory that generates random stream IDs
@@ -362,7 +369,15 @@ public abstract class StanzaHandler {
      * @throws org.jivesoftware.openfire.auth.UnauthorizedException
      *          if service is not available to sender.
      */
-    protected void processIQ(IQ packet) throws UnauthorizedException {
+    protected void processIQ(IQ packet) throws UnauthorizedException
+    {
+        // If the 'to' attribute is null, treat the IQ on behalf of the entity from which the IQ stanza originated
+        // in accordance with RFC 6120 § 10.3.3. See https://tools.ietf.org/html/rfc6120#section-10.3.3:
+        // > […] responding as if the server were the bare JID of the sending entity.
+        if ( packet.getTo() == null && PROPERTY_OVERWRITE_EMPTY_TO.getValue() ) {
+            packet.setTo( packet.getFrom().asBareJID() );
+        }
+
         router.route(packet);
         session.incrementClientPacketCount();
     }
@@ -399,6 +414,12 @@ public abstract class StanzaHandler {
      *          if service is not available to sender.
      */
     protected void processMessage(Message packet) throws UnauthorizedException {
+        // If the 'to' attribute is null, treat the IQ on behalf of the entity from which the IQ stanza originated
+        // in accordance with RFC 6120 § 10.3.1. See https://tools.ietf.org/html/rfc6120#section-10.3.1:
+        // > […] treat the message as if the 'to' address were the bare JID <localpart@domainpart> of the sending entity.
+        if ( packet.getTo() == null && PROPERTY_OVERWRITE_EMPTY_TO.getValue() ) {
+            packet.setTo( packet.getFrom().asBareJID() );
+        }
         router.route(packet);
         session.incrementClientPacketCount();
     }


### PR DESCRIPTION
RFC 6120 § 10.3. dictates that IQ and Message stanzas that have no 'to' attribute value should be processed as if the 'to' attribute value equals that of the bare JID of the sender.

This commit parses all inbound IQ and Message stanzas, setting the 'to' attribute value for stanzas that have none to the bare JID that matches the 'from' attribute value. A new system property `xmpp.server.rewrite.replace-missing-to` has been introduced that can be used to disable this functionality.