### PR TITLE
OF-2212: Allow admin console's cert to be auto-updated

### DIFF
--- a/xmppserver/src/main/webapp/import-keystore-certificate.jsp
+++ b/xmppserver/src/main/webapp/import-keystore-certificate.jsp
@@ -8,6 +8,8 @@
 <%@ page import="org.jivesoftware.util.CookieUtils" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="org.jivesoftware.openfire.container.AdminConsolePlugin" %>
+<%@ page import="java.time.Duration" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -55,6 +57,10 @@
         }
         if (errors.isEmpty()) {
             try {
+                // When updating certificates through the admin console, do not immediately restart the website, as that
+                // is very likely to lock out the administrator that is performing the changes.
+                ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+
                 final IdentityStore identityStore = XMPPServer.getInstance().getCertificateStoreManager().getIdentityStore( connectionType );
 
                 // Import certificate

--- a/xmppserver/src/main/webapp/security-keystore-signing-request.jsp
+++ b/xmppserver/src/main/webapp/security-keystore-signing-request.jsp
@@ -20,6 +20,8 @@
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ page import="org.jivesoftware.openfire.keystore.CertificateUtils" %>
 <%@ page import="java.util.Set" %>
+<%@ page import="org.jivesoftware.openfire.container.AdminConsolePlugin" %>
+<%@ page import="java.time.Duration" %>
 <%@ taglib uri="admin" prefix="admin" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -92,6 +94,11 @@
        }
        if (errors.size() == 0) {
            try {
+               // When updating certificates through the admin console, do not cause changes to restart the website, as
+               // that is very likely to log out the administrator that is performing the changes. As the keystore change
+               // event is async, this line disables restarting the plugin for a few minutes.
+               ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+
                X500NameBuilder builder = new X500NameBuilder();
                builder.addRDN(BCStyle.CN, name);
                builder.addRDN(BCStyle.OU, organizationalUnit);

--- a/xmppserver/src/main/webapp/security-keystore.jsp
+++ b/xmppserver/src/main/webapp/security-keystore.jsp
@@ -13,6 +13,7 @@
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
 <%@ page import="java.security.cert.X509Certificate" %>
 <%@ page import="java.util.*" %>
+<%@ page import="java.time.Duration" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -86,6 +87,11 @@
             {
                 try
                 {
+                    // When updating certificates through the admin console, do not cause changes to restart the website, as
+                    // that is very likely to log out the administrator that is performing the changes. As the keystore change
+                    // event is async, this line disables restarting the plugin for a few minutes.
+                    ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+
                     identityStore.delete( alias );
 
                     // Log the event
@@ -106,6 +112,11 @@
 
     if (generate) {
         try {
+            // When updating certificates through the admin console, do not cause changes to restart the website, as
+            // that is very likely to log out the administrator that is performing the changes. As the keystore change
+            // event is async, this line disables restarting the plugin for a few minutes.
+            ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+
             if (!identityStore.containsAllIdentityCertificate()) {
                 identityStore.addSelfSignedDomainCertificate();
 
@@ -128,6 +139,11 @@
         String reply = ParamUtils.getParameter(request, "reply");
         if (alias != null && reply != null && reply.trim().length() > 0) {
             try {
+                // When updating certificates through the admin console, do not cause changes to restart the website, as
+                // that is very likely to log out the administrator that is performing the changes. As the keystore change
+                // event is async, this line disables restarting the plugin for a few minutes.
+                ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+
                 identityStore.installCSRReply(alias, reply);
                 identityStore.persist();
                 // Log the event


### PR DESCRIPTION
Openfire detects changes to its keystores, and reloads the various services that use them. This, for example, allows the CertificateManager plugin to update Openfire's security certificates dynamically.

One element that does not automatically get updated after keystore changes is the webserver that is serving the admin console (which also can serve other web content). This is a conscious choice, as the admin console can be used to update the keystores. It would be very undesirable to have the admin user be logged out as a result of applying a change to the keystores. To work around this issue, the admin console remains unchanged when a keystore change is detected (although a warning will be displayed, telling an admin to restart things).

This commit ensures that the admin console is automatically updated when certificate changes are detected, unless that change happened through the admin console, by briefly pausing the auto-updating feature.