### PR TITLE
Apply XEP 0106 for group name coming from LDAP

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
@@ -84,6 +84,7 @@ public class LdapGroupProvider extends AbstractGroupProvider {
     @Override
     public Group getGroup(String groupName) throws GroupNotFoundException {
         try {
+            groupName = JID.unescapeNode(groupName);
             LdapName groupDN = manager.findGroupAbsoluteDN(groupName);
             return getGroupByDN(groupDN, new HashSet<>(Collections.singleton(groupDN.toString())));
         }


### PR DESCRIPTION
While trying to use plugin broadcast to send a message to members of a LDAP group called "Santa Casa", I realized that some clients transforms it to "Santa\20Casa", but this is not interpreted by Openfire. Openfire does it for users https://github.com/igniterealtime/Openfire/blob/master/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java#L100.