### PR TITLE
OF-2297: Gracefully remove 'lost' MUC Rooms (clustering)

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -1743,6 +1743,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         // a small moment we may not have a senior cluster member.
 
         final NodeID nodeIDOfLostNode = NodeID.getInstance(nodeID);
+        Log.debug("Cluster node {} just left the cluster.", nodeIDOfLostNode);
 
         // Remove incoming server sessions hosted in node that left the cluster
         final Set<StreamID> removedServerSessions = incomingServerSessionsByClusterNode.remove(nodeIDOfLostNode);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -536,6 +536,19 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
         return false;
     }
 
+    public void removeDirectPresence(JID ownerJID, JID recipientJID) {
+        if (recipientJID == null) {
+            return;
+        }
+        Collection<DirectedPresence> directedPresences = directedPresencesCache.get(ownerJID.toString());
+        if (directedPresences != null) {
+            String recipient = recipientJID.toBareJID();
+            for (DirectedPresence directedPresence : directedPresences) {
+                directedPresence.removeReceiver(recipient);
+            }
+        }
+    }
+
     /**
      * Removes directed presences sent to entities that are no longer available.
      */


### PR DESCRIPTION
When a cluster node breaks out of the cluster, it sometimes occur that it locally does not have access to all cache content. A common way to resolve issues surrounding this is to maintain a local copy of relevant data.

For MUC rooms, this approach is not feasible, as it would require a continuous synchronization of MUC room data (which is resource intensive).

Instead of 'recovering' lost cache data, this commit considers a MUC room that has disappeared from the cache (during a cluster leave event) to be 'broken'. Presence unavailable (with status code 333) is sent to all local occupants, indicating that they're no longer in the room.