### PR TITLE
OF-2106: UserManager.isRegisteredUser(JID address) API change

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -352,7 +352,7 @@ public class IQRouter extends BasicModule {
                 }
                 else {
                     // Check if communication to local users is allowed
-                    if (recipientJID != null && userManager.isRegisteredUser(recipientJID.getNode())) {
+                    if (recipientJID != null && userManager.isRegisteredUser(recipientJID, false)) {
                         PrivacyList list =
                                 PrivacyListManager.getInstance().getDefaultPrivacyList(recipientJID.getNode());
                         if (list != null && list.shouldBlockPacket(packet)) {
@@ -391,7 +391,7 @@ public class IQRouter extends BasicModule {
                 // RFC 6121 8.5.1.  No Such User http://xmpp.org/rfcs/rfc6121.html#rules-localpart-nosuchuser
                 // If the 'to' address specifies a bare JID <localpart@domainpart> or full JID <localpart@domainpart/resourcepart> where the domainpart of the JID matches a configured domain that is serviced by the server itself, the server MUST proceed as follows.
                 // If the user account identified by the 'to' attribute does not exist, how the stanza is processed depends on the stanza type.
-                if (recipientJID != null && recipientJID.getNode() != null && serverName.equals(recipientJID.getDomain()) && !userManager.isRegisteredUser(recipientJID.getNode()) && sessionManager.getSession(recipientJID) == null && (IQ.Type.set == packet.getType() || IQ.Type.get == packet.getType())) {
+                if (recipientJID != null && recipientJID.getNode() != null && serverName.equals(recipientJID.getDomain()) && !userManager.isRegisteredUser(recipientJID, false) && sessionManager.getSession(recipientJID) == null && (IQ.Type.set == packet.getType() || IQ.Type.get == packet.getType())) {
                     // For an IQ stanza, the server MUST return a <service-unavailable/> stanza error to the sender.
                     sendErrorPacket(packet, PacketError.Condition.service_unavailable);
                     return;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStore.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStore.java
@@ -135,14 +135,8 @@ public class OfflineMessageStore extends BasicModule implements UserEventListene
         JID recipient = message.getTo();
         String username = recipient.getNode();
         // If the username is null (such as when an anonymous user), don't store.
-        if (username == null || !UserManager.getInstance().isRegisteredUser(recipient)) {
-            Log.trace( "Not storing message for which the recipient ({}) is not a registered user.", recipient );
-            return false;
-        }
-        else
-        if (!XMPPServer.getInstance().getServerInfo().getXMPPDomain().equals(recipient.getDomain())) {
-            Log.trace( "Not storing message for which the recipient ({}) is not a local user.", recipient );
-            // Do not store messages sent to users of remote servers
+        if (username == null || !UserManager.getInstance().isRegisteredUser(recipient, false)) {
+            Log.trace( "Not storing message for which the recipient ({}) is not a registered local user.", recipient );
             return false;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStrategy.java
@@ -84,7 +84,7 @@ public class OfflineMessageStrategy extends BasicModule implements ServerFeature
             if (recipientJID == null || serverAddress.equals(recipientJID) ||
                     recipientJID.getNode() == null ||
                     message.getExtension("received", "urn:xmpp:carbons:2") != null ||
-                    !UserManager.getInstance().isRegisteredUser(recipientJID.getNode())) {
+                    !UserManager.getInstance().isRegisteredUser(recipientJID, false)) {
                 return;
             }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoInfoProvider.java
@@ -96,7 +96,7 @@ public interface DiscoInfoProvider {
 
     /**
      * Returns true if we can provide information related to the requested name and node. For
-     * example, if the requested name refers to a non-existant MUC room then the answer will be
+     * example, if the requested name refers to a non-existent MUC room then the answer will be
      * false. In case that the sender of the disco request is not authorized to discover this
      * information an UnauthorizedException will be thrown.
      *

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -664,7 +664,7 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                     // Answer features of the server itself.
                     final Set<String> result = new HashSet<>(serverFeatures.keySet());
 
-                    if ( !XMPPServer.getInstance().isLocal( senderJID ) || !UserManager.getInstance().isRegisteredUser( senderJID ) ) {
+                    if ( !UserManager.getInstance().isRegisteredUser( senderJID, false ) ) {
                         // Remove features not available to users from other servers or anonymous users.
                         // TODO this should be determined dynamically.
                         result.remove(IQPrivateHandler.NAMESPACE);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBlockingHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBlockingHandler.java
@@ -82,7 +82,7 @@ public class IQBlockingHandler extends IQHandler implements ServerFeaturesProvid
 
         final JID requester = iq.getFrom();
 
-        if ( !XMPPServer.getInstance().getUserManager().isRegisteredUser( requester ) )
+        if ( !XMPPServer.getInstance().getUserManager().isRegisteredUser( requester, false ) )
         {
             final IQ error = IQ.createResultIQ( iq );
             error.setError( PacketError.Condition.not_authorized );

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
@@ -186,7 +186,7 @@ public class IQOfflineMessagesHandler extends IQHandler implements ServerFeature
 
     @Override
     public boolean hasInfo(String name, String node, JID senderJID) {
-        return NAMESPACE.equals(node) && userManager.isRegisteredUser(senderJID.getNode());
+        return NAMESPACE.equals(node) && userManager.isRegisteredUser(senderJID, false);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivacyHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivacyHandler.java
@@ -58,7 +58,7 @@ public class IQPrivacyHandler extends IQHandler
     public IQ handleIQ(IQ packet) throws UnauthorizedException {
         IQ.Type type = packet.getType();
         JID from = packet.getFrom();
-        if (from.getNode() == null || !UserManager.getInstance().isRegisteredUser(from.getNode())) {
+        if (from.getNode() == null || !UserManager.getInstance().isRegisteredUser(from, false)) {
             // Service is unavailable for anonymous users
             IQ result = IQ.createResultIQ(packet);
             result.setChildElement(packet.getChildElement().createCopy());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivateHandler.java
@@ -75,7 +75,7 @@ public class IQPrivateHandler extends IQHandler implements ServerFeaturesProvide
         Element child = packet.getChildElement();
         Element dataElement = child.elementIterator().next();
 
-        if ( !XMPPServer.getInstance().isLocal( packet.getFrom()) || !UserManager.getInstance().isRegisteredUser( packet.getFrom()) ) {
+        if ( !UserManager.getInstance().isRegisteredUser( packet.getFrom(), false ) ) {
             replyPacket.setChildElement(packet.getChildElement().createCopy());
             replyPacket.setError(PacketError.Condition.service_unavailable);
             replyPacket.getError().setText( "Service available only to locally registered users." );

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRosterHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRosterHandler.java
@@ -172,7 +172,7 @@ public class IQRosterHandler extends IQHandler implements ServerFeaturesProvider
 
         try {
             if ((sender.getNode() == null || !RosterManager.isRosterServiceEnabled() ||
-                    !userManager.isRegisteredUser(sender.getNode())) &&
+                    !userManager.isRegisteredUser(sender, false)) &&
                     IQ.Type.get == type) {
                 // If anonymous user asks for his roster or roster service is disabled then
                 // return an empty roster

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
@@ -249,7 +249,7 @@ public class PresenceSubscribeHandler extends BasicModule implements ChannelHand
     private Roster getRoster(JID address) {
         String username;
         Roster roster = null;
-        if (localServer.isLocal(address) && userManager.isRegisteredUser(address.getNode())) {
+        if (userManager.isRegisteredUser(address, false)) {
             username = address.getNode();
             try {
                 roster = rosterManager.getRoster(username);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -237,7 +237,7 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
     private void initSession(ClientSession session) throws UserNotFoundException {
 
         // Only user sessions need to be authenticated
-        if (userManager.isRegisteredUser(session.getAddress().getNode())) {
+        if (userManager.isRegisteredUser(session.getAddress(), false)) {
             String username = session.getAddress().getNode();
 
             // Send pending subscription requests to user if roster service is enabled

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -732,8 +732,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         }
 
         // Verify the policy that allows all local, registered users to create rooms.
-        return allRegisteredUsersAllowedToCreate && UserManager.getInstance().isRegisteredUser(bareJID);
-
+        return allRegisteredUsersAllowedToCreate && UserManager.getInstance().isRegisteredUser(bareJID, false);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -358,7 +358,7 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
         packet.setTo(bareJidFrom);
 
         // Only service local, registered users.
-        if (!XMPPServer.getInstance().isLocal(senderJID) || !UserManager.getInstance().isRegisteredUser( senderJID.getNode()))
+        if ( !UserManager.getInstance().isRegisteredUser( senderJID, false ))
         {
             final IQ reply = IQ.createResultIQ(packet);
             reply.setChildElement(packet.getChildElement().createCopy());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPServiceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPServiceManager.java
@@ -197,8 +197,7 @@ public class PEPServiceManager {
     public PEPService create(JID owner) {
         // Return an error if the packet is from an anonymous, unregistered user
         // or remote user
-        if (!XMPPServer.getInstance().isLocal(owner)
-                || !UserManager.getInstance().isRegisteredUser(owner.getNode())) {
+        if (!UserManager.getInstance().isRegisteredUser(owner, false)) {
             throw new IllegalArgumentException(
                     "Request must be initiated by a local, registered user, but is not: "
                             + owner);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -683,7 +683,7 @@ public class PubSubEngine
     private void subscribeNodeAsync(final IQ iq, final JID subscriberJID, final Node node, final JID owner, final PubSubService service, final JID from, final Element childElement, final AccessModel accessModel) {
 
         // Check if the subscriber is an anonymous user
-        if (!isComponent(subscriberJID) && !isRemoteServer(subscriberJID) && !UserManager.getInstance().isRegisteredUser(subscriberJID)) {
+        if (!isComponent(subscriberJID) && !isRemoteServer(subscriberJID) && !UserManager.getInstance().isRegisteredUser(subscriberJID, true)) {
             // Anonymous users cannot subscribe to the node. Return forbidden error
             sendErrorPacket(iq, PacketError.Condition.forbidden, null);
             return;
@@ -1293,7 +1293,7 @@ public class PubSubEngine
      */
     public static CreateNodeResponse createNodeHelper(PubSubService service, JID requester, Element configuration, String nodeID, DataForm publishOptions) {
         // Verify that sender has permissions to create nodes
-        if (!service.canCreateNode(requester) || (!isComponent(requester) && !UserManager.getInstance().isRegisteredUser(requester))) {
+        if (!service.canCreateNode(requester) || (!isComponent(requester) && !UserManager.getInstance().isRegisteredUser(requester, true))) {
             // The user is not allowed to create nodes so return an error
             return new CreateNodeResponse(PacketError.Condition.forbidden, null, null);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubServiceInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubServiceInfo.java
@@ -117,7 +117,7 @@ public class PubSubServiceInfo {
             try {
                 if (username.contains("@")) {
                     JID jid = new JID(username);
-                    if (userManager.isRegisteredUser(jid)) {
+                    if (userManager.isRegisteredUser(jid, true)) {
                         return jid;
                     }
                 } else if (userManager.isRegisteredUser(username)) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubServiceInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubServiceInfo.java
@@ -120,8 +120,12 @@ public class PubSubServiceInfo {
                     if (userManager.isRegisteredUser(jid, true)) {
                         return jid;
                     }
-                } else if (userManager.isRegisteredUser(username)) {
-                    return xmppServer.createJID(username, null);
+                } else {
+                    // Assume that the value refers to a user on the local server.
+                    final JID jid = xmppServer.createJID(username, null);
+                    if (userManager.isRegisteredUser(jid, false)) {
+                        return jid;
+                    }
                 }
             } catch (IllegalArgumentException e) {
                 Log.debug("Unable to parse value '{}' as a JID.", username);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
@@ -192,12 +192,8 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
         // Delete the last unavailable presence of this user since the user is now
         // available. Only perform this operation if this is an available presence sent to
         // THE SERVER and the presence belongs to a local user.
-        if (presence.getTo() == null && server.isLocal(presence.getFrom())) {
+        if (presence.getTo() == null && userManager.isRegisteredUser(presence.getFrom(), false)) {
             String username = presence.getFrom().getNode();
-            if (username == null || !userManager.isRegisteredUser(username)) {
-                // Ignore anonymous users
-                return;
-            }
 
             // Optimization: only delete the unavailable presence information if this
             // is the first session created on the server.
@@ -235,12 +231,8 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
         // Only save the last presence status and keep track of the time when the user went
         // offline if this is an unavailable presence sent to THE SERVER and the presence belongs
         // to a local user.
-        if (presence.getTo() == null && server.isLocal(presence.getFrom())) {
+        if (presence.getTo() == null && userManager.isRegisteredUser(presence.getFrom(), false)) {
             String username = presence.getFrom().getNode();
-            if (username == null || !userManager.isRegisteredUser(username)) {
-                // Ignore anonymous users
-                return;
-            }
 
             // If the user has any remaining sessions, don't record the offline info.
             if (sessionManager.getActiveSessionCount(username) > 0) {
@@ -461,7 +453,7 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
 
     @Override
     public void sendUnavailableFromSessions(JID recipientJID, JID userJID) {
-        if (XMPPServer.getInstance().isLocal(userJID) && userManager.isRegisteredUser(userJID.getNode())) {
+        if (userManager.isRegisteredUser(userJID, false)) {
             for (ClientSession session : sessionManager.getSessions(userJID.getNode())) {
                 // Do not send an unavailable presence if the user sent a direct available presence
                 if (presenceUpdateHandler.hasDirectPresence(session.getAddress(), recipientJID)) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -397,7 +397,9 @@ public final class UserManager {
      *
      * @param username to username of the user to check it it's a registered user.
      * @return true if the specified JID belongs to a local registered user.
+     * @deprecated Replaced by {@link #isRegisteredUser(JID, boolean)}, which prevents assumptions about the domain of the user. (OF-2106)
      */
+    @Deprecated
     public boolean isRegisteredUser(final String username) {
         if (username == null || "".equals(username)) {
             return false;
@@ -422,7 +424,7 @@ public final class UserManager {
      *
      * @param user to JID of the user to check it it's a registered user.
      * @return true if the specified JID belongs to a local or remote registered user.
-     * @deprecated Replaced by {@link #isRegisteredUser(JID, boolean)}, of which the signature is clear on performing potentially costly remote lookups.
+     * @deprecated Replaced by {@link #isRegisteredUser(JID, boolean)}, of which the signature is clear on performing potentially costly remote lookups. (OF-2106)
      */
     @Deprecated
     public boolean isRegisteredUser(final JID user) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -422,8 +422,28 @@ public final class UserManager {
      *
      * @param user to JID of the user to check it it's a registered user.
      * @return true if the specified JID belongs to a local or remote registered user.
+     * @deprecated Replaced by {@link #isRegisteredUser(JID, boolean)}, of which the signature is clear on performing potentially costly remote lookups.
      */
+    @Deprecated
     public boolean isRegisteredUser(final JID user) {
+        return isRegisteredUser(user, true);
+    }
+
+    /**
+     * Returns true if the specified JID belongs to a local or remote registered user. If allowed by the 'checkRemoteDomains',
+     * argument, for remote users (i.e. domain does not match local domain) a disco#info request is going to be sent to
+     * the bare JID of the user. If 'checkRemoteDomains' is false, this method will return 'false' for all JIDs of which the
+     * domain-part does not match the local domain.
+     *
+     * <p>WARNING: If the supplied JID could be a remote user and the disco#info result packet comes back on the same
+     * thread as the one the calls this method then it will not be processed, and this method will block for 60 seconds
+     * by default. To change the timeout, update the system property <code>usermanager.remote-disco-info-timeout-seconds</code>
+     *
+     * @param user to JID of the user to check it it's a registered user.
+     * @param checkRemoteDomains false the lookup is allowed to include calls to remote XMPP domains.
+     * @return true if the specified JID belongs to a registered user.
+     */
+    public boolean isRegisteredUser(final JID user, final boolean checkRemoteDomains) {
         if (xmppServer.isLocal(user)) {
             try {
                 getUser(user.getNode());
@@ -433,7 +453,9 @@ public final class UserManager {
                 return false;
             }
         }
-        else {
+        else if (!checkRemoteDomains) {
+            return false;
+        } else {
             // Look up in the cache using the full JID
             Boolean isRegistered = remoteUsersCache.get(user.toString());
             if (isRegistered == null) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -48,6 +48,8 @@ import org.xmpp.packet.JID;
 import gnu.inet.encoding.Stringprep;
 import gnu.inet.encoding.StringprepException;
 
+import javax.annotation.Nonnull;
+
 /**
  * Manages users, including loading, creating and deleting.
  *
@@ -445,7 +447,7 @@ public final class UserManager {
      * @param checkRemoteDomains false the lookup is allowed to include calls to remote XMPP domains.
      * @return true if the specified JID belongs to a registered user.
      */
-    public boolean isRegisteredUser(final JID user, final boolean checkRemoteDomains) {
+    public boolean isRegisteredUser(@Nonnull final JID user, final boolean checkRemoteDomains) {
         if (xmppServer.isLocal(user)) {
             try {
                 getUser(user.getNode());

--- a/xmppserver/src/main/webapp/group-edit.jsp
+++ b/xmppserver/src/main/webapp/group-edit.jsp
@@ -669,7 +669,7 @@
                         <c:choose>
                             <c:when test="${webManager.XMPPServer.isLocal(member)}">
                                 <c:choose>
-                                    <c:when test="${webManager.userManager.isRegisteredUser(member) and webManager.presenceManager.isAvailable(webManager.userManager.getUser(member))}">
+                                    <c:when test="${webManager.userManager.isRegisteredUser(member, false) and webManager.presenceManager.isAvailable(webManager.userManager.getUser(member))}">
                                         <c:choose>
                                             <c:when test="${empty webManager.presenceManager.getPresence(webManager.userManager.getUser(member)).show}">
                                                 <img src="images/im_available.gif" width="16" height="16" border="0" title="<fmt:message key="user.properties.available" />" alt="<fmt:message key="user.properties.available" />">
@@ -701,7 +701,7 @@
                     </td>
                     <td>
                         <c:choose>
-                            <c:when test="${webManager.userManager.isRegisteredUser(member)}">
+                            <c:when test="${webManager.userManager.isRegisteredUser(member, false)}">
                                 <a href="user-properties.jsp?username=${fn:escapeXml(webManager.userManager.getUser(member).username)}">
                                     <c:out value="${webManager.userManager.getUser(member).username}"/>
                                 </a>

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/user/UserManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/user/UserManagerTest.java
@@ -129,17 +129,37 @@ public class UserManagerTest {
 
     @Test
     public void isRegisteredUserWillReturnTrueForLocalUsers() {
-
         final boolean result = userManager.isRegisteredUser(new JID(USER_ID, Fixtures.XMPP_DOMAIN, null));
+        assertThat(result, is(true));
+    }
 
+    @Test
+    public void isRegisteredUserFalseWillReturnTrueForLocalUsers() {
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, Fixtures.XMPP_DOMAIN, null), false);
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void isRegisteredUserTrueWillReturnTrueForLocalUsers() {
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, Fixtures.XMPP_DOMAIN, null), true);
         assertThat(result, is(true));
     }
 
     @Test
     public void isRegisteredUserWillReturnFalseForLocalNonUsers() {
-
         final boolean result = userManager.isRegisteredUser(new JID("unknown-user", Fixtures.XMPP_DOMAIN, null));
+        assertThat(result, is(false));
+    }
 
+    @Test
+    public void isRegisteredUserFalseWillReturnFalseForLocalNonUsers() {
+        final boolean result = userManager.isRegisteredUser(new JID("unknown-user", Fixtures.XMPP_DOMAIN, null), false);
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void isRegisteredUserTrueWillReturnFalseForLocalNonUsers() {
+        final boolean result = userManager.isRegisteredUser(new JID("unknown-user", Fixtures.XMPP_DOMAIN, null), true);
         assertThat(result, is(false));
     }
 
@@ -159,6 +179,47 @@ public class UserManagerTest {
         }).when(iqRouter).route(any());
 
         final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null));
+
+        assertThat(result, is(true));
+        verify(iqRouter).route(any());
+    }
+
+    @Test
+    public void isRegisteredUserFalseWillReturnFalseForRemoteUsers() {
+
+        final AtomicReference<IQResultListener> iqListener = new AtomicReference<>();
+        doAnswer(invocationOnMock -> {
+            final IQResultListener listener = invocationOnMock.getArgument(1);
+            iqListener.set(listener);
+            return null;
+        }).when(iqRouter).addIQResultListener(any(), any(), anyLong());
+
+        doAnswer(invocationOnMock -> {
+            iqListener.get().receivedAnswer(Fixtures.iqFrom(USER_FOUND_RESULT));
+            return null;
+        }).when(iqRouter).route(any());
+
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null), false);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void isRegisteredUserTrueWillReturnTrueForRemoteUsers() {
+
+        final AtomicReference<IQResultListener> iqListener = new AtomicReference<>();
+        doAnswer(invocationOnMock -> {
+            final IQResultListener listener = invocationOnMock.getArgument(1);
+            iqListener.set(listener);
+            return null;
+        }).when(iqRouter).addIQResultListener(any(), any(), anyLong());
+
+        doAnswer(invocationOnMock -> {
+            iqListener.get().receivedAnswer(Fixtures.iqFrom(USER_FOUND_RESULT));
+            return null;
+        }).when(iqRouter).route(any());
+
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null), true);
 
         assertThat(result, is(true));
         verify(iqRouter).route(any());
@@ -191,6 +252,57 @@ public class UserManagerTest {
     }
 
     @Test
+    public void isRegisteredUserFalseWillReturnFalseForUnknownRemoteUsers() {
+
+        final AtomicReference<IQResultListener> iqListener = new AtomicReference<>();
+        doAnswer(invocationOnMock -> {
+            final IQResultListener listener = invocationOnMock.getArgument(1);
+            iqListener.set(listener);
+            return null;
+        }).when(iqRouter).addIQResultListener(any(), any(), anyLong());
+
+        doAnswer(invocationOnMock -> {
+            final IQ iq = invocationOnMock.getArgument(0);
+            final Element childElement = iq.getChildElement();
+            final IQ response = IQ.createResultIQ(iq);
+            response.setChildElement(childElement.createCopy());
+            response.setError(new PacketError(PacketError.Condition.item_not_found, PacketError.Condition.item_not_found.getDefaultType()));
+            iqListener.get().receivedAnswer(response);
+            return null;
+        }).when(iqRouter).route(any());
+
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null), false);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void isRegisteredUserTrueWillReturnFalseForUnknownRemoteUsers() {
+
+        final AtomicReference<IQResultListener> iqListener = new AtomicReference<>();
+        doAnswer(invocationOnMock -> {
+            final IQResultListener listener = invocationOnMock.getArgument(1);
+            iqListener.set(listener);
+            return null;
+        }).when(iqRouter).addIQResultListener(any(), any(), anyLong());
+
+        doAnswer(invocationOnMock -> {
+            final IQ iq = invocationOnMock.getArgument(0);
+            final Element childElement = iq.getChildElement();
+            final IQ response = IQ.createResultIQ(iq);
+            response.setChildElement(childElement.createCopy());
+            response.setError(new PacketError(PacketError.Condition.item_not_found, PacketError.Condition.item_not_found.getDefaultType()));
+            iqListener.get().receivedAnswer(response);
+            return null;
+        }).when(iqRouter).route(any());
+
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null), true);
+
+        assertThat(result, is(false));
+        verify(iqRouter).route(any());
+    }
+
+    @Test
     public void isRegisteredUserWillReturnFalseForATimeout() {
 
         final AtomicReference<IQResultListener> iqListener = new AtomicReference<>();
@@ -213,6 +325,28 @@ public class UserManagerTest {
     }
 
     @Test
+    public void isRegisteredUserTrueWillReturnFalseForATimeout() {
+
+        final AtomicReference<IQResultListener> iqListener = new AtomicReference<>();
+        doAnswer(invocationOnMock -> {
+            final IQResultListener listener = invocationOnMock.getArgument(1);
+            iqListener.set(listener);
+            return null;
+        }).when(iqRouter).addIQResultListener(any(), any(), anyLong());
+
+        doAnswer(invocationOnMock -> {
+            final IQ iq = invocationOnMock.getArgument(0);
+            iqListener.get().answerTimeout(iq.getID());
+            return null;
+        }).when(iqRouter).route(any());
+
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null), true);
+
+        assertThat(result, is(false));
+        verify(iqRouter).route(any());
+    }
+
+    @Test
     public void isRegisteredUserWillReturnFalseNoAnswer() {
 
         final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null));
@@ -221,4 +355,12 @@ public class UserManagerTest {
         verify(iqRouter).route(any());
     }
 
+    @Test
+    public void isRegisteredUserTrueWillReturnFalseNoAnswer() {
+
+        final boolean result = userManager.isRegisteredUser(new JID(USER_ID, REMOTE_XMPP_DOMAIN, null), true);
+
+        assertThat(result, is(false));
+        verify(iqRouter).route(any());
+    }
 }


### PR DESCRIPTION
The existing method signature is very easy to 'get wrong', as indicated by the various places where I've fixed it (see follow-up commits in this PR). I've changed the signature to better express its desired operation, leaving the old method in place, marking it deprecated.

As a byproduct, I found OF-2107, which I think is a bug that is unlikely to have manifested itself.