### PR TITLE
OF-981: Stop suppressing warning that are no longer issued

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
@@ -426,7 +426,6 @@ public class JDBCAuthProvider implements AuthProvider, PropertyEventListener {
     /**
      * Indicates how the password is stored.
      */
-    @SuppressWarnings({"UnnecessarySemicolon"})  // Support for QDox Parser
     public enum PasswordType {
 
         /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/stats/Statistic.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/stats/Statistic.java
@@ -79,7 +79,6 @@ public interface Statistic {
     /**
      * The type of statistic.
      */
-    @SuppressWarnings({"UnnecessarySemicolon"})  // Support for QDox Parser
     enum Type {
 
         /**


### PR DESCRIPTION
With the removal of QDox, adding an otherwise unneeded semicolon is no longer needed. Those have been removed. The corresponding suppression of the warning that signals that unneeded semicolons are used can be removed too.