### PR TITLE
Publish an official container image to Docker Hub

### DIFF
--- a/.github/dockerhub.env
+++ b/.github/dockerhub.env
@@ -1,2 +1,0 @@
-DOCKERHUB_USERNAME=fishbowler
-DOCKERHUB_OPENFIREIMAGE=fishbowler/openfire

--- a/.github/dockerhub.env
+++ b/.github/dockerhub.env
@@ -1,0 +1,2 @@
+DOCKERHUB_USERNAME=fishbowler
+DOCKERHUB_OPENFIREIMAGE=fishbowler/openfire

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -3,11 +3,7 @@ name: Openfire CI
 env:
   CI: true
 
-on:
-  push:
-    branches: "**"
-  pull_request:
-    branches: "**"
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Run smack tests
         run: ./runIntegrationTests -d -l -i 127.0.0.1 || ./runIntegrationTests -d -l -i 127.0.0.1 || ./runIntegrationTests -d -l -i 127.0.0.1 # Try tests a few times, in case of flakiness
 
-  publish:
+  publish-maven:
 
     name: Publish to Maven
     runs-on: ubuntu-latest
@@ -178,3 +178,66 @@ jobs:
         env:
           IGNITE_REALTIME_MAVEN_USERNAME: ${{ secrets.IGNITE_REALTIME_MAVEN_USERNAME }}
           IGNITE_REALTIME_MAVEN_PASSWORD: ${{ secrets.IGNITE_REALTIME_MAVEN_PASSWORD }}
+
+  publish-docker:
+
+    name: Publish to Docker Hub
+    runs-on: ubuntu-latest
+    needs: [build, smack] # Add all tests when they're stable
+    if: ${{github.repository == 'Fishbowler/Openfire' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
+
+    steps:
+      - name: Set up variables
+        id: vars
+        run: |
+          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+
+      - uses: actions/checkout@v2
+        with:
+          # Defend against another commit quickly following the first
+          # We want the one that's been tested, rather than the head of master
+          ref: ${{ github.event.push.after }}
+
+      - name: Download distribution artifact from build job.
+        uses: actions/download-artifact@v2
+        with:
+          name: distribution-java11
+          path: distribution/target/distribution-base
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers # TODO: Validate that caches are faster than no caches
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push to Docker Hub
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: fishbowler/openfire:${{ steps.vars.outputs.SOURCE_TAG }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -200,6 +200,9 @@ jobs:
           name: distribution-java11
           path: distribution/target/distribution-base
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -224,6 +224,9 @@ jobs:
           name: distribution-java11
           path: distribution/target/distribution-base
 
+      - name: Fix file permissions
+        run: find . -type f -name '*.sh' -exec chmod +x {} \;
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -184,7 +184,7 @@ jobs:
     outputs:
       is_DOCKERHUB_SECRET_set: ${{ steps.checksecret_job.outputs.is_DOCKERHUB_SECRET_set }}
     steps:
-      - name: Check whether unity activation requests should be done
+      - name: Check whether Docker Publish should be done
         id: checksecret_job
         env:
             DOCKERHUB_SECRET: ${{ secrets.DOCKERHUB_USERNAME }} # Could also test DOCKERHUB_TOKEN, but either is fine

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -268,3 +268,23 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+
+  test-published-docker:
+    name: Test tagged images published to Docker Hub
+    runs-on: ubuntu-latest
+    needs: [publish-docker]
+    if: contains(github.ref, 'refs/tags/')
+    
+    services:
+      openfire:
+        image: ${{ secrets.DOCKERHUB_OPENFIREIMAGE }}:${GITHUB_REF#refs/tags/}
+        ports:
+          - 9090:9090
+    
+    steps:
+      - name: Wait for Openfire Admin to be ready
+        run: |
+          curl https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh --output ./wait-for-it.sh
+          chmod +x wait-for-it.sh
+          ./wait-for-it.sh --host openfire --port ${{ job.services.openfire.ports['9090'] }} --timeout 60 -- echo "Openfire is up!"
+    

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -204,7 +204,6 @@ jobs:
       (contains(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
 
     outputs:
-      imagename: ${{ steps.dockerhub-imagename.outputs.DOCKERHUB_OPENFIREIMAGE }}
       imagedigest: ${{ steps.docker_build.outputs.digest }}
     
     steps:
@@ -221,20 +220,6 @@ jobs:
           # Defend against another commit quickly following the first
           # We want the one that's been tested, rather than the head of master
           ref: ${{ github.event.push.after }}
-
-      - name: Set Docker Hub env vars from file
-        run: |
-          cat ".github/dockerhub.env" >>$GITHUB_ENV
-        
-      - name: Put Docker Hub repo name into outputs
-        id: dockerhub-imagename
-        run: |
-          echo "::set-output name=DOCKERHUB_OPENFIREIMAGE::${{ env.DOCKERHUB_OPENFIREIMAGE }}"
-
-      - name: Debug outputs
-        run: |
-          echo "Image: ${{ steps.dockerhub-imagename.outputs.DOCKERHUB_OPENFIREIMAGE }}"
-          echo "Outputs: ${{ toJson(steps.dockerhub-imagename.outputs) }}"
 
       - name: Download distribution artifact from build job.
         uses: actions/download-artifact@v2
@@ -262,7 +247,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push to Docker Hub
@@ -271,7 +256,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.dockerhub-imagename.outputs.DOCKERHUB_OPENFIREIMAGE }}:${{ env.SOURCE_TAG }}
+          tags: ${{ secrets.DOCKERHUB_OPENFIREIMAGE }}:${{ env.SOURCE_TAG }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
@@ -287,26 +272,31 @@ jobs:
       - name: Image digest
         run: |
           echo Images published:
-          echo ${{ steps.dockerhub-imagename.outputs.DOCKERHUB_OPENFIREIMAGE }}:${{ steps.docker_build.outputs.digest }}
-          echo ${{ steps.dockerhub-imagename.outputs.DOCKERHUB_OPENFIREIMAGE }}:${{ env.SOURCE_TAG }}
+          echo ${{ secrets.DOCKERHUB_OPENFIREIMAGE }}:${{ steps.docker_build.outputs.digest }}
+          echo ${{ secrets.DOCKERHUB_OPENFIREIMAGE }}:${{ env.SOURCE_TAG }}
 
   test-published-docker:
     name: Test tagged images published to Docker Hub
     runs-on: ubuntu-latest
     needs: [publish-docker]
     if: contains(github.ref, 'refs/tags/')
-    
-    services:
-      openfire:
-        image: ${{needs.publish-docker.outputs.imagename}}@${{needs.publish-docker.outputs.imagedigest}}
-        ports:
-          - 9090:9090
-    
+
     steps:
-      - name: Wait for Openfire Admin to be ready
-        uses: nev7n/wait_for_response@v1
-        with:
-          url: 'http://openfire:9090/'
-          responseCode: 200
-          interval: 300
+      - name: Launch & Check Openfire
+        run: |
+          docker run --name openfire -d -p 9090:9090 ${{ secrets.DOCKERHUB_OPENFIREIMAGE }}@${{needs.publish-docker.outputs.imagedigest}}
           
+          attempt_counter=0
+          max_attempts=30
+          until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9090); do
+              if [ ${attempt_counter} -eq ${max_attempts} ];then
+                echo "Max attempts reached. Openfire failed to launch."
+                exit 1
+              fi
+
+              printf '.'
+              attempt_counter=$(($attempt_counter+1))
+              sleep 1
+          done
+          echo "Openfire Admin is reachable."
+          docker logs openfire

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Check whether Docker Publish should be done
         id: checksecret_job
         env:
-            DOCKERHUB_SECRET: ${{ secrets.DOCKERHUB_USERNAME }} # Could also test DOCKERHUB_TOKEN, but either is fine
+            DOCKERHUB_SECRET: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
             echo "is_DOCKERHUB_SECRET_set: ${{ env.DOCKERHUB_SECRET != '' }}"
             echo "::set-output name=is_DOCKERHUB_SECRET_set::${{ env.DOCKERHUB_SECRET != '' }}"
@@ -203,6 +203,10 @@ jobs:
       github.event_name == 'push' && 
       (contains(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
 
+    outputs:
+      imagename: ${{ steps.dockerhub-imagename.outputs.DOCKERHUB_OPENFIREIMAGE }}
+      imagedigest: ${{ steps.docker_build.outputs.digest }}
+    
     steps:
       - name: Set up variables if we're on master
         if: ${{ github.ref == 'refs/heads/master' }}
@@ -217,6 +221,20 @@ jobs:
           # Defend against another commit quickly following the first
           # We want the one that's been tested, rather than the head of master
           ref: ${{ github.event.push.after }}
+
+      - name: Set Docker Hub env vars from file
+        run: |
+          cat ".github/dockerhub.env" >>$GITHUB_ENV
+        
+      - name: Put Docker Hub repo name into outputs
+        id: dockerhub-imagename
+        run: |
+          echo "::set-output name=DOCKERHUB_OPENFIREIMAGE::${{ env.DOCKERHUB_OPENFIREIMAGE }}"
+
+      - name: Debug outputs
+        run: |
+          echo "Image: ${{ steps.dockerhub-imagename.outputs.DOCKERHUB_OPENFIREIMAGE }}"
+          echo "Outputs: ${{ toJson(steps.dockerhub-imagename.outputs) }}"
 
       - name: Download distribution artifact from build job.
         uses: actions/download-artifact@v2
@@ -244,7 +262,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push to Docker Hub
@@ -253,7 +271,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.DOCKERHUB_OPENFIREIMAGE }}:${{ env.SOURCE_TAG }}
+          tags: ${{ steps.dockerhub-imagename.outputs.DOCKERHUB_OPENFIREIMAGE }}:${{ env.SOURCE_TAG }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
@@ -267,7 +285,10 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: |
+          echo Images published:
+          echo ${{ steps.dockerhub-imagename.outputs.DOCKERHUB_OPENFIREIMAGE }}:${{ steps.docker_build.outputs.digest }}
+          echo ${{ steps.dockerhub-imagename.outputs.DOCKERHUB_OPENFIREIMAGE }}:${{ env.SOURCE_TAG }}
 
   test-published-docker:
     name: Test tagged images published to Docker Hub
@@ -277,14 +298,15 @@ jobs:
     
     services:
       openfire:
-        image: ${{ secrets.DOCKERHUB_OPENFIREIMAGE }}:${GITHUB_REF#refs/tags/}
+        image: ${{needs.publish-docker.outputs.imagename}}@${{needs.publish-docker.outputs.imagedigest}}
         ports:
           - 9090:9090
     
     steps:
       - name: Wait for Openfire Admin to be ready
-        run: |
-          curl https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh --output ./wait-for-it.sh
-          chmod +x wait-for-it.sh
-          ./wait-for-it.sh --host openfire --port ${{ job.services.openfire.ports['9090'] }} --timeout 60 -- echo "Openfire is up!"
-    
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: 'http://openfire:9090/'
+          responseCode: 200
+          interval: 300
+          

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -175,12 +175,33 @@ jobs:
           IGNITE_REALTIME_MAVEN_USERNAME: ${{ secrets.IGNITE_REALTIME_MAVEN_USERNAME }}
           IGNITE_REALTIME_MAVEN_PASSWORD: ${{ secrets.IGNITE_REALTIME_MAVEN_PASSWORD }}
 
+  can-publish-docker:
+
+    # Based on https://github.com/GabLeRoux/github-actions-examples/blob/e0468ce2731b08bd8b1f7cd09d0b94c541310693/.github/workflows/secret_based_conditions.yml
+    name: Check if Docker Hub secrets exist
+    runs-on: ubuntu-latest
+    needs: [build, smack] # Add all tests when they're stable
+    outputs:
+      is_DOCKERHUB_SECRET_set: ${{ steps.checksecret_job.outputs.is_DOCKERHUB_SECRET_set }}
+    steps:
+      - name: Check whether unity activation requests should be done
+        id: checksecret_job
+        env:
+            DOCKERHUB_SECRET: ${{ secrets.DOCKERHUB_USERNAME }} # Could also test DOCKERHUB_TOKEN, but either is fine
+        run: |
+            echo "is_DOCKERHUB_SECRET_set: ${{ env.DOCKERHUB_SECRET != '' }}"
+            echo "::set-output name=is_DOCKERHUB_SECRET_set::${{ env.DOCKERHUB_SECRET != '' }}"
+
+
   publish-docker:
 
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
-    needs: [build, smack] # Add all tests when they're stable
-    if: ${{github.repository == 'Fishbowler/Openfire' && github.event_name == 'push' && (contains(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')}}
+    needs: [can-publish-docker]
+    if: |
+      needs.can-publish-docker.outputs.is_DOCKERHUB_SECRET_set == 'true' && 
+      github.event_name == 'push' && 
+      (contains(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
 
     steps:
       - name: Set up variables if we're on master
@@ -229,7 +250,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: fishbowler/openfire:${{ env.SOURCE_TAG }}
+          tags: ${{ secrets.DOCKERHUB_OPENFIREIMAGE }}:${{ env.SOURCE_TAG }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -221,6 +221,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          context: .
           push: true
           tags: fishbowler/openfire:${{ steps.vars.outputs.SOURCE_TAG }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -180,13 +180,16 @@ jobs:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
     needs: [build, smack] # Add all tests when they're stable
-    if: ${{github.repository == 'Fishbowler/Openfire' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
+    if: ${{github.repository == 'Fishbowler/Openfire' && github.event_name == 'push' && (contains(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')}}
 
     steps:
-      - name: Set up variables
-        id: vars
-        run: |
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+      - name: Set up variables if we're on master
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: echo "SOURCE_TAG=latest" >> $GITHUB_ENV
+
+      - name: Set up variables if we're on a tag
+        if: ${{ contains(github.ref, 'refs/tags/') }}
+        run: echo "SOURCE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
         with:
@@ -226,7 +229,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: fishbowler/openfire:${{ steps.vars.outputs.SOURCE_TAG }}
+          tags: fishbowler/openfire:${{ env.SOURCE_TAG }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/documentation/docker.html
+++ b/documentation/docker.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+
+<html lang="en">
+<head>
+    <title>Openfire: Docker Guide</title>
+    <link href="style.css" rel="stylesheet" type="text/css">
+</head>
+<body>
+    <div id="pageContainer">
+        <a name="top"></a>
+        <div id="pageHeader">
+            <div id="logo"></div>
+            <h1>Docker Guide</h1>
+        </div>
+        <div class="navigation">
+            <a href="index.html">&laquo; Back to documentation index</a>
+        </div>
+    
+        <div id="pageBody">
+            <h2>Introduction</h2>
+            <p>Openfire can be deployed as part of a container architecture. This document covers how the official images are built, how to deploy them, and how you can build your own.</p>
+
+            <h2>Builds</h2>
+            <p>The official builds of Openfire for Docker come from GitHub. When a tag is pushed, a new image is built by the CI and uploaded to Docker Hub with the same tag. Any push to the master branch is built and pushed to the 'latest' tag on Docker Hub, and whilst every effort made, these should be considered potentially unstable.</p>
+            <p>You can build the container image locally as you might any other, using <pre>docker build . -t openfire:mytag</pre>. Note that Openfire is a large application in a monorepo with a sizeable number of dependencies, and as such doesn't use a multi-stage build for Docker. Instead it builds an image from an already compiled repository. For more repeatable builds, try <pre>build/docker/buildWithDocker.sh</pre>.</p>
+
+            <h2>Usage</h2>
+            <p>You can run a simple container with <pre>docker run --rm -d -p 5222:5222 -p 5269:5269 -p 7070:7070 -p 7443:7443 -p 9090:9090 ignitereatime/openfire:sometag</pre> and configure for the internal database. You can add volumes to achieve persistance between restarts and upgrades.</p>
+            <p>For more complex or productionised setups, you could use docker-compose.
+                <pre>
+openfire:
+    image: "igniterealtime/openfire:sometag"
+    ports:
+      - "5222:5222"
+      - "5269:5269"
+      - "7070:7070"
+      - "7443:7443"
+      - "9090:9090"
+    depends_on:
+      - "postgres_service"
+    volumes:
+      - ./data/conf:/var/lib/openfire/conf
+      - ./wait-for-it.sh:/wait-for-it.sh
+    command: ["/wait-for-it.sh", "postgres_service:5432", "--", "/sbin/entrypoint.sh"]
+                </pre>
+            In this example, we've used <a href="https://github.com/vishnubob/wait-for-it/blob/master/wait-for-it.sh">wait-for-it</a> to allow a postgres database service (not shown) to finish launching prior to starting Openfire. This allows us to have premade files in /data/conf with which to launch Openfire.
+            </p>
+        </div>  
+    </div>
+</body>


### PR DESCRIPTION
Adds to the existing CI build, and uses the existing build artifacts to create and publish a docker image to Docker Hub.

- Any tag pushed to the repo will be pushed as an equivalent tag to Docker Hub
- Anything pushed to master will be pushed to :latest on Docker Hub 

I've added some consideration for forks being able to push to Docker Hub. Anyone running the CI in their fork AND with the appropriate secrets set will attempt to use them to push an image.

To make it work:

- Create an account on Docker Hub
- Create a token for the user account (https://hub.docker.com/settings/security)
- Add a repository secret (https://github.com/igniterealtime/Openfire/settings/secrets/actions) for DOCKERHUB_USERNAME and DOCKERHUB_TOKEN - (do these want to live on the repo, in case we want to publish from a different repo in the future?)
- Add a repository secret called DOCKERHUB_OPENFIREIMAGE that contains the repo to push to (which might be assumed to be "dockerhub-username/openfire", but might not be, for example if it's a user pushing to an organisation) - this should look like "igniterealtime/openfire"