### PR TITLE
OF-2030 The author is always not null.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/FMUCHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/FMUCHandler.java
@@ -960,12 +960,7 @@ public class FMUCHandler
 
             // The 'stripped' stanza is going to be distributed locally. Act as if it originates from a local user, instead of the remote FMUC one.
             final JID from;
-            if ( author != null ) {
-                from = senderRole.getRoleAddress();
-            } else {
-                Log.trace("(room: '{}'): FMUC stanza did not have 'from' value. Using room JID instead.", room.getJID() );
-                from = room.getJID();
-            }
+            from = senderRole.getRoleAddress();
             stripped.setFrom( from );
             stripped.setTo( room.getJID() );
 


### PR DESCRIPTION
The author is assigned through new at the beginning of the method, it always is not null (or the method will throw an exception) so "else" never happens.

I am playing a bit with SonarQube so you might expect few more such small patches :)