### PR TITLE
Fix discoInfo features when the server is mounting server caps

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -648,11 +648,13 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                     // Answer features of the server itself.
                     final Set<String> result = new HashSet<>(serverFeatures.keySet());
 
-                    if ( !XMPPServer.getInstance().isLocal( senderJID ) || !UserManager.getInstance().isRegisteredUser( senderJID ) ) {
-                        // Remove features not available to users from other servers or anonymous users.
-                        // TODO this should be determined dynamically.
-                        result.remove(IQPrivateHandler.NAMESPACE);
-                        result.remove(IQBlockingHandler.NAMESPACE);
+                    if ( senderJID != null ) {
+                        if ( !XMPPServer.getInstance().isLocal( senderJID ) || !UserManager.getInstance().isRegisteredUser( senderJID ) ) {
+                            // Remove features not available to users from other servers or anonymous users.
+                            // TODO this should be determined dynamically.
+                            result.remove(IQPrivateHandler.NAMESPACE);
+                            result.remove(IQBlockingHandler.NAMESPACE);
+                        }
                     }
                     return result.iterator();
                 }


### PR DESCRIPTION
When the server is mounting its stream capabilities, the packet.from is not set and remains null.

https://github.com/igniterealtime/Openfire/blob/b8e6a666e9f04b1a443481c424bc096dd87d8221/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java#L922

https://github.com/igniterealtime/Openfire/blob/b8e6a666e9f04b1a443481c424bc096dd87d8221/xmppserver/src/main/java/org/jivesoftware/openfire/entitycaps/EntityCapabilitiesManager.java#L722

So the senderJid null should be considered the server itself.

It is impacting in the calculation of the caps hash version.