### PR TITLE
OF-2170: LDAP userDN cache should contain negative lookups

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -1066,8 +1066,10 @@ public class LdapManager {
                     throw e;
                 }
             } catch ( UserNotFoundException ex ) {
-                // Cache the 'not found' event to prevent incurring costs for future lookups (that will be equally unsuccessful). OF-2170
-                userDNCache.put(username, CacheableOptional.of(null));
+                if (userDNCache != null) {
+                    // Cache the 'not found' event to prevent incurring costs for future lookups (that will be equally unsuccessful). OF-2170
+                    userDNCache.put(username, CacheableOptional.of(null));
+                }
                 throw ex;
             }
         }
@@ -1717,8 +1719,10 @@ public class LdapManager {
             catch ( UserNotFoundException ex ) {
                 Log.debug( "An exception occurred while tyring to get the user baseDn for {}", username, ex );
 
-                // Cache the 'not found' event to prevent incurring costs for future lookups (that will be equally unsuccessful). OF-2170
-                userDNCache.put(username, CacheableOptional.of(null));
+                if (userDNCache != null) {
+                    // Cache the 'not found' event to prevent incurring costs for future lookups (that will be equally unsuccessful). OF-2170
+                    userDNCache.put(username, CacheableOptional.of(null));
+                }
             }
             catch ( Exception ex )
             {


### PR DESCRIPTION
By caching lookup failures, subsequent lookups are prevented, which will increase performance.

@GregDThomas I would've used `Optional` if it was `Serializable`! ;)