### PR TITLE
Fix unavailable session (revert OF-2012)

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -741,7 +741,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         if (session.getAddress() != null && routingTable != null &&
                 session.getAddress().toBareJID().trim().length() != 0) {
             // Update route to unavailable session (anonymous or not)
-            routingTable.removeClientRoute(session.getAddress());
+            routingTable.addClientRoute(session.getAddress(), session);
         }
     }
 


### PR DESCRIPTION
Hi there,

in previous Openfire versions it was possible for a client connection to exist but to be "unavailable". 
In the admin console it looked like this: 

![](https://i.gyazo.com/27ab811692930114ece70d86c08124cd.png)
(see Presence: offline)

[OF-2012](https://igniterealtime.atlassian.net/browse/OF-2012) removed this feature by killing off the Client Route (Client Session) altogether when it sends an `unavailable` presence.

This makes it impossible for Openfire to process any packets by this client, including presences that would make it `available` again.
Besides the hassle to setup a new connection everytime this happens, it seems to me that many XMPP clients actually cannot handle this situation of an unusable connection properly, or do not notice that their connection is dead at all.

So if this effect was unintended I propose to revert [OF-2012](https://igniterealtime.atlassian.net/browse/OF-2012) (ede343d2) with this PR, to get the old behavior back.

Cheers