### PR TITLE
Using unique values to prevent inter-test interference

### DIFF
--- a/xmppserver/src/test/java/org/jivesoftware/admin/LoginLimitManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/admin/LoginLimitManagerTest.java
@@ -2,6 +2,7 @@ package org.jivesoftware.admin;
 
 import org.jivesoftware.openfire.security.SecurityAuditManager;
 import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.StringUtils;
 import org.jivesoftware.util.SystemProperty;
 import org.jivesoftware.util.TaskEngine;
 import org.junit.After;
@@ -10,6 +11,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Random;
 
 import static org.mockito.Mockito.*;
 
@@ -28,27 +31,30 @@ public class LoginLimitManagerTest {
     @Test
     public void aSuccessfulLoginWillBeAudited() {
 
-        loginLimitManager.recordSuccessfulAttempt("test-user", "a.b.c.d");
+        final String username = "test-user-a-" + StringUtils.randomString(10);
+        loginLimitManager.recordSuccessfulAttempt(username, "a.b.c.d");
 
-        verify(securityAuditManager).logEvent("test-user", "Successful admin console login attempt", "The user logged in successfully to the admin console from address a.b.c.d. ");
+        verify(securityAuditManager).logEvent(username, "Successful admin console login attempt", "The user logged in successfully to the admin console from address a.b.c.d. ");
     }
 
     @Test
     public void aFailedLoginWillBeAudited() {
 
-        loginLimitManager.recordFailedAttempt("test-user", "a.b.c.d");
+        final String username = "test-user-b-" + StringUtils.randomString(10);
+        loginLimitManager.recordFailedAttempt(username, "a.b.c.e");
 
-        verify(securityAuditManager).logEvent("test-user", "Failed admin console login attempt", "A failed login attempt to the admin console was made from address a.b.c.d. ");
+        verify(securityAuditManager).logEvent(username, "Failed admin console login attempt", "A failed login attempt to the admin console was made from address a.b.c.e. ");
     }
 
     @Test
     public void lockoutsWillBeAudited() {
 
+        final String username = "test-user-c-" + StringUtils.randomString(10);
         for(int i = 0; i < 11; i ++) {
-            loginLimitManager.recordFailedAttempt("test-user", "a.b.c.d");
+            loginLimitManager.recordFailedAttempt(username, "a.b.c.f");
         }
 
-        verify(securityAuditManager, times(10)).logEvent("test-user", "Failed admin console login attempt", "A failed login attempt to the admin console was made from address a.b.c.d. ");
-        verify(securityAuditManager, times(1)).logEvent("test-user", "Failed admin console login attempt", "A failed login attempt to the admin console was made from address a.b.c.d. Future login attempts from this address will be temporarily locked out. Future login attempts for this user will be temporarily locked out. ");
+        verify(securityAuditManager, times(10)).logEvent(username, "Failed admin console login attempt", "A failed login attempt to the admin console was made from address a.b.c.f. ");
+        verify(securityAuditManager, times(1)).logEvent(username, "Failed admin console login attempt", "A failed login attempt to the admin console was made from address a.b.c.f. Future login attempts from this address will be temporarily locked out. Future login attempts for this user will be temporarily locked out. ");
     }
 }


### PR DESCRIPTION
By using different values for username and address, there's less of a chance of individual tests affecting the others (like what we've seen happen in Github Actions).