### PR TITLE
OF-2152: Apply more explicit address verification

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/BroadcastPresenceRequest.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/BroadcastPresenceRequest.java
@@ -52,11 +52,19 @@ public class BroadcastPresenceRequest extends MUCRoomTask<Void> {
     public BroadcastPresenceRequest() {
     }
 
-    public BroadcastPresenceRequest( LocalMUCRoom room, MUCRole sender, Presence message, boolean isJoinPresence) {
+    public BroadcastPresenceRequest(@Nonnull final LocalMUCRoom room, @Nonnull final MUCRole sender, @Nonnull final Presence presence, final boolean isJoinPresence) {
         super(room);
         this.userAddressSender = sender.getUserAddress();
-        this.presence = message;
+        this.presence = presence;
         this.isJoinPresence = isJoinPresence;
+
+        if (!presence.getFrom().asBareJID().equals(room.getJID())) {
+            // At this point, the 'from' address of the to-be broadcasted stanza can be expected to be the role-address
+            // of the subject, or more broadly: it's bare JID representation should match that of the room. If that's not
+            // the case then there's a bug in Openfire. Catch this here, as otherwise, privacy-sensitive data is leaked.
+            // See: OF-2152
+            throw new IllegalArgumentException("Broadcasted presence stanza's 'from' JID " + presence.getFrom() + " does not match room JID: " + room.getJID());
+        }
     }
 
     public Presence getPresence() {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/MUCRoomTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/MUCRoomTask.java
@@ -29,6 +29,8 @@ import org.jivesoftware.util.cache.ExternalizableUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
 /**
  * Task related to a room to be executed in a cluster node. This is a base
  * class to specific room tasks. The base class just keeps track of the room
@@ -47,11 +49,12 @@ public abstract class MUCRoomTask<V> implements ClusterTask<V> {
     protected MUCRoomTask() {
     }
 
-    protected MUCRoomTask(LocalMUCRoom room) {
+    protected MUCRoomTask(@Nonnull final LocalMUCRoom room) {
         this.roomName = room.getName();
         this.subdomain = room.getMUCService().getServiceName();
     }
 
+    @Nonnull
     public LocalMUCRoom getRoom() {
         MultiUserChatService mucService = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(subdomain);
         if (mucService == null) {
@@ -71,7 +74,7 @@ public abstract class MUCRoomTask<V> implements ClusterTask<V> {
      *
      * @param runnable the task to execute.
      */
-    protected void execute(Runnable runnable) {
+    protected void execute(@Nonnull final Runnable runnable) {
         // Check if we are joining a cluster
         boolean clusterStarting = ClusterManager.isClusteringStarting();
         try {
@@ -97,7 +100,7 @@ public abstract class MUCRoomTask<V> implements ClusterTask<V> {
         return originator;
     }
 
-    public void setOriginator(boolean originator) {
+    public void setOriginator(final boolean originator) {
         this.originator = originator;
     }
 


### PR DESCRIPTION
This commit takes the explicit 'from' address verification that was put in place for Presence broadcast handling, and applies the same to Message broadcast handling.

The check has been moved up a bit, and has been applied at the constructor of the tasks that are executed asynchronously. These can be expected to generate more useful stack traces.