### PR TITLE
OF-2163: Prevent unexpected stanza modifications to leak information

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryRequest.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryRequest.java
@@ -134,7 +134,8 @@ public class HistoryRequest {
         if (!isConfigured()) {
             Iterator<Message> history = roomHistory.getMessageHistory();
             while (history.hasNext()) {
-                joinRole.send(history.next());
+                // OF-2163: Create a defensive copy of the message, to prevent the address that it is sent to to leak back into the archive.
+                joinRole.send(history.next().createCopy());
             }
         }
         else {
@@ -194,8 +195,9 @@ public class HistoryRequest {
                 historyToSend.addFirst(message);
             }
             // Send the smallest amount of traffic to the user
-            for (Object aHistoryToSend : historyToSend) {
-                joinRole.send((Message) aHistoryToSend);
+            for (final Message aHistoryToSend : historyToSend) {
+                // OF-2163: Create a defensive copy of the message, to prevent the address that it is sent to to leak back into the archive.
+                joinRole.send(aHistoryToSend.createCopy());
             }
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRole.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRole.java
@@ -209,7 +209,12 @@ public interface MUCRole {
     /**
      * Sends a packet to the user.
      *
+     * Note that sending a packet can modify it (notably, the 'to' address can be changed. If this is undesired (for
+     * example, because post-processing should not expose the modified 'to' address), then a copy of the original
+     * stanza should be provided as an argument to this method.
+     *
      * @param packet The packet to send
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2163">issue OF-2163</a>
      */
     void send( Packet packet );
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCvCardHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCvCardHandler.java
@@ -229,6 +229,7 @@ public class IQMUCvCardHandler extends IQHandler
 
         for ( final MUCRole occupant : room.getOccupants() )
         {
+            // Not needed to create a defensive copy of the stanza. It's not used anywhere else.
             occupant.send(notification);
         }
     }
@@ -245,6 +246,7 @@ public class IQMUCvCardHandler extends IQHandler
 
         for ( final MUCRole occupant : room.getOccupants() )
         {
+            // Not needed to create a defensive copy of the stanza. It's not used anywhere else.
             occupant.send(notification);
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -589,7 +589,8 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                         item.addAttribute( "role", "none" );
                         fragment.addElement( "status" ).addAttribute( "code", "332" );
 
-                        // Make sure that the presence change for each user is only sent to that user (and not broadcasted in the room)!
+                        // Make sure that the presence change for each user is only sent to that user (and not broadcast in the room)!
+                        // Not needed to create a defensive copy of the stanza. It's not used anywhere else.
                         role.send( presence );
                     }
                 }


### PR DESCRIPTION
Delivering a stanza to a MUC room occupant changes the addressing of the stanza (the room JID is replaced by the real JID). It is often undesirable that this change is applied to the original stanza (that can be processed further), as such changes can leak the privacy-sensitive real address of the recipient.

This commit creates defensive copies of the stanza that is being sent, to prevent leaking the real address of the recipient.