### PR TITLE
OF-2053 XEP-0013: return an <item-not-found/> error while retrieving specific offline message.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
@@ -110,6 +110,9 @@ public class IQOfflineMessagesHandler extends IQHandler implements ServerFeature
                     OfflineMessage offlineMsg = messageStore.getMessage(from.getNode(), creationDate);
                     if (offlineMsg != null) {
                         sendOfflineMessage(from, offlineMsg);
+                    } else {
+                        // If the requester is authorized but the node does not exist, the server MUST return a <item-not-found/> error.
+                        reply.setError(PacketError.Condition.item_not_found);
                     }
                 }
                 else if ("remove".equals(item.attributeValue("action"))) {


### PR DESCRIPTION
According to XEP-0013, If the requester is authorized but the node does not exist, the server MUST return an <item-not-found/> error.

https://xmpp.org/extensions/xep-0013.html#retrieve-specific