### PR TITLE
OF-2209: Detect and remove 'ghost users' from MUC.

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1399,6 +1399,7 @@ muc.tasks.valid_batchsize=Please enter a valid number for batch size.
 muc.tasks.valid_batchinterval=Please enter a valid number for batch interval.
 muc.tasks.valid_batchgrace=Please enter a valid number for batch grace period, that is shorter than the batch interval period.
 muc.tasks.user_setting=Idle User Settings
+muc.tasks.ping_user=Check if users are still connected after they have been idle for
 muc.tasks.never_kick=Never kick idle users.
 muc.tasks.kick_user=Kick users after they have been idle for
 muc.tasks.conversation.logging=Conversation Logging

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
@@ -27,6 +27,8 @@ import org.xmpp.component.Component;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -188,40 +190,68 @@ public interface MultiUserChatService extends Component {
     void removeUsersAllowedToCreate(Collection<JID> userJIDs);
 
     /**
-     * Sets the time to elapse between clearing of idle chat users. A <code>TimerTask</code> will be
-     * added to a <code>Timer</code> scheduled for repeated fixed-delay execution whose main
-     * responsibility is to kick users that have been idle for a certain time. A user is considered
-     * idle if he/she didn't send any message to any group chat room for a certain amount of time.
-     * See {@link #setUserIdleTime(int)}.
+     * Sets the period of the fixed-delay execution of tasks by the <code>Timer</code> whose main responsibility is
+     * to process users that have been idle for a certain time. A user is considered idle if he/she didn't send any
+     * message to any group chat room for a certain amount of time.
      *
-     * @param timeout the time to elapse between clearing of idle chat users.
+     * @param duration The fixed-delay interval in which idle checks need to be performed.
+     * @see #getIdleUserKickThreshold()
+     * @see #getIdleUserPingThreshold()
      */
-    void setKickIdleUsersTimeout(int timeout);
+    void setIdleUserTaskInterval(final @Nonnull Duration duration);
 
     /**
-     * Returns the time to elapse between clearing of idle chat users. A user is considered
-     * idle if he/she didn't send any message to any group chat room for a certain amount of time.
-     * See {@link #getUserIdleTime()}.
+     * Returns the period of fixed-delay executions of tasks that operate on idle users.
      *
-     * @return the time to elapse between clearing of idle chat users.
+     * @return The fixed-delay interval in which idle checks need to be performed.
      */
-    int getKickIdleUsersTimeout();
+    @Nonnull Duration getIdleUserTaskInterval();
 
     /**
-     * Sets the number of milliseconds a user must be idle before he/she gets kicked from all
+     * Sets the duration that a user must be idle before he/she gets kicked from all
      * the rooms. By idle we mean that the user didn't send any message to any group chat room.
      *
-     * @param idle the amount of time to wait before considering a user idle.
+     * Set to null to disable the feature.
+     *
+     * @param duration the amount of time to wait before considering a user idle.
      */
-    void setUserIdleTime(int idle);
+    void setIdleUserKickThreshold(final @Nullable Duration duration);
 
     /**
-     * Returns the number of milliseconds a user must be idle before he/she gets kicked from all
+     * Returns the duration that a user must be idle before he/she gets kicked from all
      * the rooms. By idle we mean that the user didn't send any message to any group chat room.
+     *
+     * Returns null if the feature is disabled.
      *
      * @return the amount of time to wait before considering a user idle.
      */
-    int getUserIdleTime();
+    @Nullable
+    Duration getIdleUserKickThreshold();
+
+    /**
+     * Sets the duration that a user must be idle before he/she gets pinged by the room, to
+     * determine if the user is a 'ghost user'.
+     *
+     * By idle we mean that the user didn't send any message to any group chat room.
+     *
+     * Set to null to disable the feature.
+     *
+     * @param duration the amount of time to wait before considering a user idle.
+     */
+    void setIdleUserPingThreshold(final @Nullable Duration duration);
+
+    /**
+     * Returns the duration that a user must be idle before he/she gets pinged by the rooms that they're an occupant
+     * of (to determine if they're a 'ghost user').
+     *
+     * By idle we mean that the user didn't send any message to any group chat room.
+     *
+     * Returns null if the feature is disabled.
+     *
+     * @return the amount of time to wait before considering a user idle.
+     */
+    @Nullable
+    Duration getIdleUserPingThreshold();
 
     /**
      * Sets the time to elapse between logging the room conversations. A <code>TimerTask</code> will

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -37,6 +37,7 @@ import org.jivesoftware.openfire.group.ConcurrentGroupList;
 import org.jivesoftware.openfire.group.GroupAwareList;
 import org.jivesoftware.openfire.group.GroupJID;
 import org.jivesoftware.openfire.handler.IQHandler;
+import org.jivesoftware.openfire.handler.IQPingHandler;
 import org.jivesoftware.openfire.muc.HistoryStrategy;
 import org.jivesoftware.openfire.muc.MUCEventDelegate;
 import org.jivesoftware.openfire.muc.MUCEventDispatcher;
@@ -72,18 +73,11 @@ import org.xmpp.packet.PacketError;
 import org.xmpp.packet.Presence;
 import org.xmpp.resultsetmanagement.ResultSet;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimerTask;
+import java.time.Instant;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -118,13 +112,21 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     /**
      * The time to elapse between clearing of idle chat users.
      */
-    private int user_timeout = 300000;
+    private Duration userIdleTaskInterval = Duration.ofMinutes(5);
+
     /**
-     * The number of milliseconds a user must be idle before he/she gets kicked from all the rooms.
+     * The period that a user must be idle before he/she gets kicked from all the rooms. Null to disable the feature.
      */
-    private int user_idle = -1;
+    private Duration userIdleKick = null;
+
     /**
-     * Task that kicks idle users from the rooms.
+     * The period that a user must be idle before he/she gets pinged from the rooms that they're in, to determine if
+     * they're a 'ghost'. Null to disable the feature.
+     */
+    private Duration userIdlePing = null;
+
+    /**
+     * Task that kicks and pings idle users from the rooms.
      */
     private UserTimeoutTask userTimeoutTask;
 
@@ -538,12 +540,10 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     }
 
     /**
-     * Probes the presence of any user who's last packet was sent more than 5 minute ago.
+     * Operates on users that have been inactive for a while. Depending on the configuration of Openfire, these uses
+     * could either be kicked, or be pinged (to determine if they're 'ghost users').
      */
     private class UserTimeoutTask extends TimerTask {
-        /**
-         * Remove any user that has been idle for longer than the user timeout time.
-         */
         @Override
         public void run() {
             checkForTimedOutUsers();
@@ -616,35 +616,48 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     }
 
     private void checkForTimedOutUsers() {
-        final long deadline = System.currentTimeMillis() - user_idle;
         for (final LocalMUCUser user : users.values()) {
             try (final AutoCloseableReentrantLock.AutoCloseableLock ignored = new AutoCloseableReentrantLock(MultiUserChatServiceImpl.class, user.getAddress().toString()).lock()) {
-                // If user is not present in any room then remove the user from
-                // the list of users
+                // If user is not present in any room then remove the user from the list of users.
                 if (!user.isJoined()) {
-                    removeUser(user.getAddress());
+                    removeUser(user.getAddress()); // Iterating over a collection that is weakly consistent. Removal should not cause Concurrent Modification Exception.
+                    Log.debug("Removed MUC user '{}' that does not seem to be in any room.", user.getAddress());
                     continue;
                 }
-                // Do nothing if this feature is disabled (i.e USER_IDLE equals -1)
-                if (user_idle == -1) {
-                    continue;
-                }
-                if (user.getLastPacketTime() < deadline) {
-                    String timeoutKickReason = JiveGlobals.getProperty("admin.mucRoom.timeoutKickReason",
-                            "User exceeded idle time limit.");
-                    // Kick the user from all the rooms that he/she had previuosly joined
-                    MUCRoom room;
-                    Presence kickedPresence;
+
+                final Instant lastActive = Instant.ofEpochMilli(user.getLastPacketTime());
+
+                // Kick users if 'user_idle' feature is enabled and the user has been idle for too long.
+                final boolean doKick = userIdleKick != null && lastActive.isBefore(Instant.now().minus(userIdleKick));
+
+                // Ping the user if it hasn't been kicked already, the feature is enabled, and the user has been idle for too long.
+                final boolean doPing = !doKick && userIdlePing != null && lastActive.isBefore(Instant.now().minus(userIdlePing));
+
+                if (doKick || doPing) {
+                    final String timeoutKickReason = JiveGlobals.getProperty("admin.mucRoom.timeoutKickReason", "User exceeded idle time limit.");
                     for (final LocalMUCRole role : user.getRoles()) {
-                        room = role.getChatRoom();
-                        try {
-                            kickedPresence =
-                                    room.kickOccupant(user.getAddress(), null, null, timeoutKickReason);
-                            // Send the updated presence to the room occupants
-                            room.send(kickedPresence, room.getRole());
+                        if (doKick) {
+                            // Kick the user from all the rooms that he/she had previously joined.
+                            try {
+                                final Presence kickedPresence = role.getChatRoom().kickOccupant(user.getAddress(), null, null, timeoutKickReason);
+                                // Send the updated presence to the room occupants
+                                role.getChatRoom().send(kickedPresence, role.getChatRoom().getRole());
+                                Log.debug("Kicked occupant '{}' of room '{}' due to exceeding idle time limit.", user.getAddress(), role.getChatRoom().getJID());
+                            } catch (final NotAllowedException e) {
+                                // Do nothing since we cannot kick owners or admins
+                            }
                         }
-                        catch (final NotAllowedException e) {
-                            // Do nothing since we cannot kick owners or admins
+
+                        if (doPing) {
+                            // Send a ping 'from the room' to the user, from all the rooms that he/she had previously joined.
+                            // If this ping results in a connectivity error, that will be picked up by LocalMucRoom's process
+                            // method, that detects 'ghost users', which will kick the user.
+                            final IQ pingRequest = new IQ( IQ.Type.get );
+                            pingRequest.setChildElement( IQPingHandler.ELEMENT_NAME, IQPingHandler.NAMESPACE );
+                            pingRequest.setFrom( role.getChatRoom().getJID() );
+                            pingRequest.setTo( role.getUserAddress() );
+                            router.route(pingRequest);
+                            Log.debug("Pinged occupant '{}' of room '{}' due to exceeding idle time limit.", user.getAddress(), role.getChatRoom().getJID());
                         }
                     }
                 }
@@ -990,40 +1003,67 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     }
 
     @Override
-    public void setKickIdleUsersTimeout(final int timeout) {
-        if (this.user_timeout == timeout) {
+    public void setIdleUserTaskInterval(final @Nonnull Duration duration) {
+        if (Objects.equals(duration, this.userIdleTaskInterval)) {
             return;
         }
+
         // Cancel the existing task because the timeout has changed
         if (userTimeoutTask != null) {
             userTimeoutTask.cancel();
         }
-        this.user_timeout = timeout;
+        this.userIdleTaskInterval = duration;
+
         // Create a new task and schedule it with the new timeout
         userTimeoutTask = new UserTimeoutTask();
-        TaskEngine.getInstance().schedule(userTimeoutTask, user_timeout, user_timeout);
+        TaskEngine.getInstance().schedule(userTimeoutTask, userIdleTaskInterval.toMillis(), userIdleTaskInterval.toMillis());
+
         // Set the new property value
-        MUCPersistenceManager.setProperty(chatServiceName, "tasks.user.timeout", Integer.toString(timeout));
+        MUCPersistenceManager.setProperty(chatServiceName, "tasks.user.timeout", Long.toString(userIdleTaskInterval.toMillis()));
     }
 
     @Override
-    public int getKickIdleUsersTimeout() {
-        return user_timeout;
+    @Nonnull
+    public Duration getIdleUserTaskInterval() {
+        return this.userIdleTaskInterval;
     }
 
     @Override
-    public void setUserIdleTime(final int idleTime) {
-        if (this.user_idle == idleTime) {
+    public void setIdleUserKickThreshold(final @Nullable Duration duration)
+    {
+        if (Objects.equals(duration, this.userIdleKick)) {
             return;
         }
-        this.user_idle = idleTime;
+
+        this.userIdleKick = duration;
+
         // Set the new property value
-        MUCPersistenceManager.setProperty(chatServiceName, "tasks.user.idle", Integer.toString(idleTime));
+        MUCPersistenceManager.setProperty(chatServiceName, "tasks.user.idle", userIdleKick == null ? "-1" : Long.toString(userIdleKick.toMillis()));
     }
 
     @Override
-    public int getUserIdleTime() {
-        return user_idle;
+    public Duration getIdleUserKickThreshold()
+    {
+        return userIdleKick;
+    }
+
+    @Override
+    public void setIdleUserPingThreshold(final @Nullable Duration duration)
+    {
+        if (Objects.equals(duration, this.userIdlePing)) {
+            return;
+        }
+
+        this.userIdlePing = duration;
+
+        // Set the new property value
+        MUCPersistenceManager.setProperty(chatServiceName, "tasks.user.ping", userIdlePing == null ? "-1" : Long.toString(userIdlePing.toMillis()));
+    }
+
+    @Override
+    @Nullable
+    public Duration getIdleUserPingThreshold() {
+        return userIdlePing;
     }
 
     @Override
@@ -1268,23 +1308,43 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
             }
         }
         String value = MUCPersistenceManager.getProperty(chatServiceName, "tasks.user.timeout");
-        user_timeout = 300000;
+        userIdleTaskInterval = Duration.ofMinutes(5);
         if (value != null) {
             try {
-                user_timeout = Integer.parseInt(value);
+                userIdleTaskInterval = Duration.ofMillis(Long.parseLong(value));
             }
             catch (final NumberFormatException e) {
                 Log.error("Wrong number format of property tasks.user.timeout for service "+chatServiceName, e);
             }
         }
         value = MUCPersistenceManager.getProperty(chatServiceName, "tasks.user.idle");
-        user_idle = -1;
+        userIdleKick = null;
         if (value != null) {
             try {
-                user_idle = Integer.parseInt(value);
+                final long millis = Long.parseLong(value);
+                if ( millis < 0 ) {
+                    userIdleKick = null; // feature is disabled.
+                } else {
+                    userIdleKick = Duration.ofMillis(millis);
+                }
             }
             catch (final NumberFormatException e) {
                 Log.error("Wrong number format of property tasks.user.idle for service "+chatServiceName, e);
+            }
+        }
+        value = MUCPersistenceManager.getProperty(chatServiceName, "tasks.user.ping");
+        userIdlePing = Duration.ofMinutes(8);
+        if (value != null) {
+            try {
+                final long millis = Long.parseLong(value);
+                if ( millis < 0 ) {
+                    userIdlePing = null; // feature is disabled.
+                } else {
+                    userIdlePing = Duration.ofMillis(millis);
+                }
+            }
+            catch (final NumberFormatException e) {
+                Log.error("Wrong number format of property tasks.user.ping for service "+chatServiceName, e);
             }
         }
         value = MUCPersistenceManager.getProperty(chatServiceName, "tasks.log.maxbatchsize");
@@ -1470,7 +1530,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
 
         // Run through the users every 5 minutes after a 5 minutes server startup delay (default values)
         userTimeoutTask = new UserTimeoutTask();
-        TaskEngine.getInstance().schedule(userTimeoutTask, user_timeout, user_timeout);
+        TaskEngine.getInstance().schedule(userTimeoutTask, userIdleTaskInterval.toMillis(), userIdleTaskInterval.toMillis());
 
         // Remove unused rooms from memory
         long cleanupFreq = JiveGlobals.getLongProperty("xmpp.muc.cleanupFrequency.inMinutes", CLEANUP_FREQUENCY) * 60 * 1000;

--- a/xmppserver/src/main/webapp/muc-room-occupants.jsp
+++ b/xmppserver/src/main/webapp/muc-room-occupants.jsp
@@ -31,6 +31,7 @@
 <%@ page import="org.xmpp.packet.JID" %>
 <%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
 <%@ page import="org.jivesoftware.openfire.muc.spi.RemoteMUCRole" %>
+<%@ page import="java.time.Instant" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>


### PR DESCRIPTION
This commit adds a new feature that complements the pre-existing feature that would kick idle users from a MUC room.

The new feature is defined in the section related to 'ghost users' in the MUC specification (XEP-0045). It is two-fold:

- When a room is sent a stanza that contains an error that indicates that an occupant is unreachable, drop that occupant from the room.
- When an occupant has not interacted for a configurable amount of time, send a ping to that occupant. If the occupant is unreachable, this will trigger an error to be sent back, that will be processed by the implementation of the first item in this list.

This new feature is configurable through the admin console (Group Chat > Group Chat Settings > (select service) > Other Settings), but is enabled by default.