### PR TITLE
OF-1789: Explicitly close all handlers when stopping Jetty

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -17,10 +17,7 @@
 package org.jivesoftware.openfire.http;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.jasper.servlet.JasperInitializer;
 import org.apache.tomcat.InstanceManager;
@@ -239,7 +236,27 @@ public final class HttpBindManager implements CertificateEventListener, Property
 
         try {
             httpBindServer.start();
+
+            if (handlerList.getHandlers() != null) {
+                Arrays.stream(handlerList.getHandlers()).forEach(handler -> {
+                    try {
+                        handler.start();
+                    } catch (Exception e) {
+                        Log.warn("An exception occurred while trying to start handler: {}", handler, e);
+                    }
+                });
+            }
             handlerList.start();
+
+            if ( extensionHandlers.getHandlers() != null ) {
+                Arrays.stream(extensionHandlers.getHandlers()).forEach(handler -> {
+                    try {
+                        handler.start();
+                    } catch (Exception e) {
+                        Log.warn("An exception occurred while trying to start extension handler: {}", handler, e);
+                    }
+                });
+            }
             extensionHandlers.start();
 
             CertificateManager.addListener(this);
@@ -267,8 +284,28 @@ public final class HttpBindManager implements CertificateEventListener, Property
 
         if (httpBindServer != null) {
             try {
-                handlerList.stop();
+                if ( extensionHandlers.getHandlers() != null ) {
+                    Arrays.stream(extensionHandlers.getHandlers()).forEach(handler -> {
+                        try {
+                            handler.stop();
+                        } catch (Exception e) {
+                            Log.warn("An exception occurred while trying to stop extension handler: {}", handler, e);
+                        }
+                    });
+                }
                 extensionHandlers.stop();
+
+                if ( handlerList.getHandlers() != null ) {
+                    Arrays.stream(handlerList.getHandlers()).forEach(handler -> {
+                        try {
+                            handler.stop();
+                        } catch (Exception e) {
+                            Log.warn("An exception occurred while trying to stop handler: {}", handler, e);
+                        }
+                    });
+                }
+                handlerList.stop();
+
                 httpBindServer.stop();
                 Log.info("HTTP bind service stopped");
             }


### PR DESCRIPTION
Without this, restarting Jetty (sometimes) causes an error, indiating that we're trying to start something that's already started. This seems to happen only when the handler was being used when it was supposed to be stopped (eg: have an active BOSH connection).