### PR TITLE
OF-2089 XEP-0045 7.2.13 - ofrom adresses in message stanza

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -27,7 +27,9 @@ import java.util.concurrent.*;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
+import org.dom4j.QName;
 import org.jivesoftware.database.SequenceManager;
 import org.jivesoftware.openfire.PacketRouter;
 import org.jivesoftware.openfire.XMPPServer;
@@ -62,12 +64,7 @@ import org.jivesoftware.util.cache.CacheFactory;
 import org.jivesoftware.util.cache.ExternalizableUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xmpp.packet.IQ;
-import org.xmpp.packet.JID;
-import org.xmpp.packet.Message;
-import org.xmpp.packet.Packet;
-import org.xmpp.packet.PacketError;
-import org.xmpp.packet.Presence;
+import org.xmpp.packet.*;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -1356,6 +1353,9 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         }
         // Send the message to all occupants
         message.setFrom(senderRole.getRoleAddress());
+        if (canAnyoneDiscoverJID) {
+            addRealJidToMessage(message, senderRole);
+        }
         send(message, senderRole);
         // Fire event that message was received by the room
         MUCEventDispatcher.messageReceived(getRole().getRoleAddress(), senderRole.getUserAddress(),
@@ -1608,6 +1608,20 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             mucService.logConversation(this, message, senderAddress);
         }
         mucService.messageBroadcastedTo(messageRequest.getOccupants());
+    }
+
+    /**
+     * Based on XEP-0045, section 7.2.13:
+     * If the room is non-anonymous, the service MAY include an
+     * Extended Stanza Addressing (XEP-0033) [16] element that notes the original
+     * full JID of the sender by means of the "ofrom" address type
+     */
+    public void addRealJidToMessage(Message message, MUCRole role) {
+        Element addresses = DocumentHelper.createElement(QName.get("addresses", "http://jabber.org/protocol/address"));
+        Element address = addresses.addElement("address");
+        address.addAttribute("type", "ofrom");
+        address.addAttribute("jid", role.getUserAddress().toBareJID());
+        message.addExtension(new PacketExtension(addresses));
     }
 
     /**


### PR DESCRIPTION
# Introduction

In non-anonymous rooms, participants can/should see the others' real JID. That's usually done via presences. However, according to XEP-0045, section 7.2.13 a server MAY send the real JID also as an "addresses" stanza with type "ofrom" within the message.

This PR implements that. I opted to add the field if `canAnyoneDiscoverJID` is set to true for the room. Ofc, a more sophisticated implementation might include other cases based on the participant's role.

# Testing

I wanted to write some tests for this, but `LocalMUCRoom` had some difficult to mock dependencies to singleton classes (namely the `MUCPersistenceManager` that is used in the constructor).