### PR TITLE
OF-2176 OF-763: Make Admin Console session timeout configurable

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1685,6 +1685,7 @@ system_property.xmpp.offline.autoclean.daystolive=The time in days after which u
 system_property.xmpp.offline.autoclean.checkinterval=The time in minutes after which the message store will be searched for unread messages to delete.
 system_property.xmpp.offline.autoclean.enabled=Enable / Disable auto clean of unread messages
 system_property.log.httpbind.enabled=Enable / disable logging of BOSH requests and responses.
+system_property.adminConsole.sessionTimeout=The maximum idle time of a HTTP session in the admin console.
 
 # Server properties Page
 

--- a/i18n/src/main/resources/openfire_i18n_de.properties
+++ b/i18n/src/main/resources/openfire_i18n_de.properties
@@ -1214,6 +1214,7 @@ system_property.adminConsole.siteMinderHeader=Der Name des HTTP-Headers, der den
 system_property.xmpp.offline.autoclean.daystolive=Zeit in Tagen nach der ungelesene Nachrichten aus dem Offlinenachrichtenspeicher gelöscht werden.
 system_property.xmpp.offline.autoclean.checkinterval=Gibt das Suchintervall in Minuten an, nach dem die ungelesenen Nachrichten gesucht und gelöscht werden.
 system_property.xmpp.offline.autoclean.enabled=Aktiert / Deaktiviert die Funktion der automatischen Säuberung von ungelesenen Nachrichten.
+system_property.adminConsole.sessionTimeout=Zeitlimit der Sitzung an der Admin-Konsole.
 
 # Server properties Page
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -892,6 +892,7 @@ system_property.xmpp.server.rewrite.replace-missing-to=Als de server een IQ of m
 system_property.xmpp.offline.autoclean.daystolive=Aantal dagen waarna offline berichten die nooit werden opgehaald, worden verwijderd.
 system_property.xmpp.offline.autoclean.checkinterval=De frequentie, in minuten, waarin het archief van offline berichten wordt opgeruimd.
 system_property.xmpp.offline.autoclean.enabled=Zet het automatisch opruimen van offline berichten aan of uit.
+system_property.adminConsole.sessionTimeout=De maximale tijd dat van een HTTP sessie in de beheerconsole inactief kan zijn.
 
 # Server properties Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/admin/SessionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/SessionListener.java
@@ -12,7 +12,6 @@ import javax.servlet.annotation.WebListener;
  * The session timeout is taken from the property {@code adminConsole.sessionTimeout}, the default is 30min.
  *
  * @author Guido Jaekel, guido.jaekel@gmx.de
- * @author Guus der Kinderen, guus.der.kinderen@gmail.com
  */
 
 @WebListener

--- a/xmppserver/src/main/java/org/jivesoftware/admin/SessionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/SessionListener.java
@@ -1,0 +1,32 @@
+package org.jivesoftware.admin;
+
+import org.jivesoftware.util.JiveGlobals;
+
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+import javax.servlet.annotation.WebListener;
+
+/**
+ * A http session listener that implements a configurable session timeout.<p>
+ *
+ * The session timeout is taken from the property {@code adminConsole.sessionTimeout}, the default is 30min.
+ *
+ * @author Guido Jaekel, guido.jaekel@gmx.de
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+
+@WebListener
+public class SessionListener implements HttpSessionListener {
+
+     private static final int sessionTimeout = JiveGlobals.getIntProperty( "adminConsole.sessionTimeout", 30*60 ); // secs
+
+
+     public void sessionCreated(HttpSessionEvent event){
+         event.getSession().setMaxInactiveInterval(sessionTimeout);
+     }
+
+
+     public void sessionDestroyed(HttpSessionEvent event) {
+     }
+
+}

--- a/xmppserver/src/main/java/org/jivesoftware/admin/SessionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/SessionListener.java
@@ -1,10 +1,13 @@
 package org.jivesoftware.admin;
 
 import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.SystemProperty;
 
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
 import javax.servlet.annotation.WebListener;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 /**
  * A http session listener that implements a configurable session timeout.<p>
@@ -17,11 +20,20 @@ import javax.servlet.annotation.WebListener;
 @WebListener
 public class SessionListener implements HttpSessionListener {
 
-     private static final int sessionTimeout = JiveGlobals.getIntProperty( "adminConsole.sessionTimeout", 30*60 ); // secs
-
+     public static final SystemProperty<Duration> SESSION_TIMEOUT = SystemProperty.Builder.ofType(Duration.class)
+                                                                        .setKey("adminConsole.sessionTimeout")
+                                                                        .setChronoUnit(ChronoUnit.SECONDS)
+                                                                        .setDefaultValue( Duration.ofMinutes(30) )
+                                                                        .setMinValue(Duration.ZERO)
+                                                                        .setMaxValue(Duration.ofSeconds(Integer.MAX_VALUE) )
+                                                                        .setDynamic(true)
+                                                                        .build();
 
      public void sessionCreated(HttpSessionEvent event){
-         event.getSession().setMaxInactiveInterval(sessionTimeout);
+         // Using Duration#getSeconds() isn't ideal, as that ignores part of the duration (the sign, as well as the
+         // nano-seconds). However, as the value can expected to be a positive integer, this data can safely be ignored.
+         // TODO: After moving to Java 9 or higher, this should be replaced with Duration#toSeconds()
+         event.getSession().setMaxInactiveInterval((int) SESSION_TIMEOUT.getValue().getSeconds());
      }
 
 


### PR DESCRIPTION
Add a http session listener to the Admin Console plugin that implements a configurable session timeout.

The session timeout is taken from the property `adminConsole.sessionTimeout`, the default is 30min.