### PR TITLE
Add more logging to muc failure

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1572,12 +1572,13 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
     @Nonnull
     private Presence createAnonCopy(@Nonnull BroadcastPresenceRequest request)
     {
-        if (!request.getPresence().getFrom().asBareJID().equals(this.getJID()))
-        {
+        JID requestPresenceJID = request.getPresence().getFrom();
+        JID thisJID = this.getJID();
+        if (!requestPresenceJID.asBareJID().equals(thisJID)){
             // At this point, the 'from' address of the to-be broadcasted stanza can be expected to be the role-address
             // of the user, as set in org.jivesoftware.openfire.muc.spi.LocalMUCRole.setPresence. If that's not the case
             // then there's a bug in Openfire. Catch this here, as otherwise, privacy-sensitive data is leaked.
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Request Presence JID " + requestPresenceJID + " does not match " + thisJID);
         }
 
         final Presence result = request.getPresence().createCopy();


### PR DESCRIPTION
Once caught this issue in clustering testing:

org.jivesoftware.openfire.muc.cluster.BroadcastPresenceRequest - An unexpected exception occurred while trying to broadcast a presence update from user1@xmpp.localhost.example/DaCa000346.local in the room muc1@conference.xmpp.localhost.example
java.lang.IllegalArgumentException: null
at org.jivesoftware.openfire.muc.spi.LocalMUCRoom.createAnonCopy(LocalMUCRoom.java:1580) ~[xmppserver-4.6.1-SNAPSHOT.jar:4.6.1-SNAPSHOT]
at org.jivesoftware.openfire.muc.spi.LocalMUCRoom.broadcast(LocalMUCRoom.java:1528) ~[xmppserver-4.6.1-SNAPSHOT.jar:4.6.1-SNAPSHOT]
at org.jivesoftware.openfire.muc.cluster.BroadcastPresenceRequest$1.run(BroadcastPresenceRequest.java:87) ~[xmppserver-4.6.1-SNAPSHOT.jar:4.6.1-SNAPSHOT]
at org.jivesoftware.openfire.muc.cluster.MUCRoomTask.execute(MUCRoomTask.java:81) ~[xmppserver-4.6.1-SNAPSHOT.jar:4.6.1-SNAPSHOT]
at org.jivesoftware.openfire.muc.cluster.BroadcastPresenceRequest.run(BroadcastPresenceRequest.java:82) ~[xmppserver-4.6.1-SNAPSHOT.jar:4.6.1-SNAPSHOT]
at org.jivesoftware.openfire.muc.spi.LocalMUCRoom.lambda$broadcastPresence$7(LocalMUCRoom.java:1506) ~[xmppserver-4.6.1-SNAPSHOT.jar:4.6.1-SNAPSHOT]
at java.util.concurrent.CompletableFuture.uniRun(CompletableFuture.java:719) [?:1.8.0_275]
at java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:701) [?:1.8.0_275]
at java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:457) [?:1.8.0_275]
at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289) [?:1.8.0_275]
at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056) [?:1.8.0_275]
at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692) [?:1.8.0_275]
at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:175) [?:1.8.0_275]

Couldn't reproduce it, but adding more logging in case the seemingly-impossible condition occurs again.