### PR TITLE
OF-2116 Using range retrieval for LDAP groups on Active Directory

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1721,6 +1721,7 @@ system_property.xmpp.muc.join.self-presence-timeout=Maximum duration to wait for
 system_property.ldap.pagedResultsSize=The maximum number of records to retrieve from LDAP in a single page. \
    The default value of -1 means rely on the paging of the LDAP server itself. \
    Note that if using ActiveDirectory, this should not be left at the default, and should not be set to more than the value of the ActiveDirectory MaxPageSize; 1,000 by default.
+system_property.ldap.useRangeRetrieval=Enable range retrieval for processing of large LDAP groups
 system_property.xmpp.iqdiscoinfo.xformsoftwareversion=Set to false to not allow Software Version DataForm on InfoDisco response.
 system_property.plugins.servlet.allowLocalFileReading=Determines if the plugin servlets can be used to access files outside of Openfire's home directory.
 system_property.cert.storewatcher.enabled=Automatically reloads certificate stores when they're modified on disk.
@@ -1791,8 +1792,6 @@ system_property.xmpp.taskengine.threadpool.keepalive=The number of threads in th
 system_property.xmpp.muc.allowpm.blockall=Toggles whether to block all packets from users or just messages if they do not have permission to send private messages.
 system_property.abstractGroupProvider.shared.recursive=Toggles whether shared groups recursively resolve groups that they are shared with, or limit themselves to their immediate shared groups only.
 system_property.xmpp.websocket.stream-substitution-enabled=Controls if 'stream' elements that are sent over websockets are renamed to 'open' and 'close' where appropriate. Useful to allow certain non-compliant clients (eg: Tsung) to connect.
-
-system_property.ldap.useRangeRetrieval=Enable/Disable proccessing of large LDAP Groups (Active Directory)
 
 # Server properties Page
 

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1792,6 +1792,8 @@ system_property.xmpp.muc.allowpm.blockall=Toggles whether to block all packets f
 system_property.abstractGroupProvider.shared.recursive=Toggles whether shared groups recursively resolve groups that they are shared with, or limit themselves to their immediate shared groups only.
 system_property.xmpp.websocket.stream-substitution-enabled=Controls if 'stream' elements that are sent over websockets are renamed to 'open' and 'close' where appropriate. Useful to allow certain non-compliant clients (eg: Tsung) to connect.
 
+system_property.ldap.useRangeRetrieval=Enable/Disable proccessing of large LDAP Groups (Active Directory)
+
 # Server properties Page
 
 server.properties.title=System Properties


### PR DESCRIPTION
this is a rebase of an old PR:
https://github.com/igniterealtime/Openfire/pull/1571

-using range retrieval on group lookups if needed
-using ldap.pagedResultsSize for range pagesize 

... cause there is a limit of 1500
see: https://docs.microsoft.com/de-de/previous-versions/windows/desktop/ldap/searching-using-range-retrieval?redirectedfrom=MSDN