### PR TITLE
OF-2291: Prevent ConcurrentModificationException when syncing clustered MUC occupants

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/OccupantManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/OccupantManager.java
@@ -324,7 +324,11 @@ public class OccupantManager implements MUCEventListener
      * @param task Cluster task that informs of occupants on a remote node.
      */
     public void process(@Nonnull final SyncLocalOccupantsAndSendJoinPresenceTask task) {
-        final Set<Occupant> oldOccupants = occupantsByNode.get(task.getOriginator());
+        Set<Occupant> oldOccupants = occupantsByNode.get(task.getOriginator());
+        if (oldOccupants != null) {
+            // Use defensive copy to prevent concurrent modification exceptions.
+            oldOccupants = new HashSet<>(oldOccupants);
+        }
         if (oldOccupants != null) {
             oldOccupants.forEach(oldOccupant -> replaceOccupant(oldOccupant, null, task.getOriginator()));
         }


### PR DESCRIPTION
This creates a copy of a collection over which is being operated, to prevent the collection to be modified while being iterated over.