### PR TITLE
OF-2093: Prevent JDK11 NoSuchMethodError by something else than an explicit cast because Greg pointed me to a much better solution.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,18 @@
     </properties>
 
     <profiles>
+
+        <!-- OF-2093: Ensure proper cross-compilation, using a compiler flag that's introduced in Java 9. -->
+        <profile>
+            <id>jdk9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
+
         <profile>
             <id>release</id>
             <build>


### PR DESCRIPTION
When Openfire is compiled with Java 11, but executed in Java 8 a NoSuchMethodError can be thrown when a client tries to connect. This appears to be caused by Java 11 overriding the `Buffer.flip()` method in ByteBuffer and CharBuffer. To avoid issues, this commit casts explicitly to Buffer when the flip method is used, which is the suggested fix found in https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip

I'm not sure if this is the most optimal way to fix this problem, nor if a similar fix needs to be applied in other places. In any case, the client connection issue disappears with this fix.