### PR TITLE
Update Jetty from 9.4.39 to 9.4.43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 
         <!-- Versions -->
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
-        <jetty.version>9.4.39.v20210325</jetty.version>
+        <jetty.version>9.4.43.v20210629</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <mina.version>2.1.3</mina.version>
         <bouncycastle.version>1.68</bouncycastle.version>


### PR DESCRIPTION
Update Jetty to resolve a few CVEs.
Tested Admin, C2S and HTTP-Bind (because I can't remember where Jetty is used)

Changelogs don't appear scary:
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.40.v20210413
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.41.v20210516
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.42.v20210604
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.43.v20210629