### PR TITLE
OF-2293: Prevent duplicate MUC occupants from existing

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -1147,6 +1147,12 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
      */
     public void addOccupantRole(@Nonnull final MUCRole role)
     {
+        if (occupants.contains(role)) {
+            // Ignore a data consistency problem. This indicates that a bug exists somewhere, so log it verbosely.
+            Log.warn("Not re-adding an occupant {} that already exists in room {}!", role, this.getJID(), new IllegalStateException("Duplicate occupant: " + role));
+            return;
+        }
+
         Log.trace( "Add occupant to room {}: {}", this.getJID(), role );
         occupants.add(role);
 


### PR DESCRIPTION
This commit prevents an occupant to be added to a room that already has that same occupant. This has been observed in the wild (while testing new MUC/Clustering code).

The changes in this commit do not take away the cause of the duplicated addition, which are unknown at this time. The change does take away the direct event (preventing the duplicate from being added), and logs an error message that contains a stack trace. Hopefully that can be used in the future to find the cause of the issue.