### PR TITLE
OF-963 - WebSocket keep-alive is not working as expected

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -62,13 +62,13 @@ public class StreamManager {
         public final long x;
         public final Date timestamp = new Date();
         public final Packet packet;
-        
+
         public UnackedPacket(long x, Packet p) {
             this.x = x;
             packet = p;
         }
     }
-    
+
     public static boolean isStreamManagementActive() {
         return ACTIVE.getValue();
     }
@@ -178,6 +178,11 @@ public class StreamManager {
         boolean allow = false;
         // Ensure that resource binding has occurred.
         if (session instanceof ClientSession) {
+            Object ws = session.getSessionData("ws");
+            if (ws != null && (Boolean) ws) {
+                Log.debug( "Websockets resume is not yet implemented: {}", session );
+                return false;
+            }
             AuthToken authToken = ((LocalClientSession)session).getAuthToken();
             if (authToken != null) {
                 if (!authToken.isAnonymous()) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
@@ -162,8 +162,6 @@ public class XmppWebSocket {
             closeStream(null);
         }
         if (xmppSession != null) {
-            xmppSession.getStreamManager().formalClose();
-
             if (!xmppSession.getStreamManager().getResume()) {
                 Log.debug( "Closing session {}", xmppSession );
                 xmppSession.close();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
@@ -162,9 +162,13 @@ public class XmppWebSocket {
             closeStream(null);
         }
         if (xmppSession != null) {
-            Log.debug( "Closing session {}", xmppSession );
-            xmppSession.close();
-            SessionManager.getInstance().removeSession(xmppSession);
+            xmppSession.getStreamManager().formalClose();
+
+            if (!xmppSession.getStreamManager().getResume()) {
+                Log.debug( "Closing session {}", xmppSession );
+                xmppSession.close();
+                SessionManager.getInstance().removeSession(xmppSession);
+            }
             xmppSession = null;
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
@@ -162,11 +162,9 @@ public class XmppWebSocket {
             closeStream(null);
         }
         if (xmppSession != null) {
-            if (!xmppSession.getStreamManager().getResume()) {
-                Log.debug( "Closing session {}", xmppSession );
-                xmppSession.close();
-                SessionManager.getInstance().removeSession(xmppSession);
-            }
+            Log.debug( "Closing session {}", xmppSession );
+            xmppSession.close();
+            SessionManager.getInstance().removeSession(xmppSession);
             xmppSession = null;
         }
     }
@@ -258,7 +256,7 @@ public class XmppWebSocket {
      * Initiate the stream and corresponding XMPP session.
      */
     private void initiateSession(Element stanza) {
-        
+
         String host = stanza.attributeValue("to");
         StreamError streamError = null;
         Locale language = Locale.forLanguageTag(stanza.attributeValue(QName.get("lang", XMLConstants.XML_NS_URI), "en"));
@@ -294,7 +292,7 @@ public class XmppWebSocket {
         if (JiveGlobals.getBooleanProperty("xmpp.client.validate.host", false)) {
             result = XMPPServer.getInstance().getServerInfo().getXMPPDomain().equals(host);
         }
-        return result; 
+        return result;
     }
 
     /*


### PR DESCRIPTION
This fix is to remove the test for resuming a stream session in websockets before closing the xmpp session. XEP-0198 stream resumption is not yet implemented.