### PR TITLE
Fix flappy behavior of connectivity tests

### DIFF
--- a/runConnectivityIntegrationTests
+++ b/runConnectivityIntegrationTests
@@ -274,7 +274,7 @@ function launchOpenfire {
 	# assume Openfire is fully operational once that happens (not sure if
 	# this assumption is correct).
 	echo "Waiting for Openfire…"
-	timeout 120 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 0.3; done' localhost 7070
+	timeout 120 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 0.3; done; sleep 2' localhost 7070
 }
 
 function runTests {


### PR DESCRIPTION
The BOSH-based connectivity tests regularly, but not consistently, fail on Github (but never locally, at least not for me).

It appears that it's always the first (of many) iteration that fails. Subsequent iterations of the same test seem to work.

Perhaps the test is starting 'to soon'? It's waiting for Openfire to start listening on port 7070 (which seem appropriate), but perhaps there's a brief period where that socket seems open, but data sent to it isn't properly being processed yet.

This commit adds an arbitrary 2 second wait between 'socket detected to be open' and the start of the test.