### PR TITLE
OF-2060: revert OF-974

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -1586,6 +1586,13 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         // org.jivesoftware.util.cache.CacheFactory.joinedCluster). This means that they now hold data that's
         // available on all other cluster nodes. Data that's available on the local node needs to be added again.
         restoreCacheContent();
+
+        // It does not appear to be needed to invoke any kind of event listeners for the data that was gained by joining
+        // the cluster (eg: sessions connected to other cluster nodes, now suddenly available to the local cluster node):
+        // There are six caches in play here, but only the content of one of them goes accompanied by firing off event
+        // listeners (sessionInfoCache). However, when already running in a clustered environment, those events are
+        // never broadcasted over the cluster, so there shouldn't be a need to do so for all sessions that were
+        // gained/lost when joining or leaving a cluster either.
     }
 
     @Override
@@ -1608,6 +1615,13 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         // org.jivesoftware.util.cache.CacheFactory.leftCluster). This means that they now hold no data (as a new cache
         // has been created). Data that's available on the local node needs to be added again.
         restoreCacheContent();
+
+        // It does not appear to be needed to invoke any kind of event listeners for the data that was lost by leaving
+        // the cluster (eg: sessions connected to other cluster nodes, now unavailable to the local cluster node):
+        // There are six caches in play here, but only the content of one of them goes accompanied by firing off event
+        // listeners (sessionInfoCache). However, when already running in a clustered environment, those events are
+        // never broadcasted over the cluster, so there shouldn't be a need to do so for all sessions that were
+        // gained/lost when joining or leaving a cluster either.
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterEventListener.java
@@ -34,6 +34,12 @@ public interface ClusterEventListener {
      * <p>At this point the CacheFactory holds clustered caches. That means that modifications
      * to the caches will be reflected in the cluster. The clustered caches were just
      * obtained from the cluster and no local cached data was automatically moved.</p>
+     *
+     * It is generally advisable that implementations of this method:
+     * <ul>
+     *     <li>enrich clustered cache data, by (re)adding  data from this JVM/cluster node to relevant caches</li>
+     *     <li>invoke applicable event listeners, to reflect changes in availability of data on other cluster nodes.</li>
+     * </ul>
      */
     void joinedCluster();
 
@@ -62,6 +68,12 @@ public interface ClusterEventListener {
      *
      * At this point the CacheFactory holds local caches. That means that modifications to
      * the caches will only affect this JVM.
+     *
+     * It is generally advisable that implementations of this method:
+     * <ul>
+     *     <li>restore relevant caches content, by repopulating the caches with data from this JVM/cluster node</li>
+     *     <li>invoke applicable event listeners, to reflect changes in availability of data on other cluster nodes.</li>
+     * </ul>
      */
     void leftCluster();
 
@@ -79,6 +91,10 @@ public interface ClusterEventListener {
      *
      * At this point the CacheFactory of the leaving node holds local caches. That means that modifications to
      * the caches of this JVM will not affect the leaving node but other cluster members.
+     *
+     * It is generally advisable that implementations of this method invoke applicable event listeners, to reflect
+     * changes in availability of data (related to the node that left). Often, this action is orchestrated by only
+     * one of the remaining cluster nodes: the senior member.
      *
      * @param nodeID ID of the node that is left the cluster.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -456,6 +456,11 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
         // org.jivesoftware.util.cache.CacheFactory.joinedCluster). This means that they now hold data that's
         // available on all other cluster nodes. Data that's available on the local node needs to be added again.
         restoreCacheContent();
+
+        // It does not appear to be needed to invoke any kind of event listeners for the data that was gained by joining
+        // the cluster (eg: new server features provided by other cluster nodes now available to the local cluster node):
+        // the only cache that's being used in this implementation does not have an associated event listening mechanism
+        // when data is added to or removed from it.
     }
 
     @Override
@@ -478,6 +483,11 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
         // org.jivesoftware.util.cache.CacheFactory.leftCluster). This means that they now hold no data (as a new cache
         // has been created). Data that's available on the local node needs to be added again.
         restoreCacheContent();
+
+        // It does not appear to be needed to invoke any kind of event listeners for the data that was lost by leaving
+        // the cluster (eg: server features provided only by other cluster nodes, now unavailable to the local cluster
+        // node): the only cache that's being used in this implementation does not have an associated event listening
+        // mechanism when data is added to or removed from it.
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
@@ -35,6 +35,8 @@ import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.util.cache.Cache;
 import org.jivesoftware.util.cache.CacheFactory;
 import org.jivesoftware.util.cache.ExternalizableUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.PacketError;
@@ -75,6 +77,8 @@ import java.util.stream.Collectors;
  */
 public class IQDiscoItemsHandler extends IQHandler implements ServerFeaturesProvider, ClusterEventListener,
         UserItemsProvider {
+
+    private static final Logger Log = LoggerFactory.getLogger(IQDiscoItemsHandler.class);
 
     public static final String NAMESPACE_DISCO_ITEMS = "http://jabber.org/protocol/disco#items";
     private Map<String,DiscoItemsProvider> entities = new HashMap<>();
@@ -440,23 +444,50 @@ public class IQDiscoItemsHandler extends IQHandler implements ServerFeaturesProv
 
     @Override
     public void joinedCluster() {
+        // The local node joined a cluster.
+        //
+        // Upon joining a cluster, clustered caches are reset to their clustered equivalent (by the swap from the local
+        // cache implementation to the clustered cache implementation that's done in the implementation of
+        // org.jivesoftware.util.cache.CacheFactory.joinedCluster). This means that they now hold data that's
+        // available on all other cluster nodes. Data that's available on the local node needs to be added again.
         restoreCacheContent();
     }
 
     @Override
     public void joinedCluster(byte[] nodeID) {
-        // Do nothing
+        // Another node joined a cluster that we're already part of. It is expected that
+        // the implementation of #joinedCluster() as executed on the cluster node that just
+        // joined will synchronize all relevant data. This method need not do anything.
     }
 
     @Override
     public void leftCluster() {
-        if (!XMPPServer.getInstance().isShuttingDown()) {
-            restoreCacheContent();
+        // The local cluster node left the cluster.
+        if (XMPPServer.getInstance().isShuttingDown()) {
+            // Do not put effort in restoring the correct state if we're shutting down anyway.
+            return;
         }
+
+        // Upon leaving a cluster, clustered caches are reset to their local equivalent (by the swap from the clustered
+        // cache implementation to the default cache implementation that's done in the implementation of
+        // org.jivesoftware.util.cache.CacheFactory.leftCluster). This means that they now hold no data (as a new cache
+        // has been created). Data that's available on the local node needs to be added again.
+        restoreCacheContent();
     }
 
     @Override
     public void leftCluster(byte[] nodeID) {
+        // Another node left the cluster.
+        //
+        // If the cluster node leaves in an orderly fashion, it might have broadcasted
+        // the necessary events itself. This cannot be depended on, as the cluster node
+        // might have disconnected unexpectedly (as a result of a crash or network issue).
+        //
+        // Determine what data was available only on that node, and remove that.
+        //
+        // All remaining cluster nodes will be in a race to clean up the
+        // same data. The implementation below accounts for that, by only having the
+        // senior cluster node to perform the cleanup.
         if (ClusterManager.isSeniorClusterMember()) {
             NodeID leftNode = NodeID.getInstance(nodeID);
             for (Map.Entry<String, ClusteredServerItem> entry : serverItems.entrySet()) {
@@ -486,11 +517,20 @@ public class IQDiscoItemsHandler extends IQHandler implements ServerFeaturesProv
     public void markedAsSeniorClusterMember() {
         // Do nothing
     }
+
+    /**
+     * When the local node is joining or leaving a cluster, {@link org.jivesoftware.util.cache.CacheFactory} will swap
+     * the implementation used to instantiate caches. This causes the cache content to be 'reset': it will no longer
+     * contain the data that's provided by the local node. This method restores data that's provided by the local node
+     * in the cache. It is expected to be invoked right after joining ({@link #joinedCluster()} or leaving
+     * ({@link #leftCluster()} a cluster.
+     */
     private void restoreCacheContent() {
+        Log.trace( "Restoring cache content for cache '{}' by adding all server items that are provided by the local cluster node.", serverItems.getName() );
         for (Map.Entry<String, Element> entry : localServerItems.entrySet()) {
             String jid = entry.getKey();
             Element element = entry.getValue();
-            Lock lock = CacheFactory.getLock(jid, serverItems);
+            Lock lock = serverItems.getLock(jid);
             try {
                 lock.lock();
                 ClusteredServerItem item = serverItems.get(jid);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
@@ -451,6 +451,11 @@ public class IQDiscoItemsHandler extends IQHandler implements ServerFeaturesProv
         // org.jivesoftware.util.cache.CacheFactory.joinedCluster). This means that they now hold data that's
         // available on all other cluster nodes. Data that's available on the local node needs to be added again.
         restoreCacheContent();
+
+        // It does not appear to be needed to invoke any kind of event listeners for the data that was gained by joining
+        // the cluster (eg: new server items provided by other cluster nodes now available to the local cluster node):
+        // the only cache that's being used in this implementation does not have an associated event listening mechanism
+        // when data is added to or removed from it.
     }
 
     @Override
@@ -473,6 +478,11 @@ public class IQDiscoItemsHandler extends IQHandler implements ServerFeaturesProv
         // org.jivesoftware.util.cache.CacheFactory.leftCluster). This means that they now hold no data (as a new cache
         // has been created). Data that's available on the local node needs to be added again.
         restoreCacheContent();
+
+        // It does not appear to be needed to invoke any kind of event listeners for the data that was lost by leaving
+        // the cluster (eg: server items provided only by other cluster nodes, now unavailable to the local cluster
+        // node): the only cache that's being used in this implementation does not have an associated event listening
+        // mechanism when data is added to or removed from it.
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -569,6 +569,11 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
         // org.jivesoftware.util.cache.CacheFactory.joinedCluster). This means that they now hold data that's
         // available on all other cluster nodes. Data that's available on the local node needs to be added again.
         restoreCacheContent();
+
+        // It does not appear to be needed to invoke any kind of event listeners for the data that was gained by joining
+        // the cluster (eg: directed presence provided by other cluster nodes now available to the local cluster node):
+        // the only cache that's being used in this implementation does not have an associated event listening mechanism
+        // when data is added to or removed from it.
     }
 
     @Override
@@ -591,6 +596,11 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
         // org.jivesoftware.util.cache.CacheFactory.leftCluster). This means that they now hold no data (as a new cache
         // has been created). Data that's available on the local node needs to be added again.
         restoreCacheContent();
+
+        // It does not appear to be needed to invoke any kind of event listeners for the data that was lost by leaving
+        // the cluster (eg: directed presence provided only by other cluster nodes, now unavailable to the local cluster
+        // node): the only cache that's being used in this implementation does not have an associated event listening
+        // mechanism when data is added to or removed from it.
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionInfo.java
@@ -18,6 +18,8 @@ package org.jivesoftware.openfire.session;
 
 import org.dom4j.Element;
 import org.dom4j.tree.DefaultElement;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.cluster.NodeID;
 import org.jivesoftware.util.cache.ExternalizableUtil;
 import org.xmpp.packet.Presence;
 
@@ -44,6 +46,7 @@ public class ClientSessionInfo implements Externalizable {
     private boolean offlineFloodStopped;
     private boolean messageCarbonsEnabled;
     private boolean hasRequestedBlocklist;
+    private NodeID nodeID;
 
     public ClientSessionInfo() {
     }
@@ -55,6 +58,7 @@ public class ClientSessionInfo implements Externalizable {
         offlineFloodStopped = session.isOfflineFloodStopped();
         messageCarbonsEnabled = session.isMessageCarbonsEnabled();
         hasRequestedBlocklist=session.hasRequestedBlocklist();
+        nodeID = XMPPServer.getInstance().getNodeID();
     }
 
     public Presence getPresence() {
@@ -79,6 +83,10 @@ public class ClientSessionInfo implements Externalizable {
     
     public boolean isMessageCarbonsEnabled() { return messageCarbonsEnabled; }
 
+    public NodeID getNodeID() {
+        return nodeID;
+    }
+
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {
         ExternalizableUtil.getInstance().writeSerializable(out, (DefaultElement) presence.getElement());
@@ -93,6 +101,7 @@ public class ClientSessionInfo implements Externalizable {
         ExternalizableUtil.getInstance().writeBoolean(out, offlineFloodStopped);
         ExternalizableUtil.getInstance().writeBoolean(out, messageCarbonsEnabled);    
         ExternalizableUtil.getInstance().writeBoolean(out, hasRequestedBlocklist);
+        ExternalizableUtil.getInstance().writeSerializable(out, nodeID);
     }
 
     @Override
@@ -108,5 +117,6 @@ public class ClientSessionInfo implements Externalizable {
         offlineFloodStopped = ExternalizableUtil.getInstance().readBoolean(in);
         messageCarbonsEnabled = ExternalizableUtil.getInstance().readBoolean(in);
         hasRequestedBlocklist = ExternalizableUtil.getInstance().readBoolean(in);
+        nodeID = (NodeID) ExternalizableUtil.getInstance().readSerializable(in);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1106,6 +1106,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             // Simulate that current session presence has just been received
             presenceUpdateHandler.process(session.getPresence());
         }
+        // TODO the above also (re)generates events on the local node, where these events had already occurred. Ideally, that should not happen.
+
+        // TODO shouldn't a similar action be done on the other nodes, so that the node that just joined gets informed about all sessions living on other cluster nodes?
     }
 
     @Override
@@ -1129,7 +1132,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         // has been created). Data that's available on the local node needs to be added again.
         restoreCacheContent();
 
-        // TODO all clients on other nodes are now unavailable!
+        // TODO all clients on other nodes are now unavailable! Send out the appropriate presence updates/events
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1106,9 +1106,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             // Simulate that current session presence has just been received
             presenceUpdateHandler.process(session.getPresence());
         }
-        // TODO the above also (re)generates events on the local node, where these events had already occurred. Ideally, that should not happen.
+        // TODO OF-2067: the above also (re)generates events on the local node, where these events had already occurred. Ideally, that should not happen.
 
-        // TODO shouldn't a similar action be done on the other nodes, so that the node that just joined gets informed about all sessions living on other cluster nodes?
+        // TODO OF-2066: shouldn't a similar action be done on the other nodes, so that the node that just joined gets informed about all sessions living on other cluster nodes?
     }
 
     @Override
@@ -1132,7 +1132,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         // has been created). Data that's available on the local node needs to be added again.
         restoreCacheContent();
 
-        // TODO all clients on other nodes are now unavailable! Send out the appropriate presence updates/events
+        // TODO OF-2066: all clients on other nodes are now unavailable! Send out the appropriate presence updates/events
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -25,7 +25,6 @@ import org.jivesoftware.openfire.PresenceRouter;
 import org.jivesoftware.openfire.RemotePacketRouter;
 import org.jivesoftware.openfire.RoutableChannelHandler;
 import org.jivesoftware.openfire.RoutingTable;
-import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.carbons.Received;
@@ -65,7 +64,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
+import java.util.stream.Stream;
 
 /**
  * Routing table that stores routes to client sessions, outgoing server sessions
@@ -1085,23 +1086,19 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     @Override
     public void joinedCluster()
     {
-        // Upon joining a cluster, the server can get a new ID. Here, all old IDs are replaced with the new identity.
-        final NodeID defaultNodeID = server.getDefaultNodeID();
-        final NodeID nodeID = server.getNodeID();
-        if ( !defaultNodeID.equals( nodeID ) ) // In more recent versions of Openfire, the ID does not change.
-        {
-            CacheUtil.replaceValueInCache( serversCache, defaultNodeID, nodeID );
-            CacheUtil.replaceValueInMultivaluedCache( componentsCache, defaultNodeID, nodeID );
-            CacheUtil.replaceValueInCacheByMapping( usersCache,
-                                                    clientRoute -> { if ( clientRoute.getNodeID().equals( defaultNodeID ) ) { clientRoute.setNodeID( nodeID ); } return clientRoute; } );
-            CacheUtil.replaceValueInCacheByMapping( anonymousUsersCache,
-                                                    clientRoute -> { if ( clientRoute.getNodeID().equals( defaultNodeID ) ) { clientRoute.setNodeID( nodeID ); } return clientRoute; } );
-        }
-        // Broadcast presence of local sessions to remote sessions when subscribed to presence
-        // Probe presences of remote sessions when subscribed to presence of local session
-        // Send pending subscription requests to local sessions from remote sessions
-        // Deliver offline messages sent to local sessions that were unavailable in other nodes
-        // Send available presences of local sessions to other resources of the same user
+        // The local node joined a cluster.
+        //
+        // Upon joining a cluster, clustered caches are reset to their clustered equivalent (by the swap from the local
+        // cache implementation to the clustered cache implementation that's done in the implementation of
+        // org.jivesoftware.util.cache.CacheFactory.joinedCluster). This means that they now hold data that's
+        // available on all other cluster nodes. Data that's available on the local node needs to be added again.
+        restoreCacheContent();
+
+        // Broadcast presence of local sessions to remote sessions when subscribed to presence.
+        // Probe presences of remote sessions when subscribed to presence of local session.
+        // Send pending subscription requests to local sessions from remote sessions.
+        // Deliver offline messages sent to local sessions that were unavailable in other nodes.
+        // Send available presences of local sessions to other resources of the same user.
         PresenceUpdateHandler presenceUpdateHandler = XMPPServer.getInstance().getPresenceUpdateHandler();
         for (LocalClientSession session : localRoutingTable.getClientRoutes()) {
             // Simulate that the local session has just became available
@@ -1113,107 +1110,103 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
     @Override
     public void joinedCluster(byte[] nodeID) {
-        // Do nothing
+        // Another node joined a cluster that we're already part of. It is expected that
+        // the implementation of #joinedCluster() as executed on the cluster node that just
+        // joined will synchronize all relevant data. This method need not do anything.
     }
 
     @Override
     public void leftCluster() {
-        if (!XMPPServer.getInstance().isShuttingDown()) {
-            // Upon leaving a cluster, the server uses its non-clustered/default ID again. Here, all clustered IDs are replaced with the new identity.
-            final NodeID defaultNodeID = server.getDefaultNodeID();
-            final NodeID nodeID = server.getNodeID();
-            if ( !defaultNodeID.equals( nodeID ) ) // In more recent versions of Openfire, the ID does not change.
-            {
-                CacheUtil.replaceValueInCache( serversCache, nodeID, defaultNodeID );
-                CacheUtil.replaceValueInMultivaluedCache( componentsCache, nodeID, defaultNodeID );
-                CacheUtil.replaceValueInCacheByMapping( usersCache,
-                                                        clientRoute -> { if ( clientRoute.getNodeID().equals( nodeID ) ) { clientRoute.setNodeID( defaultNodeID ); } return clientRoute; } );
-                CacheUtil.replaceValueInCacheByMapping( anonymousUsersCache,
-                                                        clientRoute -> { if ( clientRoute.getNodeID().equals( nodeID ) ) { clientRoute.setNodeID( defaultNodeID ); } return clientRoute; } );
-            }
-            // The local cluster node left the cluster.
-            //
-            // Determine what routes were available only on other cluster nodes than the local one.
-            // These need to be cleaned up, as they're no longer available to the local cluster node.
-
-            // Drop outgoing server routes from all other nodes.
-            final Set<DomainPair> removedOutgoingServerSessions = CacheUtil.retainValueInCache( serversCache, defaultNodeID );
-            removedOutgoingServerSessions.forEach( removedOutgoingServerSession -> {
-                Log.debug( "The local cluster node left the cluster. The outoing server session for '{}' was living on another cluster nodes, and is no longer available.", removedOutgoingServerSession.getRemote() );
-                localRoutingTable.removeRoute( removedOutgoingServerSession );
-            } );
-
-            // Drop component routes from all other nodes.
-            final Map<Boolean, Map<String, HashSet<NodeID>>> modified = CacheUtil.retainValueInMultiValuedCache( componentsCache, defaultNodeID );
-            modified.get( false ).keySet().forEach( removedComponentDomain -> {
-                Log.debug( "The local cluster node left the cluster. The component session for '{}' was living on one (or more) other cluster nodes, and is no longer available.", removedComponentDomain );
-                localRoutingTable.removeRoute(new DomainPair("", removedComponentDomain ));
-            } );
-
-            // Drop routes for all client sessions connected via other cluster nodes.
-            final List<String> remoteClientRoutes = new ArrayList<>();
-            for (Map.Entry<String, ClientRoute> entry : usersCache.entrySet()) {
-                if (!entry.getValue().getNodeID().equals(defaultNodeID)) {
-                    remoteClientRoutes.add(entry.getKey());
-                }
-            }
-            for (Map.Entry<String, ClientRoute> entry : anonymousUsersCache.entrySet()) {
-                if (!entry.getValue().getNodeID().equals(defaultNodeID)) {
-                    remoteClientRoutes.add(entry.getKey());
-                }
-            }
-            Log.debug( "The local cluster node left the cluster. A total of {} client sessions were living on one (or more) other cluster nodes, and are no longer available.", remoteClientRoutes.size() );
-            for (String route : remoteClientRoutes) {
-                // This call takes responsibility for cleaning up the state in RoutingTableImpl as well as SessionManager.
-                // The detour is needed, as SessionManager does not keep track what client is associated to what cluster node.
-                SessionManager.getInstance().removeRemoteClientSession( new JID(route) );
-            }
+        // The local cluster node left the cluster.
+        if (XMPPServer.getInstance().isShuttingDown()) {
+            // Do not put effort in restoring the correct state if we're shutting down anyway.
+            return;
         }
+
+        // Upon leaving a cluster, clustered caches are reset to their local equivalent (by the swap from the clustered
+        // cache implementation to the default cache implementation that's done in the implementation of
+        // org.jivesoftware.util.cache.CacheFactory.leftCluster). This means that they now hold no data (as a new cache
+        // has been created). Data that's available on the local node needs to be added again.
+        restoreCacheContent();
+
+        // TODO all clients on other nodes are now unavailable!
     }
 
     @Override
-    public void leftCluster(byte[] nodeID) {
-        
+    public void leftCluster(byte[] nodeID)
+    {
+        // Another node left the cluster.
+
         // When a peer server leaves the cluster, any remote routes that were
         // associated with the defunct node must be dropped from the routing 
         // caches that are shared by the remaining cluster member(s).
-        
-        // drop routes for all client sessions connected via the defunct cluster node
-            List<String> remoteClientRoutes = new ArrayList<>();
-            for (Map.Entry<String, ClientRoute> entry : usersCache.entrySet()) {
-                if (entry.getValue().getNodeID().equals(nodeID)) {
-                    remoteClientRoutes.add(entry.getKey());
-                }
-            }
-            for (Map.Entry<String, ClientRoute> entry : anonymousUsersCache.entrySet()) {
-                if (entry.getValue().getNodeID().equals(nodeID)) {
-                    remoteClientRoutes.add(entry.getKey());
-                }
-            }
-            Log.debug( "Cluster node {} just left the cluster. A total of {} client sessions was living there, and are no longer available.", NodeID.getInstance( nodeID ), remoteClientRoutes.size() );
-            for (String route : remoteClientRoutes) {
-                // This call takes responsibility for cleaning up the state in RoutingTableImpl as well as SessionManager.
-                // The detour is needed, as SessionManager does not keep track what client is associated to what cluster node.
-                SessionManager.getInstance().removeRemoteClientSession( new JID(route) );
-            }
 
-        // remove routes for server domains that were accessed through the defunct node
+        // Determine what components were available only on that node, and remove them.
+        // All remaining cluster nodes will be in a race to clean up the
+        // same data. The implementation below accounts for that, by only having the
+        // senior cluster node to perform the cleanup.
+        if (!ClusterManager.isSeniorClusterMember()) {
+            return;
+        }
+
+        // Drop routes for all client sessions connected via the defunct cluster node.
+        final AtomicLong removedSessionCount = new AtomicLong();
+        Stream.concat(usersCache.entrySet().stream(), anonymousUsersCache.entrySet().stream() )
+            .filter( entry -> entry.getValue().getNodeID().equals(nodeID))
+            .forEach( entry -> {
+                removedSessionCount.getAndIncrement();
+                final JID fullJID = new JID(entry.getKey());
+                removeClientRoute(fullJID);
+                if ( entry.getValue().isAvailable() )
+                {
+                    // Simulate that the session has just gone offline
+                    final Presence offline = new Presence();
+                    offline.setFrom(fullJID);
+                    offline.setTo(new JID(null, serverName, null, true));
+                    offline.setType(Presence.Type.unavailable);
+                    XMPPServer.getInstance().getPacketRouter().route(offline);
+                }
+            });
+        Log.debug( "Cluster node {} just left the cluster. A total of {} client sessions was living there, and are no longer available.", NodeID.getInstance( nodeID ), removedSessionCount.get() );
+
+        // Remove routes for server domains that were accessed through the defunct node.
         final Set<DomainPair> removedServers = CacheUtil.removeValueFromCache( serversCache, NodeID.getInstance( nodeID ) );
         removedServers.forEach( removedServer -> {
-            Log.debug( "Cluster node {} just left the cluster, and was the only node on which the outgoing server route to '{}' was living. This route will be removed.", NodeID.getInstance( nodeID ), removedServer.getRemote() );
-            localRoutingTable.removeRoute( removedServer );
+            Log.debug( "Cluster node {} just left the cluster, and was the only node on which the outgoing server route to '{}' was living. This route was removed.", NodeID.getInstance( nodeID ), removedServer.getRemote() );
         } );
 
-        // remove component routes for the defunct node
+        // Remove component routes for the defunct node.
         final Map<Boolean, Map<String, HashSet<NodeID>>> modifiedComponents = CacheUtil.removeValueFromMultiValuedCache( componentsCache, NodeID.getInstance( nodeID ) );
         modifiedComponents.get( false ).keySet().forEach( removedComponentDomain -> {
-            Log.debug( "Cluster node {} just left the cluster, and was the only node on which the external component session for '{}' was living. This route will be removed", NodeID.getInstance( nodeID ), removedComponentDomain );
-            localRoutingTable.removeRoute(new DomainPair("", removedComponentDomain ));
+            Log.debug( "Cluster node {} just left the cluster, and was the only node on which the external component session for '{}' was living. This route was removed", NodeID.getInstance( nodeID ), removedComponentDomain );
         } );
     }
 
     @Override
     public void markedAsSeniorClusterMember() {
         // Do nothing
+    }
+
+    /**
+     * When the local node is joining or leaving a cluster, {@link org.jivesoftware.util.cache.CacheFactory} will swap
+     * the implementation used to instantiate caches. This causes the cache content to be 'reset': it will no longer
+     * contain the data that's provided by the local node. This method restores data that's provided by the local node
+     * in the cache. It is expected to be invoked right after joining ({@link #joinedCluster()} or leaving
+     * ({@link #leftCluster()} a cluster.
+     */
+    private void restoreCacheContent()
+    {
+        Log.trace( "Restoring cache content for cache '{}' by adding all outgoing server routes that are connected to the local cluster node.", serversCache.getName() );
+        localRoutingTable.getServerRoutes().forEach( route -> route.getOutgoingDomainPairs().forEach( address -> serversCache.put( address, server.getNodeID()) ) );
+
+        Log.trace( "Restoring cache content for cache '{}' by adding all component routes that are connected to the local cluster node.", componentsCache.getName() );
+        localRoutingTable.getComponentRoute().forEach( route -> CacheUtil.addValueToMultiValuedCache( componentsCache, route.getAddress().getDomain(), server.getNodeID(), HashSet::new ));
+
+        Log.trace( "Restoring cache content for cache '{}', '{}' and '{}' by adding all client routes that are connected to the local cluster node.", usersCache.getName(), anonymousUsersCache.getName(), usersSessions.getName() );
+
+        // Add client sessions hosted locally to the cache (using new nodeID)
+        for (LocalClientSession session : localRoutingTable.getClientRoutes()) {
+            addClientRoute(session.getAddress(), session);
+        }
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/Cache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/Cache.java
@@ -47,6 +47,13 @@ import java.util.concurrent.locks.Lock;
  * Note that neither keys or values can be null; A {@link NullPointerException}
  * will be thrown attempting to place or retrieve null values in to the cache.
  *
+ * Caches can (but need not be) used as a mechanism that is used to share data
+ * in an Openfire cluster. When a cache is used for this purpose, it is important
+ * to realize that, when joining or leaving a cluster, the cache content will
+ * be cleared of all data that was added on the local cluster node. Typically,
+ * {@link org.jivesoftware.openfire.cluster.ClusterEventListener} is used to
+ * detect these events and restore the content of the cache.
+ *
  * @see Cacheable
  */
 public interface Cache<K extends Serializable, V extends Serializable> extends java.util.Map<K, V> {

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -873,13 +873,12 @@ public class CacheFactory {
     @SuppressWarnings("unchecked")
     public static synchronized void joinedCluster() {
         cacheFactoryStrategy = clusteredCacheFactoryStrategy;
-        // Loop through local caches and switch them to clustered cache (copy content)
+        // Loop through local caches and switch them to clustered cache (purge content)
         Arrays.stream(getAllCaches())
             .filter(CacheFactory::isClusterableCache)
             .forEach(cache -> {
                 final CacheWrapper cacheWrapper = ((CacheWrapper) cache);
                 final Cache clusteredCache = cacheFactoryStrategy.createCache(cacheWrapper.getName());
-                clusteredCache.putAll(cache);
                 cacheWrapper.setWrappedCache(clusteredCache);
             });
         clusteringStarting = false;
@@ -895,13 +894,12 @@ public class CacheFactory {
         clusteringStarted = false;
         cacheFactoryStrategy = localCacheFactoryStrategy;
 
-        // Loop through clustered caches and change them to local caches (copy content)
+        // Loop through clustered caches and change them to local caches (purge content)
         Arrays.stream(getAllCaches())
             .filter(CacheFactory::isClusterableCache)
             .forEach(cache -> {
                 final CacheWrapper cacheWrapper = ((CacheWrapper) cache);
                 final Cache standaloneCache = cacheFactoryStrategy.createCache(cacheWrapper.getName());
-                standaloneCache.putAll(cache);
                 cacheWrapper.setWrappedCache(standaloneCache);
             });
         log.info("Clustering stopped; cache migration complete");


### PR DESCRIPTION
(the description of the PR is copied from the commit message of the second commit, which holds most relevant changes)

When a server joins or leaves a cluster, the implementation that's behind the Cache interface is swapped. When switching _to_ a clustered implementation (_from_ a local/non-clustered implementation), the replacement cache can be used to interact with the cache content that's shared in the cluster. When switching _from_ a clustered implementation (_to_ a local/non-clustered implementation) the cache is replaced with a new (empty) default cache.

OF-974 (now reverted) introduced a change that caused the content from the old implementation to be copied to the new one during the switch-over. This prevented data to be 'lost'. This approach has a considerable drawbacks: When data exists in both caches under the same key, one of the entries will be lost. Depending on the usage of a cache, different techniques to merge data can be desirable. The solution for OF-974 does not allow for that. Also, OF-974 assumes that it is desirable to retain data from the cluster after the node leaves the cluster. This is questionable. In cases, usage-specific code is needed to 'clean up' caches. This leads to a fragmentation of the responsibility of maintaining the cache content over various places: the utilizing code of the cache, as well as the CacheFactory. This adds code complexity.

The original strategy (which has been restored by reverting OF-974) was for code to anticipate that, during cluster join and leave action, the data from the local node was missing from the cache. This introduced the various `restoreCacheContent` method implementations. This has it's own challenges: there's the problem of 'missing data' (which lead to OF-974 in the first place), but also of not having access to the state of the cache prior to the change makes it hard to detect what changes are applied, which in turn makes it difficult to invoke corresponding event listeners, etc). It does, however, allow for far more granular control over the cache content, on a per-usage base. Additionally, cache content control can more easily be implemented in one central place, reducing complexity of the solution.

This commit restores the original strategy, mainly by restoring notion of 'caches will not contain local data directly after a switchover' and re-introducing various `restoreCacheContent` implementations, in places that currently inherit from `ClusterEventListener`.