### PR TITLE
OF-2273: Ensure that self-presence mods are made when joining anon room

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -1508,7 +1508,8 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
 
         if (!canBroadcastPresence(sender.getRole())) {
             // Just send the presence to the sender of the presence
-            sender.send(stanza);
+            final Presence selfPresence = createSelfPresenceCopy(new BroadcastPresenceRequest(this, sender, stanza, isJoinPresence));
+            sender.send(selfPresence);
             return CompletableFuture.completedFuture(null);
         }
 


### PR DESCRIPTION
When joining a room is configured to restrict presence broadcasts, the reflected 'self-presence' should still have all added annotations as it'd otherwise get.

This fixes a bug where people can't join such a room (as the client doesn't receive the proper self-presence stanza as a result of the join)