### PR TITLE
Bump maven version in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.2-jdk-8 as packager
+FROM maven:3.6.3-jdk-8 as packager
 WORKDIR /usr/src
 
 COPY ./pom.xml .


### PR DESCRIPTION
Release notes (https://maven.apache.org/docs/3.6.3/release-notes.html) indicate some useful fixes, especially

> [MNG-6759] - [REGRESSION] Maven fails to use <repositories> section from dependency when resolving transitive dependencies in some cases
