### PR TITLE
OF-2080: Prevent caching null item

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CachingPubsubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CachingPubsubPersistenceProvider.java
@@ -655,24 +655,25 @@ public class CachingPubsubPersistenceProvider implements PubSubPersistenceProvid
                 // allows clustered item cache to be primed by first request
                 result = itemCache.get(itemIdentifier);
                 if (result == null) {
-                    log.debug("No cached item found. Obtaining it from delegate.");
+                    log.trace("No cached item found. Obtaining it from delegate. Item identifier: {}", itemIdentifier);
                     result = delegate.getPublishedItem( node, itemIdentifier );
                     if (result != null) {
-                        log.debug("Caching item obtained from delegate.");
+                        log.trace("Caching item obtained from delegate.");
                         itemCache.put(itemIdentifier, result);
                     } else {
-                        log.debug("Delegate doesn't have an item. It does not appear to exist.");
+                        log.trace("Delegate doesn't have an item. It does not appear to exist.");
                     }
                 } else {
-                    log.debug("Found cached item on second attempt (after acquiring lock)");
+                    log.trace("Found cached item on second attempt (after acquiring lock). Item identifier: {}", itemIdentifier);
                 }
 
             } finally {
                 itemLock.unlock();
             }
         } else {
-            log.debug("Found cached item on first attempt (no lock)");
+            log.trace("Found cached item on first attempt (no lock). Item identifier: {}", itemIdentifier);
         }
+        log.debug( "Item for item identifier {} was {} on node {}", itemIdentifier, result == null ? "not found" : "found", node.getUniqueIdentifier() );
         return result;
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CachingPubsubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CachingPubsubPersistenceProvider.java
@@ -657,7 +657,12 @@ public class CachingPubsubPersistenceProvider implements PubSubPersistenceProvid
                 if (result == null) {
                     log.debug("No cached item found. Obtaining it from delegate.");
                     result = delegate.getPublishedItem( node, itemIdentifier );
-                    itemCache.put(itemIdentifier, result);
+                    if (result != null) {
+                        log.debug("Caching item obtained from delegate.");
+                        itemCache.put(itemIdentifier, result);
+                    } else {
+                        log.debug("Delegate doesn't have an item. It does not appear to exist.");
+                    }
                 } else {
                     log.debug("Found cached item on second attempt (after acquiring lock)");
                 }


### PR DESCRIPTION
When an item is being requested that does not exist, the existing code for the CachingPubsubPersistenceProvider attempts to cache null, which is not allowed.

This modification simply skips caching the value. We could consider adding an Optional (to reflect the negative lookup), but that needs additional checking. I'm not sure if it'd work with the async persistence of content that's implemented in this class.