### PR TITLE
OF-2046: Ignore comments in sidebar-admin.xml

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/admin/AdminConsole.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AdminConsole.java
@@ -65,6 +65,7 @@ public class AdminConsole {
      */
     public static void addModel(String name, InputStream in) throws Exception {
         SAXReader saxReader = new SAXReader();
+        saxReader.setIgnoreComments(true);
         Document doc = saxReader.read(in);
         addModel(name, (Element)doc.selectSingleNode("/adminconsole"));
     }
@@ -214,6 +215,7 @@ public class AdminConsole {
         }
         try {
             SAXReader saxReader = new SAXReader();
+            saxReader.setIgnoreComments(true);
             Document doc = saxReader.read(in);
             coreModel = (Element)doc.selectSingleNode("/adminconsole");
         }


### PR DESCRIPTION
Under certain conditions (that I have been unable to reproduce) adding comments in the admin-sidebar.xml appears to influence the rendering of the admin console.

It has been reported that reconfiguring the SAX reader to ignore comments prevents the issue from occurring.

Although I've not been able to reproduce the issue, ignoring comments is sufficiently benign that it doesn't hurt to add that to the implementation.