### PR TITLE
OF-2159: Do not re-use origin-id when generating a stanza

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/stanzaid/StanzaIDUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/stanzaid/StanzaIDUtil.java
@@ -22,7 +22,8 @@ public class StanzaIDUtil
     private static final Logger Log = LoggerFactory.getLogger( StanzaIDUtil.class );
 
     /**
-     * Modifies the stanza that's passed as a packet by adding a Stanza ID.
+     * Modifies the stanza that's passed as a packet by adding a Stanza ID on behalf of what is assumed to be a local
+     * entity.
      *
      * @param packet The inbound packet (cannot be null).
      * @param self The ID of the 'local' entity that will generate the stanza ID (cannot be null).
@@ -78,7 +79,8 @@ public class StanzaIDUtil
             }
         }
 
-        final String id = generateUniqueAndStableStanzaID( packet );
+        final String id = UUID.randomUUID().toString();
+        Log.debug( "Using newly generated value '{}' for stanza that has id '{}'.", id, packet.getID() );
 
         final Element stanzaIdElement = parentElement.addElement( QName.get( "stanza-id", "urn:xmpp:sid:0" ) );
         stanzaIdElement.addAttribute( "id", id );
@@ -93,26 +95,12 @@ public class StanzaIDUtil
      *
      * @param packet The stanza for what to return the ID (cannot be null).
      * @return The ID (never null or empty string).
+     * @deprecated Use UUID.randomUUID() instead
      */
+    @Deprecated // Remove in or after Openfire 4.8.0
     public static String generateUniqueAndStableStanzaID( final Packet packet )
     {
-        String result = null;
-
-        final Iterator<Element> existingElementIterator = packet.getElement().elementIterator( QName.get( "origin-id", "urn:xmpp:sid:0" ) );
-        while (existingElementIterator.hasNext() && (result == null || result.isEmpty() ) )
-        {
-            final Element element = existingElementIterator.next();
-            result = element.attributeValue( "id" );
-        }
-
-        if ( result == null || result.isEmpty() ) {
-            result = UUID.randomUUID().toString();
-            Log.debug( "Using newly generated value '{}' for stanza that has id '{}'.", result, packet.getID() );
-        } else {
-            Log.debug( "Using origin-id provided value '{}' for stanza that has id '{}'.", result, packet.getID() );
-        }
-
-        return result;
+        return UUID.randomUUID().toString();
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/stanzaid/StanzaIDUtilTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/stanzaid/StanzaIDUtilTest.java
@@ -21,70 +21,7 @@ import static org.junit.Assert.assertEquals;
 public class StanzaIDUtilTest
 {
     /**
-     * Test if {@link StanzaIDUtil.generateUniqueAndStableStanzaID} generates a UUID value
-     * if the provided input does not have a 'origin-id' value
-     */
-    @Test
-    public void testGenerateUUIDWhenNoOriginIDPresent() throws Exception
-    {
-        // Setup fixture.
-        final Packet input = new Message();
-
-        // Execute system under test.
-        final String result = StanzaIDUtil.generateUniqueAndStableStanzaID( input );
-
-        // Verify results.
-        Assert.assertNotNull( result );
-        try
-        {
-            UUID.fromString( result );
-        }
-        catch ( IllegalArgumentException ex )
-        {
-            Assert.fail();
-        }
-    }
-
-    /**
-     * Test if {@link StanzaIDUtil.generateUniqueAndStableStanzaID} uses the 'origin-id' provided value,
-     * if that's present.
-     */
-    @Test
-    public void testUseOriginIDWhenPresent() throws Exception
-    {
-        // Setup fixture.
-        final Packet input = new Message();
-        final String expected = "de305d54-75b4-431b-adb2-eb6b9e546013";
-        input.getElement().addElement( "origin-id", "urn:xmpp:sid:0" ).addAttribute( "id", expected );
-
-        // Execute system under test.
-        final String result = StanzaIDUtil.generateUniqueAndStableStanzaID( input );
-
-        // Verify results.
-        assertEquals( expected, result );
-    }
-
-    /**
-     * Test if {@link StanzaIDUtil.generateUniqueAndStableStanzaID} uses the 'origin-id' provided value,
-     * if that's present, even when the value is not a UUID.
-     */
-    @Test
-    public void testUseOriginIDWhenPresentNonUUID() throws Exception
-    {
-        // Setup fixture.
-        final Packet input = new Message();
-        final String expected = "not-a-uuid";
-        input.getElement().addElement( "origin-id", "urn:xmpp:sid:0" ).addAttribute( "id", expected );
-
-        // Execute system under test.
-        final String result = StanzaIDUtil.generateUniqueAndStableStanzaID( input );
-
-        // Verify results.
-        assertEquals( expected, result );
-    }
-
-    /**
-     * Test if {@link StanzaIDUtil.ensureUniqueAndStableStanzaID} adds a stanza-id element
+     * Test if {@link StanzaIDUtil#ensureUniqueAndStableStanzaID(Packet, JID)} adds a stanza-id element
      * with proper 'by' and UUID value if the provided input does not have a 'origin-id'
      * element.
      */
@@ -114,7 +51,7 @@ public class StanzaIDUtilTest
     }
 
     /**
-     * Test if {@link StanzaIDUtil.ensureUniqueAndStableStanzaID} overwrites a stanza-id
+     * Test if {@link StanzaIDUtil#ensureUniqueAndStableStanzaID(Packet, JID)} overwrites a stanza-id
      * element when another is present with the same 'by' value.
      */
     @Test
@@ -148,7 +85,7 @@ public class StanzaIDUtilTest
     }
 
     /**
-     * Test if {@link StanzaIDUtil.ensureUniqueAndStableStanzaID} does not overwrites
+     * Test if {@link StanzaIDUtil#ensureUniqueAndStableStanzaID(Packet, JID)} does not overwrites
      * a stanza-id element when another is present with a different 'by' value.
      */
     @Test
@@ -172,8 +109,8 @@ public class StanzaIDUtilTest
     }
 
     /**
-     * Test if {@link StanzaIDUtil.ensureUniqueAndStableStanzaID} uses the provided
-     * origin-id value, if there's one.
+     * Test if {@link StanzaIDUtil#ensureUniqueAndStableStanzaID(Packet, JID)} uses a different value, if the provided
+     * data has an origin-id value.
      */
     @Test
     public void testUseOriginIdElement() throws Exception
@@ -200,7 +137,7 @@ public class StanzaIDUtilTest
         {
             Assert.fail();
         }
-        Assert.assertEquals( expected, stanzaIDElement.attributeValue( "id" ) );
+        Assert.assertNotEquals( expected, stanzaIDElement.attributeValue( "id" ) );
         assertEquals( self.toString(), stanzaIDElement.attributeValue( "by" ) );
     }
 


### PR DESCRIPTION
This fixes a misunderstanding of the text in the XEP. Although origin-id must be retained, its value shouldn't be re-used, as the local entity can't trust the owner to have used a unique value.