### PR TITLE
use older ubuntu for aioxmpp tests (Epoll issue?)

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -54,7 +54,8 @@ jobs:
   aioxmpp:
 
     name: Execute aioxmpp-based CI tests
-    runs-on: ubuntu-latest
+    # ubuntu-latest may have issues with Epoll python events
+    runs-on: ubuntu-18.04
     needs: build
 
     steps:


### PR DESCRIPTION
Whilst pulling my hair out, I realized that Github Actions updated the `ubuntu-latest` about the time failures started to happen.  I then noticed python using the `epoll` reactor, which sometimes can be sensitive to the Linux distro being used.  Rolling back to `ubuntu-18.04` has worked twice for me, watch it fail here.