### PR TITLE
Remove multi-stage Docker build, add separate dockerised maven build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,20 @@
 .gitignore
 Dockerfile
 .github
+.idea
+.mvn
+.settings
 .vscode
+
+build
+!build/docker
+distribution
+!distribution/target/distribution-base
+documentation
+i18n
+plugins
+starter
+xmppserver
 
 # Deeper stuff
 **/.DS_Store
@@ -13,4 +26,3 @@ Dockerfile
 **/.project
 **/.settings
 **/*.iml
-**/target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,10 @@
-FROM maven:3.6.3-jdk-11 as packager
-WORKDIR /usr/src
-
-COPY ./pom.xml .
-COPY ./i18n/pom.xml ./i18n/
-COPY ./xmppserver/pom.xml ./xmppserver/
-COPY ./starter/pom.xml ./starter/
-COPY ./starter/libs/* ./starter/libs/
-COPY ./plugins/pom.xml ./plugins/
-COPY ./plugins/openfire-plugin-assembly-descriptor/pom.xml ./plugins/openfire-plugin-assembly-descriptor/
-COPY ./distribution/pom.xml ./distribution/
-RUN mvn dependency:go-offline --fail-never
-
-COPY ./LICENSE.txt .
-COPY ./starter ./starter/
-COPY ./plugins ./plugins/
-COPY ./distribution ./distribution/
-COPY ./i18n ./i18n/
-COPY ./xmppserver ./xmppserver/
-
-RUN mvn package
-
 FROM openjdk:11-jre
+
 ENV OPENFIRE_USER=openfire \
     OPENFIRE_DIR=/usr/local/openfire \
     OPENFIRE_DATA_DIR=/var/lib/openfire \
     OPENFIRE_LOG_DIR=/var/log/openfire
+
 RUN apt-get update -qq \
     && apt-get install -yqq sudo \
     && adduser --disabled-password --quiet --system --home $OPENFIRE_DATA_DIR --gecos "Openfire XMPP server" --group $OPENFIRE_USER \
@@ -33,13 +13,13 @@ RUN apt-get update -qq \
 COPY ./build/docker/entrypoint.sh /sbin/entrypoint.sh
 RUN chmod 755 /sbin/entrypoint.sh
 
-COPY --from=packager --chown=openfire:openfire /usr/src/distribution/target/distribution-base /usr/local/openfire
-WORKDIR /usr/local/openfire
+COPY --chown=openfire:openfire ./distribution/target/distribution-base /usr/local/openfire
 RUN mv ${OPENFIRE_DIR}/conf ${OPENFIRE_DIR}/conf_org \
     && mv ${OPENFIRE_DIR}/plugins ${OPENFIRE_DIR}/plugins_org \
     && mv ${OPENFIRE_DIR}/resources/security ${OPENFIRE_DIR}/resources/security_org
 
 LABEL maintainer="florian.kinder@fankserver.com"
+WORKDIR /usr/local/openfire
 
 EXPOSE 3478 3479 5222 5223 5229 5262 5263 5275 5276 7070 7443 7777 9090 9091
 VOLUME ["${OPENFIRE_DATA_DIR}"]

--- a/build/docker/buildWithDocker.sh
+++ b/build/docker/buildWithDocker.sh
@@ -2,6 +2,7 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 OFROOT=$(realpath "$SCRIPTPATH/../../")
 DOMAPMAVEN=true
 CREATEMAVEN=false
+SKIPTESTS=false
 
 usage()
 {
@@ -9,9 +10,10 @@ usage()
     echo ""
     echo "  -m: Don't attempt to map host maven cache to container"
     echo "  -c: Create a local maven cache if one doesn't exist"
+    echo "  -s: Skip building or running tests. Use with care."
 }
 
-while getopts cm OPTION "$@"; do
+while getopts cms OPTION "$@"; do
     case $OPTION in
         c)
             CREATEMAVEN=true
@@ -19,9 +21,12 @@ while getopts cm OPTION "$@"; do
         m)
             DOMAPMAVEN=false
             ;;
-        \? ) usage;;
-        :  ) usage;;
-        *  ) usage;;
+        s)
+            SKIPTESTS=true
+            ;;
+        \? ) usage && exit 0;;
+        :  ) usage && exit 1;;
+        *  ) usage && exit 1;;
     esac
 done
 
@@ -49,5 +54,10 @@ DOCKERCMD+=(
     maven:3.6.3-jdk-11 \
     mvn clean package
 )
+if [ $SKIPTESTS == true ]; then
+    DOCKERCMD+=(
+        -Dmaven.test.skip -DskipTests
+    )
+fi
 
 "${DOCKERCMD[@]}"

--- a/build/docker/buildWithDocker.sh
+++ b/build/docker/buildWithDocker.sh
@@ -1,0 +1,53 @@
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+OFROOT=$(realpath "$SCRIPTPATH/../../")
+DOMAPMAVEN=true
+CREATEMAVEN=false
+
+usage()
+{
+	echo "Builds Openfire using a Maven docker container"
+    echo ""
+    echo "  -m: Don't attempt to map host maven cache to container"
+    echo "  -c: Create a local maven cache if one doesn't exist"
+}
+
+while getopts cm OPTION "$@"; do
+    case $OPTION in
+        c)
+            CREATEMAVEN=true
+            ;;
+        m)
+            DOMAPMAVEN=false
+            ;;
+        \? ) usage;;
+        :  ) usage;;
+        *  ) usage;;
+    esac
+done
+
+if [ $DOMAPMAVEN == true ]; then
+    if [ -z "$HOME" ]; then
+        echo "Cannot map Maven cache - HOME variable is not set"
+    fi
+    if [ ! -d "$HOME/.m2" ] && [ $CREATEMAVEN == true ]; then
+        mkdir "$HOME/.m2"
+    fi
+    if [ -d "$HOME/.m2" ]; then
+        MAVENMAP="-v=$HOME/.m2:/root/.m2"
+    fi
+fi
+
+DOCKERCMD=(
+    docker run -it --rm
+    -v="$OFROOT":/usr/src/openfire
+)
+if [ -n "$MAVENMAP" ]; then
+    DOCKERCMD+=("$MAVENMAP")
+fi
+DOCKERCMD+=(
+    -w /usr/src/openfire
+    maven:3.6.3-jdk-11 \
+    mvn clean package
+)
+
+"${DOCKERCMD[@]}"

--- a/build/docker/entrypoint.sh
+++ b/build/docker/entrypoint.sh
@@ -60,16 +60,12 @@ initialize_data_dir
 initialize_log_dir
 copy_provided_plugins
 
-JAVACMD=`which java 2> /dev/null `
+export OPENFIRE_HOME="${OPENFIRE_DIR}"
+
 # default behaviour is to launch openfire
 if [[ -z ${1} ]]; then
-  exec start-stop-daemon --start --chuid ${OPENFIRE_USER}:${OPENFIRE_USER} --exec $JAVACMD -- \
-    -server \
-    -DopenfireHome="${OPENFIRE_DIR}" \
-    -Dopenfire.lib.dir=${OPENFIRE_DIR}/lib \
-    -Dlog4j.configurationFile=${OPENFIRE_DIR}/lib/log4j2.xml \
-    -classpath ${OPENFIRE_DIR}/lib/startup.jar \
-    -jar ${OPENFIRE_DIR}/lib/startup.jar ${EXTRA_ARGS}
+  exec start-stop-daemon --start --chuid ${OPENFIRE_USER}:${OPENFIRE_USER} \
+    --exec "${OPENFIRE_DIR}/bin/openfire.sh" -- ${EXTRA_ARGS}
 else
   exec "$@"
 fi

--- a/build/docker/entrypoint.sh
+++ b/build/docker/entrypoint.sh
@@ -45,7 +45,7 @@ initialize_log_dir() {
 copy_provided_plugins() {
   if [ -d "/opt/plugins" ]; then
     echo "Copying user-provided plugins"
-    cp -R /opt/plugins/* ${OPENFIRE_DIR}/plugins/
+    cp -nR /opt/plugins/* ${OPENFIRE_DIR}/plugins/
   fi
 }
 

--- a/build/docker/entrypoint.sh
+++ b/build/docker/entrypoint.sh
@@ -42,6 +42,13 @@ initialize_log_dir() {
   ln -sf ${OPENFIRE_LOG_DIR} ${OPENFIRE_DIR}/logs
 }
 
+copy_provided_plugins() {
+  if [ -d "/opt/plugins" ]; then
+    echo "Copying user-provided plugins"
+    cp -R /opt/plugins/* ${OPENFIRE_DIR}/plugins/
+  fi
+}
+
 # allow arguments to be passed to openfire launch
 if [[ ${1:0:1} = '-' ]]; then
   EXTRA_ARGS="$@"
@@ -51,6 +58,7 @@ fi
 rewire_openfire
 initialize_data_dir
 initialize_log_dir
+copy_provided_plugins
 
 JAVACMD=`which java 2> /dev/null `
 # default behaviour is to launch openfire


### PR DESCRIPTION
Ditches the multi-stage docker build.

The high number of dependencies means that any POM change means an invalidation of cache, so a redownloading of the whole internet, and makes for a very slow build time.
Fixed this by moving the build to a separate script that does a docker *run* of the official maven image, with a volume mapping the m2 cache of the host.

The container build is closer to "standard" - grabbing built files from the distribution into a container. Lays the groundwork for publishing an official Docker image later.

It also:
* moves the CMD to an ENTRYPOINT, allowing for additional parameters (e.g. for java debugging)
* adds a step to the entrypoint script to copy plugins from /opt/plugins, allowing these to be provided for install at runtime e.g. `docker run -v=/my/special/plugins:/opt/plugins/ openfire:latest`

Caching may partially mitigate https://igniterealtime.atlassian.net/browse/OF-1867, but doesn't solve it.