### PR TITLE
OF-2180: Fixes that a local muc role is overridden by a remote muc role after …

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
@@ -32,6 +32,7 @@ import org.jivesoftware.database.SequenceManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.cluster.ClusterEventListener;
 import org.jivesoftware.openfire.cluster.ClusterManager;
+import org.jivesoftware.openfire.cluster.NodeID;
 import org.jivesoftware.openfire.container.BasicModule;
 import org.jivesoftware.openfire.event.UserEventDispatcher;
 import org.jivesoftware.openfire.event.UserEventListener;
@@ -909,7 +910,7 @@ public class MultiUserChatManager extends BasicModule implements ClusterEventLis
             Log.warn("Unexpectedly received a 'null' result when querying senior cluster member for MUC Service information.");
             return;
         }
-
+        NodeID thisNodeID = XMPPServer.getInstance().getNodeID();
         for (final ServiceInfo serviceInfo : result) {
             MultiUserChatService service;
             service = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(serviceInfo.getSubdomain());
@@ -943,6 +944,10 @@ public class MultiUserChatManager extends BasicModule implements ClusterEventLis
                 // Add remote occupants to local room
                 // TODO Handle conflict of nicknames (OF-2165)
                 for (final OccupantAddedEvent event : roomInfo.getOccupants()) {
+                    if (thisNodeID.equals(event.getNodeID())){
+                        // Do not add occupants as RemoteMucRole who are already on this node as LocalMucRole
+                        continue;
+                    }
                     event.setSendPresence(true);
                     event.run();
                 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1201,12 +1201,12 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
     }
 
     public void leaveRoom(OccupantLeftEvent event) {
-        MUCRole leaveRole = event.getRole();
-        if (leaveRole == null) {
-            return;
-        }
         lock.writeLock().lock();
         try {
+            MUCRole leaveRole = event.getRole();
+            if (leaveRole == null) {
+                return;
+            }
             // Removes the role from the room
             removeOccupantRole(leaveRole);
 
@@ -1286,7 +1286,10 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
                 return occupants.isEmpty() ? null : occupants;
             });
 
-            occupantsByFullJID.remove(userAddress);
+            // Remove this MucRole only if it is the same MucRole as the leaveRole, because it is possible that
+            // a client on a cluster node rejoins and the OccupantAddedEvent arrives before the OccupantLeftEvent from
+            // the previous cluster node.
+            occupantsByFullJID.computeIfPresent(userAddress,(jid, mucRole) -> mucRole.equals(leaveRole) ? null : mucRole);
         }
         finally {
             lock.writeLock().unlock();


### PR DESCRIPTION
…cluster start up

It is a follow up to https://discourse.igniterealtime.org/t/null-pointer-exception-joining-a-room/88995/21?u=chp but not introduced by https://discourse.igniterealtime.org/t/null-pointer-exception-joining-a-room/88995/7?u=chp

If a cluster node starts, then it can happen that a client establishes a connection and joins the muc before the cluster connection is ready (e.g.: by a plugin, which needs very long time to start).

If the cluster connection is ready, then the senior member queries all the mucs including the online users of the mucs from this cluster node. The cluster node then queries the Mucs including the online users of the cluster from the senior node and enters them in its own maps. However, the cluster node receives its online users again as a RemoteMucRole and overwrites its own LocalMucRole. The consequence is that the user can still send messages, but no longer receive them.