### PR TITLE
OF-2210: Restore SessionDestroyed event handling

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -741,7 +741,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         if (session.getAddress() != null && routingTable != null &&
                 session.getAddress().toBareJID().trim().length() != 0) {
             // Update route to unavailable session (anonymous or not)
-            routingTable.removeClientRoute(session.getAddress());
+            routingTable.addClientRoute(session.getAddress(), session); // Note that _adding_ the route is not a typo, as previously assumed. See OF-2210 and OF-2012.
         }
     }
 


### PR DESCRIPTION
This reverts the change for OF-2012, which erroneously assumed it was fixing a typo.

Marking a session as unavailable is different from removing a session. By removing the session in this method, it later can't be found, and event listeners are not triggered as a result.

This is where @GregDThomas owes me an "I told you so" - he challenged OF-2012 at the time. :)