### PR TITLE
Various improvements for instances that have many MUC rooms

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -889,6 +889,8 @@ groupchat.service.properties.error_already_exists=A service with the specified n
 groupchat.service.properties.label_service_description=Group chat service description (optional):
 groupchat.service.properties.save=Save Properties
 groupchat.service.settings_affect=Changes you make here will affect the group chat service:
+groupchat.service.properties.label_service_preload=Pre-load MUC rooms in memory when initially starting the service
+groupchat.service.properties.label_service_preloaddays=Pre-load MUC rooms that have registered activity in the last ... days:
 groupchat.service.properties.label_service_cleanupdays=Remove empty MUC Rooms after ... days:
 groupchat.service.properties.label_service_muckeep=Disable MUC room cleanup for this service
 

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -889,10 +889,15 @@ groupchat.service.properties.error_already_exists=A service with the specified n
 groupchat.service.properties.label_service_description=Group chat service description (optional):
 groupchat.service.properties.save=Save Properties
 groupchat.service.settings_affect=Changes you make here will affect the group chat service:
+
+groupchat.service.properties.memory_management.legend=Memory Management
+groupchat.service.properties.memory_management_description=MUC rooms are persisted in the database, but can be loaded in \
+  memory to improve performance (when a room is being operated on that is not loaded in memory, it will be loaded in \
+  memory on demand). The settings below configure this behavior.
 groupchat.service.properties.label_service_preload=Pre-load MUC rooms in memory when initially starting the service
 groupchat.service.properties.label_service_preloaddays=Pre-load MUC rooms that have registered activity in the last ... days:
-groupchat.service.properties.label_service_cleanupdays=Remove empty MUC Rooms after ... days:
-groupchat.service.properties.label_service_muckeep=Disable MUC room cleanup for this service
+groupchat.service.properties.label_service_cleanupdays=Unload empty MUC rooms after ... days from memory:
+groupchat.service.properties.label_service_muckeep=Disable MUC room unloading for this service
 
 # Group Chat History Settings Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
@@ -156,12 +156,33 @@ public final class MUCRoomHistory {
     public void addOldMessage(String senderJID, String nickname, Date sentDate, String subject,
             String body, String stanza)
     {
+        try {
+            addOldMessage(senderJID, nickname, sentDate, subject, body, stanza, setupSAXReader());
+        } catch (Exception ex) {
+            Log.error("Failed to parse payload XML", ex);
+        }
+    }
+
+    /**
+     * Creates a new message and adds it to the history. The new message will be created based on
+     * the provided information. This information will likely come from the database when loading
+     * the room history from the database.
+     *
+     * @param senderJID the sender's JID of the message to add to the history.
+     * @param nickname the sender's nickname of the message to add to the history.
+     * @param sentDate the date when the message was sent to the room.
+     * @param subject the subject included in the message.
+     * @param body the body of the message.
+     * @param stanza the stanza to add
+     */
+    public void addOldMessage(String senderJID, String nickname, Date sentDate, String subject,
+                              String body, String stanza, SAXReader xmlReader)
+    {
         Message message = new Message();
         message.setType(Message.Type.groupchat);
         if (stanza != null) {
             // payload initialized as XML string from DB
             try {
-                SAXReader xmlReader = setupSAXReader();
                 Element element = xmlReader.read(new StringReader(stanza)).getRootElement();
                 for (Element child : (List<Element>)element.elements()) {
                     Namespace ns = child.getNamespace();
@@ -213,7 +234,7 @@ public final class MUCRoomHistory {
         historyStrategy.addMessage(message);
     }
 
-    private SAXReader setupSAXReader() throws SAXException {
+    public static SAXReader setupSAXReader() throws SAXException {
         SAXReader xmlReader = new SAXReader();
         xmlReader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         xmlReader.setFeature("http://xml.org/sax/features/external-general-entities", false);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/GetNewMemberRoomsRequest.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/GetNewMemberRoomsRequest.java
@@ -53,7 +53,7 @@ public class GetNewMemberRoomsRequest implements ClusterTask<List<RoomInfo>> {
         // Get all services that have local occupants and include them in the reply
         for (MultiUserChatService mucService : XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatServices()) {
             // Get rooms that have local occupants and include them in the reply
-            for (MUCRoom room : mucService.getChatRooms()) {
+            for (MUCRoom room : mucService.getActiveChatRooms()) { // non-actively loaded rooms won't have occupants anyway.
                 LocalMUCRoom localRoom = (LocalMUCRoom) room;
                 Collection<MUCRole> localOccupants = new ArrayList<>();
                 for (MUCRole occupant : room.getOccupants()) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceInfo.java
@@ -55,7 +55,7 @@ public class ServiceInfo implements Externalizable {
         this.isHidden = service.isHidden();
         rooms = new ArrayList<>();
         // Get rooms that have occupants and include them in the reply
-        for (MUCRoom room : service.getChatRooms()) {
+        for (MUCRoom room : service.getActiveChatRooms()) {
             LocalMUCRoom localRoom = (LocalMUCRoom) room;
             if (!room.getOccupants().isEmpty()) {
                 rooms.add(new RoomInfo(localRoom, localRoom.getOccupants()));

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/FMUCHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/FMUCHandler.java
@@ -44,8 +44,8 @@ public class FMUCHandler
         .setDefaultValue(false)
         .addListener( isEnabled -> {
             XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatServices().forEach(
-                service -> service.getChatRooms().forEach(
-                    mucRoom -> mucRoom.getFmucHandler().applyConfigurationChanges()
+                service -> service.getAllRoomNames().forEach(
+                    name -> service.getChatRoom(name).getFmucHandler().applyConfigurationChanges()
                 )
             );
         })

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMuclumbusSearchHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMuclumbusSearchHandler.java
@@ -190,7 +190,7 @@ public class IQMuclumbusSearchHandler
         }
 
         // Search for chatrooms matching the request params.
-        List<MUCRoom> mucs = searchForChatrooms( params );
+        List<MUCRoomSearchInfo> mucs = searchForChatrooms( params );
 
         switch ( params.getKey() )
         {
@@ -203,11 +203,11 @@ public class IQMuclumbusSearchHandler
                 break;
         }
 
-        final ResultSet<MUCRoom> searchResults = new ResultSetImpl<>( mucs );
+        final ResultSet<MUCRoomSearchInfo> searchResults = new ResultSetImpl<>( mucs );
 
         // See if the requesting entity would like to apply 'result set management'
         final Element set = iq.getChildElement().element( QName.get( "set", ResultSet.NAMESPACE_RESULT_SET_MANAGEMENT ) );
-        final List<MUCRoom> mucrsm;
+        final List<MUCRoomSearchInfo> mucrsm;
 
         // apply RSM only if the element exists, and the (total) results set is not empty.
         final boolean applyRSM = set != null && !mucs.isEmpty();
@@ -318,12 +318,12 @@ public class IQMuclumbusSearchHandler
         return result;
     }
 
-    protected List<MUCRoom> searchForChatrooms( final SearchParameters params )
+    protected List<MUCRoomSearchInfo> searchForChatrooms( final SearchParameters params )
     {
         Log.debug( "Searching for rooms based on search parameters." );
 
-        List<MUCRoom> mucs = new ArrayList<>();
-        for ( MUCRoom room : mucService.getChatRooms() )
+        List<MUCRoomSearchInfo> mucs = new ArrayList<>();
+        for ( MUCRoomSearchInfo room : mucService.getAllRoomSearchInfo() )
         {
             boolean find = false;
 
@@ -379,11 +379,11 @@ public class IQMuclumbusSearchHandler
         return mucs;
     }
 
-    static Element generateResultElement( final List<MUCRoom> rooms )
+    static Element generateResultElement( final List<MUCRoomSearchInfo> rooms )
     {
         Log.debug( "Generating result element." );
         final Element res = DocumentHelper.createElement( QName.get( RESPONSE_ELEMENT_NAME, NAMESPACE ) );
-        for ( final MUCRoom room : rooms )
+        for ( final MUCRoomSearchInfo room : rooms )
         {
             final Element item = res.addElement( "item" );
             item.addAttribute( "address", room.getJID().toString() );
@@ -422,10 +422,10 @@ public class IQMuclumbusSearchHandler
      * @param mucs The unordered list that will be sorted.
      * @return The order list of MUC rooms.
      */
-    public static List<MUCRoom> sortByAddress( List<MUCRoom> mucs )
+    public static List<MUCRoomSearchInfo> sortByAddress( List<MUCRoomSearchInfo> mucs )
     {
         Log.trace( "Sorting by address." );
-        mucs.sort( Comparator.comparing( MUCRoom::getJID ) );
+        mucs.sort( Comparator.comparing( MUCRoomSearchInfo::getJID) );
         return mucs;
     }
 
@@ -436,7 +436,7 @@ public class IQMuclumbusSearchHandler
      * @param mucs The unordered list that will be sorted.
      * @return The sorted list of MUC rooms.
      */
-    public static List<MUCRoom> sortByUserAmount( List<MUCRoom> mucs )
+    public static List<MUCRoomSearchInfo> sortByUserAmount( List<MUCRoomSearchInfo> mucs )
     {
         Log.trace( "Sorting by occupant count." );
         mucs.sort( ( o1, o2 ) -> o2.getOccupantsCount() - o1.getOccupantsCount() );
@@ -452,10 +452,10 @@ public class IQMuclumbusSearchHandler
      * @return ''true'' if the room may be included in search results, ''false''
      * otherwise.
      */
-    private static boolean canBeIncludedInResult( MUCRoom room )
+    private static boolean canBeIncludedInResult( MUCRoomSearchInfo room )
     {
         // Check if locked rooms may be discovered
-        final boolean discoverLocked = MUCPersistenceManager.getBooleanProperty( room.getMUCService().getServiceName(), "discover.locked", true );
+        final boolean discoverLocked = MUCPersistenceManager.getBooleanProperty( room.getServiceName(), "discover.locked", true );
 
         if ( !discoverLocked && room.isLocked() )
         {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
@@ -10,15 +10,25 @@ import org.jivesoftware.openfire.muc.MUCRoom;
 
 /**
  * this class supports the simple LocalMUCRoom management including remove,add and query.
+ *
+ * Note that this implementation provides a representation of rooms that are currently actively loaded in memory only.
+ * More rooms might exist in the database.
+ *
  * @author <a href="mailto:583424568@qq.com">wuchang</a>
  * 2016-1-14
  */
 public class LocalMUCRoomManager {
     private final Map<String, LocalMUCRoom> rooms = new ConcurrentHashMap<>();
-     
+
+    /**
+     * Returns the number of chat rooms that are currently actively loaded in memory.
+     *
+     * @return a chat room count.
+     */
     public int getNumberChatRooms(){
         return rooms.size();
     }
+
     public void addRoom(final String roomname, final LocalMUCRoom room){
         rooms.put(roomname, room);
         GroupEventDispatcher.addListener(room);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
@@ -547,7 +547,7 @@ public class MUCPersistenceManager {
      * will be executed only when the service is starting up.
      *
      * @param chatserver the chat server that will hold the loaded rooms.
-     * @param cleanupDate rooms that hadn't been used before this date won't be loaded.
+     * @param cleanupDate rooms that hadn't been used after this date won't be loaded.
      * @param packetRouter the PacketRouter that loaded rooms will use to send packets.
      * @return a collection with all the persistent rooms.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCRoomSearchInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCRoomSearchInfo.java
@@ -1,0 +1,103 @@
+package org.jivesoftware.openfire.muc.spi;
+
+
+import org.jivesoftware.openfire.muc.MUCRoom;
+import org.xmpp.packet.JID;
+import org.xmpp.resultsetmanagement.Result;
+
+public class MUCRoomSearchInfo implements Result {
+
+    private final String serviceName;
+    private final JID jid;
+    private final String name;
+    private final String subject;
+    private final String naturalLanguageName;
+    private final String description;
+    private final boolean isLocked;
+    private final boolean isPublicRoom;
+    private final int occupantsCount;
+    private final int participantCount;
+    private final int maxUsers;
+    private final boolean isMembersOnly;
+    private final boolean isPasswordProtected;
+    private final boolean canAnyoneDiscoverJID;
+
+
+    public MUCRoomSearchInfo(final MUCRoom room) {
+        this.serviceName = room.getMUCService().getServiceName();
+        this.jid = room.getJID();
+        this.name = room.getName();
+        this.subject = room.getSubject();
+        this.naturalLanguageName = room.getNaturalLanguageName();
+        this.description = room.getDescription();
+        this.isLocked = room.isLocked();
+        this.isPublicRoom = room.isPublicRoom();
+        this.occupantsCount = room.getOccupantsCount();
+        this.participantCount = room.getParticipants().size();
+        this.maxUsers = room.getMaxUsers();
+        this.isMembersOnly = room.isMembersOnly();
+        this.isPasswordProtected = room.isPasswordProtected();
+        this.canAnyoneDiscoverJID = room.canAnyoneDiscoverJID();
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public JID getJID() {
+        return jid;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getNaturalLanguageName() {
+        return naturalLanguageName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isLocked() {
+        return isLocked;
+    }
+
+    public boolean isPublicRoom() {
+        return isPublicRoom;
+    }
+
+    public int getOccupantsCount() {
+        return occupantsCount;
+    }
+
+    public int getParticipantCount() {
+        return participantCount;
+    }
+
+    public int getMaxUsers() {
+        return maxUsers;
+    }
+
+    public boolean isMembersOnly() {
+        return isMembersOnly;
+    }
+
+    public boolean isPasswordProtected() {
+        return isPasswordProtected;
+    }
+
+    public boolean canAnyoneDiscoverJID() {
+        return canAnyoneDiscoverJID;
+    }
+
+    @Override
+    public String getUID() {
+        return getJID().toString();
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1543,12 +1543,16 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
 
         Log.info(LocaleUtils.getLocalizedString("startup.starting.muc", Collections.singletonList(getServiceDomain())));
 
-        // Load all the persistent rooms to memory
-        for (final LocalMUCRoom room : MUCPersistenceManager.loadRoomsFromDB(this, this.getCleanupDate(), router)) {
-            localMUCRoomManager.addRoom(room.getName().toLowerCase(),room);
+        final int preloadDays = MUCPersistenceManager.getIntProperty(chatServiceName, "preload.days", 30);
+        if (preloadDays > 0) {
+            // Load all the persistent rooms to memory
+            final Instant cutoff = Instant.now().minus(Duration.ofDays(preloadDays));
+            for (final LocalMUCRoom room : MUCPersistenceManager.loadRoomsFromDB(this, Date.from(cutoff), router)) {
+                localMUCRoomManager.addRoom(room.getName().toLowerCase(), room);
 
-            // Start FMUC, if desired.
-            room.getFmucHandler().applyConfigurationChanges();
+                // Start FMUC, if desired.
+                room.getFmucHandler().applyConfigurationChanges();
+            }
         }
     }
 

--- a/xmppserver/src/main/webapp/muc-room-summary.jsp
+++ b/xmppserver/src/main/webapp/muc-room-summary.jsp
@@ -24,6 +24,7 @@
 %>
 <%@ page import="org.jivesoftware.openfire.muc.MultiUserChatService" %>
 <%@ page import="org.xmpp.packet.JID" %>
+<%@ page import="java.util.stream.Collectors" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -67,13 +68,13 @@
     }
 
     // Get the rooms in the server
-    List<MUCRoom> rooms = mucService.getChatRooms();
-    Collections.sort(rooms, new Comparator<MUCRoom>() {
-        public int compare(MUCRoom room1, MUCRoom room2) {
-            return room1.getName().toLowerCase().compareTo(room2.getName().toLowerCase());
+//    List<MUCRoom> rooms = mucService.getChatRooms();
+    List<String> names = mucService.getAllRoomNames().stream().sorted(new Comparator<String>() {
+        public int compare(String room1, String room2) {
+            return room1.toLowerCase().compareTo(room2.toLowerCase());
         }
-    });
-    int roomsCount = rooms.size();
+    } ).collect(Collectors.toList());
+    int roomsCount = names.size();
 
     // paginator vars
     int numPages = (int)Math.ceil((double)roomsCount/(double)range);
@@ -169,7 +170,7 @@
 <tbody>
 
 <%  // Print the list of rooms
-    Iterator<MUCRoom> roomsPage = rooms.subList(start, maxRoomIndex).iterator();
+    Iterator<String> roomsPage = names.subList(start, maxRoomIndex).iterator();
     if (!roomsPage.hasNext()) {
 %>
     <tr>
@@ -182,7 +183,8 @@
     }
     int i = start;
     while (roomsPage.hasNext()) {
-        MUCRoom room = roomsPage.next();
+        String name = roomsPage.next();
+        MUCRoom room = mucService.getChatRoom(name); // This will load the room on-demand if it's not yet in memory.
         i++;
 %>
     <tr class="jive-<%= (((i%2)==0) ? "even" : "odd") %>">

--- a/xmppserver/src/main/webapp/muc-service-delete.jsp
+++ b/xmppserver/src/main/webapp/muc-service-delete.jsp
@@ -58,9 +58,14 @@
     if (delete) {
         // Delete the rooms in the service
         if (muc != null) {
-            for (MUCRoom room : muc.getChatRooms()) {
+            for (MUCRoom room : muc.getActiveChatRooms()) {
                 // If the room still exists then destroy it
                 room.destroyRoom(null, reason);
+            }
+
+            // Destroy all rooms that were not loaded in memory.
+            for (final String name : muc.getAllRoomNames()) {
+                muc.getChatRoom(name).destroyRoom(null, reason);
             }
             // Log the event
             webManager.logEvent("destroyed MUC service "+mucname, "reason = "+reason);

--- a/xmppserver/src/main/webapp/muc-service-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-service-edit-form.jsp
@@ -47,8 +47,18 @@
     boolean success = request.getParameter("success") != null;
     String mucname = ParamUtils.getParameter(request,"mucname");
     String mucdesc = ParamUtils.getParameter(request,"mucdesc");
+    int muccleanupdays = ParamUtils.getIntParameter(request, "muccleanupdays", 30);
+    boolean muckeep = ParamUtils.getBooleanParameter(request, "muckeep");
+    int mucpreloaddays = ParamUtils.getIntParameter(request, "mucpreloaddays", 30);
+    boolean mucpreload = ParamUtils.getBooleanParameter(request, "mucpreload");
     Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
     String csrfParam = ParamUtils.getParameter(request, "csrf");
+    if (muckeep) {
+        muccleanupdays = 0;
+    }
+    if (!mucpreload) {
+        mucpreloaddays = 0;
+    }
 
     if (save) {
         if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
@@ -71,7 +81,7 @@
     }
 
     // Handle a save
-    Map<String,String> errors = new HashMap<String,String>();
+    Map<String,String> errors = new HashMap<>();
     if (save) {
         // Make sure that the MUC Service is lower cased.
         mucname = mucname.toLowerCase();
@@ -86,7 +96,7 @@
                 errors.put("mucname", e.getMessage());
             }
         }
-        if (errors.size() == 0) {
+        if (errors.isEmpty()) {
             // Create or update the service.
             if (!create) {
                 webManager.getMultiUserChatManager().updateMultiUserChatService(mucname, mucname, mucdesc);
@@ -104,42 +114,40 @@
             }
 
             // Update settings only after the service has been created.
-            // TODO move the parsing and validation of these parameters to the section above, that does that for all other parameters.
-            String muccleanupdays = ParamUtils.getParameter(request, "muccleanupdays");
-            if (muccleanupdays != null) {
-                MUCPersistenceManager.setProperty(mucname, "unload.empty_days", muccleanupdays);
+            if (ParamUtils.getParameter(request, "muccleanupdays") != null || muckeep) { // Only explicitly store if set (otherwise use default).
+                MUCPersistenceManager.setProperty(mucname, "unload.empty_days", Integer.toString(muccleanupdays));
             }
 
-            if (ParamUtils.getParameter(request, "muckeep") != null) {
-                if (ParamUtils.getParameter(request, "muckeep").equalsIgnoreCase("on")) {
-                    MUCPersistenceManager.setProperty(mucname, "unload.empty_days", "0");
-                }
+            if (ParamUtils.getParameter(request, "mucpreloaddays") != null || !mucpreload) { // Only explicitly store if set (otherwise use default).
+                MUCPersistenceManager.setProperty(mucname, "preload.days", Integer.toString(mucpreloaddays));
             }
 
             // Log the event
             if (!create) {
-                webManager.logEvent("updated MUC service configuration for "+mucname, "name = "+mucname+"\ndescription = "+mucdesc);
+                webManager.logEvent("updated MUC service configuration for "+mucname, "name = "+mucname+"\ndescription = "+mucdesc+"\ncleanup = "+muccleanupdays+"\npreload = "+mucpreloaddays);
                 response.sendRedirect("muc-service-edit-form.jsp?success=true&mucname="+mucname);
                 return;
             } else {
-                webManager.logEvent("created MUC service "+mucname, "name = "+mucname+"\ndescription = "+mucdesc);
+                webManager.logEvent("created MUC service "+mucname, "name = "+mucname+"\ndescription = "+mucdesc+"\ncleanup = "+muccleanupdays+"\npreload = "+mucpreloaddays);
                 response.sendRedirect("muc-service-edit-form.jsp?success=true&mucname="+mucname);
                 return;
             }
         }
     }    
    
-    boolean muckeep = false;
-    String muccleanupdays = "30"; // default
 
     // When creating a new service (as opposed to editing an existing one), mucName will be initially empty (OF-1954)
 	if (mucname != null) {
-        muccleanupdays = MUCPersistenceManager.getProperty(mucname, "unload.empty_days", muccleanupdays);
+        muccleanupdays = MUCPersistenceManager.getIntProperty(mucname, "unload.empty_days", 30);
+        mucpreloaddays = MUCPersistenceManager.getIntProperty(mucname, "preload.days", 30);
+    } else {
+	    // Defaults for new room.
+	    muccleanupdays = 30;
+	    mucpreloaddays = 30;
     }
 
-	if (Integer.parseInt(muccleanupdays)<=0) {
-        muckeep = true;
-    }
+	muckeep = muccleanupdays<=0;
+	mucpreload = mucpreloaddays>0;
 %>
 
 <html>
@@ -154,15 +162,14 @@
 <meta name="helpPage" content="edit_group_chat_service_properties.html"/>    
 <script>
 	function checkMUCKeep() {
-		var checkedValue = null;
-		var inputKeeps = document.getElementsByName('muckeep');
+		var toggle = document.getElementsByName('muckeep');
 		var inputCleanups = document.getElementsByName('muccleanupdays');
-
-		if (inputKeeps[0].checked) {			
-			inputCleanups[0].disabled = true;			
-		} else {
-			inputCleanups[0].disabled = false;
-		}
+		inputCleanups[0].disabled = toggle[0].checked;
+	}
+	function checkMUCPreload() {
+        var toggle = document.getElementsByName('mucpreload');
+        var days = document.getElementsByName('mucpreloaddays');
+        days[0].disabled = !toggle[0].checked;
 	}
 </script>
 </head>
@@ -250,6 +257,23 @@
             </tr>
             <tr>
                 <td class="c1">
+                    <fmt:message key="groupchat.service.properties.label_service_preload" />
+                </td>
+                <td>
+                    <input type="checkbox" name="mucpreload" <%= mucpreload ? "checked" : "" %> onClick="checkMUCPreload();">
+                </td>
+            </tr>
+            <tr>
+                <td class="c1">
+                    <fmt:message key="groupchat.service.properties.label_service_preloaddays" />
+                </td>
+                <td>
+                    <input type="number" size="4" maxlength="3" name="mucpreloaddays" <%= mucpreload ? "" : "disabled" %> value="<%= mucpreloaddays %>">
+                </td>
+            </tr>
+
+            <tr>
+                <td class="c1">
                    <fmt:message key="groupchat.service.properties.label_service_muckeep" />
                 </td>
                 <td>
@@ -261,7 +285,7 @@
                    <fmt:message key="groupchat.service.properties.label_service_cleanupdays" />
                 </td>
                 <td>
-                    <input type="number" size="4" maxlength="3" name="muccleanupdays" <%= muckeep ? "disabled" : "" %> value="<%= (muccleanupdays != null ? StringUtils.escapeForXML(muccleanupdays) : "") %>">
+                    <input type="number" size="4" maxlength="3" name="muccleanupdays" <%= muckeep ? "disabled" : "" %> value="<%= muccleanupdays %>">
                 </td>
             </tr>
         </table>

--- a/xmppserver/src/main/webapp/muc-service-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-service-edit-form.jsp
@@ -255,6 +255,20 @@
                     <input type="text" size="30" maxlength="150" name="mucdesc" value="<%= (mucdesc != null ? StringUtils.escapeForXML(mucdesc) : "") %>">
                 </td>
             </tr>
+        </table>
+    </div>
+
+    <br/>
+
+    <p>
+        <fmt:message key="groupchat.service.properties.memory_management_description" />
+    </p>
+
+    <div class="jive-contentBoxHeader">
+        <fmt:message key="groupchat.service.properties.memory_management.legend" />
+    </div>
+    <div class="jive-contentBox">
+        <table cellpadding="3" cellspacing="0" border="0">
             <tr>
                 <td class="c1">
                     <fmt:message key="groupchat.service.properties.label_service_preload" />


### PR DESCRIPTION
The commits in this PR should:
- increase performance when loading many MUC rooms from the database
- allow administrators to disable pre-loading all MUC rooms from the database at startup
- stop Openfire from ignoring rooms that are unloaded from memory
- improve the admin console

Please refer to the commit messages for more details.