### PR TITLE
OF-2164: MUC Service config changes should propagate through the cluster

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -283,7 +283,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     /**
      * Flag that indicates if MUC service is hidden from services views.
      */
-    private final boolean isHidden;
+    private boolean isHidden;
 
     /**
      * Delegate responds to events for the MUC service.
@@ -2106,6 +2106,10 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         }
         final int endPos = buf.length() > 1 ? buf.length() - 1 : 0;
         return buf.substring(0, endPos);
+    }
+
+    public void setHidden(boolean isHidden) {
+        this.isHidden = isHidden;
     }
 
     @Override


### PR DESCRIPTION
When a MUC service (eg 'conference') is being modified (currently only possible in the admin console), these changes should be picked up by all other cluster nodes.

This commit achieves this by adding two modifications:
1. Enabling the code that was foreseen to broadcast MUCServiceProperty changes by registering the class that already was a listener to the dispatcher (so that it actually gets invoked when an event occurs).
2. Adding code that, when a service is updated, reloads the description and 'isHidden' flag from the database (these properties are no regular properties, and stored in a different database table).