### PR TITLE
OF-2174: Reduce verbosity of authentication failures

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -322,8 +322,14 @@ public class ScramSha1SaslServer implements SaslServer {
                 salt = DatatypeConverter.parseBase64Binary(saltshaker);
             }
             return salt;
-        } catch (UserNotFoundException | UnsupportedOperationException | ConnectionException | InternalUnauthenticatedException e) {
-            Log.warn("Exception in SCRAM.getSalt():", e);
+        } catch (UserNotFoundException e) {
+            Log.debug("User '{}' not found. Cannot obtain its salt.", username, e);
+            // Return a random salt if the user doesn't exist to mimic an invalid password.
+            byte[] salt = new byte[24];
+            random.nextBytes(salt);
+            return salt;
+        } catch (UnsupportedOperationException | ConnectionException | InternalUnauthenticatedException e) {
+            Log.warn("Exception in SCRAM.getSalt() for user '{}':", username, e);
             byte[] salt = new byte[24];
             random.nextBytes(salt);
             return salt;


### PR DESCRIPTION
When an anonymous or non-existing user tries to log in, a very alerting warning can be logged, when the authentication mechanism in use tries to make use of the user's salt (which does not exist). This needlessly alarms administrators. The verbosity should be turned down a notch or two.