### PR TITLE
Fix that a user can not rejoin a muc after connecting to another node…

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/OccupantAddedEvent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/OccupantAddedEvent.java
@@ -58,7 +58,7 @@ public class OccupantAddedEvent extends MUCRoomTask<Void> {
         roleAddress = occupant.getRoleAddress();
         userAddress = occupant.getUserAddress();
         reportedFmucAddress = occupant.getReportedFmucAddress();
-        nodeID = XMPPServer.getInstance().getNodeID();
+        nodeID = occupant.getNodeID();
     }
 
 


### PR DESCRIPTION
… in the cluster with the same resource and nickname.

See https://discourse.igniterealtime.org/t/null-pointer-exception-joining-a-room/88995/6 for description an solution