### PR TITLE
fix ClassCastExceptions

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRole.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRole.java
@@ -378,6 +378,31 @@ public interface MUCRole {
                 default: return none;
             }
         }
+
+        /**
+         * Returns the affiliation associated with the specified value.
+         *
+         * @param value the value.
+         * @return the associated affiliation.
+         */
+        public static Role fromString(String value) {
+            switch (value) {
+                case "moderator": return moderator;
+                case "participant": return participant;
+                case "visitor": return visitor;
+                default: return none;
+            }
+        }
+
+        @Override
+        public String toString() {
+            switch (this.value) {
+                case 0: return "moderator";
+                case 1: return "participant";
+                case 2: return "visitor";
+                default: return "none";
+            }
+        }
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -3283,7 +3283,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         ExternalizableUtil.getInstance().writeSafeUTF(out, description);
         ExternalizableUtil.getInstance().writeBoolean(out, canOccupantsChangeSubject);
         ExternalizableUtil.getInstance().writeInt(out, maxUsers);
-        ExternalizableUtil.getInstance().writeStringList(out, rolesToBroadcastPresence.stream().map(Enum::name).collect(Collectors.toList())); // This uses stringlist for compatibility with Openfire 4.6.0. Can be replaced the next major release.
+        ExternalizableUtil.getInstance().writeSerializableCollection(out, rolesToBroadcastPresence);
         ExternalizableUtil.getInstance().writeBoolean(out, publicRoom);
         ExternalizableUtil.getInstance().writeBoolean(out, persistent);
         ExternalizableUtil.getInstance().writeBoolean(out, moderated);
@@ -3336,7 +3336,7 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
         description = ExternalizableUtil.getInstance().readSafeUTF(in);
         canOccupantsChangeSubject = ExternalizableUtil.getInstance().readBoolean(in);
         maxUsers = ExternalizableUtil.getInstance().readInt(in);
-        rolesToBroadcastPresence.addAll(ExternalizableUtil.getInstance().readStringList(in).stream().map(MUCRole.Role::valueOf).collect(Collectors.toSet())); // This uses stringlist for compatibility with Openfire 4.6.0. Can be replaced the next major release.
+        ExternalizableUtil.getInstance().readSerializableCollection(in, rolesToBroadcastPresence, getClass().getClassLoader());
         publicRoom = ExternalizableUtil.getInstance().readBoolean(in);
         persistent = ExternalizableUtil.getInstance().readBoolean(in);
         moderated = ExternalizableUtil.getInstance().readBoolean(in);


### PR DESCRIPTION
fixes:

- https://discourse.igniterealtime.org/t/error-500-retrieving-rooms-info-with-rest-api-plugin/89851 and related :: cast enum to string by overriding Role#toString
- https://discourse.igniterealtime.org/t/hazelcast-pluginservlet-roomremovedevent-classcastexception/90088 - also happens when updating/saving a MUC created on local cluster node :: use collection serializer instead of stringlist -- comment/motivation about/for backwards compatibility w/4.6.0 removed

This resolves ClassCastExceptions being thrown in OF 4.6.x w/RestAPI plugin 1.5.0.
OF 4.6.4 should finally be compatible with RestAPI plugin. I suggest RestAPI plugin release v1.5.0 as STABLE.
As things currently stand, v1.4.0 is incompatible with OF v4.6.x.