### PR TITLE
Added support to join as participant in moderated rooms even if user is not a member.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoom.java
@@ -600,6 +600,10 @@ public class LocalMUCRoom implements MUCRoom, GroupEventListener {
             return MUCRole.Role.participant;
         }
         else {
+             // if true, default to participant even if the room is moderated
+            if(JiveGlobals.getXMLProperty("xmpp.muc.room.defaultToParticipant", false)){
+                return MUCRole.Role.participant;
+            }
             return isModerated() ? MUCRole.Role.visitor : MUCRole.Role.participant;
         }
     }


### PR DESCRIPTION
Not sure if this has been discussed in the past, but it was something I needed.

Is there any reason why the user must always start as a visitor if a room is moderated? IMO it makes sense that you can join as a participant and start chatting right away even if the room has moderation.