### PR TITLE
[OF-2112] Fixed NPE when routing an IQ without a "from" attribute

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -330,8 +330,11 @@ public class IQRouter extends BasicModule {
         }
         try {
             // Check for registered components, services or remote servers
+            // It is generally permissible to route stanzas that have no 'from' attribute. However,
+            // they are not allowed in s2s traffic.
             if (recipientJID != null &&
-                    (routingTable.hasComponentRoute(recipientJID) || routingTable.hasServerRoute(new DomainPair(packet.getFrom().getDomain(), recipientJID.getDomain())))) {
+                (routingTable.hasComponentRoute(recipientJID) ||
+                    (packet.getFrom() != null && routingTable.hasServerRoute(new DomainPair(packet.getFrom().getDomain(), recipientJID.getDomain()))))) {
                 // A component/service/remote server was found that can handle the Packet
                 routingTable.routePacket(recipientJID, packet, false);
                 return;


### PR DESCRIPTION
Stanzas without a from attribute are generally fine. So it's not ok to raise an exception when trying to route one in `IQRouter`.

In the PR, no exception will be thrown but also the stanza will NOT be routed if it's S2S and also doesn't have a "from".