### PR TITLE
Fix muc occupants are inconsistent in cluster environments

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1277,12 +1277,12 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         lock.writeLock().lock();
         try {
             occupantsByNickname.computeIfPresent(nickname.toLowerCase(), (n, occupants) -> {
-                occupants.remove(leaveRole);
+                occupants.removeIf(role -> role.equals(leaveRole));
                 return occupants.isEmpty() ? null : occupants;
             });
 
             occupantsByBareJID.computeIfPresent(bareJID,(jid, occupants) -> {
-                occupants.remove(leaveRole);
+                occupants.removeIf(role -> role.equals(leaveRole));
                 return occupants.isEmpty() ? null : occupants;
             });
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/RemoteMUCRole.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/RemoteMUCRole.java
@@ -33,6 +33,7 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
 
 /**
  * Representation of a room occupant of a local room that is being hosted by
@@ -222,5 +223,28 @@ public class RemoteMUCRole implements MUCRole, Externalizable {
             reportedFmucAddress = null;
         }
         nodeID = NodeID.getInstance(ExternalizableUtil.getInstance().readByteArray(in));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this==o) return true;
+        if (o==null || getClass()!=o.getClass()) return false;
+
+        RemoteMUCRole that = (RemoteMUCRole) o;
+        if (!Objects.equals(nickname, that.nickname)) return false;
+        if (!Objects.equals(userAddress, that.userAddress)) return false;
+        if (!Objects.equals(roleAddress, that.roleAddress)) return false;
+        if (!Objects.equals(room, that.room)) return false;
+        return Objects.equals(nodeID, that.nodeID);
+    }
+
+    @Override
+    public int hashCode() {
+        int result =  (nickname!=null ? nickname.hashCode():0);
+        result = 31 * result + (userAddress!=null ? userAddress.hashCode():0);
+        result = 31 * result + (roleAddress!=null ? roleAddress.hashCode():0);
+        result = 31 * result + (room!=null ? room.hashCode():0);
+        result = 31 * result + (nodeID!=null ? nodeID.hashCode():0);
+        return result;
     }
 }


### PR DESCRIPTION
A previous pull request of mine introduced an error. Sorry for that! On line https://github.com/igniterealtime/Openfire/pull/1783/files#diff-b86408b4457498abe59b1e502335092bbde8e71b3b33e146e2b117c204a568efR1292  an equals is made. However, RemoteMucRole has not implemented the equals method, so the occupants on remote nodes are not kicked and still receive messages.  -> maybe critical

Steps to reproduce:

Before:
1. a cluster environment of minimum 2 nodes
2. two users are online on the same cluster node
3. a muc with both users, one of them is owner
4. both users have joined the muc room
5. open the admin console on both cluster nodes, then navigate to the room info and view the "muc-room-occupants.jsp" page. you can see there are 2 / X users online and in the liste below there are 2 occupants listed

Do:
the owner changes the affiliation of the other user to 'none'

After:
1. open the admin console on both cluster nodes, then navigate to the room info and view the "muc-room-occupants.jsp" page. you can see on one node there is  1/X occupants online and only the owner is listed below but on the other node there is no change except the affiliation of the other occupant is change to none.
2. the kicked user still can receive messages from this muc (we used an own client and see the messages on the stream on client site)

With this pull request the number (1/X) of online occupants (changes in LocalMucRoom) and the list below on the "muc-room-occupants.jsp" (changes in RemoteMucRole) show always the correct state on all cluster nodes. Also occupants are kicked of the room correctly  (changes in RemoteMucRole).

BUT i am not really sure about the fields that are used for hashCode and equals. @guusdk @GregDThomas  should they use more fields?

Another thing is, that occupantsByNickname and occupantsByBareJID have list of roles. Is it ok to just remove ALL muc roles which are equals (changes in LocalMucRoom)?