### PR TITLE
OF-2282: Only re-configure logging when settings differ from default

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/Log.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Log.java
@@ -93,13 +93,17 @@ public final class Log {
     }
 
     public static void setDebugEnabled(final boolean enabled) {
-        debugEnabled = enabled;
-        setLogLevel();
+        if (enabled != debugEnabled) {
+            debugEnabled = enabled;
+            setLogLevel();
+        }
     }
 
     public static void setTraceEnabled(final boolean enabled) {
-        traceEnabled = enabled;
-        setLogLevel();
+        if (enabled != traceEnabled) {
+            traceEnabled = enabled;
+            setLogLevel();
+        }
     }
 
     private static void setLogLevel() {


### PR DESCRIPTION
At boot time, do not overwrite the configuration of the logging system, unless there is something to change (eg: don't reconfigure using default values).

This prevents an issue where the logging configuration at boot time is overwriting the log4j2.xml file-provided configuration while there's no need to (effectively making it impossible to have anything logged lower than 'info' at boot time).