### PR TITLE
Add warm-up connection to connectivity tests

### DIFF
--- a/runConnectivityIntegrationTests
+++ b/runConnectivityIntegrationTests
@@ -164,6 +164,18 @@ public class ConnectivityTest
                 .build();
         final int iterations = 50;
 
+        // For some reason, the first connection on a freshly started instance on CI seems to fail. This attempts to work
+        // around that problem by ignoring the first connection attempt.
+        final XMPPBOSHConnection warmupCon = new XMPPBOSHConnection(config);
+        warmupCon.connect();
+        try {
+            warmupCon.login("john", "secret");
+        } catch (Throwable e) {
+            System.out.println("Warm-up connection failed with error message: " + e.getMessage());
+        } finally {
+            warmupCon.disconnect();
+        }
+
         // Execute system under test.
         int result = 0;
         for (int i=0; i<iterations; i++) {
@@ -200,6 +212,18 @@ public class ConnectivityTest
                 .setSecurityMode(ConnectionConfiguration.SecurityMode.disabled)
                 .build();
         final int iterations = 50;
+
+        // For some reason, the first connection on a freshly started instance on CI seems to fail. This attempts to work
+        // around that problem by ignoring the first connection attempt.
+        final XMPPTCPConnection warmupCon = new XMPPTCPConnection(config);
+        warmupCon.connect();
+        try {
+            warmupCon.login("john", "secret");
+        } catch (Throwable e) {
+            System.out.println("Warm-up connection failed with error message: " + e.getMessage());
+        } finally {
+            warmupCon.disconnect();
+        }
 
         // Execute system under test.
         int result = 0;


### PR DESCRIPTION
For reasons beyond me, one connection (out of many) for the BOSH connectivity test seems to fail - but only on the infrastructure for Github Actions.

From the output, it appears to be the _first_ connection that fails. I suspect that this is triggered by a weird scheduling/timing/eventing thingy that is specific to that environment.

This commit adds an additional connection attempt, for which the outcome will be ignored. Hopefully by 'warming up' the system under test, we get more stable results.