### PR TITLE
OF-2161: Ensure that SSID for MUC PMs is the MUC JID

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
@@ -248,7 +248,7 @@ public class LocalMUCUser implements MUCUser
 
         lastPacketTime = System.currentTimeMillis();
 
-        StanzaIDUtil.ensureUniqueAndStableStanzaID(packet, packet.getTo());
+        StanzaIDUtil.ensureUniqueAndStableStanzaID(packet, packet.getTo().asBareJID());
 
         // Determine if this user has a pre-existing role in the addressed room.
         final MUCRole preExistingRole = roles.get(roomName);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
@@ -224,9 +224,7 @@ public class LocalMUCUser implements MUCUser
      *   <li>Otherwise, rewrite the sender address and send to the room.</li>
      * </ul>
      *
-     * @param packet          The stanza to route
-     * @param roomName        The name of the room that the stanza was addressed to.
-     * @param preExistingRole The role of this user in the addressed room prior to processing of this stanza, if any.
+     * @param packet The stanza to route
      */
     @Override
     public void process( Packet packet ) throws UnauthorizedException, PacketException


### PR DESCRIPTION
When a private message that's exchanged in a MUC room is processed, it receives a stable and unique stanza ID. As per specification, Openfire adds a 'by' attribute. However, for private messages, this value is a full JID (representing the nickname of the user that sent the message), instead of a bare JID (representing the room in which the message was exchanged). This is fixed by ensuring that the JID used is a bare JID.