### PR TITLE
OF-2304: Non-MUC-occupants should not be able to change nicknames

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1335,7 +1335,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     {
         Log.trace("Occupant '{}' of room '{}' tries to change its nickname to '{}'.", preExistingRole.getUserAddress(), room.getName(), nickname);
 
-        if ( room.getOccupantsByBareJID(packet.getFrom().asBareJID()).size() > 1 )
+        if ( room.getOccupantsByBareJID(packet.getFrom().asBareJID()).isEmpty() )
         {
             Log.trace("Nickname change request denied: requestor '{}' is not an occupant of the room.", packet.getFrom().asBareJID());
             sendErrorPacket(packet, PacketError.Condition.not_acceptable, "You are not an occupant of this chatroom.");


### PR DESCRIPTION
The code that detects if the requestor of a nickname change is an occupant in the room needs fixing.

Many thanks to @MightyMop for identifying this problem and suggesting a fix.