### PR TITLE
OF-2213: Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 
         <!-- Versions -->
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
-        <jetty.version>9.4.35.v20201120</jetty.version>
+        <jetty.version>9.4.39.v20210325</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <mina.version>2.1.3</mina.version>
         <bouncycastle.version>1.68</bouncycastle.version>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -347,7 +347,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
-            <version>2.6.2</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -319,7 +319,7 @@
         <dependency>
             <groupId>com.rometools</groupId>
             <artifactId>rome</artifactId>
-            <version>1.12.0</version>
+            <version>1.15.0</version>
         </dependency>
 
         <!-- Random stuff -->

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -367,7 +367,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.12</version>
+            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>com.cenqua.shaj</groupId>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -411,7 +411,7 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.2</version>
+            <version>2.3.3</version>
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -433,7 +433,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.14</version>
+            <version>42.2.19</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.jtds</groupId>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -382,7 +382,7 @@
         <dependency>
             <groupId>org.jsmpp</groupId>
             <artifactId>jsmpp</artifactId>
-            <version>2.3.7</version>
+            <version>2.3.10</version>
         </dependency>
         <dependency>
             <groupId>opensymphony</groupId>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -443,7 +443,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>7.2.2.jre8</version>
+            <version>7.4.1.jre8</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
I've been testing out Snyk on my fork, and it's spotted a number of out-of-date deps

- Jetty
- Apache Commons Pool2
- jSMPP
- Rome
- Postgresql JDBC driver
- MSSQL Server JDBC driver

This PR updates these deps to current versions, mosty via cherrypicks from the autogen'd PRs it creates.

I've tested Rome & Jetty locally. Pool2 and Jetty both get exercised by the CI tests. I've tested the JDBC drivers by exercising them in a branch that merges this with the database upgrade tests (see #1805) and those passed (https://github.com/Fishbowler/Openfire/actions/runs/726286422).

Only Jetty is a security upgrade, fixing https://nvd.nist.gov/vuln/detail/CVE-2021-28165