### PR TITLE
OF-2068 Display the versions of various nodes in the cluster

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -3555,6 +3555,7 @@ system.clustering.using-embedded-db=Clustering is not available when using an em
 system.clustering.not-installed=Clustering support was not found on the system. Install a <a href="available-plugins.jsp">plugin</a> that adds clustering support.
 system.clustering.not-valid-license=Clustering license is not valid. You need to update your license to enable clustering.
 system.clustering.starting=Clustering is being started. It may take up to 30 seconds to complete. Click {0}here{1} to refresh.
+system.clustering.versions.label=Cluster Versions Overview
 
 # Security Auditor page
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/GetClusteredVersions.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/GetClusteredVersions.java
@@ -1,0 +1,57 @@
+package org.jivesoftware.openfire.cluster;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.container.PluginMetadata;
+import org.jivesoftware.util.cache.ClusterTask;
+import org.jivesoftware.util.cache.ExternalizableUtil;
+
+public class GetClusteredVersions implements ClusterTask<GetClusteredVersions> {
+
+    private static final long serialVersionUID = -4081828933134021041L;
+    private String openfireVersion;
+    private Map<String, String> pluginVersions;
+
+    public String getOpenfireVersion() {
+        return openfireVersion;
+    }
+
+    public Map<String, String> getPluginVersions() {
+        return pluginVersions;
+    }
+
+    @Override
+    public GetClusteredVersions getResult() {
+        return this;
+    }
+
+    @Override
+    public void writeExternal(final ObjectOutput out) throws IOException {
+        final ExternalizableUtil util = ExternalizableUtil.getInstance();
+        util.writeSafeUTF(out, openfireVersion);
+        util.writeStringMap(out, pluginVersions);
+    }
+
+    @Override
+    public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
+        final ExternalizableUtil util = ExternalizableUtil.getInstance();
+        openfireVersion = util.readSafeUTF(in);
+        pluginVersions = util.readStringMap(in);
+    }
+
+    @Override
+    public void run() {
+        final XMPPServer xmppServer = XMPPServer.getInstance();
+        openfireVersion = xmppServer.getServerInfo().getVersion().toString();
+        pluginVersions = new HashMap<>();
+        pluginVersions = xmppServer.getPluginManager().getMetadataExtractedPlugins().values().stream()
+            .filter(pluginMetadata -> !pluginMetadata.getCanonicalName().equals("admin"))
+            .collect(Collectors.toMap(
+                PluginMetadata::getName, pluginMetadata -> pluginMetadata.getVersion().toString()));
+    }
+}

--- a/xmppserver/src/main/webapp/system-clustering.jsp
+++ b/xmppserver/src/main/webapp/system-clustering.jsp
@@ -42,6 +42,18 @@
 <%@ page import="org.jivesoftware.openfire.cluster.ClusterEventListener" %>
 <%@ page import="java.util.concurrent.Semaphore" %>
 <%@ page import="java.util.concurrent.TimeUnit" %>
+<%@ page import="org.jivesoftware.openfire.cluster.GetClusteredVersions" %>
+<%@ page import="org.jivesoftware.openfire.cluster.NodeID" %>
+<%@ page import="java.util.HashMap" %>
+<%@ page import="com.google.common.collect.Table" %>
+<%@ page import="com.google.common.collect.HashBasedTable" %>
+<%@ page import="java.util.Set" %>
+<%@ page import="java.util.TreeSet" %>
+<%@ page import="java.util.Collections" %>
+<%@ page import="java.util.ArrayList" %>
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.Comparator" %>
+<%@ page import="java.util.Objects" %>
 
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
 <% webManager.init(request, response, session, application, out ); %>
@@ -158,7 +170,9 @@
     int maxClusterNodes = ClusterManager.getMaxClusterNodes();
     clusteringEnabled = ClusterManager.isClusteringStarted() || ClusterManager.isClusteringStarting();
 
-    Collection<ClusterNodeInfo> clusterNodesInfo = ClusterManager.getNodesInfo();
+    final List<ClusterNodeInfo> clusterNodesInfo = new ArrayList<>(ClusterManager.getNodesInfo());
+    // Sort them so they are always consistent in order
+    clusterNodesInfo.sort((o1, o2) -> o1.getHostName().compareTo(o2.getHostName()));
     // Get some basic statistics from the cluster nodes
     // TODO Set a timeout so the page can load fast even if a node is taking too long to answer
     Collection<Map<String, Object>> statistics =
@@ -189,6 +203,28 @@
         percentage = outgoing == 0 ? 0 : current * 100 / outgoing;
         statsMap.put(GetBasicStatistics.OUTGOING, current + " (" + Math.round(percentage) + "%)");
     }
+    // Note; if any one node in the cluster does not have the GetClusterVersions task, running
+    // CacheFactory.doSynchronousClusterTask() on all nodes will return an empty collection. For
+    // that reason, run the task on each node individually.
+    final Table<NodeID, String, String> pluginVersions = HashBasedTable.create();
+    final Set<String> plugins = new TreeSet<>();
+    clusterNodesInfo.forEach(clusterNodeInfo -> {
+        final NodeID nodeID = clusterNodeInfo.getNodeID();
+        final GetClusteredVersions clusteredVersions = CacheFactory.doSynchronousClusterTask(
+            new GetClusteredVersions(), nodeID.toByteArray());
+        if (clusteredVersions != null) {
+            pluginVersions.put(nodeID, "Openfire", clusteredVersions.getOpenfireVersion());
+            clusteredVersions.getPluginVersions().forEach((pluginName, pluginVersion) -> {
+                plugins.add(pluginName);
+                pluginVersions.put(nodeID, pluginName, pluginVersion);
+            });
+        }
+    });
+    pageContext.setAttribute("localNodeID", XMPPServer.getInstance().getNodeID());
+    pageContext.setAttribute("pluginVersions", pluginVersions);
+    pageContext.setAttribute("plugins", plugins);
+    pageContext.setAttribute("clusteringStarted", CacheFactory.isClusteringStarted());
+    pageContext.setAttribute("clusterNodesInfo", clusterNodesInfo);
 %>
 
 <p>
@@ -449,6 +485,48 @@
         </table>
 </div>
 
-
+<c:if test="${clusteringStarted}">
+    <div class="jive-contentBoxHeader">
+        <fmt:message key="system.clustering.versions.label"/>
+    </div>
+    <div class="jive-contentBox">
+        <table style="white-space: nowrap; padding: 3px; border-spacing: 2px; border-collapse: collapse">
+            <thead>
+            <tr>
+                <th style="width: 1%"></th>
+                <th style="width: 1%"><fmt:message key="short.title"/></th>
+                <c:forEach items="${plugins}" var="plugin">
+                    <th style="width: 1%"><c:out value="${plugin}"/></th>
+                </c:forEach>
+            </tr>
+            </thead>
+            <tbody>
+            <!--@elvariable id="clusterNodeInfo" type="org.jivesoftware.openfire.cluster.ClusterNodeInfo>"-->
+            <c:forEach items="${clusterNodesInfo}" var="clusterNodeInfo">
+                <tr <c:if test="${localNodeID == clusterNodeInfo.nodeID}">class="local"</c:if>
+                    style="vertical-align:middle">
+                    <th style="width: 1%">
+                        <c:out value="${clusterNodeInfo.hostName}"/>
+                    </th>
+                    <td class="jive-description" style="width: 1%">
+                        <c:out value="${pluginVersions.get(clusterNodeInfo.nodeID, 'Openfire')}"/>
+                        <c:if test="${pluginVersions.get(localNodeID, 'Openfire') != pluginVersions.get(clusterNodeInfo.nodeID, 'Openfire')}">
+                            <img src="images/warning-16x16.gif" width="16" height="16" alt="Warning">
+                        </c:if>
+                    </td>
+                    <c:forEach items="${plugins}" var="plugin">
+                        <td class="jive-description" style="width: 1%">
+                            <c:out value="${pluginVersions.get(clusterNodeInfo.nodeID, plugin)}"/>
+                            <c:if test="${pluginVersions.get(localNodeID, plugin) != pluginVersions.get(clusterNodeInfo.nodeID, plugin)}">
+                                <img src="images/warning-16x16.gif" width="16" height="16" alt="Warning">
+                            </c:if>
+                        </td>
+                    </c:forEach>
+                </tr>
+            </c:forEach>
+            </tbody>
+        </table>
+    </div>
+</c:if>
 </body>
 </html>


### PR DESCRIPTION
This is to fix https://github.com/igniterealtime/openfire-hazelcast-plugin/issues/47 but it turned out to be easier to implement this in core Openfire rather than the clustering plugin itself. @guusdk is it worth raising an Openfire JIRA ticket to cover this off?

It was also fairly easy to display the various plugin versions too - probably useful as I've certainly tripped myself up when running subtly different versions on different nodes.

If any version is different, then a warning symbol is displayed.

What you see if you're running an old version of Openfire in the cluster;
![With old server](https://user-images.githubusercontent.com/435813/91456002-ac254800-e87a-11ea-9bb0-d6582437f7e5.png)

What you see when that version has been upgraded;
![With new server](https://user-images.githubusercontent.com/435813/91456042-b6474680-e87a-11ea-9794-e382eb659530.png)
(note the different version of the Hazelcast plugin and the missing XML Debugger plugin)

And what the other node sees:
![From other side](https://user-images.githubusercontent.com/435813/91456156-da0a8c80-e87a-11ea-9f72-a3dbad1c04b5.png)

