### PR TITLE
Fix Github SHA for maven

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -289,7 +289,7 @@ jobs:
         with:
           # Defend against another commit quickly following the first
           # We want the one that's been tested, rather than the head of master
-          ref: ${github.event.head}
+          ref: ${github.event.push.after}
       - name: Set up Java for publishing
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Fixes the broken git pull in the publish job introduced in #1716 