### PR TITLE
OF-2146: Fix affiliation and role change broadcasts in MUC

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRole.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRole.java
@@ -33,12 +33,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Defines the permissions and actions that a MUCUser may use in
- * a particular room. Each MUCRole defines the relationship between
- * a MUCRoom and a MUCUser.
- * <p>
- * MUCUsers can play different roles in different chatrooms.
- * </p>
+ * Defines the permissions and actions that a MUCUser currently may use in a particular room. Each MUCRole defines the
+ * relationship between a MUCRoom and a MUCUser.
+ *
+ * MUCUsers can play different roles in different chat rooms.
+ *
  * @author Gaston Dombiak
  */
 public interface MUCRole {
@@ -64,9 +63,11 @@ public interface MUCRole {
      * It is common for the chatroom or other chat room members to change
      * the role of users (a moderator promoting another user to moderator
      * status for example).
-     * <p>
+     *
      * Owning ChatUsers should have their membership roles updated.
-     * </p>
+     *
+     * A role is a temporary position or privilege level within a room, distinct from a user's long-lived affiliation
+     * with the room. A role lasts only for the duration of an occupant's visit to a room.
      *
      * @param newRole The new role that the user will play.
      * @throws NotAllowedException   Thrown if trying to change the moderator role to an owner or
@@ -77,12 +78,17 @@ public interface MUCRole {
     /**
      * Obtain the role state of the user.
      *
+     * A role is a temporary position or privilege level within a room, distinct from a user's long-lived affiliation
+     * with the room. A role lasts only for the duration of an occupant's visit to a room.
+     *
      * @return The role status of this user.
      */
     Role getRole();
 
     /**
-     * Call this method to promote or demote a user's affiliation in a chatroom.
+     * Call this method to promote or demote a user's affiliation in a chatroom. An affiliation is a long-lived
+     * association or connection with a room. Affiliation is distinct from role. An affiliation lasts across a user's
+     * visits to a room.
      *
      * @param newAffiliation the new affiliation that the user will play.
      * @throws NotAllowedException thrown if trying to ban an owner or an administrator.
@@ -90,7 +96,8 @@ public interface MUCRole {
     void setAffiliation( Affiliation newAffiliation ) throws NotAllowedException;
 
     /**
-     * Obtain the affiliation state of the user.
+     * Obtain the affiliation state of the user, which is a long-lived association or connection with a room.
+     * Affiliation is distinct from role. An affiliation lasts across a user's visits to a room.
      *
      * @return The affiliation status of this user.
      */
@@ -308,6 +315,10 @@ public interface MUCRole {
         fmuc.addAttribute("from", reportingFmucAddress.toString() );
     }
 
+    /**
+     * A temporary position or privilege level within a room, distinct from a user's long-lived affiliation with the
+     * room. A role lasts only for the duration of an occupant's visit to a room.
+     */
     enum Role {
 
         /**
@@ -362,6 +373,10 @@ public interface MUCRole {
         }
     }
 
+    /**
+     * A long-lived association or connection with a room. Affiliation is distinct from role. An affiliation lasts
+     * across a user's visits to a room.
+     */
     enum Affiliation {
 
         /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -1073,7 +1073,14 @@ public interface MUCRoom extends Externalizable, Result {
     void sendInvitationRejection( JID to, String reason, JID from );
 
     /**
-     * Sends a packet to the user.
+     * Sends a packet to the occupants of the room.
+     *
+     * The second argument defines the sender/originator of the stanza. Typically, this is the same entity that's also
+     * the 'subject' of the stanza (eg: someone that changed its presence or nickname). It is important to realize that
+     * this needs to be the case. When, for example, an occupant is made a moderator, the 'sender' typically is the
+     * entity that granted the role to another entity. It is also possible for the sender to be a reflection of the room
+     * itself. This scenario typically occurs when the sender can't be identified as an occupant of the room, such as,
+     * for example, changes applied through the Openfire admin console.
      *
      * @param packet The packet to send
      * @param sender Representation of the entity that sent the stanza.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1508,87 +1508,131 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             );
     }
 
-    public void broadcast(BroadcastPresenceRequest presenceRequest) {
-        String jid = null;
-        Presence presence = presenceRequest.getPresence();
-        JID to = presence.getTo();
-        Element frag = presence.getChildElement("x", "http://jabber.org/protocol/muc#user");
-        // Don't include the occupant's JID if the room is semi-anon and the new occupant
-        // is not a moderator
-        if (!canAnyoneDiscoverJID()) {
-            jid = frag.element("item").attributeValue("jid");
-        }
+    /**
+     * Broadcasts the presence stanza as captured by the argument to all occupants that are local to the JVM (in other
+     * words, it excludes occupants that are connected to other cluster nodes, as well as occupants connected via FMUC).
+     *
+     * @param presenceRequest The presence stanza
+     */
+    public void broadcast(@Nonnull BroadcastPresenceRequest presenceRequest)
+    {
+        Log.debug("Broadcasting presence update in room {} for occupant {}", this.getName(), presenceRequest.getPresence().getFrom() );
 
-        for (MUCRole occupant : occupantsByFullJID.values()) {
+        final Presence presence = presenceRequest.getPresence();
+
+        // Three distinct flavors of the presence stanzas can be sent:
+        // 1. The original stanza (that includes the real JID of the user), usable when the room is not semi-anon or when the occupant is a moderator.
+        // 2. One that does not include the real JID of the user (if the room is semi-anon and the occupant isn't a moderator)
+        // 3. One that is reflected to the joining user (this stanza has additional status codes, signalling 'self-presence')
+        final Presence nonAnonPresence = presence.createCopy(); // create a copy, as the 'to' will be overwritten when dispatched!
+        final Presence anonPresence = createAnonCopy(presenceRequest);
+        final Presence selfPresence = createSelfPresenceCopy(presenceRequest);
+
+        for (final MUCRole occupant : occupantsByFullJID.values())
+        {
             try
             {
-                if (occupant.getPresence().getFrom().equals(to)) {
-                    // Depending on the event for which the presence is broadcast, it's possible that the subject of
-                    // the stanza is not yet (or no longer, in case of a 'leave') in 'occupantsByFullJID'. This introduces
-                    // an issue where sometimes, the presence update is not delivered to this entity. To work around this
-                    // issue, we always send the presence update to the addressed entity, whether or not it's part of the
-                    // 'occupantsByFullJID' collection. To prevent duplicate stanzas, we'll skip the entity in case we
-                    // encounter it while iterating over this collection.
-                    continue; // Skip for now.
-                }
-
                 // Do not send broadcast presence to occupants hosted in other cluster nodes or other FMUC nodes.
                 if (!occupant.isLocal() || occupant.isRemoteFmuc()) {
+                    Log.trace( "Not sending presence update of '{}' to {}: This occupant is not local.", presence.getFrom(), occupant.getUserAddress() );
                     continue;
                 }
 
-                // Don't include the occupant's JID if the room is semi-anon and the new occupant is not a moderator
-                if (!canAnyoneDiscoverJID()) {
-                    if (MUCRole.Role.moderator == occupant.getRole()) {
-                        frag.element("item").addAttribute("jid", jid);
-                    }
-                    else {
-                        frag.element("item").addAttribute("jid", null);
-                    }
+                // Determine what stanza flavor to send to this occupant.
+                final Presence toSend;
+                if (occupant.getPresence().getFrom().equals(presence.getTo())) {
+                    // This occupant is the subject of the stanza. Send the 'self-presence' stanza.
+                    Log.trace( "Sending self-presence of '{}' to {}", presence.getFrom(), occupant.getUserAddress() );
+                    toSend = selfPresence;
+                } else if ( !canAnyoneDiscoverJID && MUCRole.Role.moderator != occupant.getRole() ) {
+                    Log.trace( "Sending anonymized presence of '{}' to {}: The room is semi-anon, and this occupant is not a moderator.", presence.getFrom(), occupant.getUserAddress() );
+                    toSend = anonPresence;
+                } else {
+                    Log.trace( "Sending presence of '{}' to {}", presence.getFrom(), occupant.getUserAddress() );
+                    toSend = nonAnonPresence;
                 }
-                occupant.send(presence);
+
+                // Send stanza to this occupant.
+                occupant.send(toSend);
             }
             catch ( Exception e )
             {
                 Log.warn( "An unexpected exception prevented a presence update from {} to be broadcasted to {}.", presence.getFrom(), occupant.getUserAddress(), e );
             }
         }
-
-        // Send the stanza to the subject of the stanza. See comment in the iteration above.
-        try
-        {
-            // Some status codes should only be included in the "self-presence", which is only sent to the user, but not to other occupants.
-            Presence selfPresence = presence.createCopy();
-            Element fragSelfPresence = selfPresence.getChildElement("x", "http://jabber.org/protocol/muc#user");
-            fragSelfPresence.addElement("status").addAttribute("code", "110");
-
-            // Only in the context of entering the room status code 100, 201 and 210 should be sent.
-            // http://xmpp.org/registrar/mucstatus.html
-            if ( presenceRequest.isJoinPresence() )
-            {
-                boolean isRoomNew = isLocked() && creationDate.getTime() == lockedTime;
-                if ( canAnyoneDiscoverJID() )
-                {
-                    // // XEP-0045: Example 26.
-                    // If the user is entering a room that is non-anonymous (i.e., which informs all occupants of each occupant's full JID as shown above), the service MUST warn the user by including a status code of "100" in the initial presence that the room sends to the new occupant
-                    fragSelfPresence.addElement("status").addAttribute("code", "100");
-                }
-                if ( isRoomNew )
-                {
-                    fragSelfPresence.addElement("status").addAttribute("code", "201");
-                }
-            }
-
-            selfPresence.setTo( presenceRequest.getUserAddressSender() ); // Cannot depend on a occupant being present, due to race conditions!
-            router.route(selfPresence);
-        }
-        catch ( Exception e )
-        {
-            Log.warn( "An unexpected exception prevented a presence update to be echo'd back to the sender {}.", presenceRequest.getUserAddressSender(), e );
-        }
     }
 
-    private void broadcast(@Nonnull Message message, @Nonnull MUCRole sender) {
+    /**
+     * Creates a copy of the presence stanza encapsulated in the argument, that is suitable to be sent to entities that
+     * have no permission to view the real JID of the sender.
+     *
+     * @param request The object encapsulating the presence to be broadcast.
+     * @return A copy of the stanza to be broadcast.
+     */
+    @Nonnull
+    private Presence createAnonCopy(@Nonnull BroadcastPresenceRequest request)
+    {
+        if (!request.getPresence().getFrom().asBareJID().equals(this.getJID()))
+        {
+            // At this point, the 'from' address of the to-be broadcasted stanza can be expected to be the role-address
+            // of the user, as set in org.jivesoftware.openfire.muc.spi.LocalMUCRole.setPresence. If that's not the case
+            // then there's a bug in Openfire. Catch this here, as otherwise, privacy-sensitive data is leaked.
+            throw new IllegalArgumentException();
+        }
+
+        final Presence result = request.getPresence().createCopy();
+        final Element frag = result.getChildElement("x", "http://jabber.org/protocol/muc#user");
+        frag.element("item").addAttribute("jid", null);
+        return result;
+    }
+
+    /**
+     * Creates a copy of the presence stanza encapsulated in the argument, that is suitable to be sent back to the
+     * entity that is the subject of the presence update (a 'self-presence'). The returned stanza contains several
+     * flags that indicate to the receiving client that the information relates to their user.
+     *
+     * @param request The object encapsulating the presence to be broadcast.
+     * @return A copy of the stanza to be broadcast.
+     */
+    @Nonnull
+    private Presence createSelfPresenceCopy(@Nonnull BroadcastPresenceRequest request)
+    {
+        if (!request.getPresence().getFrom().asBareJID().equals(this.getJID()))
+        {
+            // At this point, the 'from' address of the to-be broadcasted stanza can be expected to be the role-address
+            // of the user, as set in org.jivesoftware.openfire.muc.spi.LocalMUCRole.setPresence. If that's not the case
+            // then there's a bug in Openfire. Catch this here, as otherwise, privacy-sensitive data is leaked.
+            throw new IllegalArgumentException();
+        }
+
+        final Presence result = request.getPresence().createCopy();
+        Element fragSelfPresence = result.getChildElement("x", "http://jabber.org/protocol/muc#user");
+        fragSelfPresence.addElement("status").addAttribute("code", "110");
+
+        // Only in the context of entering the room status code 100, 201 and 210 should be sent.
+        // http://xmpp.org/registrar/mucstatus.html
+        if ( request.isJoinPresence() )
+        {
+            boolean isRoomNew = isLocked() && creationDate.getTime() == lockedTime;
+            if ( canAnyoneDiscoverJID() )
+            {
+                // XEP-0045: Example 26.
+                // If the user is entering a room that is non-anonymous (i.e., which informs all occupants of each occupant's full JID as shown above),
+                // the service MUST warn the user by including a status code of "100" in the initial presence that the room sends to the new occupant
+                fragSelfPresence.addElement("status").addAttribute("code", "100");
+            }
+
+            if ( isRoomNew )
+            {
+                fragSelfPresence.addElement("status").addAttribute("code", "201");
+            }
+        }
+
+        return result;
+    }
+
+    private void broadcast(@Nonnull Message message, @Nonnull MUCRole sender)
+    {
         // If FMUC is active, propagate the message through FMUC first. Note that when a master-slave mode is active,
         // we need to wait for an echo back, before the message can be broadcasted locally. The 'propagate' method will
         // return a CompletableFuture object that is completed as soon as processing can continue.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1523,9 +1523,12 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             try
             {
                 if (occupant.getPresence().getFrom().equals(to)) {
-                    // A race condition can occur where 'occupantsByFullJID' does not yet (or no longer, in case of a 'leave') contain
-                    // the originator of the presence stanza. To work around this, the "self-presence" is sent after all other occupants
-                    // have been processed.
+                    // Depending on the event for which the presence is broadcast, it's possible that the subject of
+                    // the stanza is not yet (or no longer, in case of a 'leave') in 'occupantsByFullJID'. This introduces
+                    // an issue where sometimes, the presence update is not delivered to this entity. To work around this
+                    // issue, we always send the presence update to the addressed entity, whether or not it's part of the
+                    // 'occupantsByFullJID' collection. To prevent duplicate stanzas, we'll skip the entity in case we
+                    // encounter it while iterating over this collection.
                     continue; // Skip for now.
                 }
 
@@ -1551,9 +1554,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             }
         }
 
-        // A race condition can occur where 'occupantsByFullJID' does not yet (or no longer, in case of a 'leave') contain
-        // the originator of the presence stanza. To work around this, the "self-presence" is sent after all other occupants
-        // have been processed.
+        // Send the stanza to the subject of the stanza. See comment in the iteration above.
         try
         {
             // Some status codes should only be included in the "self-presence", which is only sent to the user, but not to other occupants.


### PR DESCRIPTION
This effectively undoes a workaround that was introduced when implementing FMUC. That workaround introces the issue described in OF-2146.

After many hours of testing, we've not been able to reproduce the original issue that the workaround intends to fix.