### PR TITLE
Check 'xmppSession' is not null

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
@@ -183,7 +183,7 @@ public class XmppWebSocket {
      */
     void deliver(String packet)
     {
-        if (isWebSocketOpen())
+        if (isWebSocketOpen() && xmppSession != null)
         {
             try {
                 xmppSession.incrementServerPacketCount();


### PR DESCRIPTION
Hi, I found XmppWebSocket#deliver has possibility of causing NullPointerException.
It is expensive to cause Exception. Downtime may occur when the connection with a large number of clients is disconnected.

I tested with a large number of clients, and LB health checks failed due to high CPU usage when many clients were disconnected unexpectedly.

Thanks.