### PR TITLE
OF-2065: Entries of the 'Components' cache should not expire

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -132,6 +132,7 @@ public class CacheFactory {
         cacheNames.put("Routing Users Cache", "routeUser");
         cacheNames.put("Routing AnonymousUsers Cache", "routeAnonymousUser");
         cacheNames.put("Routing User Sessions", "routeUserSessions");
+        cacheNames.put("Components", "components");
         cacheNames.put("Components Sessions", "componentsSessions");
         cacheNames.put("Connection Managers Sessions", "connManagerSessions");
         cacheNames.put("Incoming Server Sessions", "incServerSessions");
@@ -194,6 +195,8 @@ public class CacheFactory {
         cacheProps.put(PROPERTY_PREFIX_CACHE + "routeAnonymousUser" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "routeUserSessions" + PROPERTY_SUFFIX_SIZE, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "routeUserSessions" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
+        cacheProps.put(PROPERTY_PREFIX_CACHE + "components" + PROPERTY_SUFFIX_SIZE, -1L);
+        cacheProps.put(PROPERTY_PREFIX_CACHE + "components" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "componentsSessions" + PROPERTY_SUFFIX_SIZE, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "componentsSessions" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "connManagerSessions" + PROPERTY_SUFFIX_SIZE, -1L);


### PR DESCRIPTION
There's no way in code that content can be retrieved after it has been expired (other than the component reconnecting). The javadoc also states that entries shouldn't expire. This commit adds explicit configuration that ensures this behavior (the default configuration _does_ configure the cache to eventually expire).