### PR TITLE
OF-2268: Prevent concurrency issue when starting JMX

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/JMXManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/JMXManager.java
@@ -137,7 +137,7 @@ public class JMXManager {
         XMPP_JMX_ENABLED.setValue(enabled);
     }
 
-    public static JMXManager getInstance() {
+    public static synchronized JMXManager getInstance() {
         if (instance == null) {
             instance = new JMXManager();
             if (isEnabled()) {


### PR DESCRIPTION
This commit ensures that the JMX manager is not started more than once, preventing concurrency issues.