### PR TITLE
UserManager getUser method overloaded for JID

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -292,6 +292,10 @@ public final class UserManager {
             throw new UserNotFoundException("user cannot be null");
         }
 
+        if (!xmppServer.isLocal(user)) {
+            throw new UserNotFoundException("Cannot get remote user");
+        }
+
         return getUser(user.getNode());
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -281,6 +281,21 @@ public final class UserManager {
     }
 
     /**
+     * Returns the User specified by jid node.
+     *
+     * @param user the username of the user.
+     * @return the User that matches {@code username}.
+     * @throws UserNotFoundException if the user does not exist.
+     */
+    public User getUser(final JID user) throws UserNotFoundException {
+        if (user == null) {
+            throw new UserNotFoundException("user cannot be null");
+        }
+
+        return getUser(user.getNode());
+    }
+
+    /**
      * Returns the total number of users in the system.
      *
      * @return the total number of users.


### PR DESCRIPTION
There is a usage in the form of `webManager.userManager.getUser(member)` in the [group-edit.jsp](https://github.com/igniterealtime/Openfire/blob/c4cbe6564c9aa5fc6593bb1ebbcde1dbdf1e6764/xmppserver/src/main/webapp/group-edit.jsp#L672) file. The `member` is of type JID, but it is converted to string when called. And it comes to getUser method as "username@example.com". This is "java.lang.IllegalArgumentException: The input 'username@example.com' is not a valid JID node part: Contains prohibited code points." causing error.

This PR fixed that issue.