### PR TITLE
OF-2296: Remove duplicate event listener registration

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -343,8 +343,6 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
 
         localMUCRoomManager = new LocalMUCRoomManager(this);
         occupantManager = new OccupantManager(this);
-
-        ClusterManager.addListener(this);
     }
 
     @Override


### PR DESCRIPTION
By registering MultiUserChatServiceImpl as a ClusterEventListener twice, it gets invoked more than once, which can cause problems.