### PR TITLE
OF-2113: Add a proper dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,16 @@
+# Root level stuff
 .git
 .gitignore
 Dockerfile
+.github
+.vscode
+
+# Deeper stuff
+**/.DS_Store
+**/.classpath
+**/.factorypath
+**/.idea
+**/.project
+**/.settings
+**/*.iml
+**/target


### PR DESCRIPTION
Stop passing locally built artifacts into to the docker build and causing unpredictable outputs. This has repeatedly stung me in the past.

Future Me needs this, and will thank you.