### PR TITLE
OF-2047: Set, instead of add headers to HTTP responses

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
@@ -201,7 +201,7 @@ public class AuthCheckFilter implements Filter {
         HttpServletRequest request = (HttpServletRequest)req;
         HttpServletResponse response = (HttpServletResponse)res;
         // Do not allow framing; OF-997
-        response.addHeader("X-Frame-Options", JiveGlobals.getProperty("adminConsole.frame-options", "same"));
+        response.setHeader("X-Frame-Options", JiveGlobals.getProperty("adminConsole.frame-options", "same"));
         // Reset the defaultLoginPage variable
         String loginPage = defaultLoginPage;
         if (loginPage == null) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
@@ -239,9 +239,9 @@ public class HttpBindServlet extends HttpServlet {
         if ("GET".equals(request.getMethod())) {
             if (JiveGlobals.getBooleanProperty("xmpp.httpbind.client.no-cache.enabled", true)) {
                 // Prevent caching of responses
-                response.addHeader("Cache-Control", "no-store");
+                response.setHeader("Cache-Control", "no-store");
                 response.addHeader("Cache-Control", "no-cache");
-                response.addHeader("Pragma", "no-cache");
+                response.setHeader("Pragma", "no-cache");
             }
             content = "_BOSH_(\"" + StringEscapeUtils.escapeEcmaScript(content) + "\")";
         }


### PR DESCRIPTION
Occasionally, Openfire enriches HTTP responses with additional headers.

HTTP responses can have duplicate headers. This often is not desired. To prevent this problem, Openfire should 'set' rather than 'add' headers. The former overwrites any preexisting headers of the same name.