### PR TITLE
OF-2168: MUC presence broadcast supression based on role

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -998,29 +998,30 @@ public interface MUCRoom extends Externalizable, Result {
     void setPublicRoom( boolean publicRoom );
 
     /**
-     * Returns the list of roles of which presence will be broadcasted to the rest of the occupants.
+     * Returns the list of roles of which presence will be broadcast to the rest of the occupants.
      * This feature is useful for implementing "invisible" occupants.
      * 
-     * @return the list of roles of which presence will be broadcasted to the rest of the occupants.
+     * @return the list of roles of which presence will be broadcast to the rest of the occupants.
      */
-    List<String> getRolesToBroadcastPresence();
+    @Nonnull
+    List<MUCRole.Role> getRolesToBroadcastPresence();
 
     /**
-     * Sets the list of roles of which presence will be broadcasted to the rest of the occupants.
+     * Sets the list of roles of which presence will be broadcast to the rest of the occupants.
      * This feature is useful for implementing "invisible" occupants.
      * 
-     * @param rolesToBroadcastPresence the list of roles of which presence will be broadcasted to 
+     * @param rolesToBroadcastPresence the list of roles of which presence will be broadcast to
      * the rest of the occupants.
      */
-    void setRolesToBroadcastPresence( List<String> rolesToBroadcastPresence );
+    void setRolesToBroadcastPresence(@Nonnull final List<MUCRole.Role> rolesToBroadcastPresence );
 
     /**
-     * Returns true if the presences of the requested role will be broadcasted.
+     * Returns true if the presences of the requested role will be broadcast.
      * 
-     * @param roleToBroadcast the role to check if its presences will be broadcasted.
-     * @return true if the presences of the requested role will be broadcasted.
+     * @param roleToBroadcast the role to check if its presences will be broadcast.
+     * @return true if the presences of the requested role will be broadcast.
      */
-    boolean canBroadcastPresence( String roleToBroadcast );
+    boolean canBroadcastPresence( @Nonnull final MUCRole.Role roleToBroadcast );
 
     /**
      * Locks the room so that users cannot join the room. Only the owner of the room can lock/unlock

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
@@ -19,6 +19,7 @@ package org.jivesoftware.openfire.muc.spi;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
@@ -276,7 +277,7 @@ public class IQOwnerHandler {
         field = completedForm.getField("muc#roomconfig_presencebroadcast");
         if (field != null) {
             values = new ArrayList<>(field.getValues());
-            room.setRolesToBroadcastPresence(values);
+            room.setRolesToBroadcastPresence(values.stream().map(MUCRole.Role::valueOf).collect(Collectors.toList()));
         }
 
         field = completedForm.getField("muc#roomconfig_publicroom");
@@ -465,8 +466,8 @@ public class IQOwnerHandler {
 
             field = configurationForm.getField("muc#roomconfig_presencebroadcast");
             field.clearValues();
-            for (String roleToBroadcast : room.getRolesToBroadcastPresence()) {
-                field.addValue(roleToBroadcast);
+            for (MUCRole.Role roleToBroadcast : room.getRolesToBroadcastPresence()) {
+                field.addValue(roleToBroadcast.toString());
             }
 
             field = configurationForm.getField("muc#roomconfig_publicroom");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
@@ -218,16 +218,16 @@ public class MUCPersistenceManager {
             room.setCanAnyoneDiscoverJID(rs.getInt("canDiscoverJID") == 1);
             room.setLogEnabled(rs.getInt("logEnabled") == 1);
             room.setSubject(rs.getString("subject"));
-            List<String> rolesToBroadcast = new ArrayList<>();
+            List<MUCRole.Role> rolesToBroadcast = new ArrayList<>();
             String roles = StringUtils.zeroPadString(Integer.toBinaryString(rs.getInt("rolesToBroadcast")), 3);
             if (roles.charAt(0) == '1') {
-                rolesToBroadcast.add("moderator");
+                rolesToBroadcast.add(MUCRole.Role.moderator);
             }
             if (roles.charAt(1) == '1') {
-                rolesToBroadcast.add("participant");
+                rolesToBroadcast.add(MUCRole.Role.participant);
             }
             if (roles.charAt(2) == '1') {
-                rolesToBroadcast.add("visitor");
+                rolesToBroadcast.add(MUCRole.Role.visitor);
             }
             room.setRolesToBroadcastPresence(rolesToBroadcast);
             room.setLoginRestrictedToNickname(rs.getInt("useReservedNick") == 1);
@@ -618,16 +618,16 @@ public class MUCPersistenceManager {
                     room.setCanAnyoneDiscoverJID(resultSet.getInt("canDiscoverJID") == 1);
                     room.setLogEnabled(resultSet.getInt("logEnabled") == 1);
                     room.setSubject(resultSet.getString("subject"));
-                    List<String> rolesToBroadcast = new ArrayList<>();
+                    List<MUCRole.Role> rolesToBroadcast = new ArrayList<>();
                     String roles = StringUtils.zeroPadString(Integer.toBinaryString(resultSet.getInt("rolesToBroadcast")), 3);
                     if (roles.charAt(0) == '1') {
-                        rolesToBroadcast.add("moderator");
+                        rolesToBroadcast.add(MUCRole.Role.moderator);
                     }
                     if (roles.charAt(1) == '1') {
-                        rolesToBroadcast.add("participant");
+                        rolesToBroadcast.add(MUCRole.Role.participant);
                     }
                     if (roles.charAt(2) == '1') {
-                        rolesToBroadcast.add("visitor");
+                        rolesToBroadcast.add(MUCRole.Role.visitor);
                     }
                     room.setRolesToBroadcastPresence(rolesToBroadcast);
                     room.setLoginRestrictedToNickname(resultSet.getInt("useReservedNick") == 1);
@@ -1216,11 +1216,11 @@ public class MUCPersistenceManager {
      * @return an integer based on the binary representation of the roles to broadcast.
      */
     private static int marshallRolesToBroadcast(MUCRoom room) {
-        StringBuilder buffer = new StringBuilder();
-        buffer.append((room.canBroadcastPresence("moderator") ? "1" : "0"));
-        buffer.append((room.canBroadcastPresence("participant") ? "1" : "0"));
-        buffer.append((room.canBroadcastPresence("visitor") ? "1" : "0"));
-        return Integer.parseInt(buffer.toString(), 2);
+        final String buffer =
+            (room.canBroadcastPresence(MUCRole.Role.moderator) ? "1" : "0") +
+            (room.canBroadcastPresence(MUCRole.Role.participant) ? "1" : "0") +
+            (room.canBroadcastPresence(MUCRole.Role.visitor) ? "1" : "0");
+        return Integer.parseInt(buffer, 2);
     }
 
     /**

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -33,6 +33,7 @@
 %>
 <%@ page import="org.jivesoftware.openfire.muc.NotAllowedException"%>
 <%@ page import="org.jivesoftware.openfire.muc.spi.MUCPersistenceManager" %>
+<%@ page import="org.jivesoftware.openfire.muc.MUCRole" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -225,13 +226,13 @@
 
             final FormField broadcastField = dataForm.addField("muc#roomconfig_presencebroadcast", null, null);
             if (broadcastModerator) {
-                broadcastField.addValue("moderator");
+                broadcastField.addValue(MUCRole.Role.moderator);
             }
             if (broadcastParticipant) {
-                broadcastField.addValue("participant");
+                broadcastField.addValue(MUCRole.Role.participant);
             }
             if (broadcastVisitor) {
-                broadcastField.addValue("visitor");
+                broadcastField.addValue(MUCRole.Role.visitor);
             }
 
             dataForm.addField("muc#roomconfig_publicroom", null, null).addValue(publicRoom ? "1": "0");
@@ -318,9 +319,9 @@
             description = room.getDescription();
             roomSubject = room.getSubject();
             maxUsers = Integer.toString(room.getMaxUsers());
-            broadcastModerator = room.canBroadcastPresence("moderator");
-            broadcastParticipant = room.canBroadcastPresence("participant");
-            broadcastVisitor = room.canBroadcastPresence("visitor");
+            broadcastModerator = room.canBroadcastPresence(MUCRole.Role.moderator);
+            broadcastParticipant = room.canBroadcastPresence(MUCRole.Role.participant);
+            broadcastVisitor = room.canBroadcastPresence(MUCRole.Role.visitor);
             password = room.getPassword();
             confirmPassword = room.getPassword();
             whois = (room.canAnyoneDiscoverJID() ? "anyone" : "moderator");


### PR DESCRIPTION
Openfire offers functionality to suppress the broadcast of occupants that have a certain role. The old implementation is based on the definition of that role that should be present in the presence stanza to be broadcast.

When the presence stanza that is being processed does, for some reason, not include this role, the implementation fails. NullPointerExceptions have been observed in relation to this.

It should be a lot safer to base the broadcast/do not broadcast decision based on the role that is assigned to the user, as this prevents the need to parse a stanza. This commit applies this new strategy.

Additionally, this commit replaces the string-based represention of a role with a type-safe variant.