### PR TITLE
Ignore .factorypath files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out/
 .settings
 .project
 .classpath
+.factorypath
 
 # Ignore MacOSX files
 .DS_Store


### PR DESCRIPTION
I'm a monster who chooses to do Java work in VS Code on occasion, and these files are generated by the maven plugin.