### PR TITLE
OF-2196: Add dependency for JAXB-API in Java 11

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -409,6 +409,11 @@
             <version>2.3.1</version>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-bmp</artifactId>
             <version>3.5</version>


### PR DESCRIPTION
Fixes https://igniterealtime.atlassian.net/browse/OF-2196

Adds an extra dependency to let XML REST APIs that depended on Java 8 APIs work on Java 11. Most importantly, it fixes support for the Rest API Plugin.