### PR TITLE
OF-2281: Prevent invalid sublist

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/InMemoryPubSubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/InMemoryPubSubPersistenceProvider.java
@@ -323,7 +323,7 @@ public class InMemoryPubSubPersistenceProvider implements PubSubPersistenceProvi
     {
         log.debug( "Getting published items for node {} (max: {}).", node.getUniqueIdentifier(), maxRows );
         List<PublishedItem> publishedItems = getPublishedItems( node );
-        if ( publishedItems.size() > maxRows )
+        if ( maxRows >= 0 && publishedItems.size() > maxRows )
         {
             publishedItems = publishedItems.subList( publishedItems.size() - maxRows, publishedItems.size() );
         }


### PR DESCRIPTION
At times, a negative value is provided as the 'max amount of items' (probably signifying that there's no limit), when asking for a collection of published pubsub items for a particular node. In that case, an exception occurred while trying to get the sub-collection of the total collection of items to be returned.