### PR TITLE
OF-2275 / OF-2276: Send privacy-related status codes in MUC rooms

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1635,6 +1635,15 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
                 fragSelfPresence.addElement("status").addAttribute("code", "100");
             }
 
+            if ( isLogEnabled() )
+            {
+                // XEP-0045 section 7.2.12: Room Logging:
+                // If the user is entering a room in which the discussions are logged (...), the service (..) MUST also
+                // warn the user that the discussions are logged. This is done by including a status code of "170" in
+                // the initial presence that the room sends to the new occupant
+                fragSelfPresence.addElement("status").addAttribute("code", "170");
+            }
+
             if ( isRoomNew )
             {
                 fragSelfPresence.addElement("status").addAttribute("code", "201");


### PR DESCRIPTION
This adds support for sections "[7.2.12 Room Logging](https://xmpp.org/extensions/xep-0045.html#enter-logging)" and "[10.2.1 Notification of Configuration Changes](10.2.1 Notification of Configuration Changes)" of XEP-0045 (as introduced by version 1.21 of that XEP).