### PR TITLE
JMX support for thread pools

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1718,6 +1718,10 @@ system_property.xmpp.httpbind.worker.threads=Maximum number of threads used to p
 system_property.xmpp.httpbind.worker.timeout=Duration that unused, surplus threads that once processed BOSH data are kept alive. See also property 'httpbind.client.processing.threads-timeout'
 system_property.xmpp.httpbind.worker.cleanupcheck=Interval in which a check is executed that will cleanup unused/inactive BOSH sessions.
 
+system_property.xmpp.jmx.enabled=Enables / disables JMX support in Openfire
+system_property.xmpp.jmx.secure=Controls if the JMX connector is configured to require Openfire admin credentials.
+system_property.xmpp.jmx.port=Defines the TCP port number for the JMX connector.
+
 # Server properties Page
 
 server.properties.title=System Properties

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1731,6 +1731,9 @@ system_property.xmpp.client.roster.threadpool.keepalive=The number of threads in
 system_property.provider.transfer.proxy.threadpool.size.core=The number of threads to keep in the thread pool that powers proxy (SOCKS5) connections, even if they are idle.
 system_property.provider.transfer.proxy.threadpool.size.max=The maximum number of threads to allow in the thread pool that powers proxy (SOCKS5) connections.
 system_property.provider.transfer.proxy.threadpool.keepalive=The number of threads in the thread pool that powers proxy (SOCKS5) connections is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
+system_property.xmpp.pep.threadpool.size.core=The number of threads to keep in the thread pool used to send PEP notifications, even if they are idle.
+system_property.xmpp.pep.threadpool.size.max=The maximum number of threads to allow in the thread pool used to send PEP notifications.
+system_property.xmpp.pep.threadpool.keepalive=The number of threads in the thread pool used to send PEP notifications is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
 
 # Server properties Page
 

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1722,6 +1722,10 @@ system_property.xmpp.jmx.enabled=Enables / disables JMX support in Openfire
 system_property.xmpp.jmx.secure=Controls if the JMX connector is configured to require Openfire admin credentials.
 system_property.xmpp.jmx.port=Defines the TCP port number for the JMX connector.
 
+system_property.xmpp.archivemanager.threadpool.size.core=The number of threads to keep in the thread pool that writes messages to the database, even if they are idle.
+system_property.xmpp.archivemanager.threadpool.size.max=The maximum number of threads to allow in the thread pool that writes messages to the database.
+system_property.xmpp.archivemanager.threadpool.keepalive=The number of threads in the thread pool that writes messages to the database is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
+
 # Server properties Page
 
 server.properties.title=System Properties

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1734,6 +1734,9 @@ system_property.provider.transfer.proxy.threadpool.keepalive=The number of threa
 system_property.xmpp.pep.threadpool.size.core=The number of threads to keep in the thread pool used to send PEP notifications, even if they are idle.
 system_property.xmpp.pep.threadpool.size.max=The maximum number of threads to allow in the thread pool used to send PEP notifications.
 system_property.xmpp.pep.threadpool.keepalive=The number of threads in the thread pool used to send PEP notifications is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
+system_property.xmpp.taskengine.threadpool.size.core=The number of threads to keep in the thread pool that is used to execute tasks of Openfire's TaskEngine, even if they are idle.
+system_property.xmpp.taskengine.threadpool.size.max=The maximum number of threads to allow in the thread pool that is used to execute tasks of Openfire's TaskEngine.
+system_property.xmpp.taskengine.threadpool.keepalive=The number of threads in the thread pool that is used to execute tasks of Openfire's TaskEngine is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
 
 # Server properties Page
 

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1728,6 +1728,9 @@ system_property.xmpp.archivemanager.threadpool.keepalive=The number of threads i
 system_property.xmpp.client.roster.threadpool.size.core=The number of threads to keep in the thread pool that is used to invoke roster event listeners, even if they are idle.
 system_property.xmpp.client.roster.threadpool.size.max=The maximum number of threads to allow in the thread pool that is used to invoke roster event listeners.
 system_property.xmpp.client.roster.threadpool.keepalive=The number of threads in the thread pool that is used to invoke roster event listeners is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
+system_property.provider.transfer.proxy.threadpool.size.core=The number of threads to keep in the thread pool that powers proxy (SOCKS5) connections, even if they are idle.
+system_property.provider.transfer.proxy.threadpool.size.max=The maximum number of threads to allow in the thread pool that powers proxy (SOCKS5) connections.
+system_property.provider.transfer.proxy.threadpool.keepalive=The number of threads in the thread pool that powers proxy (SOCKS5) connections is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
 
 # Server properties Page
 

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1725,6 +1725,9 @@ system_property.xmpp.jmx.port=Defines the TCP port number for the JMX connector.
 system_property.xmpp.archivemanager.threadpool.size.core=The number of threads to keep in the thread pool that writes messages to the database, even if they are idle.
 system_property.xmpp.archivemanager.threadpool.size.max=The maximum number of threads to allow in the thread pool that writes messages to the database.
 system_property.xmpp.archivemanager.threadpool.keepalive=The number of threads in the thread pool that writes messages to the database is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
+system_property.xmpp.client.roster.threadpool.size.core=The number of threads to keep in the thread pool that is used to invoke roster event listeners, even if they are idle.
+system_property.xmpp.client.roster.threadpool.size.max=The maximum number of threads to allow in the thread pool that is used to invoke roster event listeners.
+system_property.xmpp.client.roster.threadpool.keepalive=The number of threads in the thread pool that is used to invoke roster event listeners is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
 
 # Server properties Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/JMXManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/JMXManager.java
@@ -2,10 +2,10 @@ package org.jivesoftware.openfire;
 
 import java.lang.management.ManagementFactory;
 import java.rmi.registry.Registry;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
+import javax.annotation.Nonnull;
+import javax.management.ObjectName;
 import javax.management.remote.JMXAuthenticator;
 import javax.management.remote.JMXPrincipal;
 import javax.management.remote.JMXServiceURL;
@@ -15,7 +15,7 @@ import org.eclipse.jetty.jmx.ConnectorServer;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.jivesoftware.openfire.admin.AdminManager;
 import org.jivesoftware.openfire.auth.AuthFactory;
-import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.SystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,11 +28,55 @@ public class JMXManager {
 
     private static final Logger Log = LoggerFactory.getLogger(JMXManager.class);
 
-    private static final String XMPP_JMX_ENABLED = "xmpp.jmx.enabled";
-    private static final String XMPP_JMX_SECURE = "xmpp.jmx.secure";
-    private static final String XMPP_JMX_PORT = "xmpp.jmx.port";
-    
-    public static final int DEFAULT_PORT = Registry.REGISTRY_PORT;
+    /**
+     * Enables / disables JMX support in Openfire. This option can be
+     * configured via the admin console or by setting the following
+     * system property:
+     * <pre>
+     *    xmpp.jmx.enabled=true (default: false)
+     * </pre>
+     */
+    public static final SystemProperty<Boolean> XMPP_JMX_ENABLED = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("xmpp.jmx.enabled")
+        .setDynamic(false) // This property strictly speaking is somewhat 'dynamic', but generally, it's used only at boot time to see if Beans etc. are to be registered. Reboot is required to have JMX functionality.
+        .setDefaultValue(false)
+        .build();
+
+    /**
+     * Controls if the JMX connector is configured to require
+     * Openfire admin credentials. This option can be configured via
+     * the admin console or by setting the following system property:
+     * <pre>
+     *    xmpp.jmx.secure=false (default: true)
+     * </pre>
+     */
+    public static final SystemProperty<Boolean> XMPP_JMX_SECURE = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("xmpp.jmx.secure")
+        .setDynamic(false)
+        .setDefaultValue(true)
+        .build();
+
+    /**
+     * Defines the TCP port number for the JMX connector. This option can
+     * be configured via the admin console or by setting the following
+     * system property:
+     * <pre>
+     *    xmpp.jmx.port=[port] (default: 1099)
+     * </pre>
+     */
+    public static final SystemProperty<Integer> XMPP_JMX_PORT = SystemProperty.Builder.ofType(Integer.class)
+        .setKey("xmpp.jmx.port")
+        .setDynamic(false) // This property strictly speaking is 'dynamic', but generally, it's used only at boot time to see if Beans etc. are to be registered. Reboot is required to have JMX functionality.
+        .setDefaultValue(Registry.REGISTRY_PORT)
+        .setMinValue(1)
+        .setMaxValue(65535)
+        .build();
+
+    /**
+     * @deprecated Replaced by XMPP_JMX_PORT.getDefaultValue()
+     */
+    @Deprecated // Remove in or after Openfire 4.8.0
+    public static final int DEFAULT_PORT = XMPP_JMX_PORT.getDefaultValue();
     
     private static JMXManager instance = null;
     
@@ -40,21 +84,21 @@ public class JMXManager {
     private ConnectorServer jmxServer;
 
     /**
-     * Returns true if the JMX connector is configured to require 
+     * Returns true if the JMX connector is configured to require
      * Openfire admin credentials. This option can be configured via
      * the admin console or by setting the following system property:
      * <pre>
      *    xmpp.jmx.secure=false (default: true)
      * </pre>
-     * 
+     *
      * @return true if the JMX connector requires authentication
      */
     public static boolean isSecure() {
-        return JiveGlobals.getBooleanProperty(XMPP_JMX_SECURE, true);
+        return XMPP_JMX_SECURE.getValue();
     }
-    
+
     public static void setSecure(boolean secure) {
-        JiveGlobals.setProperty("xmpp.jmx.secure", String.valueOf(secure));
+        XMPP_JMX_SECURE.setValue(secure);
     }
 
     /**
@@ -68,11 +112,11 @@ public class JMXManager {
      * @return Port number for the JMX connector
      */
     public static int getPort() {
-        return JiveGlobals.getIntProperty(XMPP_JMX_PORT, DEFAULT_PORT);
+        return XMPP_JMX_PORT.getValue();
     }
-    
+
     public static void setPort(int port) {
-        JiveGlobals.setProperty("xmpp.jmx.port", String.valueOf(port));
+        XMPP_JMX_PORT.setValue(port);
     }
 
     /**
@@ -86,11 +130,11 @@ public class JMXManager {
      * @return true if JMX support is enabled
      */
     public static boolean isEnabled() {
-        return JiveGlobals.getBooleanProperty(XMPP_JMX_ENABLED, false);
+        return XMPP_JMX_ENABLED.getValue();
     }
-    
+
     public static void setEnabled(boolean enabled) {
-        JiveGlobals.setProperty("xmpp.jmx.enabled", String.valueOf(enabled));
+        XMPP_JMX_ENABLED.setValue(enabled);
     }
 
     public static JMXManager getInstance() {
@@ -161,5 +205,91 @@ public class JMXManager {
 
     public void setContainer(MBeanContainer mbContainer) {
         this.mbContainer = mbContainer;
+    }
+
+    /**
+     * Registers a MBean in the platform MBean server, replacing any MBean that might have been registered earlier using
+     * the same object name.
+     *
+     * This method will log but otherwise ignore any exception that is thrown when registrating the bean.
+     *
+     * @param mbean The bean to register
+     * @param name The identifier to register the bean under.
+     * @return the ObjectName instance used the register the bean.
+     */
+    public static ObjectName tryRegister(@Nonnull final Object mbean, @Nonnull final String name)
+    {
+        try {
+            final ObjectName objectName = new ObjectName(name);
+            tryRegister(mbean, objectName);
+            return objectName;
+        } catch (Exception e) {
+            Log.warn("Failed to register MBean with platform MBean server, using object name: {}", name, e);
+            return null;
+        }
+    }
+
+    /**
+     * Registers a MBean in the platform MBean server, replacing any MBean that might have been registered earlier using
+     * the same object name.
+     *
+     * This method will log but otherwise ignore any exception that is thrown when registrating the bean.
+     *
+     * @param mbean The bean to register
+     * @param objectName The identifier to register the bean under.
+     */
+    public static void tryRegister(@Nonnull final Object mbean, @Nonnull final ObjectName objectName)
+    {
+        if (!isEnabled()) {
+            Log.trace("Not Registering MBean with platform MBean server (using object name: {}) as JMX functionality in Openfire is disabled.", objectName);
+            return;
+        }
+
+        getInstance(); // Ensure that the instance is started before trying to register anything.
+
+        Log.trace("Registering MBean with platform MBean server, using object name: {}", objectName);
+        tryUnregister(objectName);
+
+        try {
+            getInstance().getContainer().getMBeanServer().registerMBean(mbean, objectName);
+            Log.debug("Successfully registered MBean with platform MBean server, using object name: {}", objectName);
+        } catch (Exception e) {
+            Log.warn("Failed to register MBean with platform MBean server, using object name: {}", objectName, e);
+        }
+    }
+
+    /**
+     * Unregisters a MBean from the platform MBean server.
+     *
+     * This method will log but otherwise ignore any exception that is thrown when unregistering the bean.
+     *
+     * @param name The identifier that was used to register the bean under.
+     */
+    public static void tryUnregister(@Nonnull final String name) {
+        try {
+            final ObjectName objectName = new ObjectName(name);
+            tryUnregister(objectName);
+        } catch (Exception e) {
+            Log.warn("Failed to unregister MBean with platform MBean server, using object name: {}", name, e);
+        }
+    }
+
+    /**
+     * Unregisters a MBean from the platform MBean server.
+     *
+     * This method will log but otherwise ignore any exception that is thrown when unregistering the bean.
+     *
+     * @param objectName The identifier that was used to register the bean under.
+     */
+    public static void tryUnregister(@Nonnull final ObjectName objectName) {
+        try {
+            Log.debug("Unregistering MBean from platform MBean server (if one was registered), using object name: {}", objectName);
+            if (getInstance().getContainer().getMBeanServer().isRegistered(objectName)) {
+                getInstance().getContainer().getMBeanServer().unregisterMBean(objectName);
+                Log.debug("Successfully unregistered MBean from platform MBean server, using object name: {}", objectName.getCanonicalName());
+            }
+        } catch (Exception e) {
+            Log.warn("Failed to unregister MBean with platform MBean server, using object name: {}", objectName, e);
+        }
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mbean/ThreadPoolExecutorDelegate.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mbean/ThreadPoolExecutorDelegate.java
@@ -1,0 +1,119 @@
+package org.jivesoftware.openfire.mbean;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * A delegate for a {@link ThreadPoolExecutor} instance, to expose a subset of its functionality as an MBean (as defined by
+ * {@link ThreadPoolExecutorDelegateMBean}.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class ThreadPoolExecutorDelegate implements ThreadPoolExecutorDelegateMBean
+{
+    private final ThreadPoolExecutor delegate;
+
+    public ThreadPoolExecutorDelegate(@Nonnull final ThreadPoolExecutor delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Returns the core number of threads.
+     *
+     * @return the core number of threads
+     */
+    @Override
+    public int getCorePoolSize() {
+        return delegate.getCorePoolSize();
+    }
+
+    /**
+     * Returns the current number of threads in the pool.
+     *
+     * @return the number of threads
+     */
+    @Override
+    public int getPoolSize() {
+        return delegate.getPoolSize();
+    }
+
+    /**
+     * Returns the largest number of threads that have ever
+     * simultaneously been in the pool.
+     *
+     * @return the number of threads
+     */
+    @Override
+    public int getLargestPoolSize() {
+        return delegate.getLargestPoolSize();
+    }
+
+    /**
+     * Returns the maximum allowed number of threads.
+     *
+     * @return the maximum allowed number of threads
+     */
+    @Override
+    public int getMaximumPoolSize() {
+        return delegate.getMaximumPoolSize();
+    }
+
+    /**
+     * Returns the approximate number of threads that are actively executing tasks.
+     *
+     * @return the number of threads
+     */
+    @Override
+    public int getActiveCount() {
+        return delegate.getActiveCount();
+    }
+
+    /**
+     * Returns the number of tasks that are currently waiting to be executed by the delegate executor.
+     *
+     * @return the task queue size
+     */
+    @Override
+    public int getQueuedTaskCount() {
+        return delegate.getQueue().size();
+    }
+
+    /**
+     * Returns the number of additional elements that task queue used by the delegate executor
+     * can ideally (in the absence of memory or resource constraints) accept without blocking,
+     * or {@code Integer.MAX_VALUE} if there is no intrinsic limit.
+     *
+     * @return the remaining capacity
+     */
+    @Override
+    public int getQueueRemainingCapacity() {
+        return delegate.getQueue().remainingCapacity();
+    }
+
+    /**
+     * Returns the approximate total number of tasks that have ever been
+     * scheduled for execution. Because the states of tasks and
+     * threads may change dynamically during computation, the returned
+     * value is only an approximation.
+     *
+     * @return the number of tasks
+     */
+    @Override
+    public long getTaskCount() {
+        return delegate.getTaskCount();
+    }
+
+    /**
+     * Returns the approximate total number of tasks that have
+     * completed execution. Because the states of tasks and threads
+     * may change dynamically during computation, the returned value
+     * is only an approximation, but one that does not ever decrease
+     * across successive calls.
+     *
+     * @return the number of tasks
+     */
+    @Override
+    public long getCompletedTaskCount() {
+        return delegate.getCompletedTaskCount();
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mbean/ThreadPoolExecutorDelegateMBean.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mbean/ThreadPoolExecutorDelegateMBean.java
@@ -1,0 +1,84 @@
+package org.jivesoftware.openfire.mbean;
+
+/**
+ * MBean definition for a Threadpool-based executor (@link {@link java.util.concurrent.ThreadPoolExecutor}
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public interface ThreadPoolExecutorDelegateMBean
+{
+    String BASE_OBJECT_NAME = "org.igniterealtime.openfire:type=ThreadPoolExecutor,name=";
+
+    /**
+     * Returns the core number of threads.
+     *
+     * @return the core number of threads
+     */
+    int getCorePoolSize();
+
+    /**
+     * Returns the current number of threads in the pool.
+     *
+     * @return the number of threads
+     */
+    int getPoolSize();
+
+    /**
+     * Returns the largest number of threads that have ever
+     * simultaneously been in the pool.
+     *
+     * @return the number of threads
+     */
+    int getLargestPoolSize();
+
+    /**
+     * Returns the maximum allowed number of threads.
+     *
+     * @return the maximum allowed number of threads
+     */
+    int getMaximumPoolSize();
+
+    /**
+     * Returns the approximate number of threads that are actively executing tasks.
+     *
+     * @return the number of threads
+     */
+    int getActiveCount();
+
+    /**
+     * Returns the number of tasks that are currently waiting to be executed by the delegate executor.
+     *
+     * @return the task queue size
+     */
+    int getQueuedTaskCount();
+
+    /**
+     * Returns the number of additional elements that task queue used by the delegate executor
+     * can ideally (in the absence of memory or resource constraints) accept without blocking,
+     * or {@code Integer.MAX_VALUE} if there is no intrinsic limit.
+     *
+     * @return the remaining capacity
+     */
+    int getQueueRemainingCapacity();
+
+    /**
+     * Returns the approximate total number of tasks that have ever been
+     * scheduled for execution. Because the states of tasks and
+     * threads may change dynamically during computation, the returned
+     * value is only an approximation.
+     *
+     * @return the number of tasks
+     */
+    long getTaskCount();
+
+    /**
+     * Returns the approximate total number of tasks that have
+     * completed execution. Because the states of tasks and threads
+     * may change dynamically during computation, the returned value
+     * is only an approximation, but one that does not ever decrease
+     * across successive calls.
+     *
+     * @return the number of tasks
+     */
+    long getCompletedTaskCount();
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/MINAConnectionAcceptor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/MINAConnectionAcceptor.java
@@ -109,7 +109,7 @@ class MINAConnectionAcceptor extends ConnectionAcceptor
 
             if ( JMXManager.isEnabled() )
             {
-                configureJMX( socketAcceptor, name );
+                // configureJMX( socketAcceptor, name );
             }
 
             final DefaultIoFilterChainBuilder filterChain = socketAcceptor.getFilterChain();

--- a/xmppserver/src/test/java/org/jivesoftware/admin/LoginLimitManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/admin/LoginLimitManagerTest.java
@@ -1,15 +1,17 @@
 package org.jivesoftware.admin;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import org.jivesoftware.openfire.security.SecurityAuditManager;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.SystemProperty;
 import org.jivesoftware.util.TaskEngine;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LoginLimitManagerTest {
@@ -17,11 +19,10 @@ public class LoginLimitManagerTest {
     private LoginLimitManager loginLimitManager;
 
     @Mock private SecurityAuditManager securityAuditManager;
-    @Mock private TaskEngine taskEngine;
 
     @Before
     public void setUp() {
-        loginLimitManager = new LoginLimitManager(securityAuditManager, taskEngine);
+        loginLimitManager = new LoginLimitManager(securityAuditManager, TaskEngine.getInstance());
     }
 
     @Test


### PR DESCRIPTION
This exposes statistics of most of Openfire's thread pools via JMX (OF-2257). In the process of implementing this, I found a couple of thread pools that had hard-coded configuration. I made that configurable (OF-2258). 