### PR TITLE
OF-2244 Store presence stanza for offline subscription requests

### DIFF
--- a/distribution/src/database/openfire_db2.sql
+++ b/distribution/src/database/openfire_db2.sql
@@ -59,6 +59,7 @@ CREATE TABLE ofRoster (
   ask                   INTEGER         NOT NULL,
   recv                  INTEGER         NOT NULL,
   nick                  VARCHAR(255),
+  stanza                CLOB,
   CONSTRAINT ofRoster_pk PRIMARY KEY (rosterID)
 );
 CREATE INDEX ofRoster_username_idx ON ofRoster (username ASC);
@@ -390,7 +391,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 32);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_hsqldb.sql
+++ b/distribution/src/database/openfire_hsqldb.sql
@@ -59,6 +59,7 @@ CREATE TABLE ofRoster (
   ask                   INTEGER         NOT NULL,
   recv                  INTEGER         NOT NULL,
   nick                  VARCHAR(255),
+  stanza                LONGVARCHAR,
   CONSTRAINT ofRoster_pk PRIMARY KEY (rosterID)
 );
 CREATE INDEX ofRoster_username_idx ON ofRoster (username);
@@ -376,7 +377,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 32);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
 
 // Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -56,6 +56,7 @@ CREATE TABLE ofRoster (
   ask                   TINYINT         NOT NULL,
   recv                  TINYINT         NOT NULL,
   nick                  VARCHAR(255),
+  stanza                TEXT,
   PRIMARY KEY (rosterID),
   INDEX ofRoster_unameid_idx (username),
   INDEX ofRoster_jid_idx (jid(255))
@@ -366,7 +367,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 32);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
 
 # Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -61,6 +61,7 @@ CREATE TABLE ofRoster (
   ask                   INTEGER         NOT NULL,
   recv                  INTEGER         NOT NULL,
   nick                  VARCHAR2(255),
+  stanza                VARCHAR2(4000),
   CONSTRAINT ofRoster_pk PRIMARY KEY (rosterID)
 );
 CREATE INDEX ofRoster_username_idx ON ofRoster (username ASC);
@@ -374,7 +375,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 32);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -63,6 +63,7 @@ CREATE TABLE ofRoster (
   ask                   INTEGER         NOT NULL,
   recv                  INTEGER         NOT NULL,
   nick                  VARCHAR(255),
+  stanza                TEXT,
   CONSTRAINT ofRoster_pk PRIMARY KEY (rosterID)
 );
 CREATE INDEX ofRoster_username_idx ON ofRoster (username);
@@ -382,7 +383,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 32);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -61,6 +61,7 @@ CREATE TABLE ofRoster (
   ask                   INTEGER         NOT NULL,
   recv                  INTEGER         NOT NULL,
   nick                  NVARCHAR(255),
+  stanza                NTEXT,
   CONSTRAINT ofRoster_pk PRIMARY KEY (rosterID)
 );
 CREATE INDEX ofRoster_username_idx ON ofRoster (username ASC);
@@ -379,7 +380,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 32);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -60,6 +60,7 @@ CREATE TABLE ofRoster (
   ask                   INTEGER         NOT NULL,
   recv                  INTEGER         NOT NULL,
   nick                  NVARCHAR(255)   NULL,
+  stanza                TEXT,
   CONSTRAINT ofRoster_pk PRIMARY KEY (rosterID)
 )
 CREATE INDEX ofRoster_username_idx ON ofRoster (username ASC)
@@ -379,7 +380,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1)
 INSERT INTO ofID (idType, id) VALUES (26, 2)
 INSERT INTO ofID (idType, id) VALUES (27, 1)
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 32)
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 33)
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/upgrade/33/openfire_db2.sql
+++ b/distribution/src/database/upgrade/33/openfire_db2.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ofRoster ADD COLUMN stanza CLOB;
+
+UPDATE ofVersion SET version = 33 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/33/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/33/openfire_hsqldb.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ofRoster ADD COLUMN stanza LONGVARCHAR NULL;
+
+UPDATE ofVersion SET version = 33 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/33/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/33/openfire_mysql.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ofRoster ADD COLUMN stanza TEXT NULL;
+
+UPDATE ofVersion SET version = 33 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/33/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/33/openfire_oracle.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ofRoster ADD stanza VARCHAR2(4000) NULL;
+
+UPDATE ofVersion SET version = 33 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/33/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/33/openfire_postgresql.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ofRoster ADD COLUMN stanza TEXT NULL;
+
+UPDATE ofVersion SET version = 33 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/33/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/33/openfire_sqlserver.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ofRoster ADD stanza NTEXT NULL;
+
+UPDATE ofVersion SET version = 33 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/33/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/33/openfire_sybase.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ofRoster ADD COLUMN stanza TEXT NULL;
+
+UPDATE ofVersion SET version = 33 WHERE name = 'openfire';

--- a/xmppserver/src/main/java/org/jivesoftware/admin/AdminConsole.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AdminConsole.java
@@ -234,6 +234,9 @@ public class AdminConsole {
         }
         catch (Exception e) {
             Log.error("Failure when parsing main admin-sidebar.xml file", e);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
         }
         try {
             in.close();
@@ -274,6 +277,9 @@ public class AdminConsole {
                     msg += " from resource: " + url.toString();
                 }
                 Log.warn(msg, e);
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
             }
             try {
                 if(classLoader != null && gitprops.isEmpty()){

--- a/xmppserver/src/main/java/org/jivesoftware/admin/AdminConsole.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AdminConsole.java
@@ -17,13 +17,12 @@
 package org.jivesoftware.admin;
 
 import org.dom4j.*;
-import org.dom4j.io.SAXReader;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.util.ClassUtils;
 import org.jivesoftware.util.LocaleUtils;
+import org.jivesoftware.util.SAXReaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -68,7 +67,7 @@ public class AdminConsole {
      * @throws Exception if an error occurs when parsing the XML or adding it to the model.
      */
     public static void addModel(String name, InputStream in) throws Exception {
-        Document doc = getDocument(in);
+        Document doc = SAXReaderUtil.readDocument(in);
         addModel(name, (Element)doc.selectSingleNode("/adminconsole"));
     }
 
@@ -230,7 +229,7 @@ public class AdminConsole {
             return;
         }
         try {
-            Document doc = getDocument(in);
+            Document doc = SAXReaderUtil.readDocument(in);
             coreModel = (Element)doc.selectSingleNode("/adminconsole");
         }
         catch (Exception e) {
@@ -496,14 +495,5 @@ public class AdminConsole {
                 return 0;
             }
         }
-    }
-
-    private static Document getDocument(InputStream in) throws SAXException, DocumentException {
-        SAXReader saxReader = new SAXReader();
-        saxReader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        saxReader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        saxReader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        saxReader.setIgnoreComments(true);
-        return saxReader.read(in);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
@@ -68,7 +68,7 @@ public class SchemaManager {
     /**
      * Current Openfire database schema version.
      */
-    private static final int DATABASE_VERSION = 32  ;
+    private static final int DATABASE_VERSION = 33;
 
     /**
      * Checks the Openfire database schema to ensure that it's installed and up to date.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -39,8 +39,6 @@ import com.google.common.util.concurrent.SimpleTimeLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.io.SAXReader;
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.database.JNDIDataSourceProvider;
 import org.jivesoftware.openfire.admin.AdminManager;
@@ -119,17 +117,11 @@ import org.jivesoftware.openfire.update.UpdateManager;
 import org.jivesoftware.openfire.user.User;
 import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.openfire.vcard.VCardManager;
-import org.jivesoftware.util.InitializationException;
-import org.jivesoftware.util.JiveGlobals;
-import org.jivesoftware.util.LocaleUtils;
-import org.jivesoftware.util.Log;
-import org.jivesoftware.util.SystemProperty;
-import org.jivesoftware.util.TaskEngine;
+import org.jivesoftware.util.*;
 import org.jivesoftware.openfire.archive.ArchiveManager;
 import org.jivesoftware.util.cache.CacheFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 
@@ -1134,8 +1126,7 @@ public class XMPPServer {
         if (openfireHome == null) {
             try (InputStream in = getClass().getResourceAsStream("/openfire_init.xml")) {
                 if (in != null) {
-                    Document doc = readDocument(in);
-                    String path = doc.getRootElement().getText();
+                    String path = SAXReaderUtil.readRootElement(in).getText();
                     try {
                         if (path != null) {
                             openfireHome = verifyHome(path, jiveConfigName);
@@ -1162,14 +1153,6 @@ public class XMPPServer {
             // Set the name of the config file
             JiveGlobals.setConfigName(jiveConfigName);
         }
-    }
-
-    private Document readDocument(InputStream in) throws SAXException, DocumentException {
-        SAXReader reader = new SAXReader();
-        reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        return reader.read(in);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -1140,6 +1140,9 @@ public class XMPPServer {
             catch (Exception e) {
                 System.err.println("Error loading openfire_init.xml to find home.");
                 e.printStackTrace();
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginCacheConfigurator.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginCacheConfigurator.java
@@ -76,8 +76,10 @@ public class PluginCacheConfigurator {
             for (Node mapping: mappings) {
                 registerCache(pluginName, mapping);
             }
-        }
-        catch (ExecutionException | InterruptedException e) {
+        } catch (ExecutionException e) {
+            Log.error(e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             Log.error(e.getMessage(), e);
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginCacheConfigurator.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginCacheConfigurator.java
@@ -20,11 +20,13 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.Node;
 import org.dom4j.io.SAXReader;
+import org.jivesoftware.util.SAXReaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
@@ -69,13 +71,13 @@ public class PluginCacheConfigurator {
 
     public void configure(String pluginName) {
         try {
-            Document cacheXml = readDocument(configDataStream);
+            Document cacheXml = SAXReaderUtil.readDocument(configDataStream);
             List<Node> mappings = cacheXml.selectNodes("/cache-config/cache-mapping");
             for (Node mapping: mappings) {
                 registerCache(pluginName, mapping);
             }
         }
-        catch (DocumentException | SAXException e) {
+        catch (ExecutionException | InterruptedException e) {
             Log.error(e.getMessage(), e);
         }
     }
@@ -103,13 +105,5 @@ public class PluginCacheConfigurator {
         }
 
         return paramMap;
-    }
-
-    private Document readDocument(InputStream in) throws SAXException, DocumentException {
-        SAXReader reader = new SAXReader();
-        reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        return reader.read(in);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -724,6 +724,9 @@ public class PluginManager
                 count = 0;
             }
             failureToLoadCount.put( canonicalName, ++count );
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             return false;
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -16,54 +16,31 @@
 
 package org.jivesoftware.openfire.container;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.DirectoryStream;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.jar.JarFile;
-import java.util.zip.ZipException;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.spi.LoggerContext;
 import org.dom4j.Attribute;
 import org.dom4j.Document;
 import org.dom4j.Element;
-import org.dom4j.io.SAXReader;
 import org.jivesoftware.admin.AdminConsole;
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.util.JavaSpecVersion;
-import org.jivesoftware.util.JiveGlobals;
-import org.jivesoftware.util.LocaleUtils;
-import org.jivesoftware.util.StringUtils;
-import org.jivesoftware.util.SystemProperty;
-import org.jivesoftware.util.Version;
+import org.jivesoftware.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
 
 import javax.annotation.concurrent.GuardedBy;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.jar.JarFile;
+import java.util.zip.ZipException;
 
 /**
  * Manages plugins.
@@ -617,8 +594,7 @@ public class PluginManager
             }
 
             // Instantiate the plugin!
-            final SAXReader saxReader = setupSAXReader();
-            final Document pluginXML = saxReader.read( pluginConfig.toFile() );
+            final Document pluginXML = SAXReaderUtil.readDocument( pluginConfig.toFile() );
 
             final String className = pluginXML.selectSingleNode( "/plugin/class" ).getText().trim();
             final Plugin plugin;
@@ -750,15 +726,6 @@ public class PluginManager
             failureToLoadCount.put( canonicalName, ++count );
             return false;
         }
-    }
-
-    private SAXReader setupSAXReader() throws SAXException {
-        final SAXReader saxReader = new SAXReader();
-        saxReader.setEncoding( "UTF-8" );
-        saxReader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        saxReader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        saxReader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        return saxReader;
     }
 
     private PluginDevEnvironment configurePluginDevEnvironment( final Path pluginDir, String classesDir, String webRoot ) throws IOException

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadataHelper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadataHelper.java
@@ -16,24 +16,20 @@
 
 package org.jivesoftware.openfire.container;
 
-import java.io.IOException;
+import org.dom4j.Document;
+import org.dom4j.Element;
+import org.jivesoftware.admin.AdminConsole;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.util.JavaSpecVersion;
+import org.jivesoftware.util.SAXReaderUtil;
+import org.jivesoftware.util.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import org.dom4j.Document;
-import org.dom4j.Element;
-import org.dom4j.io.SAXReader;
-import org.jivesoftware.admin.AdminConsole;
-import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.util.JavaSpecVersion;
-import org.jivesoftware.util.Version;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xml.sax.EntityResolver;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
 /**
  * Various helper methods to retrieve plugin metadat from plugin.xml files.
@@ -552,8 +548,7 @@ public class PluginMetadataHelper
             final Path pluginConfig = pluginDir.resolve( "plugin.xml" );
             if ( Files.exists( pluginConfig ) )
             {
-                final SAXReader saxReader = setupSAXReader();
-                final Document pluginXML = saxReader.read( pluginConfig.toFile() );
+                final Document pluginXML = SAXReaderUtil.readDocument( pluginConfig.toFile() );
                 final Element element = (Element) pluginXML.selectSingleNode( xpath );
                 if ( element != null )
                 {
@@ -566,17 +561,5 @@ public class PluginMetadataHelper
             Log.error( "Unable to get element value '{}' from plugin.xml of plugin in '{}':", xpath, pluginDir, e );
         }
         return null;
-    }
-
-    private static SAXReader setupSAXReader() throws SAXException {
-        final SAXReader saxReader = new SAXReader();
-        saxReader.setEntityResolver((publicId, systemId) -> {
-            throw new IOException("External entity denied: " + publicId + " // " + systemId);
-        });
-        saxReader.setEncoding( "UTF-8" );
-        saxReader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        saxReader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        saxReader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        return saxReader;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadataHelper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadataHelper.java
@@ -559,6 +559,10 @@ public class PluginMetadataHelper
         catch ( Exception e )
         {
             Log.error( "Unable to get element value '{}' from plugin.xml of plugin in '{}':", xpath, pluginDir, e );
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+
         }
         return null;
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdVCardProvider.java
@@ -15,23 +15,19 @@
  */
 package org.jivesoftware.openfire.crowd;
 
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
 import org.dom4j.Element;
-import org.dom4j.io.SAXReader;
 import org.jivesoftware.openfire.crowd.jaxb.User;
 import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.openfire.vcard.DefaultVCardProvider;
 import org.jivesoftware.util.AlreadyExistsException;
 import org.jivesoftware.util.NotFoundException;
+import org.jivesoftware.util.SAXReaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 
 /**
  * VCard provider for Crowd.
@@ -74,12 +70,11 @@ public class CrowdVCardProvider extends DefaultVCardProvider {
                             .replace("@firstname@", user.firstName)
                             .replace("@email@", user.email)
                             .replace("@nickname@", username);
-                    vcard = readDocument(new StringReader(str)).getRootElement();
-                    
+                    vcard = SAXReaderUtil.readRootElement(str);
                 } catch (UserNotFoundException unfe) {
                     LOG.error("Unable to find user:" + String.valueOf(username) + " for loading its vcard", unfe);
                     return null;
-                } catch (DocumentException | SAXException e) {
+                } catch (ExecutionException | InterruptedException e) {
                     LOG.error("vcard parsing error", e);
                     return null;
                 }
@@ -154,13 +149,5 @@ public class CrowdVCardProvider extends DefaultVCardProvider {
         }
 
         return super.updateVCard(username, vCard);
-    }
-
-    private Document readDocument(Reader in) throws SAXException, DocumentException {
-        SAXReader reader = new SAXReader();
-        reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        return reader.read(in);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdVCardProvider.java
@@ -72,10 +72,14 @@ public class CrowdVCardProvider extends DefaultVCardProvider {
                             .replace("@nickname@", username);
                     vcard = SAXReaderUtil.readRootElement(str);
                 } catch (UserNotFoundException unfe) {
-                    LOG.error("Unable to find user:" + String.valueOf(username) + " for loading its vcard", unfe);
+                    LOG.error("Unable to find user '{}' for loading its vcard", username, unfe);
                     return null;
-                } catch (ExecutionException | InterruptedException e) {
-                    LOG.error("vcard parsing error", e);
+                } catch (ExecutionException e) {
+                    LOG.error("VCard parsing error", e);
+                    return null;
+                } catch (InterruptedException e) {
+                    LOG.error("VCard parsing interrupted", e);
+                    Thread.currentThread().interrupt();
                     return null;
                 }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
@@ -151,12 +151,12 @@ public class PresenceSubscribeHandler extends BasicModule implements ChannelHand
             try {
                 Roster senderRoster = getRoster(senderJID);
                 if (senderRoster != null) {
-                    manageSub(recipientJID, true, type, senderRoster);
+                    manageSub(recipientJID, true, presence, senderRoster);
                 }
                 Roster recipientRoster = getRoster(recipientJID);
                 boolean recipientSubChanged = false;
                 if (recipientRoster != null) {
-                    recipientSubChanged = manageSub(senderJID, false, type, recipientRoster);
+                    recipientSubChanged = manageSub(senderJID, false, presence, recipientRoster);
                 }
 
                 // Do not forward the packet to the recipient if the presence is of type subscribed
@@ -268,17 +268,18 @@ public class PresenceSubscribeHandler extends BasicModule implements ChannelHand
      *
      * @param target    The roster target's jid (the item's jid to be changed)
      * @param isSending True if the request is being sent by the owner
-     * @param type      The subscription change type (subscribe, unsubscribe, etc.)
+     * @param presence      The subscription stanza
      * @param roster    The Roster that is updated.
      * @return {@code true} if the subscription state has changed.
      */
-    private boolean manageSub(JID target, boolean isSending, Presence.Type type, Roster roster)
-            throws UserAlreadyExistsException, SharedGroupException
+    private boolean manageSub(JID target, boolean isSending, Presence presence, Roster roster)
+            throws UserAlreadyExistsException, SharedGroupException, IllegalArgumentException
     {
         RosterItem item = null;
         RosterItem.AskType oldAsk;
         RosterItem.SubType oldSub = null;
         RosterItem.RecvType oldRecv;
+        Presence.Type type = presence.getType();
         boolean newItem = false;
         try {
             if (roster.isRosterItem(target)) {
@@ -291,6 +292,9 @@ public class PresenceSubscribeHandler extends BasicModule implements ChannelHand
                     // an unsubscription or receiving an unsubscription request or a
                     // subscription approval from an unknown user
                     return false;
+                }
+                if (Presence.Type.subscribe != type) {
+                    throw new IllegalArgumentException("manageSub asked to manage non-subscription presence");
                 }
                 item = roster.createRosterItem(target, false, true);
                 newItem = true;
@@ -311,6 +315,9 @@ public class PresenceSubscribeHandler extends BasicModule implements ChannelHand
                 if (item.getSubStatus() != RosterItem.SUB_NONE ||
                         item.getRecvStatus() != RosterItem.RECV_SUBSCRIBE) {
                     roster.broadcast(item, false);
+                } else {
+                    // For <presence type='subscribe'/>, we should update the stored stanza here.
+                    item.setStoredSubscribeStanza(presence);
                 }
             }
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -244,10 +244,11 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
             if (RosterManager.isRosterServiceEnabled()) {
                 Roster roster = rosterManager.getRoster(username);
                 for (RosterItem item : roster.getRosterItems()) {
-                    if (item.getRecvStatus() == RosterItem.RECV_SUBSCRIBE) {
-                        session.process(createSubscribePresence(item.getJid(),
-                                session.getAddress().asBareJID(), true));
-                    } else if (item.getRecvStatus() == RosterItem.RECV_UNSUBSCRIBE) {
+                    if (item.getRecvStatus() == RosterItem.RecvType.SUBSCRIBE) {
+                        Presence presence = item.getSubscribeStanza();
+                        presence.setTo(session.getAddress().asBareJID());
+                        session.process(presence);
+                    } else if (item.getRecvStatus() == RosterItem.RecvType.UNSUBSCRIBE) {
                         session.process(createSubscribePresence(item.getJid(),
                                 session.getAddress().asBareJID(), false));
                     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
@@ -181,6 +181,9 @@ public final class MUCRoomHistory {
                 }
             } catch (Exception ex) {
                 Log.error("Failed to parse payload XML", ex);
+                if (ex instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
         message.setSubject(subject);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
@@ -19,17 +19,15 @@ package org.jivesoftware.openfire.muc;
 import org.dom4j.Attribute;
 import org.dom4j.Element;
 import org.dom4j.Namespace;
-import org.dom4j.io.SAXReader;
 import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.jivesoftware.util.SAXReaderUtil;
 import org.jivesoftware.util.XMPPDateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 
 import javax.annotation.Nullable;
-import java.io.StringReader;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -156,34 +154,12 @@ public final class MUCRoomHistory {
     public void addOldMessage(String senderJID, String nickname, Date sentDate, String subject,
             String body, String stanza)
     {
-        try {
-            addOldMessage(senderJID, nickname, sentDate, subject, body, stanza, setupSAXReader());
-        } catch (Exception ex) {
-            Log.error("Failed to parse payload XML", ex);
-        }
-    }
-
-    /**
-     * Creates a new message and adds it to the history. The new message will be created based on
-     * the provided information. This information will likely come from the database when loading
-     * the room history from the database.
-     *
-     * @param senderJID the sender's JID of the message to add to the history.
-     * @param nickname the sender's nickname of the message to add to the history.
-     * @param sentDate the date when the message was sent to the room.
-     * @param subject the subject included in the message.
-     * @param body the body of the message.
-     * @param stanza the stanza to add
-     */
-    public void addOldMessage(String senderJID, String nickname, Date sentDate, String subject,
-                              String body, String stanza, SAXReader xmlReader)
-    {
         Message message = new Message();
         message.setType(Message.Type.groupchat);
         if (stanza != null) {
             // payload initialized as XML string from DB
             try {
-                Element element = xmlReader.read(new StringReader(stanza)).getRootElement();
+                Element element = SAXReaderUtil.readRootElement(stanza);
                 for (Element child : (List<Element>)element.elements()) {
                     Namespace ns = child.getNamespace();
                     if (ns == null || ns.getURI().equals("jabber:client") || ns.getURI().equals("jabber:server")) {
@@ -232,15 +208,6 @@ public final class MUCRoomHistory {
             delayInformation.addAttribute("from", room.getRole().getRoleAddress().toString());
         }
         historyStrategy.addMessage(message);
-    }
-
-    public static SAXReader setupSAXReader() throws SAXException {
-        SAXReader xmlReader = new SAXReader();
-        xmlReader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        xmlReader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        xmlReader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        xmlReader.setEncoding("UTF-8");
-        return xmlReader;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyListProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyListProvider.java
@@ -168,6 +168,9 @@ public class PrivacyListProvider {
         }
         catch (Exception e) {
             Log.error(e.getMessage(), e);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
         }
 
         return privacyList;
@@ -220,6 +223,9 @@ public class PrivacyListProvider {
         }
         catch (Exception e) {
             Log.error(e.getMessage(), e);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
         }
 
         return privacyList;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PublishedItem.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PublishedItem.java
@@ -173,7 +173,10 @@ public class PublishedItem implements Serializable {
                     try {
                         payload = SAXReaderUtil.readRootElement(payloadXML);
                     } catch (Exception ex) {
-                         log.error("Failed to parse payload XML", ex);
+                        log.error("Failed to parse payload XML", ex);
+                        if (ex instanceof InterruptedException) {
+                            Thread.currentThread().interrupt();
+                        }
                     }
                 }
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
@@ -62,14 +62,14 @@ public class DefaultRosterItemProvider implements RosterItemProvider {
     private static final Logger Log = LoggerFactory.getLogger(DefaultRosterItemProvider.class);
 
     private static final String CREATE_ROSTER_ITEM =
-            "INSERT INTO ofRoster (username, rosterID, jid, sub, ask, recv, nick) " +
-            "VALUES (?, ?, ?, ?, ?, ?, ?)";
+            "INSERT INTO ofRoster (username, rosterID, jid, sub, ask, recv, nick, stanza) " +
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
     private static final String UPDATE_ROSTER_ITEM =
             "UPDATE ofRoster SET sub=?, ask=?, recv=?, nick=?, stanza=? WHERE rosterID=?";
     private static final String DELETE_ROSTER_ITEM_GROUPS =
             "DELETE FROM ofRosterGroups WHERE rosterID=?";
     private static final String CREATE_ROSTER_ITEM_GROUPS =
-            "INSERT INTO ofRosterGroups (rosterID, %s, groupName, stanza) VALUES (?, ?, ?, ?)";
+            "INSERT INTO ofRosterGroups (rosterID, %s, groupName) VALUES (?, ?, ?)";
     private static final String DELETE_ROSTER_ITEM =
             "DELETE FROM ofRoster WHERE rosterID=?";
     private static final String LOAD_USERNAMES =
@@ -113,6 +113,7 @@ public class DefaultRosterItemProvider implements RosterItemProvider {
             pstmt.setInt(5, item.getAskStatus().getValue());
             pstmt.setInt(6, item.getRecvStatus().getValue());
             pstmt.setString(7, item.getNickname());
+            pstmt.setString(8, item.getStoredSubscribeStanza() == null ? null : item.getStoredSubscribeStanza().toXML());
             pstmt.executeUpdate();
 
             item.setID(rosterID);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
@@ -304,8 +304,11 @@ public class DefaultRosterItemProvider implements RosterItemProvider {
 
             rosterItemCache.put( username, itemList );
         }
-        catch (SQLException | InterruptedException | ExecutionException e) {
+        catch (SQLException | ExecutionException e) {
             Log.error(LocaleUtils.getLocalizedString("admin.error"), e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
         finally {
             DbConnectionManager.closeConnection(rs, pstmt, con);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
@@ -133,7 +133,7 @@ public class DefaultRosterItemProvider implements RosterItemProvider {
             pstmt.setInt(2, item.getAskStatus().getValue());
             pstmt.setInt(3, item.getRecvStatus().getValue());
             pstmt.setString(4, item.getNickname());
-            pstmt.setString(5, item.getStoredSubscribeStanza().toXML());
+            pstmt.setString(5, item.getStoredSubscribeStanza() == null ? null : item.getStoredSubscribeStanza().toXML());
             pstmt.setLong(6, rosterID);
             pstmt.executeUpdate();
             // Close now the statement (do not wait to be GC'ed)

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
@@ -297,6 +297,9 @@ public class DefaultRosterItemProvider implements RosterItemProvider {
                         RosterItem.RecvType.getTypeFromInt(rs.getInt(5)),
                         rs.getString(6),
                         null);
+                if (presence != null) {
+                    item.setStoredSubscribeStanza(presence);
+                }
                 // Add the loaded RosterItem (ie. user contact) to the result
                 itemList.add(item);
                 itemsByID.put(item.getID(), item);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItem.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItem.java
@@ -617,7 +617,9 @@ public class RosterItem implements Cacheable, Externalizable {
         size += CacheSizes.sizeOfInt(); // askStatus
         size += CacheSizes.sizeOfInt(); // recvStatus
         size += CacheSizes.sizeOfLong(); // id
-        size += CacheSizes.sizeOfString(subscribeStanza.toXML());
+        if (subscribeStanza != null) {
+            size += CacheSizes.sizeOfString(subscribeStanza.toXML());
+        }
         return size;
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/PluginDownloadManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/PluginDownloadManager.java
@@ -94,6 +94,10 @@ public class PluginDownloadManager {
         }
         catch (Exception e) {
             Log.error(e.getMessage(), e);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+
         }
 
         return false;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
@@ -163,6 +163,9 @@ public class UpdateManager extends BasicModule {
                             }
                             catch (Exception e) {
                                 Log.error("Error checking for updates", e);
+                                if (e instanceof InterruptedException) {
+                                    Thread.currentThread().interrupt();
+                                }
                             }
                             // Keep track of the last time we checked for updates.
                             final Instant lastUpdate = Instant.now();
@@ -181,6 +184,7 @@ public class UpdateManager extends BasicModule {
                 }
                 catch (InterruptedException e) {
                     Log.error(e.getMessage(), e);
+                    Thread.currentThread().interrupt();
                 }
                 finally {
                     // Clean up reference to this thread
@@ -783,6 +787,9 @@ public class UpdateManager extends BasicModule {
             xmlResponse = SAXReaderUtil.readDocument(file);
         } catch (Exception e) {
             Log.error("Error reading server-update.xml", e);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             return;
         }
 
@@ -833,6 +840,9 @@ public class UpdateManager extends BasicModule {
             xmlResponse = SAXReaderUtil.readDocument(file);
         } catch (Exception e) {
             Log.error("Error reading available-plugins.xml", e);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             return;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
@@ -71,6 +71,9 @@ public class DefaultVCardProvider implements VCardProvider {
             }
             catch (Exception e) {
                 Log.error("Error loading vCard of username: " + username, e);
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
             }
             finally {
                 DbConnectionManager.closeConnection(rs, pstmt, con);

--- a/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
@@ -223,7 +223,7 @@ public final class SAXReaderUtil
             try {
                 return constructNewReader();
             } catch (SAXException e) {
-                Log.error("Unable to parse XML data.", e);
+                Log.error("Unable to construct a new XML parser.", e);
                 return null;
             }
         });

--- a/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
@@ -91,11 +91,27 @@ public final class SAXReaderUtil
     }
 
     /**
+     * Schedules parsing of the provided input stream into an XML Document as an asynchronous process. This method
+     * returns a {@link Future} object that can be used to obtain the result of the asynchronous process.
+     *
+     * The XML parsing is delegated to a limited set of parsers, that is fronted by an Executor Service. The amount of
+     * parsers that are available is equal to the amount of threads available in the Executor Service. This can be
+     * optimized by using the SystemProperties in this class.
+     *
+     * @param stream The data to be parsed as an XML Document.
+     * @return A Future representing pending completion of parsing the provided data as an XML Document.
+     */
+    public static Future<Document> readDocumentAsync(@Nonnull final InputStream stream) {
+        return parserService.submit(new ParserTask(stream));
+    }
+
+    /**
      * Parses an XML Document from the content provided by an input stream.
      *
-     * The XML parsing is delegated to a limited set of parsers. When a parser is not immediately available, this method
-     * will block until one becomes available. The availability of parsers can be optimized by using the SystemProperties
-     * in this class.
+     * Equivalent to calling <tt>readDocumentAsync(input).get()</tt>
+     *
+     * The XML parsing is delegated to a limited set of parsers, as documented in {@link #readDocumentAsync(InputStream)}.
+     * When a parser is not immediately available, this method will block until one becomes available.
      *
      * @param stream The data to be parsed as an XML Document.
      * @return an XML Document.
@@ -103,7 +119,7 @@ public final class SAXReaderUtil
      * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Document readDocument(@Nonnull final InputStream stream) throws ExecutionException, InterruptedException {
-        return parserService.submit(new ParserTask(stream)).get();
+        return readDocumentAsync(stream).get();
     }
 
     /**
@@ -121,11 +137,27 @@ public final class SAXReaderUtil
     }
 
     /**
+     * Schedules parsing of the provided text into an XML Document as an asynchronous process. This method
+     * returns a {@link Future} object that can be used to obtain the result of the asynchronous process.
+     *
+     * The XML parsing is delegated to a limited set of parsers, that is fronted by an Executor Service. The amount of
+     * parsers that are available is equal to the amount of threads available in the Executor Service. This can be
+     * optimized by using the SystemProperties in this class.
+     *
+     * @param text The data to be parsed as an XML Document.
+     * @return A Future representing pending completion of parsing the provided data as an XML Document.
+     */
+    public static Future<Document> readDocumentAsync(@Nonnull final String text) {
+        return parserService.submit(new ParserTask(new StringReader(text)));
+    }
+
+    /**
      * Parses an XML Document from the provided text.
      *
-     * The XML parsing is delegated to a limited set of parsers. When a parser is not immediately available, this method
-     * will block until one becomes available. The availability of parsers can be optimized by using the SystemProperties
-     * in this class.
+     * Equivalent to calling <tt>readDocumentAsync(input).get()</tt>
+     *
+     * The XML parsing is delegated to a limited set of parsers, as documented in {@link #readDocumentAsync(String)}.
+     * When a parser is not immediately available, this method will block until one becomes available.
      *
      * @param text The data to be parsed as an XML Document.
      * @return an XML Document.
@@ -133,7 +165,7 @@ public final class SAXReaderUtil
      * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Document readDocument(@Nonnull final String text) throws ExecutionException, InterruptedException {
-        return parserService.submit(new ParserTask(new StringReader(text))).get();
+        return readDocumentAsync(text).get();
     }
 
     /**
@@ -151,11 +183,27 @@ public final class SAXReaderUtil
     }
 
     /**
+     * Schedules parsing of the provided reader into an XML Document as an asynchronous process. This method
+     * returns a {@link Future} object that can be used to obtain the result of the asynchronous process.
+     *
+     * The XML parsing is delegated to a limited set of parsers, that is fronted by an Executor Service. The amount of
+     * parsers that are available is equal to the amount of threads available in the Executor Service. This can be
+     * optimized by using the SystemProperties in this class.
+     *
+     * @param reader The data to be parsed as an XML Document.
+     * @return A Future representing pending completion of parsing the provided data as an XML Document.
+     */
+    public static Future<Document> readDocumentAsync(@Nonnull final Reader reader) {
+        return parserService.submit(new ParserTask(reader));
+    }
+
+    /**
      * Parses an XML Document from the content provided by a reader.
      *
-     * The XML parsing is delegated to a limited set of parsers. When a parser is not immediately available, this method
-     * will block until one becomes available. The availability of parsers can be optimized by using the SystemProperties
-     * in this class.
+     * Equivalent to calling <tt>readDocumentAsync(input).get()</tt>
+     *
+     * The XML parsing is delegated to a limited set of parsers, as documented in {@link #readDocumentAsync(Reader)}.
+     * When a parser is not immediately available, this method will block until one becomes available.
      *
      * @param reader The data to be parsed as an XML Document.
      * @return an XML Document.
@@ -163,7 +211,7 @@ public final class SAXReaderUtil
      * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Document readDocument(@Nonnull final Reader reader) throws ExecutionException, InterruptedException {
-        return parserService.submit(new ParserTask(reader)).get();
+        return readDocumentAsync(reader).get();
     }
 
     /**
@@ -181,11 +229,27 @@ public final class SAXReaderUtil
     }
 
     /**
+     * Schedules parsing of content of afile into an XML Document as an asynchronous process. This method
+     * returns a {@link Future} object that can be used to obtain the result of the asynchronous process.
+     *
+     * The XML parsing is delegated to a limited set of parsers, that is fronted by an Executor Service. The amount of
+     * parsers that are available is equal to the amount of threads available in the Executor Service. This can be
+     * optimized by using the SystemProperties in this class.
+     *
+     * @param file The data to be parsed as an XML Document.
+     * @return A Future representing pending completion of parsing the provided data as an XML Document.
+     */
+    public static Future<Document> readDocumentAsync(@Nonnull final File file) {
+        return parserService.submit(new ParserTask(file));
+    }
+
+    /**
      * Parses an XML Document from the content provided by a file.
      *
-     * The XML parsing is delegated to a limited set of parsers. When a parser is not immediately available, this method
-     * will block until one becomes available. The availability of parsers can be optimized by using the SystemProperties
-     * in this class.
+     * Equivalent to calling <tt>readDocumentAsync(input).get()</tt>
+     *
+     * The XML parsing is delegated to a limited set of parsers, as documented in {@link #readDocumentAsync(File)}.
+     * When a parser is not immediately available, this method will block until one becomes available.
      *
      * @param file The data to be parsed as an XML Document.
      * @return an XML Document.
@@ -193,7 +257,7 @@ public final class SAXReaderUtil
      * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Document readDocument(@Nonnull final File file) throws ExecutionException, InterruptedException {
-        return parserService.submit(new ParserTask(file)).get();
+        return readDocumentAsync(file).get();
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.util;
+
+import org.dom4j.Document;
+import org.dom4j.Element;
+import org.dom4j.io.SAXReader;
+import org.jivesoftware.openfire.JMXManager;
+import org.jivesoftware.openfire.mbean.ThreadPoolExecutorDelegate;
+import org.jivesoftware.openfire.mbean.ThreadPoolExecutorDelegateMBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.*;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.*;
+
+/**
+ * A utility class that provides a level of abstraction around the creation of a SAXReader instance suitable for XMPP
+ * parsing, as well as maintaining a set of readers ready, available for (bulk) processing.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public final class SAXReaderUtil
+{
+    // Note: this combines a ExecutorService with ThreadLocal usage, which introduces the potential to introduce memory
+    //       leaks. The tasks executed by the service make use of a thread-local parser, to avoid the overhead of having
+    //       to recreate these. When threads are terminated (after inactivity), this parser cannot be cleaned up (the
+    //       API of ThreadPoolExecutor does not provide this functionality). This means that a reference to the value of
+    //       the ThreadLocal (the parser) will retain a reference to its ClassLoader, which prevents garbage collection.
+    //       As the class of the instance of the parser (SAXReader.class) is loaded by the core classloader in Openfire,
+    //       this should only prevent garbage collection of a ClassLoader that should only be garbage collected when
+    //       Openfire is shutting down. However, this structure MUST NOT be used using for a value a Class that's loaded
+    //       by a plugin. The reference to the PluginClassLoader won't be cleaned, which prevents garbage collection of
+    //       the plugin, which prevents the plugin from properly unloading (eg, when it is updated/restarted), which
+    //       over time will lead to a wide variety of hard-to-diagnose issues.
+
+    private static final Logger Log = LoggerFactory.getLogger(SAXReaderUtil.class);
+
+    public static final SystemProperty<Integer> PARSER_SERVICE_CORE_POOL_SIZE = SystemProperty.Builder.ofType(Integer.class)
+                                                                                    .setKey("xmpp.xmlutil.parser.core-pool-size")
+                                                                                    .setMinValue(0)
+                                                                                    .setDefaultValue(0)
+                                                                                    .setDynamic(false)
+                                                                                    .build();
+
+    public static final SystemProperty<Integer> PARSER_SERVICE_MAX_POOL_SIZE = SystemProperty.Builder.ofType(Integer.class)
+                                                                                    .setKey("xmpp.xmlutil.parser.maximum-pool-size")
+                                                                                    .setMinValue(1)
+                                                                                    .setDefaultValue(25)
+                                                                                    .setDynamic(false)
+                                                                                    .build();
+
+    public static final SystemProperty<Duration> PARSER_SERVICE_KEEP_ALIVE_TIME = SystemProperty.Builder.ofType(Duration.class)
+                                                                                    .setKey("xmpp.xmlutil.parser.keep_alive_time")
+                                                                                    .setChronoUnit(ChronoUnit.SECONDS)
+                                                                                    .setMinValue(Duration.ofMillis(0))
+                                                                                    .setDefaultValue(Duration.ofMinutes(1))
+                                                                                    .setDynamic(false)
+                                                                                    .build();
+
+    private static final ThreadPoolExecutor parserService = new ThreadPoolExecutor(
+                                                            PARSER_SERVICE_CORE_POOL_SIZE.getValue(),
+                                                            PARSER_SERVICE_MAX_POOL_SIZE.getValue(),
+                                                            PARSER_SERVICE_KEEP_ALIVE_TIME.getValue().toMillis(), TimeUnit.MILLISECONDS,
+                                                            new SynchronousQueue<>());
+
+    static
+    {
+        if (JMXManager.isEnabled()) {
+            final ThreadPoolExecutorDelegateMBean mBean = new ThreadPoolExecutorDelegate(parserService);
+            JMXManager.tryRegister(mBean, ThreadPoolExecutorDelegateMBean.BASE_OBJECT_NAME + "saxReaderUtil");
+        }
+    }
+
+    /**
+     * Parses an XML Document from the content provided by an input stream.
+     *
+     * The XML parsing is delegated to a limited set of parsers. When a parser is not immediately available, this method
+     * will block until one becomes available. The availability of parsers can be optimized by using the SystemProperties
+     * in this class.
+     *
+     * @param stream The data to be parsed as an XML Document.
+     * @return an XML Document.
+     */
+    public static Document readDocument(@Nonnull final InputStream stream) throws ExecutionException, InterruptedException {
+        return parserService.submit(new ParserTask(stream)).get();
+    }
+
+    /**
+     * Parses an XML Document from the content provided by an input stream and returns the root element of the document.
+     *
+     * Equivalent to calling <tt>readDocument(input).getRootElement()</tt>
+     *
+     * @param stream The data to be parsed as an XML Document.
+     * @return an XML Document root element.
+     */
+    public static Element readRootElement(@Nonnull final InputStream stream) throws ExecutionException, InterruptedException {
+        return readDocument(stream).getRootElement();
+    }
+
+    /**
+     * Parses an XML Document from the provided text.
+     *
+     * The XML parsing is delegated to a limited set of parsers. When a parser is not immediately available, this method
+     * will block until one becomes available. The availability of parsers can be optimized by using the SystemProperties
+     * in this class.
+     *
+     * @param text The data to be parsed as an XML Document.
+     * @return an XML Document.
+     */
+    public static Document readDocument(@Nonnull final String text) throws ExecutionException, InterruptedException {
+        return parserService.submit(new ParserTask(new StringReader(text))).get();
+    }
+
+    /**
+     * Parses an XML Document from the provided text and returns the root element of the document.
+     *
+     * Equivalent to calling <tt>readDocument(input).getRootElement()</tt>
+     *
+     * @param text The data to be parsed as an XML Document.
+     * @return an XML Document root element.
+     */
+    public static Element readRootElement(@Nonnull final String text) throws ExecutionException, InterruptedException {
+        return readDocument(text).getRootElement();
+    }
+
+    /**
+     * Parses an XML Document from the content provided by a reader.
+     *
+     * The XML parsing is delegated to a limited set of parsers. When a parser is not immediately available, this method
+     * will block until one becomes available. The availability of parsers can be optimized by using the SystemProperties
+     * in this class.
+     *
+     * @param reader The data to be parsed as an XML Document.
+     * @return an XML Document.
+     */
+    public static Document readDocument(@Nonnull final Reader reader) throws ExecutionException, InterruptedException {
+        return parserService.submit(new ParserTask(reader)).get();
+    }
+
+    /**
+     * Parses an XML Document from the content provided by a reader and returns the root element of the document.
+     *
+     * Equivalent to calling <tt>readDocument(input).getRootElement()</tt>
+     *
+     * @param reader The data to be parsed as an XML Document.
+     * @return an XML Document root element.
+     */
+    public static Element readRootElement(@Nonnull final Reader reader) throws ExecutionException, InterruptedException {
+        return readDocument(reader).getRootElement();
+    }
+
+    /**
+     * Parses an XML Document from the content provided by a file.
+     *
+     * The XML parsing is delegated to a limited set of parsers. When a parser is not immediately available, this method
+     * will block until one becomes available. The availability of parsers can be optimized by using the SystemProperties
+     * in this class.
+     *
+     * @param file The data to be parsed as an XML Document.
+     * @return an XML Document.
+     */
+    public static Document readDocument(@Nonnull final File file) throws ExecutionException, InterruptedException {
+        return parserService.submit(new ParserTask(file)).get();
+    }
+
+    /**
+     * Parses an XML Document from the content provided by a file and returns the root element of the document.
+     *
+     * Equivalent to calling <tt>readDocument(input).getRootElement()</tt>
+     *
+     * @param file The data to be parsed as an XML Document.
+     * @return an XML Document root element.
+     */
+    public static Element readRootElement(@Nonnull final File file) throws ExecutionException, InterruptedException {
+        return readDocument(file).getRootElement();
+    }
+
+    /**
+     * Constructs a new SAXReader instance, configured for XMPP parsing.
+     *
+     * @return A new SAXReader instance.
+     */
+    private static SAXReader constructNewReader() throws SAXException
+    {
+        final SAXReader saxReader = new SAXReader();
+        saxReader.setEncoding( "UTF-8" );
+        saxReader.setIgnoreComments(true);
+
+        // Guard against various known vulnerabilities (see OF-2094).
+        saxReader.setEntityResolver((publicId, systemId) -> {
+            throw new IOException("External entity denied: " + publicId + " // " + systemId);
+        });
+        saxReader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        saxReader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        saxReader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        saxReader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+
+        return saxReader;
+    }
+
+    private static class ParserTask implements Callable<Document>
+    {
+        private static final ThreadLocal<SAXReader> localSAXReader = ThreadLocal.withInitial(()-> {
+            try {
+                return constructNewReader();
+            } catch (SAXException e) {
+                Log.error("Unable to parse XML data.", e);
+                return null;
+            }
+        });
+
+        @Nullable
+        private final InputStream stream;
+
+        @Nullable
+        private final Reader reader;
+
+        @Nullable
+        private final File file;
+
+        public ParserTask(@Nonnull final InputStream stream) {
+            this.stream = stream;
+            this.reader = null;
+            this.file = null;
+        }
+
+        public ParserTask(@Nonnull final Reader reader) {
+            this.stream = null;
+            this.reader = reader;
+            this.file = null;
+        }
+
+        public ParserTask(@Nonnull final File file) {
+            this.stream = null;
+            this.reader = null;
+            this.file = file;
+        }
+
+        @Override
+        public Document call() throws Exception {
+            if (stream != null) {
+                return localSAXReader.get().read(stream);
+            } else if (reader != null) {
+                return localSAXReader.get().read(reader);
+            } else if (file != null) {
+                return localSAXReader.get().read(file);
+            } else {
+                // Did you forget to add an 'else' block for the new type that you added?
+                throw new IllegalStateException("Unable to parse data. Data is either null, or of an unrecognized type.");
+            }
+        }
+    }
+
+//    // This allows for a quick and dirty verification that the SAXReader instances that are values of the ThreadLocal
+//    // are indeed garbage collected after the threads expire. To verify, use jmap to dump a histogram that shows the
+//    // number of instances directly after starting the application, and after the first 'sleep' has expired (and all
+//    // threads should have been terminated by the Service).
+//    public static void main(String[] args) throws ExecutionException, InterruptedException {
+//        for (int i = 0; i<300; i++) {
+//            XmlUtils.readDocument(new java.io.StringReader("<foo></foo>"));
+//        }
+//        System.out.println("Histo should now have up to 25 SAXReader instances.");
+//        Thread.sleep(65_000); // wait for threads to time out
+//        System.gc();
+//        System.out.println("Histo should now have 0 SAXReader instances.");
+//        Thread.sleep(65_000);
+//    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
@@ -99,6 +99,8 @@ public final class SAXReaderUtil
      *
      * @param stream The data to be parsed as an XML Document.
      * @return an XML Document.
+     * @throws ExecutionException on any error that occurs during parsing (this typically has a {@link org.dom4j.DocumentException} as its cause).
+     * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Document readDocument(@Nonnull final InputStream stream) throws ExecutionException, InterruptedException {
         return parserService.submit(new ParserTask(stream)).get();
@@ -111,6 +113,8 @@ public final class SAXReaderUtil
      *
      * @param stream The data to be parsed as an XML Document.
      * @return an XML Document root element.
+     * @throws ExecutionException on any error that occurs during parsing (this typically has a {@link org.dom4j.DocumentException} as its cause).
+     * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Element readRootElement(@Nonnull final InputStream stream) throws ExecutionException, InterruptedException {
         return readDocument(stream).getRootElement();
@@ -125,6 +129,8 @@ public final class SAXReaderUtil
      *
      * @param text The data to be parsed as an XML Document.
      * @return an XML Document.
+     * @throws ExecutionException on any error that occurs during parsing (this typically has a {@link org.dom4j.DocumentException} as its cause).
+     * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Document readDocument(@Nonnull final String text) throws ExecutionException, InterruptedException {
         return parserService.submit(new ParserTask(new StringReader(text))).get();
@@ -137,6 +143,8 @@ public final class SAXReaderUtil
      *
      * @param text The data to be parsed as an XML Document.
      * @return an XML Document root element.
+     * @throws ExecutionException on any error that occurs during parsing (this typically has a {@link org.dom4j.DocumentException} as its cause).
+     * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Element readRootElement(@Nonnull final String text) throws ExecutionException, InterruptedException {
         return readDocument(text).getRootElement();
@@ -151,6 +159,8 @@ public final class SAXReaderUtil
      *
      * @param reader The data to be parsed as an XML Document.
      * @return an XML Document.
+     * @throws ExecutionException on any error that occurs during parsing (this typically has a {@link org.dom4j.DocumentException} as its cause).
+     * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Document readDocument(@Nonnull final Reader reader) throws ExecutionException, InterruptedException {
         return parserService.submit(new ParserTask(reader)).get();
@@ -163,6 +173,8 @@ public final class SAXReaderUtil
      *
      * @param reader The data to be parsed as an XML Document.
      * @return an XML Document root element.
+     * @throws ExecutionException on any error that occurs during parsing (this typically has a {@link org.dom4j.DocumentException} as its cause).
+     * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Element readRootElement(@Nonnull final Reader reader) throws ExecutionException, InterruptedException {
         return readDocument(reader).getRootElement();
@@ -177,6 +189,8 @@ public final class SAXReaderUtil
      *
      * @param file The data to be parsed as an XML Document.
      * @return an XML Document.
+     * @throws ExecutionException on any error that occurs during parsing (this typically has a {@link org.dom4j.DocumentException} as its cause).
+     * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Document readDocument(@Nonnull final File file) throws ExecutionException, InterruptedException {
         return parserService.submit(new ParserTask(file)).get();
@@ -189,6 +203,8 @@ public final class SAXReaderUtil
      *
      * @param file The data to be parsed as an XML Document.
      * @return an XML Document root element.
+     * @throws ExecutionException on any error that occurs during parsing (this typically has a {@link org.dom4j.DocumentException} as its cause).
+     * @throws InterruptedException when the task that is scheduled to perform the parsing gets interrupted during the execution of the task.
      */
     public static Element readRootElement(@Nonnull final File file) throws ExecutionException, InterruptedException {
         return readDocument(file).getRootElement();

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ExternalizableUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ExternalizableUtil.java
@@ -19,14 +19,15 @@ package org.jivesoftware.util.cache;
 import org.dom4j.DocumentException;
 import org.dom4j.Element;
 import org.dom4j.io.SAXReader;
+import org.jivesoftware.util.SAXReaderUtil;
+import org.xml.sax.SAXException;
 
 import java.io.*;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Utility methods to assist in working with the Externalizable interfaces. This class
@@ -47,29 +48,6 @@ public class ExternalizableUtil {
 
     static {
         instance = new ExternalizableUtil();
-    }
-
-    /**
-     * Pool of SAX Readers. SAXReader is not thread safe so we need to have a pool of readers.
-     */
-    private final static int POOL_SIZE = 10;
-    private final BlockingQueue<SAXReader> xmlReaders = new LinkedBlockingQueue<>(POOL_SIZE);
-
-    private SAXReader takeSAXReader() throws InterruptedException {
-        SAXReader xmlReader;
-        if (! xmlReaders.isEmpty()) {
-            xmlReader = new SAXReader();
-            xmlReader.setEncoding("UTF-8");
-        } else {
-            xmlReader = xmlReaders.take();
-        }
-        return xmlReader;
-    }
-
-    private void returnSAXReader(SAXReader xmlReader) {
-        if (xmlReader != null) {
-            xmlReaders.offer(xmlReader); // If full, toss it.
-        }
     }
 
     public static ExternalizableUtil getInstance() {
@@ -402,19 +380,28 @@ public class ExternalizableUtil {
         return strategy.readStrings(in, collection);
     }
 
+    /**
+     * Writes an XML element to the output.
+     *
+     * @param out     the output stream.
+     * @param element the XML element.
+     * @throws IOException if an error occurs.
+     */
     public void writeXML(DataOutput out, Element element) throws IOException {
         strategy.writeSafeUTF(out, element.asXML());
     }
 
+    /**
+     * Reads an XML element from the input stream.
+     * @param in The input stream
+     * @return An XML element.
+     * @throws IOException if an error occurs.
+     */
     public Element readXML(DataInput in) throws IOException {
-        SAXReader xmlReader = null;
         try {
-            xmlReader = takeSAXReader();
-            return xmlReader.read(new StringReader(readSafeUTF(in))).getRootElement();
-        } catch(DocumentException | InterruptedException e) {
-            throw new IOException(e.getMessage());
-        } finally {
-            returnSAXReader(xmlReader);
+            return SAXReaderUtil.readRootElement(readSafeUTF(in));
+        } catch(ExecutionException | InterruptedException e) {
+            throw new IOException("Unable to parse data as XML", e);
         }
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/util/SAXReaderUtilTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/SAXReaderUtilTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.util;
+
+import org.dom4j.Document;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Verifies the implementation of {@link SAXReaderUtil}
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class SAXReaderUtilTest
+{
+    /**
+     * Asserts that XML text can be parsed when provided as a String.
+     */
+    @Test
+    public void testString() throws Exception
+    {
+        // Setup test fixture.
+        final String input = "<foo><bar>test</bar></foo>";
+
+        // Execute system under test.
+        final Document output = SAXReaderUtil.readDocument(input);
+
+        // Verify result.
+        assertNotNull(output);
+        assertEquals("foo", output.getRootElement().getName());
+        assertNotNull(output.getRootElement().element("bar"));
+        assertEquals("test", output.getRootElement().elementText("bar"));
+    }
+
+    /**
+     * Asserts that XML text can be parsed when provided as a Reader.
+     */
+    @Test
+    public void testReader() throws Exception
+    {
+        // Setup test fixture.
+        final Reader input = new StringReader("<foo><bar>test</bar></foo>");
+
+        // Execute system under test.
+        final Document output = SAXReaderUtil.readDocument(input);
+
+        // Verify result.
+        assertNotNull(output);
+        assertEquals("foo", output.getRootElement().getName());
+        assertNotNull(output.getRootElement().element("bar"));
+        assertEquals("test", output.getRootElement().elementText("bar"));
+    }
+
+    /**
+     * Asserts that XML text can be parsed when provided as an InputStream.
+     */
+    @Test
+    public void testInputStream() throws Exception
+    {
+        // Setup test fixture.
+        final InputStream input =  new ByteArrayInputStream("<foo><bar>test</bar></foo>".getBytes(StandardCharsets.UTF_8));
+
+        // Execute system under test.
+        final Document output = SAXReaderUtil.readDocument(input);
+
+        // Verify result.
+        assertNotNull(output);
+        assertEquals("foo", output.getRootElement().getName());
+        assertNotNull(output.getRootElement().element("bar"));
+        assertEquals("test", output.getRootElement().elementText("bar"));
+    }
+}


### PR DESCRIPTION
This is best reviewed by commit:

* First, ExternaliableUtil is extended to allow direct serialization of XML, allowing easy extension of Externalizable objects to serializing XML.
* Next, the RosterItem and DefaultRosterItemProvider are extended to support storage of the Presence stanza causing the request.
* Finally, PresenceSubscribeHandler and PresenceUpdateHandler are extended to store and use this stored stanza instead of constructing their own.