### PR TITLE
Use java11 images for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.3-jdk-8 as packager
+FROM maven:3.6.3-jdk-11 as packager
 WORKDIR /usr/src
 
 COPY ./pom.xml .
@@ -14,7 +14,7 @@ RUN mvn dependency:go-offline
 COPY . .
 RUN mvn package
 
-FROM openjdk:8-jre
+FROM openjdk:11-jre
 COPY --from=packager /usr/src/distribution/target/distribution-base /usr/local/openfire
 COPY --from=packager /usr/src/build/docker/entrypoint.sh /sbin/entrypoint.sh
 WORKDIR /usr/local/openfire


### PR DESCRIPTION
Since we already build and test on both java versions, there would seem to be no harm in moving to the newer Java version.

The java11 images also have arm variants, making Openfire easier to develop and run on a Raspberry Pi (or the Apple M1, when Docker becomes stable there)