### PR TITLE
OF-2256: Add CORS support to WebSocket Service

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
@@ -46,16 +46,8 @@ import org.slf4j.LoggerFactory;
  */
 public class OpenfireWebSocketServlet extends WebSocketServlet {
 
-    private static final long serialVersionUID = 7281841492829464605L;
+    private static final long serialVersionUID = 1074354600476010708L;
     private static final Logger Log = LoggerFactory.getLogger(OpenfireWebSocketServlet.class);
-
-    private HttpBindManager boshManager;
-
-    @Override
-    public void init() throws ServletException {
-        super.init();
-        boshManager = HttpBindManager.getInstance();
-    }
 
     @Override
     public void destroy()
@@ -81,6 +73,7 @@ public class OpenfireWebSocketServlet extends WebSocketServlet {
         // add CORS headers for all HTTP responses (errors, etc.)
         if (HttpBindManager.HTTP_BIND_CORS_ENABLED.getValue())
         {
+            final HttpBindManager boshManager = HttpBindManager.getInstance();
             if (boshManager.isAllOriginsAllowed()) {
                 // Set the Access-Control-Allow-Origin header to * to allow all Origin to do the CORS
                 response.setHeader("Access-Control-Allow-Origin", HttpBindManager.HTTP_BIND_CORS_ALLOW_ORIGIN_ALL);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
@@ -101,25 +101,21 @@ public class OpenfireWebSocketServlet extends WebSocketServlet {
         final int messageSize = JiveGlobals.getIntProperty("xmpp.parser.buffer.size", 1048576);
         factory.getPolicy().setMaxTextMessageBufferSize(messageSize * 5);
         factory.getPolicy().setMaxTextMessageSize(messageSize);
-        factory.setCreator(new WebSocketCreator() {
-            @Override
-            public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp)
-            {
-                try {
-                    for (String subprotocol : req.getSubProtocols())
+        factory.setCreator((req, resp) -> {
+            try {
+                for (String subprotocol : req.getSubProtocols())
+                {
+                    if ("xmpp".equals(subprotocol))
                     {
-                        if ("xmpp".equals(subprotocol))
-                        {
-                            resp.setAcceptedSubProtocol(subprotocol);
-                            return new XmppWebSocket();
-                        }
+                        resp.setAcceptedSubProtocol(subprotocol);
+                        return new XmppWebSocket();
                     }
-                } catch (Exception e) {
-                    Log.warn(MessageFormat.format("Unable to load websocket factory: {0} ({1})", e.getClass().getName(), e.getMessage()));
                 }
-                Log.warn("Failed to create websocket for {}:{} make a request at {}", req.getRemoteAddress(), req.getRemotePort(), req.getRequestPath() );
-                return null;
+            } catch (Exception e) {
+                Log.warn(MessageFormat.format("Unable to load websocket factory: {0} ({1})", e.getClass().getName(), e.getMessage()));
             }
+            Log.warn("Failed to create websocket for {}:{} make a request at {}", req.getRemoteAddress(), req.getRemotePort(), req.getRequestPath() );
+            return null;
         });
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
@@ -79,11 +79,11 @@ public class OpenfireWebSocketServlet extends WebSocketServlet {
     protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
     {
         // add CORS headers for all HTTP responses (errors, etc.)
-        if (boshManager.isCORSEnabled())
+        if (HttpBindManager.HTTP_BIND_CORS_ENABLED.getValue())
         {
             if (boshManager.isAllOriginsAllowed()) {
                 // Set the Access-Control-Allow-Origin header to * to allow all Origin to do the CORS
-                response.setHeader("Access-Control-Allow-Origin", HttpBindManager.HTTP_BIND_CORS_ALLOW_ORIGIN_DEFAULT);
+                response.setHeader("Access-Control-Allow-Origin", HttpBindManager.HTTP_BIND_CORS_ALLOW_ORIGIN_ALL);
             } else {
                 // Get the Origin header from the request and check if it is in the allowed Origin Map.
                 // If it is allowed write it back to the Access-Control-Allow-Origin header of the respond.
@@ -92,12 +92,13 @@ public class OpenfireWebSocketServlet extends WebSocketServlet {
                     response.setHeader("Access-Control-Allow-Origin", origin);
                 }
             }
-            response.setHeader("Access-Control-Allow-Methods", HttpBindManager.HTTP_BIND_CORS_ALLOW_METHODS_DEFAULT);
-            response.setHeader("Access-Control-Allow-Headers", HttpBindManager.HTTP_BIND_CORS_ALLOW_HEADERS_DEFAULT);
-            response.setHeader("Access-Control-Max-Age", HttpBindManager.HTTP_BIND_CORS_MAX_AGE_DEFAULT);
+            response.setHeader("Access-Control-Allow-Methods", String.join(",", HttpBindManager.HTTP_BIND_CORS_ALLOW_METHODS.getValue()));
+            response.setHeader("Access-Control-Allow-Headers", String.join(",", HttpBindManager.HTTP_BIND_CORS_ALLOW_HEADERS.getValue()));
+            response.setHeader("Access-Control-Max-Age", String.valueOf(HttpBindManager.HTTP_BIND_CORS_MAX_AGE.getValue().getSeconds())); // TODO replace with 'toSeconds()' after dropping support for Java 8
         }
         super.service(request, response);
     }
+
     @Override
     public void configure(WebSocketServletFactory factory)
     {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
@@ -112,7 +112,7 @@ public class OpenfireWebSocketServlet extends WebSocketServlet {
                     }
                 }
             } catch (Exception e) {
-                Log.warn(MessageFormat.format("Unable to load websocket factory: {0} ({1})", e.getClass().getName(), e.getMessage()));
+                Log.warn("Unable to load websocket factory", e);
             }
             Log.warn("Failed to create websocket for {}:{} make a request at {}", req.getRemoteAddress(), req.getRemotePort(), req.getRequestPath() );
             return null;


### PR DESCRIPTION
In OpenMeetings (a part of Pàdé), one may switch form old-style BOSH to WebSockets for the XMPP controll connection.  but unlike the BOSH Service, the Websocket Service don't yet support CORS response headers.

Add this by using the code from https://github.com/igniterealtime/Openfire/blob/master/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java

