### PR TITLE
OF-2201: Improve error message during LDAP setup

### DIFF
--- a/xmppserver/src/main/webapp/setup/setup-ldap-group_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-group_test.jsp
@@ -43,7 +43,7 @@
         }
     } else {
         // Information was not found in the HTTP Session. Internal error?
-        errorDetail = LocaleUtils.getLocalizedString("setup.ldap.test.internal-server-error");
+        errorDetail = LocaleUtils.getLocalizedString("setup.invalid_session");
     }
 
     pageContext.setAttribute( "errorDetail", errorDetail );

--- a/xmppserver/src/main/webapp/setup/setup-ldap-server_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-server_test.jsp
@@ -63,6 +63,8 @@
                 }
             }
         }
+    } else {
+        errorDetail = LocaleUtils.getLocalizedString("setup.invalid_session");
     }
 
     pageContext.setAttribute( "success", success );

--- a/xmppserver/src/main/webapp/setup/setup-ldap-user_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-user_test.jsp
@@ -66,7 +66,7 @@
     }
     else {
         // Information was not found in the HTTP Session. Internal error?
-        errorDetail = LocaleUtils.getLocalizedString("setup.ldap.user.test.internal-server-error");
+        errorDetail = LocaleUtils.getLocalizedString("setup.invalid_session");
     }
 
     pageContext.setAttribute( "attributes", attributes );


### PR DESCRIPTION
This commit ensures that a helpful error message is shown to the end-user when setup fails due to a broken HTTP session.