### PR TITLE
OF-2061: The default configuration of PEP nodes should be to persist …

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPService.java
@@ -155,7 +155,7 @@ public class PEPService implements PubSubService, Cacheable {
             leafDefaultConfiguration.setNotifyConfigChanges(true);
             leafDefaultConfiguration.setNotifyDelete(true);
             leafDefaultConfiguration.setNotifyRetract(true);
-            leafDefaultConfiguration.setPersistPublishedItems(false);
+            leafDefaultConfiguration.setPersistPublishedItems(true);
             leafDefaultConfiguration.setMaxPublishedItems(1);
             leafDefaultConfiguration.setPresenceBasedDelivery(false);
             leafDefaultConfiguration.setSendItemSubscribe(true);


### PR DESCRIPTION
…items

When clients do not explicitly set this option (and Conversations, for example, doesn't), then data will 'disappear' over time.