### PR TITLE
OF-2031: Update dom4j to version 2.1.3

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.1</version>
+            <version>2.1.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Version 2.1.3 fixes a vulnerability identified as CVE-2020-10683