### PR TITLE
Messages with a type "normal" SHOULD be stored offline.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStrategy.java
@@ -116,9 +116,9 @@ public class OfflineMessageStrategy extends BasicModule implements ServerFeature
                 // 8.5.3.  localpart@domainpart/resourcepart
                 // 8.5.3.2.1.  Message
 
-                // For a message stanza of type "normal", "groupchat", or "headline", the server MUST either (a) silently ignore the stanza
+                // For a message stanza of type "groupchat", or "headline", the server MUST either (a) silently ignore the stanza
                 // or (b) return an error stanza to the sender, which SHOULD be <service-unavailable/>.
-                if (message.getType() == Message.Type.normal || message.getType() == Message.Type.groupchat || message.getType() == Message.Type.headline) {
+                if (message.getType() == Message.Type.groupchat || message.getType() == Message.Type.headline) {
                     // Depending on the OfflineMessageStragey, we may silently ignore or bounce
                     if (type == Type.bounce) {
                         bounce(message);


### PR DESCRIPTION
According to XEP-0160:

normal -- Messages with a 'type' attribute whose value is "normal" (or messages with no 'type' attribute) SHOULD be stored offline.