### PR TITLE
OF-2195: Add Git SHA to Admin header

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -57,6 +57,42 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>git-info</id>
+            <activation>
+                <file>
+                    <exists>${maven.multiModuleProjectDirectory}/.git</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>pl.project13.maven</groupId>
+                        <artifactId>git-commit-id-plugin</artifactId>
+                        <version>4.0.3</version>
+                        <executions>
+                            <execution>
+                                <id>get-the-git-infos</id>
+                                <goals>
+                                    <goal>revision</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <dotGitDirectory>${maven.multiModuleProjectDirectory}/.git</dotGitDirectory>
+                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                            <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                            <includeOnlyProperties>
+                                <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+                                <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+                            </includeOnlyProperties>
+                            <commitIdGenerationMode>full</commitIdGenerationMode>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -129,7 +165,6 @@
                     <argLine>-Duser.language=us -Duser.country=US</argLine>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
 

--- a/xmppserver/src/main/webapp/decorators/main.jsp
+++ b/xmppserver/src/main/webapp/decorators/main.jsp
@@ -99,7 +99,7 @@
                     <a href="/index.jsp"><img src="/images/login_logo.gif" alt="Openfire" width="179" height="53" /></a>
                 </div>
                 <div id="jive-userstatus">
-                    <%= AdminConsole.getAppName() %> <%= AdminConsole.getVersionString() %><br/>
+                    <%= AdminConsole.getAppName() %> <%= AdminConsole.getVersionString() %>, build <%= AdminConsole.getGitSHAString() %><br/>
                     <fmt:message key="admin.logged_in_as"><fmt:param value="<strong>${usernameHtmlEscaped}</strong>"/></fmt:message> - <a href="<%= path %>/index.jsp?logout=true"><%= LocaleUtils.getLocalizedString("global.logout") %></a><br/>
                     <fmt:message key="admin.clustering.status"/> -
                         <% if (ClusterManager.isClusteringEnabled()) { %>

--- a/xmppserver/src/main/webapp/decorators/setup.jsp
+++ b/xmppserver/src/main/webapp/decorators/setup.jsp
@@ -134,7 +134,7 @@
                     <a href="/index.jsp"><img src="/images/login_logo.gif" alt="Openfire" width="179" height="53" /></a>
                 </div>
                 <div id="jive-userstatus">
-                    <%= AdminConsole.getAppName() %> <%= AdminConsole.getVersionString() %><br/>
+                    <%= AdminConsole.getAppName() %> <%= AdminConsole.getVersionString() %>, build <%= AdminConsole.getGitSHAString() %><br/>
                 </div>
                 <div id="jive-nav">
                     <div id="jive-nav-left"></div>


### PR DESCRIPTION
Add a subtle git sha to the footer so that we can observe the exact provenance of a given Admin interface

![image](https://user-images.githubusercontent.com/2117083/104824286-557bd300-5848-11eb-8c0c-864e39094438.png)
