### PR TITLE
Github Actions: Only run maven publish on IgniteRealtime, not on forks

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -122,7 +122,7 @@ jobs:
     name: Publish to Maven
     runs-on: ubuntu-latest
     needs: [aioxmpp, smack]
-    if: ${{github.ref == 'refs/heads/master' && github.event_name == 'push'}}
+    if: ${{github.repository == 'igniterealtime/Openfire' && github.ref == 'refs/heads/master' && github.event_name == 'push'}}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
It fails on forks, since it has no secrets, but would be nice not to fail.

e.g. https://github.com/akrherz/Openfire/actions/runs/310663956

Oops.