### PR TITLE
OF-2114 Upgrade Bouncy castle to 1.66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <jetty.version>9.4.31.v20200723</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <mina.version>2.1.3</mina.version>
-        <bouncycastle.version>1.65</bouncycastle.version>
+        <bouncycastle.version>1.66</bouncycastle.version>
         <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.13.3</log4j.version>
     </properties>


### PR DESCRIPTION
In order to fix https://github.com/igniterealtime/openfire-pade-plugin/issues/76, we have to upgrade BC to 1.66