### PR TITLE
OF-2260: Add user's name to listing of group members

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1057,6 +1057,7 @@ group.edit.members_description=Use the form below to add users to this group. On
   will be able to remove them, or give certain users administrative rights over the group.
 group.edit.add_user=Add User:
 group.edit.username=Username
+group.edit.name=Name
 group.edit.admin=Admin
 group.edit.remove=Remove
 group.edit.user_hint=No members in this group. Use the form above to add some.

--- a/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
+++ b/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
@@ -503,6 +503,7 @@ group.edit.members_description=Použijte spodní formulář pro přidání uživ
   je můžete odebírat nebo jim přidělovat určitá administrátorská oprávnění ke skupině.
 group.edit.add_user=Přidat uživatele:
 group.edit.username=Uživatelské jméno
+group.edit.name=Jméno
 group.edit.admin=Administrátor
 group.edit.remove=Odstranit
 group.edit.user_hint=Ve skupině nejsou žádní členové. Použijte předchozí formulář pro jejich přidání.

--- a/i18n/src/main/resources/openfire_i18n_de.properties
+++ b/i18n/src/main/resources/openfire_i18n_de.properties
@@ -624,6 +624,7 @@ group.edit.members_description=Die Form unten verwenden, um Nutzer zu dieser Gru
   können sie entfernt werden, oder bestimmten Nutzern können Gruppenadministratorenrechte gegeben werden.
 group.edit.add_user=Benutzer hinzufügen:
 group.edit.username=Benutzername
+group.edit.name=Name
 group.edit.admin=Administrator
 group.edit.remove=Entfernen
 group.edit.user_hint=Keine Mitglieder in dieser Gruppe. Das Formular oben verwenden, um welche hinzuzufügen.

--- a/i18n/src/main/resources/openfire_i18n_es.properties
+++ b/i18n/src/main/resources/openfire_i18n_es.properties
@@ -595,6 +595,7 @@ group.edit.members_description=Use el formulario siguiente para agregar usuarios
         podrá quitarlos o darles permisos de administración sobre el grupo.
 group.edit.add_user=Agregar Usuario:
 group.edit.username=Nombre
+group.edit.name=Nombre
 group.edit.admin=Administrador
 group.edit.remove=Borrar
 group.edit.user_hint=No hay miembros en este grupo. Use el formulario anterior para agregar algunos.

--- a/i18n/src/main/resources/openfire_i18n_fr.properties
+++ b/i18n/src/main/resources/openfire_i18n_fr.properties
@@ -2062,3 +2062,4 @@ connection-mode.plain=plain text (with STARTSSL)
 connection-mode.legacy=encrypted (legacy-mode)
 connection-mode.unspecified=unspecified
 index.certificate-warning=Unable to find certificate that is valid for the server domain.
+group.edit.name=Nom

--- a/i18n/src/main/resources/openfire_i18n_ja_JP.properties
+++ b/i18n/src/main/resources/openfire_i18n_ja_JP.properties
@@ -2428,3 +2428,4 @@ connection-type.unspecified=unspecified
 connection-mode.plain=plain text (with STARTSSL)
 connection-mode.legacy=encrypted (legacy-mode)
 connection-mode.unspecified=unspecified
+group.edit.name=名前

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -2528,3 +2528,4 @@ vcard.read_only=Het VCard beheer-systeem is in 'alleen-lezen' modus.
 ssl.certificates.keystore.no_complete_installed=Het geinstalleerde certificaat omvat niet alle identiteiten van deze server. Klik {0}hier{1} om het geinstalleerde\
 certificaat te vervangen door een die dat wel doet of {2}hier{3} om een ondertekend certificaat met bijbehorende\
 private key te installeren.
+group.edit.name=Naam

--- a/i18n/src/main/resources/openfire_i18n_pl_PL.properties
+++ b/i18n/src/main/resources/openfire_i18n_pl_PL.properties
@@ -2418,3 +2418,4 @@ connection-type.unspecified=unspecified
 connection-mode.plain=plain text (with STARTSSL)
 connection-mode.legacy=encrypted (legacy-mode)
 connection-mode.unspecified=unspecified
+group.edit.name=Nazwa

--- a/i18n/src/main/resources/openfire_i18n_pt_BR.properties
+++ b/i18n/src/main/resources/openfire_i18n_pt_BR.properties
@@ -2449,3 +2449,4 @@ connection-mode.plain=plain text (with STARTSSL)
 connection-mode.legacy=encrypted (legacy-mode)
 connection-mode.unspecified=unspecified
 index.certificate-warning=Unable to find certificate that is valid for the server domain.
+group.edit.name=Nome

--- a/i18n/src/main/resources/openfire_i18n_pt_PT.properties
+++ b/i18n/src/main/resources/openfire_i18n_pt_PT.properties
@@ -2984,3 +2984,4 @@ connection-mode.legacy=encrypted (legacy-mode)
 connection-mode.unspecified=unspecified
 ssl.certificates.keystore.no_installed=A certificate for the domain of this server is missing. Click {0}here{1} to generate a self-signed \
   certificate or {2}here{3} to import a signed certificate and its private key.
+group.edit.name=Nome

--- a/i18n/src/main/resources/openfire_i18n_ru_RU.properties
+++ b/i18n/src/main/resources/openfire_i18n_ru_RU.properties
@@ -2901,3 +2901,4 @@ system.dns.srv.check.label.priority=Приоритет
 system.dns.srv.check.label.weight=Вес
 system.dns.srv.check.recordbox.title=Записи DNS SRV
 system.dns.srv.check.recordbox.description=В приведенной ниже таблице перечислены все записи SRV DNS для домена XMPP, которые являются службами этого сервера Openfire. Первая таблица содержит все записи клиент-сервер, а последняя таблица - все записи сервер-сервер.
+group.edit.name=Имя

--- a/i18n/src/main/resources/openfire_i18n_sk.properties
+++ b/i18n/src/main/resources/openfire_i18n_sk.properties
@@ -2279,3 +2279,4 @@ connection-type.unspecified=unspecified
 connection-mode.plain=plain text (with STARTSSL)
 connection-mode.legacy=encrypted (legacy-mode)
 connection-mode.unspecified=unspecified
+group.edit.name=Názov

--- a/i18n/src/main/resources/openfire_i18n_zh_CN.properties
+++ b/i18n/src/main/resources/openfire_i18n_zh_CN.properties
@@ -2417,3 +2417,4 @@ connection-type.unspecified=不指定
 connection-mode.plain=纯文本（使用STARTSSL）
 connection-mode.legacy=加密（传统模式）
 connection-mode.unspecified=不指定
+group.edit.name=名称

--- a/xmppserver/src/main/webapp/group-edit.jsp
+++ b/xmppserver/src/main/webapp/group-edit.jsp
@@ -622,6 +622,7 @@
             <tr>
                 <th>&nbsp;</th>
                 <th nowrap><fmt:message key="group.edit.username" /></th>
+                <th nowrap><fmt:message key="group.edit.name" /></th>
                 <c:if test="${not webManager.groupManager.readOnly}">
                     <th width="1%" nowrap class="jive-table-th-center"><fmt:message key="group.edit.admin" /></th>
                     <th width="1%" nowrap class="jive-table-th-center"><fmt:message key="group.edit.remove" /></th>
@@ -632,7 +633,7 @@
 
             <c:if test="${listPager.totalItemCount == 0}">
                 <tr>
-                    <td align="center" colspan="4">
+                    <td align="center" colspan="5">
                         <br>
                         <fmt:message key="group.edit.user_hint" />
                         <br>
@@ -655,6 +656,7 @@
                              onclick="submitForm();"
                         >
                     </th>
+                    <th><!-- TODO: add search for full name here --></th>
                     <c:if test="${not webManager.groupManager.readOnly}">
                         <th></th>
                         <th></th>
@@ -711,6 +713,11 @@
                             </c:otherwise>
                         </c:choose>
                     </td>
+                    <td>
+                        <c:if test="${webManager.userManager.isRegisteredUser(member, false)}">
+                            <c:out value="${webManager.userManager.getUser(member).name}"/>
+                        </c:if>
+                    </td>
                     <c:if test="${not webManager.groupManager.readOnly}">
                         <td align="center">
                             <input type="checkbox" name="admin" value="${fn:escapeXml(member)}" ${group.admins.contains(member) ? 'checked' : ''}>
@@ -724,7 +731,7 @@
 
             <c:if test="${ ( listPager.totalItemCount != 0 ) and (not webManager.groupManager.readOnly)}">
                 <tr>
-                    <td colspan="2">&nbsp;</td>
+                    <td colspan="3">&nbsp;</td>
                     <td align="center">
                         <input type="submit" name="updateMember" value="Update">
                     </td>


### PR DESCRIPTION
When looking at the members of a group, it's handy to have listed the (full) name of each member, instead of only its username.

![image](https://user-images.githubusercontent.com/4253898/120209685-41e96b80-c22f-11eb-91de-5b69a8662ada.png)

I know I should've added a search filter, but that takes more time than what I have available now.