### PR TITLE
OF-2097: Allow CAPS info to be shown on the admin console

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1972,6 +1972,11 @@ session.details.anon-false=No
 session.details.flomr-status=Flexible Offline Message Retrieval
 session.details.flomr-enabled=Enabled
 session.details.flomr-disabled=Disabled
+session.details.entity_capabilities=Entity Capabilities (CAPS) information
+session.details.entity_capabilities.identity=Identity
+session.details.entity_capabilities.feature=Feature
+session.details.hide-extended=Show Less Details
+session.details.show-extended=Show More Details
 
 # Session row Page
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1086,6 +1086,11 @@ session.details.back_button=Terug naar overzicht
 session.details.node=Node
 session.details.local=Local
 session.details.remote=Remote
+session.details.entity_capabilities=Entity Capabilities (CAPS) informatie
+session.details.entity_capabilities.identity=Identiteit
+session.details.entity_capabilities.feature=Eigenschap
+session.details.hide-extended=Toon Minder Details
+session.details.show-extended=Toon Meer Details
 
 # Session row Page
 


### PR DESCRIPTION
This adds Entity Capabilities (as announced by the client) to the session details page. As this information is not very useful for the average user, I've hidden it behind a 'show more details' button.