### PR TITLE
OF-2240: Add self-presence status to kick presence to "kickee"

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -2854,7 +2854,10 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
 
                 // Send a defensive copy (to not leak a change to the 'to' address - this is possibly overprotective here,
                 // but we're erring on the side of caution) of the unavailable presence to the banned user.
-                kickedRole.send(kickPresence.createCopy());
+                Presence kickSelfPresence = kickPresence.createCopy();
+                Element fragKickSelfPresence = kickSelfPresence.getChildElement("x", "http://jabber.org/protocol/muc#user");
+                fragKickSelfPresence.addElement("status").addAttribute("code", "110");
+                kickedRole.send(kickSelfPresence);
 
                 // Remove the occupant from the room's occupants lists
                 OccupantLeftEvent event = new OccupantLeftEvent(this, kickedRole);


### PR DESCRIPTION
Openfire has specific logic for detecting when self-presence needs to occur on a broadcast. Kick works by sending a specific presence to the kicked user, removing them from the MUC, then sending the broadcast - the logic is never invoked.

This change adds the self-presence to that kick.

I've used some yet-to-be-contributed additional tests for Smack to test that it both failed before the change and succeeded afterwards. See https://github.com/Fishbowler/Smack/commit/0e6963330804580a43f82b61f667fc40163189da