### PR TITLE
OF-2177: CacheableOptional should have a toString implemenation

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/CacheableOptional.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/CacheableOptional.java
@@ -66,6 +66,13 @@ public class CacheableOptional<T extends Serializable> implements Cacheable {
     }
 
     @Override
+    public String toString() {
+        return "CacheableOptional{" +
+            (value == null ? "absent value" : "value=" + value) +
+            '}';
+    }
+
+    @Override
     public int getCachedSize() throws CannotCalculateSizeException {
         final int sizeOfValue = CacheSizes.sizeOfAnything(value);
         if (value == null) {


### PR DESCRIPTION
When CacheableOptional has a toString, the cache summary pages on the admin console would show more useful data than object references.