### PR TITLE
OF-2077: Improvements around cluster tasks that relate to pubsub.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
@@ -177,7 +177,7 @@ public class NodeSubscription {
      * owner JID or a full JID if the owner wants to receive the notification at a particular
      * resource.<p>
      *
-     * Moreover, since subscriber and owner are separated it should be theorically possible to
+     * Moreover, since subscriber and owner are separated it should be theoretically possible to
      * have a different owner JID (e.g. gato@server1.com) and a subscriber JID
      * (e.g. gato@server2.com). Note that letting this case to happen may open the pubsub service
      * to get spam or security problems. However, the pubsub service should avoid this case to
@@ -190,7 +190,7 @@ public class NodeSubscription {
     }
 
     /**
-     * Retuns the JID of the entity that owns this subscription. The owner entity will have
+     * Returns the JID of the entity that owns this subscription. The owner entity will have
      * a {@link NodeAffiliate} for the owner JID. The owner may have more than one subscription
      * with the node based on what this message
      * {@link org.jivesoftware.openfire.pubsub.Node#isMultipleSubscriptionsEnabled()}.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -1428,6 +1428,7 @@ public class PubSubEngine
                         newNode.saveToDB();
                     }
 
+                    // TODO Replace with a cluster task that does not interact with the database (OF-2141).
                     CacheFactory.doClusterTask(new RefreshNodeTask(newNode));
                 }
                 else {
@@ -1515,7 +1516,9 @@ public class PubSubEngine
                 // (and update the backend store)
                 node.configure(completedForm);
 
+                // TODO Replace with a cluster task that does not interact with the database (OF-2141).
                 CacheFactory.doClusterTask(new RefreshNodeTask(node));
+
                 // Return that node configuration was successful
                 router.route(IQ.createResultIQ(iq));
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/AffiliationTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/AffiliationTask.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import java.io.IOException;
@@ -11,47 +27,98 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
+import javax.annotation.Nonnull;
+
+/**
+ * Updates the affiliation of a particular entity, for a particular pubsub node.
+ *
+ * Note that this task aims to update in-memory state only: it will not apply affiliation changes to persistent data
+ * storage (it is assumed that the cluster node where the task originated takes responsibility for that). As a result,
+ * this task might not apply changes if the node that is the subject of this task is currently not loaded in-memory of
+ * the cluster node on which this task operates.
+ */
 public class AffiliationTask extends NodeTask
 {
     private static final Logger log = LoggerFactory.getLogger(AffiliationTask.class);
 
+    /**
+     * Address of the entity that needs an update to the affiliation with a pubsub node.
+     */
     private JID jid;
+
+    /**
+     * The new pubsub node affiliation of an entity.
+     */
     private NodeAffiliate.Affiliation affiliation;
 
+    /**
+     * This no-argument constructor is provided for serialization purposes. It should generally not be used otherwise.
+     */
     public AffiliationTask()
     {
     }
 
-    public AffiliationTask(Node node, JID jid, NodeAffiliate.Affiliation affiliation)
+    /**
+     * Constructs a new task that updates the affiliation of a particular entity with a specific pubsub node.
+     *
+     * @param node The pubsub node that this task relates to.
+     * @param jid The address of the entity that has an affiliation with the pubsub node.
+     * @param affiliation The affiliation that the entity has with the pubsub node.
+     */
+    public AffiliationTask(@Nonnull Node node, @Nonnull JID jid, @Nonnull NodeAffiliate.Affiliation affiliation)
     {
         super(node);
         this.jid = jid;
         this.affiliation = affiliation;
     }
 
+    /**
+     * Provides the address of the entity that has a new affiliation with a pubsub node.
+     *
+     * @return the address of an entity.
+     */
     public JID getJID()
     {
         return jid;
     }
 
+    /**
+     * @deprecated Replaced by {@link #getAffiliation()}
+     */
+    @Deprecated // TODO Remove this method in Openfire 4.7 or later.
     public NodeAffiliate.Affiliation getAffilation()
+    {
+        return affiliation;
+    }
+
+    /**
+     * The new affiliation with a pubsub node.
+     *
+     * @return a pubsub node affiliation.
+     */
+    public NodeAffiliate.Affiliation getAffiliation()
     {
         return affiliation;
     }
     
     @Override
     public void run() {
+        // Note: this implementation should apply changes in-memory state only. It explicitly needs not update
+        // persisted data storage, as this can be expected to be done by the cluster node that issued this task.
+        // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] New affiliation : {}", toString());
 
-        Node node = getNode();
+        final Node node = getNode();
+
+        // Create a new affiliate if the entity is not an affiliate yet.
         NodeAffiliate affiliate = node.getAffiliate(jid);
         if (affiliate == null) {
+            // No existing affiliate: create a new one.
             affiliate = new NodeAffiliate(node, jid);
-            affiliate.setAffiliation(affiliation);
             node.addAffiliate(affiliate);
-        } else {
-            affiliate.setAffiliation(affiliation);
         }
+
+        affiliate.setAffiliation(affiliation);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/AffiliationTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/AffiliationTask.java
@@ -108,7 +108,7 @@ public class AffiliationTask extends NodeTask
         // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] New affiliation : {}", toString());
 
-        final Node node = getNode();
+        final Node node = getNodeIfLoaded();
 
         // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
         // in this case since any changes that might have been applied here will also have been applied to the database

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/AffiliationTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/AffiliationTask.java
@@ -110,6 +110,14 @@ public class AffiliationTask extends NodeTask
 
         final Node node = getNode();
 
+        // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
+        // in this case since any changes that might have been applied here will also have been applied to the database
+        // by the cluster node where this task originated, meaning that those changes get loaded from the database when
+        // the pubsub node is retrieved from the database in the future (OF-2077)
+        if (node == null) {
+            return;
+        }
+
         // Create a new affiliate if the entity is not an affiliate yet.
         NodeAffiliate affiliate = node.getAffiliate(jid);
         if (affiliate == null) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/AffiliationTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/AffiliationTask.java
@@ -19,6 +19,7 @@ package org.jivesoftware.openfire.pubsub.cluster;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Optional;
 
 import org.jivesoftware.openfire.pubsub.Node;
 import org.jivesoftware.openfire.pubsub.NodeAffiliate;
@@ -108,15 +109,17 @@ public class AffiliationTask extends NodeTask
         // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] New affiliation : {}", toString());
 
-        final Node node = getNodeIfLoaded();
+        final Optional<Node> optNode = getNodeIfLoaded();
 
         // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
         // in this case since any changes that might have been applied here will also have been applied to the database
         // by the cluster node where this task originated, meaning that those changes get loaded from the database when
         // the pubsub node is retrieved from the database in the future (OF-2077)
-        if (node == null) {
+        if (!optNode.isPresent()) {
             return;
         }
+
+        final Node node = optNode.get();
 
         // Create a new affiliate if the entity is not an affiliate yet.
         NodeAffiliate affiliate = node.getAffiliate(jid);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/CancelSubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/CancelSubscriptionTask.java
@@ -61,17 +61,18 @@ public class CancelSubscriptionTask extends SubscriptionTask
         log.debug("[TASK] Cancel Subscription : {}", toString());
 
         final Node node = getNode();
+        final NodeSubscription subscription = getSubscription();
 
         // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
         // in this case since any changes that might have been applied here will also have been applied to the database
         // by the cluster node where this task originated, meaning that those changes get loaded from the database when
-        // the pubsub node is retrieved from the database in the future.
-        if (node == null) {
+        // the pubsub node is retrieved from the database in the future (OF-2077)
+        if (node == null || subscription == null) {
             return;
         }
 
         // This method will make a db call, but it will simply do nothing since
         // the record will already be deleted. // TODO OF-2139 prevent unnecessary database interaction.
-        node.cancelSubscription(getSubscription(), false);
+        node.cancelSubscription(subscription, false);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/CancelSubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/CancelSubscriptionTask.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import org.jivesoftware.openfire.pubsub.Node;
@@ -5,15 +21,33 @@ import org.jivesoftware.openfire.pubsub.NodeSubscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
+/**
+ * A cluster task used to cancel a pubsub node subscription (a relation between an entity an a pubsub node).
+ *
+ * Note that this task aims to update in-memory state only: it will not apply affiliation changes to persistent data
+ * storage (it is assumed that the cluster node where the task originated takes responsibility for that). As a result,
+ * this task might not apply changes if the node that is the subject of this task is currently not loaded in-memory of
+ * the cluster node on which this task operates.
+ */
 public class CancelSubscriptionTask extends SubscriptionTask
 {
     private static final Logger log = LoggerFactory.getLogger(CancelSubscriptionTask.class);
 
+    /**
+     * This no-argument constructor is provided for serialization purposes. It should generally not be used otherwise.
+     */
     public CancelSubscriptionTask()
     {
     }
 
-    public CancelSubscriptionTask(NodeSubscription subscription)
+    /**
+     * Constructs a new task that cancels a subscription to a pubsub node.
+     *
+     * @param subscription The to-be-cancelled subscription
+     */
+    public CancelSubscriptionTask(@Nonnull final NodeSubscription subscription)
     {
         super(subscription);
     }
@@ -21,17 +55,23 @@ public class CancelSubscriptionTask extends SubscriptionTask
     @Override
     public void run()
     {
+        // Note: this implementation should apply changes in-memory state only. It explicitly needs not update
+        // persisted data storage, as this can be expected to be done by the cluster node that issued this task.
+        // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] Cancel Subscription : {}", toString());
 
-        Node node = getNode();
-        
-        // This will only occur if a PEP service is not loaded.  We can safely do nothing in this 
-        // case since any changes will get loaded from the db when it is loaded.
-        if (node == null)
+        final Node node = getNode();
+
+        // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
+        // in this case since any changes that might have been applied here will also have been applied to the database
+        // by the cluster node where this task originated, meaning that those changes get loaded from the database when
+        // the pubsub node is retrieved from the database in the future.
+        if (node == null) {
             return;
-        
+        }
+
         // This method will make a db call, but it will simply do nothing since
-        // the record will already be deleted.
+        // the record will already be deleted. // TODO OF-2139 prevent unnecessary database interaction.
         node.cancelSubscription(getSubscription(), false);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/CancelSubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/CancelSubscriptionTask.java
@@ -60,8 +60,8 @@ public class CancelSubscriptionTask extends SubscriptionTask
         // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] Cancel Subscription : {}", toString());
 
-        final Node node = getNode();
-        final NodeSubscription subscription = getSubscription();
+        final Node node = getNodeIfLoaded();
+        final NodeSubscription subscription = getSubscriptionIfLoaded();
 
         // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
         // in this case since any changes that might have been applied here will also have been applied to the database

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/FlushTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/FlushTask.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import java.io.IOException;
@@ -8,20 +24,42 @@ import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.pubsub.CachingPubsubPersistenceProvider;
 import org.jivesoftware.openfire.pubsub.Node;
 import org.jivesoftware.openfire.pubsub.PubSubPersistenceProvider;
-import org.jivesoftware.openfire.pubsub.PubSubPersistenceProviderManager;
 import org.jivesoftware.util.cache.ClusterTask;
 import org.jivesoftware.util.cache.ExternalizableUtil;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
+/**
+ * A cluster task used to instruct other cluster nodes that they must flush pending changes to pubsub nodes to the
+ * persistent data storage.
+ *
+ * This task can be used to flush all pending changes, or the pending changes related to a specific node only.
+ */
 public class FlushTask implements ClusterTask<Void>
 {
+    /**
+     * The unique identifier for the pubsub node that is the subject of the task, in case the task is specific to one
+     * pubsub node. When this task should apply to all nodes, this value will be null.
+     *
+     * @see Node#getUniqueIdentifier()
+     */
+    @Nullable
 	private Node.UniqueIdentifier uniqueIdentifier;
 
-	public FlushTask( Node.UniqueIdentifier uniqueIdentifier )
+    /**
+     * Instantiates a flush task for a specific node.
+     *
+     * @param uniqueIdentifier The identifier of the node to flush.
+     */
+	public FlushTask(@Nonnull final Node.UniqueIdentifier uniqueIdentifier )
 	{
 		this.uniqueIdentifier = uniqueIdentifier;
 	}
 
+    /**
+     * Instantiates a flush task for a system-wide flush of pending changes.
+     */
     public FlushTask()
     {
 		this.uniqueIdentifier = null;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
@@ -63,7 +63,7 @@ public class ModifySubscriptionTask extends SubscriptionTask
         // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] Modify subscription : {}", toString());
 
-        final Node node = getNode();
+        final Node node = getNodeIfLoaded();
 
         // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
         // in this case since any changes that might have been applied here will also have been applied to the database

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
@@ -17,8 +17,10 @@
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.pubsub.Node;
 import org.jivesoftware.openfire.pubsub.NodeSubscription;
 import org.jivesoftware.openfire.pubsub.PubSubPersistenceProviderManager;
+import org.jivesoftware.openfire.pubsub.PubSubService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +63,18 @@ public class ModifySubscriptionTask extends SubscriptionTask
         // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] Modify subscription : {}", toString());
 
+        final Node node = getNode();
+
+        // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
+        // in this case since any changes that might have been applied here will also have been applied to the database
+        // by the cluster node where this task originated, meaning that those changes get loaded from the database when
+        // the pubsub node is retrieved from the database in the future (OF-2077)
+        if (node == null) {
+            return;
+        }
+
         // Forcefully (re)load the subscription from the database, which resets any in-memory representation.
-        XMPPServer.getInstance().getPubSubModule().getPersistenceProvider().loadSubscription( getService(), getNode(), getSubscriptionId());
+        // TODO OF-2140 Remove database interaction. Instead of reloading, modify the existing in-memory representation with data from this task.
+        XMPPServer.getInstance().getPubSubModule().getPersistenceProvider().loadSubscription(node, getSubscriptionId());
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import org.jivesoftware.openfire.XMPPServer;
@@ -6,16 +22,33 @@ import org.jivesoftware.openfire.pubsub.PubSubPersistenceProviderManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
+/**
+ * A cluster task used to modify a pubsub node subscription (a relation between an entity an a pubsub node).
+ *
+ * Note that this task aims to update in-memory state only: it will not apply affiliation changes to persistent data
+ * storage (it is assumed that the cluster node where the task originated takes responsibility for that). As a result,
+ * this task might not apply changes if the node that is the subject of this task is currently not loaded in-memory of
+ * the cluster node on which this task operates.
+ */
 public class ModifySubscriptionTask extends SubscriptionTask
 {
     private static final Logger log = LoggerFactory.getLogger(ModifySubscriptionTask.class);
 
+    /**
+     * This no-argument constructor is provided for serialization purposes. It should generally not be used otherwise.
+     */
     public ModifySubscriptionTask()
     {
-
     }
 
-    public ModifySubscriptionTask(NodeSubscription subscription)
+    /**
+     * Constructs a new task that modifies a subscription to a pubsub node.
+     *
+     * @param subscription The to-be-modified subscription
+     */
+    public ModifySubscriptionTask(@Nonnull final NodeSubscription subscription)
     {
         super(subscription);
     }
@@ -23,7 +56,12 @@ public class ModifySubscriptionTask extends SubscriptionTask
     @Override
     public void run()
     {
+        // Note: this implementation should apply changes in-memory state only. It explicitly needs not update
+        // persisted data storage, as this can be expected to be done by the cluster node that issued this task.
+        // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] Modify subscription : {}", toString());
+
+        // Forcefully (re)load the subscription from the database, which resets any in-memory representation.
         XMPPServer.getInstance().getPubSubModule().getPersistenceProvider().loadSubscription( getService(), getNode(), getSubscriptionId());
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.util.Optional;
 
 /**
  * A cluster task used to modify a pubsub node subscription (a relation between an entity an a pubsub node).
@@ -63,15 +64,17 @@ public class ModifySubscriptionTask extends SubscriptionTask
         // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] Modify subscription : {}", toString());
 
-        final Node node = getNodeIfLoaded();
+        final Optional<Node> optNode = getNodeIfLoaded();
 
         // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
         // in this case since any changes that might have been applied here will also have been applied to the database
         // by the cluster node where this task originated, meaning that those changes get loaded from the database when
         // the pubsub node is retrieved from the database in the future (OF-2077)
-        if (node == null) {
+        if (!optNode.isPresent()) {
             return;
         }
+
+        final Node node = optNode.get();
 
         // Forcefully (re)load the subscription from the database, which resets any in-memory representation.
         // TODO OF-2140 Remove database interaction. Instead of reloading, modify the existing in-memory representation with data from this task.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NewSubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NewSubscriptionTask.java
@@ -62,9 +62,9 @@ public class NewSubscriptionTask extends SubscriptionTask
         // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] New subscription : {}", toString());
 
-        final PubSubService service = getService();
-        final Node node = getNode();
-        final NodeSubscription subscription = getSubscription();
+        final PubSubService service = getServiceIfLoaded();
+        final Node node = getNodeIfLoaded();
+        final NodeSubscription subscription = getSubscriptionIfLoaded();
 
         // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
         // in this case since any changes that might have been applied here will also have been applied to the database

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NewSubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NewSubscriptionTask.java
@@ -1,21 +1,55 @@
+/*
+ * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import org.jivesoftware.openfire.pubsub.Node;
 import org.jivesoftware.openfire.pubsub.NodeAffiliate;
 import org.jivesoftware.openfire.pubsub.NodeSubscription;
+import org.jivesoftware.openfire.pubsub.PubSubService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
+/**
+ * A cluster task used to create a pubsub node subscription (a relation between an entity an a pubsub node).
+ *
+ * Note that this task aims to update in-memory state only: it will not apply affiliation changes to persistent data
+ * storage (it is assumed that the cluster node where the task originated takes responsibility for that). As a result,
+ * this task might not apply changes if the node that is the subject of this task is currently not loaded in-memory of
+ * the cluster node on which this task operates.
+ */
 public class NewSubscriptionTask extends SubscriptionTask
 {
     private static final Logger log = LoggerFactory.getLogger(NewSubscriptionTask.class);
 
+    /**
+     * This no-argument constructor is provided for serialization purposes. It should generally not be used otherwise.
+     */
     public NewSubscriptionTask()
     {
-
     }
 
-    public NewSubscriptionTask(NodeSubscription subscription)
+    /**
+     * Constructs a new task that creates a subscription to a pubsub node.
+     *
+     * @param subscription The to-be-created subscription
+     */
+    public NewSubscriptionTask(@Nonnull final NodeSubscription subscription)
     {
         super(subscription);
     }
@@ -23,14 +57,22 @@ public class NewSubscriptionTask extends SubscriptionTask
     @Override
     public void run()
     {
+        // Note: this implementation should apply changes in-memory state only. It explicitly needs not update
+        // persisted data storage, as this can be expected to be done by the cluster node that issued this task.
+        // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] New subscription : {}", toString());
 
-        Node node = getNode();
+        final PubSubService service = getService();
+        final Node node = getNode();
+        final NodeSubscription subscription = getSubscription();
 
-        // This will only occur if a PEP service is not loaded.  We can safely do nothing in this 
-        // case since any changes will get loaded from the db when it is loaded.
-        if (node == null)
+        // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
+        // in this case since any changes that might have been applied here will also have been applied to the database
+        // by the cluster node where this task originated, meaning that those changes get loaded from the database when
+        // the pubsub node is retrieved from the database in the future (OF-2077)
+        if (service == null || node == null || subscription == null) {
             return;
+        }
 
         if (node.getAffiliate(getOwner()) == null)
         {
@@ -39,17 +81,17 @@ public class NewSubscriptionTask extends SubscriptionTask
             affiliate.setAffiliation(NodeAffiliate.Affiliation.none);
             node.addAffiliate(affiliate);
         }
-        node.addSubscription(getSubscription());
+        node.addSubscription(subscription);
 
-        if (node.isPresenceBasedDelivery() && node.getSubscriptions(getSubscription().getOwner()).size() == 1)
+        if (node.isPresenceBasedDelivery() && node.getSubscriptions(subscription.getOwner()).size() == 1)
         {
-            if (getSubscription().getPresenceStates().isEmpty())
+            if (subscription.getPresenceStates().isEmpty())
             {
                 // Subscribe to the owner's presence since the node is only
                 // sending events to online subscribers and this is the first
                 // subscription of the user and the subscription is not
                 // filtering notifications based on presence show values.
-                getService().presenceSubscriptionRequired(getNode(), getOwner());
+                service.presenceSubscriptionRequired(node, getOwner());
             }
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NodeChangeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NodeChangeTask.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import java.io.IOException;
@@ -9,32 +25,98 @@ import org.jivesoftware.openfire.pubsub.Node;
 import org.jivesoftware.util.cache.ClusterTask;
 import org.jivesoftware.util.cache.ExternalizableUtil;
 
+import javax.annotation.Nonnull;
+
 /**
- * Base class of clustering tasks for pubsub. It simply stores/retrieves the
- * node.
- * 
+ * Base class of clustering tasks for pubsub. It simply stores/retrieves the node.
+ *
+ * This implementation should not be used (and is retained for backwards compatibility only).
+ *
+ * This class is only safe when used for a singleton pubsub service, as instantiated through
+ * {@link org.jivesoftware.openfire.pubsub.PubSubModule}
+ *
+ * Unlike other cluster tasks, this task will forcefully (re)load the node from backend storage on every cluster node
+ * where the task is executed. This can add significant overhead, and should be avoided if possible.
+ *
  * @author Robin Collier
- * 
+ * @deprecated Use a task that uses unique pubsub node identifiers, and that does not forcefully load from database, such as @{link {@link NodeTask}
  */
+@Deprecated // TODO Remove this implementation in Openfire 4.7 or later.
 public abstract class NodeChangeTask implements ClusterTask<Void>
 {
+    /**
+     * The node identifier, unique in context of the service, for the pubsub node that is the subject of the task.
+     *
+     * @see Node#getNodeID()
+     */
     private String nodeId;
+
+    /**
+     * The node that is the subject of this task.
+     */
     transient private Node node;
 
+    /**
+     * This no-argument constructor is provided for serialization purposes. It should generally not be used otherwise.
+     */
     public NodeChangeTask()
     {
-
     }
 
-    public NodeChangeTask(String nodeIdent)
+    /**
+     * Constructs a new task for a pubsub node.
+     *
+     * Note that the provided value should refer to a node that exists in the singleton pubsub service, as instantiated
+     * through {@link org.jivesoftware.openfire.pubsub.PubSubModule}
+     *
+     * @param nodeId the (service-specific) node identifier for the pubsub node that is the subject of the task.
+     */
+    public NodeChangeTask(@Nonnull final String nodeId)
     {
-        nodeId = nodeIdent;
+        this.nodeId = nodeId;
     }
 
-    public NodeChangeTask(Node node)
+    /**
+     * Constructs a new task for a pubsub node.
+     *
+     * Note that the provided value should be a node that exists in the singleton pubsub service, as instantiated
+     * through {@link org.jivesoftware.openfire.pubsub.PubSubModule}
+     *
+     * @param node the pubsub node that is the subject of the task.
+     */
+    public NodeChangeTask(@Nonnull final Node node)
     {
         this.node = node;
         nodeId = node.getUniqueIdentifier().getNodeId();
+    }
+
+    /**
+     * Finds the pubsub node that is the subject of this task.
+     *
+     * Unlike what is common practise for cluster tasks, this method will return a pubsub node even when it was
+     * previously not loaded in memory. Hence, this method can introduce significant overhead when used in a cluster.
+     *
+     * It is advisable to use {@link NodeTask} instead.
+     *
+     * @return A pubsub node
+     */
+    public Node getNode()
+    {
+        if (node == null) {
+            node = XMPPServer.getInstance().getPubSubModule().getNode(nodeId);
+        }
+        return node;
+    }
+
+    /**
+     * The node identifier, unique in context of the service, for the pubsub node that is the subject of the task.
+     *
+     * @return a node identifier
+     * @see Node#getNodeID()
+     */
+    public String getNodeId()
+    {
+        return nodeId;
     }
 
     @Override
@@ -47,17 +129,5 @@ public abstract class NodeChangeTask implements ClusterTask<Void>
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException
     {
         nodeId = ExternalizableUtil.getInstance().readSafeUTF(in);
-    }
-
-    public Node getNode()
-    {
-        if (node == null)
-            node = XMPPServer.getInstance().getPubSubModule().getNode(nodeId);
-        return node;
-    }
-
-    public String getNodeId()
-    {
-        return nodeId;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Ignite Realtime Foundatin. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import java.io.IOException;
@@ -12,33 +28,107 @@ import org.jivesoftware.util.cache.ClusterTask;
 import org.jivesoftware.util.cache.ExternalizableUtil;
 import org.xmpp.packet.JID;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A cluster task used work with a particular pubsub node.
+ *
+ * As with most cluster tasks, it is important to realize that these tasks are intended to interact only in a limited
+ * way with the data on the cluster node where they're executed on. Generally speaking, the cluster node that initiates
+ * the task takes responsibility for all of the 'heavy lifting', such as the persistence of data (in the backend data
+ * storage/database) for the functionality that the cluster task relates to. The other cluster nodes typically need not
+ * to repeat that effort. Specifically, the goal of executing cluster tasks on other cluster nodes should typically be
+ * limited to updating in-memory state on the cluster node.
+ */
 public abstract class NodeTask implements ClusterTask<Void>
 {
+    /**
+     * The unique identifier for the pubsub node that is the subject of the task.
+     *
+     * This value is a combination of the data that's captured in {@link #nodeId} and {@link #serviceId}, which are
+     * primarily retained in the API for backwards compatibility reasons.
+     *
+     * @see Node#getUniqueIdentifier()
+     */
     protected transient Node.UniqueIdentifier uniqueNodeIdentifier;
+
+    /**
+     * The node identifier, unique in context of the service, for the pubsub node that is the subject of the task.
+     *
+     * The value of this field is combined with that of {@link #serviceId} in {@link #uniqueNodeIdentifier}. To retain
+     * (serialization) compatibility with older versions, the nodeId field is retained. It is, however, advisable to
+     * make use of {@link #uniqueNodeIdentifier} instead, as that is guaranteed to provide a system-wide unique value
+     * (whereas the nodeId value is unique only context of the pubsub service).
+     *
+     * @see Node#getNodeID()
+     */
     protected String nodeId;
+
+    /**
+     * The service identifier for the pubsub node that is the subject of the task.
+     */
     protected String serviceId;
 
+    /**
+     * This no-argument constructor is provided for serialization purposes. It should generally not be used otherwise.
+     */
     protected NodeTask()
     {
-
     }
 
-    protected NodeTask(Node node)
+    /**
+     * Constructs a new task for a specific pubsub node.
+     *
+     * @param node The pubsub node that this task operates on.
+     */
+    protected NodeTask(@Nonnull Node node)
     {
         uniqueNodeIdentifier = node.getUniqueIdentifier();
         nodeId = node.getUniqueIdentifier().getNodeId();
         serviceId = node.getUniqueIdentifier().getServiceIdentifier().getServiceId();
     }
 
+    /**
+     * Returns the unique identifier of the pubsub node that this task aims to update.
+     *
+     * Usage of this method, that provides a system-wide unique value, should generally be preferred over the use of
+     * {@link #getNodeId()}, that returns a value that is unique only context of the pubsub service.
+     *
+     * @return A unique node identifier.
+     * @see Node#getUniqueIdentifier()
+     */
     public Node.UniqueIdentifier getUniqueNodeIdentifier() {
         return uniqueNodeIdentifier;
     }
 
+    /**
+     * The node identifier, unique in context of the service, for the pubsub node that is the subject of the task.
+     *
+     * It is advisable to make use of {@link #getUniqueNodeIdentifier()} instead of this method, as that is guaranteed
+     * to provide a system-wide unique value (whereas the nodeId value is unique only context of the pubsub service).
+     *
+     * @return a node identifier
+     * @see #getUniqueNodeIdentifier()
+     * @see Node#getNodeID()
+     */
     public String getNodeId()
     {
         return nodeId;
     }
 
+    /**
+     * Finds the pubsub node that is the subject of this task.
+     *
+     * Note that null, instead of a pubsub node instance, might be returned when the pubsub service is not currently
+     * loaded in-memory on the cluster node that the task is executing on (although there is no guarantee that when this
+     * method returns a non-null pubsub service, it was previously not loaded in-memory)! The rationale for this is that
+     * this cluster tasks does not need to operate on data that is not in memory, as such operations are the
+     * responsibility of the cluster node that initiates the cluster task.
+     *
+     * @return A pubsub node
+     */
+    @Nullable
     public Node getNode()
     {
         PubSubService svc = getService();
@@ -46,10 +136,23 @@ public abstract class NodeTask implements ClusterTask<Void>
         return svc != null ? svc.getNode(nodeId) : null;
     }
 
+    /**
+     * Finds the pubsub service for the pubsub node that is the subject of this task.
+     *
+     * Note that null, instead of a pubsub service instance, might be returned when the pubsub service is not currently
+     * loaded in-memory on the cluster node that the task is executing on (although there is no guarantee that when this
+     * method returns a non-null pubsub service, it was previously not loaded in-memory)! The rationale for this is that
+     * this cluster tasks does not need to operate on data that is not in memory, as such operations are the
+     * responsibility of the cluster node that initiates the cluster task.
+     *
+     * @return A pubsub service
+     */
+    @Nullable
     public PubSubService getService()
     {
-        if (XMPPServer.getInstance().getPubSubModule().getServiceID().equals(serviceId))
+        if (XMPPServer.getInstance().getPubSubModule().getServiceID().equals(serviceId)) {
             return XMPPServer.getInstance().getPubSubModule();
+        }
         else
         {
             PEPServiceManager serviceMgr = XMPPServer.getInstance().getIQPEPHandler().getServiceManager();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
@@ -19,6 +19,7 @@ package org.jivesoftware.openfire.pubsub.cluster;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Optional;
 
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.pep.PEPServiceManager;
@@ -128,12 +129,12 @@ public abstract class NodeTask implements ClusterTask<Void>
      *
      * @return A pubsub node
      */
-    @Nullable
-    public Node getNodeIfLoaded()
+    @Nonnull
+    public Optional<Node> getNodeIfLoaded()
     {
-        final PubSubService svc = getServiceIfLoaded();
+        final Optional<PubSubService> svc = getServiceIfLoaded();
 
-        return svc != null ? svc.getNode(nodeId) : null;
+        return svc.map(pubSubService -> pubSubService.getNode(nodeId));
     }
 
     /**
@@ -147,7 +148,7 @@ public abstract class NodeTask implements ClusterTask<Void>
     @Deprecated // TODO Remove this method in Openfire 4.8 or later.
     public Node getNode()
     {
-        return getNodeIfLoaded();
+        return getNodeIfLoaded().orElse(null);
     }
 
     /**
@@ -161,17 +162,17 @@ public abstract class NodeTask implements ClusterTask<Void>
      *
      * @return A pubsub service
      */
-    @Nullable
-    public PubSubService getServiceIfLoaded()
+    @Nonnull
+    public Optional<PubSubService> getServiceIfLoaded()
     {
         if (XMPPServer.getInstance().getPubSubModule().getServiceID().equals(serviceId)) {
-            return XMPPServer.getInstance().getPubSubModule();
+            return Optional.of(XMPPServer.getInstance().getPubSubModule());
         }
         else
         {
             PEPServiceManager serviceMgr = XMPPServer.getInstance().getIQPEPHandler().getServiceManager();
             JID service = new JID( serviceId );
-            return serviceMgr.hasCachedService(service) ? serviceMgr.getPEPService(service) : null;
+            return serviceMgr.hasCachedService(service) ? Optional.of(serviceMgr.getPEPService(service)) : Optional.empty();
         }
     }
 
@@ -186,7 +187,7 @@ public abstract class NodeTask implements ClusterTask<Void>
     @Nullable
     public PubSubService getService()
     {
-        return getServiceIfLoaded();
+        return getServiceIfLoaded().orElse(null);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
@@ -129,11 +129,25 @@ public abstract class NodeTask implements ClusterTask<Void>
      * @return A pubsub node
      */
     @Nullable
-    public Node getNode()
+    public Node getNodeIfLoaded()
     {
-        PubSubService svc = getService();
+        final PubSubService svc = getServiceIfLoaded();
 
         return svc != null ? svc.getNode(nodeId) : null;
+    }
+
+    /**
+     * This method is replaced by {@link #getNodeIfLoaded()}, which performs the exact same operation, but is named
+     * differently to better express intent.
+     *
+     * @deprecated Renamed to {@link #getNodeIfLoaded()}
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2077">Issue OF-2077: NullPointerException with Pubsub(PEP?) and clustering</a>
+     */
+    @Nullable
+    @Deprecated // TODO Remove this method in Openfire 4.8 or later.
+    public Node getNode()
+    {
+        return getNodeIfLoaded();
     }
 
     /**
@@ -148,7 +162,7 @@ public abstract class NodeTask implements ClusterTask<Void>
      * @return A pubsub service
      */
     @Nullable
-    public PubSubService getService()
+    public PubSubService getServiceIfLoaded()
     {
         if (XMPPServer.getInstance().getPubSubModule().getServiceID().equals(serviceId)) {
             return XMPPServer.getInstance().getPubSubModule();
@@ -159,6 +173,20 @@ public abstract class NodeTask implements ClusterTask<Void>
             JID service = new JID( serviceId );
             return serviceMgr.hasCachedService(service) ? serviceMgr.getPEPService(service) : null;
         }
+    }
+
+    /**
+     * This method is replaced by {@link #getServiceIfLoaded()}, which performs the exact same operation, but is named
+     * differently to better express intent.
+     *
+     * @deprecated Renamed to {@link #getServiceIfLoaded()}
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2077">Issue OF-2077: NullPointerException with Pubsub(PEP?) and clustering</a>
+     */
+    @Deprecated // TODO Remove this method in Openfire 4.8 or later.
+    @Nullable
+    public PubSubService getService()
+    {
+        return getServiceIfLoaded();
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
@@ -68,7 +68,7 @@ public class RefreshNodeTask extends NodeTask
         // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] Refreshing node - nodeID: {}", getNodeId());
 
-        final PubSubService service = getService();
+        final PubSubService service = getServiceIfLoaded();
 
         // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
         // in this case since any changes that might have been applied here will also have been applied to the database

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.util.Optional;
 
 /**
  * Forces the node to be refreshed from the database. This will load a node from
@@ -68,15 +69,17 @@ public class RefreshNodeTask extends NodeTask
         // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] Refreshing node - nodeID: {}", getNodeId());
 
-        final PubSubService service = getServiceIfLoaded();
+        final Optional<PubSubService> optService = getServiceIfLoaded();
 
         // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
         // in this case since any changes that might have been applied here will also have been applied to the database
         // by the cluster node where this task originated, meaning that those changes get loaded from the database when
         // the pubsub node is retrieved from the database in the future (OF-2077)
-        if (service == null) {
+        if (!optService.isPresent()) {
             return;
         }
+
+        final PubSubService service = optService.get();
 
         XMPPServer.getInstance().getPubSubModule().getPersistenceProvider().loadNode(service, getUniqueNodeIdentifier());
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
@@ -18,6 +18,7 @@ package org.jivesoftware.openfire.pubsub.cluster;
 
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.pubsub.Node;
+import org.jivesoftware.openfire.pubsub.PubSubService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,11 @@ import javax.annotation.Nonnull;
  * Forces the node to be refreshed from the database. This will load a node from
  * the database and then add it to the service. If the node already existed it
  * will be replaced, thereby refreshing it from persistence.
+ *
+ * Note that this task aims to update in-memory state only: it will not apply affiliation changes to persistent data
+ * storage (it is assumed that the cluster node where the task originated takes responsibility for that). As a result,
+ * this task might not apply changes if the node that is the subject of this task is currently not loaded in-memory of
+ * the cluster node on which this task operates.
  *
  * Unlike other cluster tasks, this task will forcefully (re)load the node from backend storage on every cluster node
  * where the task is executed. This can add significant overhead, and should be avoided if possible.
@@ -57,7 +63,21 @@ public class RefreshNodeTask extends NodeTask
     @Override
     public void run()
     {
+        // Note: this implementation should apply changes in-memory state only. It explicitly needs not update
+        // persisted data storage, as this can be expected to be done by the cluster node that issued this task.
+        // Applying such changes in this task would, at best, needlessly require resources.
         log.debug("[TASK] Refreshing node - nodeID: {}", getNodeId());
-        XMPPServer.getInstance().getPubSubModule().getPersistenceProvider().loadNode(getService(), getUniqueNodeIdentifier());
+
+        final PubSubService service = getService();
+
+        // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
+        // in this case since any changes that might have been applied here will also have been applied to the database
+        // by the cluster node where this task originated, meaning that those changes get loaded from the database when
+        // the pubsub node is retrieved from the database in the future (OF-2077)
+        if (service == null) {
+            return;
+        }
+
+        XMPPServer.getInstance().getPubSubModule().getPersistenceProvider().loadNode(service, getUniqueNodeIdentifier());
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
@@ -1,28 +1,55 @@
+/*
+ * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.pubsub.Node;
-import org.jivesoftware.openfire.pubsub.PubSubPersistenceProviderManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
 
 /**
  * Forces the node to be refreshed from the database. This will load a node from
  * the database and then add it to the service. If the node already existed it
  * will be replaced, thereby refreshing it from persistence.
- * 
+ *
+ * Unlike other cluster tasks, this task will forcefully (re)load the node from backend storage on every cluster node
+ * where the task is executed. This can add significant overhead, and should be avoided if possible.
+ *
  * @author Robin Collier
- * 
  */
 public class RefreshNodeTask extends NodeTask
 {
     private static final Logger log = LoggerFactory.getLogger(RefreshNodeTask.class);
 
+    /**
+     * This no-argument constructor is provided for serialization purposes. It should generally not be used otherwise.
+     */
     public RefreshNodeTask()
     {
     }
 
-    public RefreshNodeTask(Node node)
+    /**
+     * Constructs a new task that refreshes a specific pubsub node.
+     *
+     * @param node The pubsub node that this task relates to.
+     */
+    public RefreshNodeTask(@Nonnull final Node node)
     {
         super(node);
     }
@@ -33,5 +60,4 @@ public class RefreshNodeTask extends NodeTask
         log.debug("[TASK] Refreshing node - nodeID: {}", getNodeId());
         XMPPServer.getInstance().getPubSubModule().getPersistenceProvider().loadNode(getService(), getUniqueNodeIdentifier());
     }
-
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RemoveNodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RemoveNodeTask.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.util.Optional;
 
 /**
  * Removes a newly deleted node from memory across the cluster.
@@ -59,16 +60,16 @@ public class RemoveNodeTask extends NodeTask
     {
         log.debug("[TASK] Removing node - nodeID: {}", getNodeId());
 
-        final PubSubService service = getServiceIfLoaded();
+        final Optional<PubSubService> optService = getServiceIfLoaded();
 
         // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
         // in this case since any changes that might have been applied here will also have been applied to the database
         // by the cluster node where this task originated, meaning that those changes get loaded from the database when
         // the pubsub node is retrieved from the database in the future (OF-2077)
-        if (service == null) {
+        if (!optService.isPresent()) {
             return;
         }
 
-        service.removeNode(getNodeId());
+        optService.get().removeNode(getNodeId());
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RemoveNodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RemoveNodeTask.java
@@ -1,24 +1,49 @@
+/*
+ * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import org.jivesoftware.openfire.pubsub.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
 /**
  * Removes a newly deleted node from memory across the cluster.
  *
  * @author Tom Evans
- *
  */
 public class RemoveNodeTask extends NodeTask
 {
     private static final Logger log = LoggerFactory.getLogger(RemoveNodeTask.class);
 
+    /**
+     * This no-argument constructor is provided for serialization purposes. It should generally not be used otherwise.
+     */
     public RemoveNodeTask()
     {
     }
 
-    public RemoveNodeTask(Node node)
+    /**
+     * Constructs a new task that removes a specific node from a pubsub node.
+     *
+     * @param node The pubsub node that this task relates to.
+     */
+    public RemoveNodeTask(@Nonnull final Node node)
     {
         super(node);
     }
@@ -29,5 +54,4 @@ public class RemoveNodeTask extends NodeTask
         log.debug("[TASK] Removing node - nodeID: {}", getNodeId());
         getService().removeNode(getNodeId());
     }
-
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RemoveNodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RemoveNodeTask.java
@@ -59,7 +59,7 @@ public class RemoveNodeTask extends NodeTask
     {
         log.debug("[TASK] Removing node - nodeID: {}", getNodeId());
 
-        final PubSubService service = getService();
+        final PubSubService service = getServiceIfLoaded();
 
         // This will only occur if a PEP service is not loaded on this particular cluster node. We can safely do nothing
         // in this case since any changes that might have been applied here will also have been applied to the database

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/SubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/SubscriptionTask.java
@@ -68,11 +68,6 @@ public abstract class SubscriptionTask extends NodeTask
     private NodeSubscription.State state;
 
     /**
-     * The node subscription that is the subject of this task.
-     */
-    transient private NodeSubscription subscription;
-
-    /**
      * This no-argument constructor is provided for serialization purposes. It should generally not be used otherwise.
      */
     public SubscriptionTask()
@@ -152,11 +147,7 @@ public abstract class SubscriptionTask extends NodeTask
             return null;
         }
 
-        if (subscription == null)
-        {
-            subscription = new NodeSubscription(node, owner, subJid, state, subId);
-        }
-        return subscription;
+        return new NodeSubscription(node, owner, subJid, state, subId);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/SubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/SubscriptionTask.java
@@ -139,15 +139,29 @@ public abstract class SubscriptionTask extends NodeTask
      * @return a pubsub node subscription
      */
     @Nullable
-    public NodeSubscription getSubscription()
+    public NodeSubscription getSubscriptionIfLoaded()
     {
-        final Node node = getNode();
+        final Node node = getNodeIfLoaded();
         if (node == null) {
             // When this cluster node does not have the pubsub node loaded in memory, no updates are needed (OF-2077).
             return null;
         }
 
         return new NodeSubscription(node, owner, subJid, state, subId);
+    }
+
+    /**
+     * This method is replaced by {@link #getSubscriptionIfLoaded()} ()}, which performs the exact same operation, but is named
+     * differently to better express intent.
+     *
+     * @deprecated Renamed to {@link #getSubscriptionIfLoaded()}
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2077">Issue OF-2077: NullPointerException with Pubsub(PEP?) and clustering</a>
+     */
+    @Deprecated // TODO Remove this method in Openfire 4.8 or later.
+    @Nullable
+    public NodeSubscription getSubscription()
+    {
+        return getSubscriptionIfLoaded();
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/SubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/SubscriptionTask.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jivesoftware.openfire.pubsub.cluster;
 
 import java.io.IOException;
@@ -9,19 +25,59 @@ import org.jivesoftware.openfire.pubsub.NodeSubscription.State;
 import org.jivesoftware.util.cache.ExternalizableUtil;
 import org.xmpp.packet.JID;
 
+import javax.annotation.Nonnull;
+
+/**
+ * A cluster task used work with a particular subscription (a relation between an entity an a pubsub node) of a pubsub node.
+ *
+ * Note that this task aims to update in-memory state only: it will not apply affiliation changes to persistent data
+ * storage (it is assumed that the cluster node where the task originated takes responsibility for that). As a result,
+ * this task might not apply changes if the node that is the subject of this task is currently not loaded in-memory of
+ * the cluster node on which this task operates.
+ */
 public abstract class SubscriptionTask extends NodeTask
 {
+    /**
+     * The ID that uniquely identifies the subscription of the user in the node.
+     *
+     * @see NodeSubscription#getID()
+     */
     private String subId;
+
+    /**
+     * The address of the entity that owns this subscription.
+     *
+     * @see NodeSubscription#getOwner()
+     */
     private JID owner;
+
+    /**
+     * The address that is going to receive the event notifications.
+     *
+     * @see NodeSubscription#getJID()
+     */
     private JID subJid;
+
+    /**
+     * The state of the subscription.
+     *
+     * @see NodeSubscription#getState()
+     */
     private NodeSubscription.State state;
+
+    /**
+     * The node subscription that is the subject of this task.
+     */
     transient private NodeSubscription subscription;
 
+    /**
+     * This no-argument constructor is provided for serialization purposes. It should generally not be used otherwise.
+     */
     public SubscriptionTask()
     {
     }
 
-    public SubscriptionTask(NodeSubscription subscription)
+    public SubscriptionTask(@Nonnull final NodeSubscription subscription)
     {
         super(subscription.getNode());
         subId = subscription.getID();
@@ -30,26 +86,55 @@ public abstract class SubscriptionTask extends NodeTask
         subJid = subscription.getJID();
     }
 
+    /**
+     * Returns the ID that uniquely identifies the subscription of the user in the node.
+     *
+     * @return a unique node subscription identifier.
+     * @see NodeSubscription#getID()
+     */
     public String getSubscriptionId()
     {
         return subId;
     }
 
+    /**
+     * Returns the address of the entity that owns this subscription.
+     *
+     * @return The address of the owner of the subscription.
+     * @see NodeSubscription#getOwner()
+     */
     public JID getOwner()
     {
         return owner;
     }
 
+    /**
+     * Returns the address that is going to receive the event notifications.
+     *
+     * @return the address that will receive notifications.
+     * @see NodeSubscription#getJID()
+     */
     public JID getSubscriberJid()
     {
         return subJid;
     }
 
+    /**
+     * Returns the state of the subscription.
+     *
+     * @return subscription state
+     * @see NodeSubscription#getState()
+     */
     public NodeSubscription.State getState()
     {
         return state;
     }
 
+    /**
+     * Finds the pubsub node subscription that is the subject of this task.
+     *
+     * @return a pubsub node subscription
+     */
     public NodeSubscription getSubscription()
     {
         if (subscription == null)

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/SubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/SubscriptionTask.java
@@ -19,6 +19,7 @@ package org.jivesoftware.openfire.pubsub.cluster;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Optional;
 
 import org.jivesoftware.openfire.pubsub.Node;
 import org.jivesoftware.openfire.pubsub.NodeSubscription;
@@ -138,16 +139,13 @@ public abstract class SubscriptionTask extends NodeTask
      *
      * @return a pubsub node subscription
      */
-    @Nullable
-    public NodeSubscription getSubscriptionIfLoaded()
+    @Nonnull
+    public Optional<NodeSubscription> getSubscriptionIfLoaded()
     {
-        final Node node = getNodeIfLoaded();
-        if (node == null) {
-            // When this cluster node does not have the pubsub node loaded in memory, no updates are needed (OF-2077).
-            return null;
-        }
+        final Optional<Node> node = getNodeIfLoaded();
 
-        return new NodeSubscription(node, owner, subJid, state, subId);
+        // When this cluster node does not have the pubsub node loaded in memory, no updates are needed (OF-2077).
+        return node.map(value -> new NodeSubscription(value, owner, subJid, state, subId));
     }
 
     /**
@@ -161,7 +159,7 @@ public abstract class SubscriptionTask extends NodeTask
     @Nullable
     public NodeSubscription getSubscription()
     {
-        return getSubscriptionIfLoaded();
+        return getSubscriptionIfLoaded().orElse(null);
     }
 
     @Override


### PR DESCRIPTION
This PR contains various commits that:
- improve the documentation to express the intent of the implementation
- mark code that should not be used as deprecated
- Fix implementations that unconditionally attempted to execute changes on pubsub entities that potentially are not loaded (OF-2077)
- rename some methods, also to better express intent (to avoid future variants of OF-2077).

Please refer to the comments on individual commits for more details.