### PR TITLE
OF-2155: Set X-Frame-Options to "SAMEORIGIN"

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
@@ -201,7 +201,7 @@ public class AuthCheckFilter implements Filter {
         HttpServletRequest request = (HttpServletRequest)req;
         HttpServletResponse response = (HttpServletResponse)res;
         // Do not allow framing; OF-997
-        response.setHeader("X-Frame-Options", JiveGlobals.getProperty("adminConsole.frame-options", "same"));
+        response.setHeader("X-Frame-Options", JiveGlobals.getProperty("adminConsole.frame-options", "SAMEORIGIN"));
         // Reset the defaultLoginPage variable
         String loginPage = defaultLoginPage;
         if (loginPage == null) {


### PR DESCRIPTION
Fixes OF-2155. Changes the header value from "same" to "sameorigin", fixing a Chrome console error - "same" isn't [a valid value](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#directives) for this header.