### PR TITLE
use python 3.9 for testing

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.9
      
       - name: Run aioxmpp tests
         run: ./runAioxmppIntegrationTests -d -l -h example.org -i 127.0.0.1 || ./runAioxmppIntegrationTests -d -l -h example.org -i 127.0.0.1 || ./runAioxmppIntegrationTests -d -l -h example.org -i 127.0.0.1 # Try tests a few times, in case of flakiness

--- a/runAioxmppIntegrationTests
+++ b/runAioxmppIntegrationTests
@@ -138,10 +138,10 @@ function launchOpenfire {
 function runTests {
 	echo "Starting Integration Tests (using aioxmpp)…"
     pushd "${AIOXMPPDIR}"
-    which python3.6
+    which python3.9
 	if [ -d output ]; then rm -Rf output; fi
     mkdir output
-    python3.6 -m aioxmpp.e2etest --e2etest-config="${AIOXMPPCONFIG}" --e2etest-only -e 'test_set_topic' -e 'test_publish_and_purge' -e 'test_publish_multiple_and_get_by_id' tests 2>&1 | tee output/aioxmpp.test.output.txt
+    python3.9 -m aioxmpp.e2etest --e2etest-config="${AIOXMPPCONFIG}" --e2etest-only -e 'test_set_topic' -e 'test_publish_and_purge' -e 'test_publish_multiple_and_get_by_id' tests 2>&1 | tee output/aioxmpp.test.output.txt
 	if [ ${PIPESTATUS[0]} -ne 0 ]; then false; fi;
     popd
 }


### PR DESCRIPTION
Perhaps the flakiness we see in the aioxmpp tests are due to async bugs in python 3.6.  perhaps python 3.9 has less bugs like that :)