### PR TITLE
OF-2054: Add form field type to XEP-0157 form field

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -41,6 +41,7 @@ import org.jivesoftware.util.cache.CacheFactory;
 import org.jivesoftware.util.SystemProperty;
 import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
+import org.xmpp.forms.FormField.Type;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.PacketError;
@@ -749,6 +750,7 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
 
                         final FormField fieldAdminAddresses = dataForm.addField();
                         fieldAdminAddresses.setVariable("admin-addresses");
+                        fieldAdminAddresses.setType(Type.list_multi);
 
                         final UserManager userManager = UserManager.getInstance();
                         for ( final JID admin : admins )


### PR DESCRIPTION
If form fields do no mention type, they are by default assumed to be of type text-single. This causes problem for clients in cases where multiple form field values are included without mentioning type. Check [here](https://xmpp.org/extensions/xep-0157.html#example-2).

However, field standardisation for the same xep-0157 [here](https://xmpp.org/extensions/xep-0157.html#registrar-formtype) suggests that the form field type is list-multi. And so, it is better if the server adds type to form fields as this saves the client from first checking `FORM_TYPE` and determine form field type as per standardisation .
Solves OF-2054