### PR TITLE
OF-2179: Accommodate MUC occupants re-joining on another cluster node

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRole.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRole.java
@@ -47,6 +47,8 @@ public interface MUCRole {
     /**
      * Obtain the current presence status of a user in a chatroom.
      *
+     * The 'from' address of the presence stanza is guaranteed to reflect the room role of this role.
+     *
      * @return The presence of the user in the room.
      */
     Presence getPresence();


### PR DESCRIPTION
Occupants of a MUC room have, in a clustered setup' one cluster node where they are considered 'local' to. It has been observed that for some occupants, notably those that are joined through server-to-server / federation, can change over time.

This commit:
- generates a warning when it detects that a occupant has unexpectedly switched from node (detection is based on the cluster member that performs a presence stanza update on behalf of the occupant).
- re-homes an occupant that appears to 'rejoin' (without having left the room), but does so from a different cluster node.