### PR TITLE
OF-2169: Prevent exception for missing LDAP attribute

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
@@ -557,7 +557,7 @@ public class LdapVCardProvider implements VCardProvider, PropertyEventListener {
                     // perform the replacement.
                     for ( Map.Entry<String, String> entry : replacements.entrySet() ) {
                         final String placeholder = entry.getKey();
-                        final String replacement = entry.getValue();
+                        final String replacement = entry.getValue() != null ? entry.getValue() : "";
                         format = format.replace(placeholder, replacement);
                         Log.trace("Replaced attribute '{}' with '{}'", placeholder, replacement);
                     }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/ldap/VCardTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/ldap/VCardTest.java
@@ -297,8 +297,31 @@ public class VCardTest
     }
 
     /**
+     * Verifies that, using a simplified template, element values that are matched, but have no mapped value, get
+     * replaced with an empty value.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2169">OF-2169</a>
+     */
+    @Test
+    public void testReplaceMissingMappedValue() throws Exception
+    {
+        // Setup fixture.
+        final Document doc = DocumentHelper.parseText("<vcard><el>{placeholder}</el></vcard>");
+        final LdapVCardProvider.VCardTemplate template = new LdapVCardProvider.VCardTemplate(doc);
+        final Map<String, String> attributes = new HashMap<>();
+
+        // Execute system under test.
+        final LdapVCardProvider.VCard vCard = new LdapVCardProvider.VCard(template);
+        final Element result = vCard.getVCard(attributes);
+
+        // Verify result.
+        assertNotNull( result );
+        assertEquals( "<vcard><el></el></vcard>", result.asXML() );
+    }
+
+    /**
      * Verifies that, using a simplified template, element values that are not a placeholder do not get replaced, even
-     * if the elemnent value contains a separator character used in the implementation to distinguish individual
+     * if the element value contains a separator character used in the implementation to distinguish individual
      * placeholders.
      *
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-1947">OF-1947</a>


### PR DESCRIPTION
When a VCard template refers to an attribute that a user does not have, the resulting value should be empty. This commit prevents a NullPointerException to be thrown.