### PR TITLE
fix numeration on muc-room-summary table

### DIFF
--- a/xmppserver/src/main/webapp/muc-room-summary.jsp
+++ b/xmppserver/src/main/webapp/muc-room-summary.jsp
@@ -163,7 +163,7 @@
 %>
     <tr class="jive-<%= (((i%2)==0) ? "even" : "odd") %>">
         <td width="1%">
-            <%= i %>
+            <%= (i-1) %>
         </td>
         <td width="45%" valign="middle">
             <% if (room.getName().equals(room.getNaturalLanguageName())) { %>


### PR DESCRIPTION
now starting with 1 on first line

Issue: the muc line number in table starts with 2, not with 1 on first line