### PR TITLE
OF-2265: Websocket delivery should not depend on XmppSession being present

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
@@ -186,7 +186,11 @@ public class XmppWebSocket {
         if (isWebSocketOpen())
         {
             try {
-                xmppSession.incrementServerPacketCount();
+                if (xmppSession != null) { // OF-2265 In certain circumstances, the xmppSession can be absent (eg: when sending an error).
+                    xmppSession.incrementServerPacketCount();
+                } else {
+                    Log.debug("Packet delivery when no xmppSession is present. Should only occur exceptionally. Session: {}, Packet: {}", wsSession, packet);
+                }
                 wsSession.getRemote().sendStringByFuture(packet);
             } catch (Exception e) {
                 Log.error("Packet delivery failed; session: " + wsSession, e);


### PR DESCRIPTION
Although normally, an XmppSession will be available, that won't be the case when, for example, sending an error about the XmppSession not being available.

Not doing packet accounting (and resetting an idle time) is preferable to not delivering the message due to a NullPointerException.