### PR TITLE
Defend against flaky tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ rpmbuild/
 debian/
 
 .gradle
+
+aioxmpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - mvn verify -P ci
   - JAVAC_MAJOR_VERSION=$(javac -version | sed -E 's/javac ([[:digit:]]+).*/\1/')
   - if [[ ${JAVAC_MAJOR_VERSION} -gt 8 ]]; then ./runIntegrationTests -gl ; fi
-  - TERM="dumb" ./runAioxmppIntegrationTests -l
+  - n=0; until [ "$n" -ge 3 ]; do TERM="dumb" ./runAioxmppIntegrationTests -l && break; n=$((n+1)); done # Try tests a few times, in case of flakiness
 install: true
 deploy:
   provider: script


### PR DESCRIPTION
Some PRs are failing due to 1 flaky test in the aioxmpp suite. For now, retry 3 times to get PRs with accurate info.

This isn't the real solution. This is an interim solution to help the CI surface accurate feedback.
(Next steps: Fix or exclude the test in aioxmpp)