### PR TITLE
OF-2148: Change to wider type to prevent information loss

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/database/ProfiledConnectionEntry.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/ProfiledConnectionEntry.java
@@ -35,7 +35,7 @@ public class ProfiledConnectionEntry {
     /**
      * The total time spent executing the query (in milliseconds).
      */
-    public int totalTime;
+    public long totalTime;
 
     public ProfiledConnectionEntry(String sql) {
         this.sql = sql;


### PR DESCRIPTION
Prevent a possible issue where a wider type gets added to narrower type.

Ideally, this is replaced by proper types (eg: Duration, Instant), but the cost/benefit of applying that larger change does not pay off.