### PR TITLE
OF-2292: Prevent ConcurrentModificationException when syncing cluster…

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/OccupantManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/OccupantManager.java
@@ -436,7 +436,7 @@ public class OccupantManager implements MUCEventListener
         // Defensive copy to prevent modifying the returned set
         Set<Occupant> returnValue = new HashSet<>(occupantsBeingRemoved);
 
-        occupantsBeingRemoved.forEach(o -> replaceOccupant(o, null, nodeID));
+        returnValue.forEach(o -> replaceOccupant(o, null, nodeID));
 
         return returnValue;
     }


### PR DESCRIPTION
…ed MUC occupants

This creates a copy of a collection over which is being operated, to prevent the collection to be modified while being iterated over.