### PR TITLE
OF-2313: Do not depend on clustered cache when resolving cluster outage

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/IncomingServerSessionInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/IncomingServerSessionInfo.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.session;
+
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.cluster.NodeID;
+import org.jivesoftware.util.cache.ExternalizableUtil;
+
+import javax.annotation.Nonnull;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Incoming server session information to be used when running in a cluster. The session information is shared between
+ * cluster nodes and is meant to be used by remote sessions to avoid invocation remote calls and instead use cached
+ * information.
+ *
+ * Note that instances of this class typically contain a snapshot of some of the data of a {@link LocalIncomingServerSession}
+ * instance. Updates to that parent instance are not automatically reflected in instances of this class.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class IncomingServerSessionInfo implements Externalizable
+{
+    private NodeID nodeID;
+    private Set<String> validatedDomains;
+
+    public IncomingServerSessionInfo() {
+    }
+
+    public NodeID getNodeID() {
+        return nodeID;
+    }
+
+    public Set<String> getValidatedDomains() {
+        return validatedDomains;
+    }
+
+    public IncomingServerSessionInfo(@Nonnull final LocalIncomingServerSession serverSession) {
+        this.nodeID = XMPPServer.getInstance().getNodeID();
+        validatedDomains = new HashSet<>(serverSession.getValidatedDomains());
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        ExternalizableUtil.getInstance().writeSerializable(out, nodeID);
+        ExternalizableUtil.getInstance().writeSerializableCollection(out, validatedDomains);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        nodeID = (NodeID) ExternalizableUtil.getInstance().readSerializable(in);
+        validatedDomains = new HashSet<>();
+        ExternalizableUtil.getInstance().readSerializableCollection(in, validatedDomains, this.getClass().getClassLoader());
+    }
+
+    @Override
+    public String toString() {
+        return "IncomingServerSessionInfo{" +
+            "nodeID=" + nodeID +
+            ", validatedDomains=" + validatedDomains +
+            '}';
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/IncomingServerSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/IncomingServerSessionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software and Ignite Realtime Community 2021. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,14 +50,22 @@ public class IncomingServerSessionTask extends RemoteSessionTask {
     public void run() {
         super.run();
 
-        if (operation == Operation.getLocalDomain) {
-            result = ((IncomingServerSession) getSession()).getLocalDomain();
-        }
-        else if (operation == Operation.getAddress) {
-            result = getSession().getAddress();
-        }
-        else if (operation == Operation.isUsingServerDialback) {
-            result = ((IncomingServerSession) getSession()).isUsingServerDialback();
+        switch (operation) {
+            case getLocalDomain:
+                result = ((IncomingServerSession) getSession()).getLocalDomain();
+                break;
+
+            case getAddress:
+                result = getSession().getAddress();
+                break;
+
+            case isUsingServerDialback:
+                result = ((IncomingServerSession) getSession()).isUsingServerDialback();
+                break;
+
+            case getValidatedDomains:
+                result = ((IncomingServerSession) getSession()).getValidatedDomains();
+                break;
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software and Ignite Realtime Community 2021. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.jivesoftware.openfire.session;
 
-import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.openfire.streammanagement.StreamManager;
 import org.jivesoftware.util.TaskEngine;
 import org.jivesoftware.util.cache.ClusterTask;
 import org.jivesoftware.util.cache.ExternalizableUtil;
@@ -196,6 +194,7 @@ public abstract class RemoteSessionTask implements ClusterTask<Object> {
          * Operations of incoming server sessions
          */
         getLocalDomain,
-        getAddress
+        getAddress,
+        getValidatedDomains
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
@@ -27,12 +27,7 @@ import org.jivesoftware.openfire.cluster.NodeID;
 import org.jivesoftware.openfire.muc.MUCRole;
 import org.jivesoftware.openfire.muc.MUCRoom;
 import org.jivesoftware.openfire.muc.spi.OccupantManager;
-import org.jivesoftware.openfire.session.ClientSession;
-import org.jivesoftware.openfire.session.ClientSessionInfo;
-import org.jivesoftware.openfire.session.DomainPair;
-import org.jivesoftware.openfire.session.LocalClientSession;
-import org.jivesoftware.openfire.session.LocalIncomingServerSession;
-import org.jivesoftware.openfire.session.LocalOutgoingServerSession;
+import org.jivesoftware.openfire.session.*;
 import org.jivesoftware.openfire.spi.ClientRoute;
 import org.jivesoftware.util.CollectionUtils;
 import org.xmpp.packet.JID;
@@ -403,14 +398,14 @@ public class ConsistencyChecks {
      * @return A consistency state report.
      */
     public static Multimap<String, String> generateReportForSessionManagerIncomingServerSessions(
-        @Nonnull final Cache<StreamID, NodeID> incomingServerSessionsCache,
+        @Nonnull final Cache<StreamID, IncomingServerSessionInfo> incomingServerSessionsCache,
         @Nonnull final Collection<LocalIncomingServerSession> localIncomingServerSessions,
         @Nonnull final Map<NodeID, Set<StreamID>> incomingServerSessionsByClusterNode
     ) {
         final Set<NodeID> clusterNodeIDs = ClusterManager.getNodesInfo().stream().map(ClusterNodeInfo::getNodeID).collect(Collectors.toSet());
 
         // Take snapshots of all data structures at as much the same time as possible.
-        final ConcurrentMap<StreamID, NodeID> cache = new ConcurrentHashMap<>(incomingServerSessionsCache);
+        final ConcurrentMap<StreamID, IncomingServerSessionInfo> cache = new ConcurrentHashMap<>(incomingServerSessionsCache);
         final List<StreamID> localIncomingServerSessionsStreamIDs = localIncomingServerSessions.stream().map(LocalIncomingServerSession::getStreamID).collect(Collectors.toList());
         final List<StreamID> remoteIncomingServerSessions = incomingServerSessionsByClusterNode.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
         final List<String> remoteIncomingServerSessionsWithNodeId = new ArrayList<>();

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyMonitor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyMonitor.java
@@ -141,7 +141,7 @@ public class ConsistencyMonitor
                 offenders.add(RoutingTableImpl.C2S_SESSION_NAME);
             }
 
-            final Collection<String> incomingServerSessionsFailures = sessionManager.clusteringStateConsistencyReportForIncomingServerSessions().get("fail");
+            final Collection<String> incomingServerSessionsFailures = sessionManager.clusteringStateConsistencyReportForIncomingServerSessionInfos().get("fail");
             if (incomingServerSessionsFailures != null && !incomingServerSessionsFailures.isEmpty()) {
                 offenders.add(SessionManager.ISS_CACHE_NAME);
             }

--- a/xmppserver/src/main/webapp/system-clustering-data-consistency-check.jsp
+++ b/xmppserver/src/main/webapp/system-clustering-data-consistency-check.jsp
@@ -35,7 +35,7 @@
     pageContext.setAttribute("clusteringStateConsistencyReportForServerRoutes", ((RoutingTableImpl) XMPPServer.getInstance().getRoutingTable()).clusteringStateConsistencyReportForServerRoutes());
     pageContext.setAttribute("clusteringStateConsistencyReportForComponentRoutes", ((RoutingTableImpl) XMPPServer.getInstance().getRoutingTable()).clusteringStateConsistencyReportForComponentRoutes());
     pageContext.setAttribute("clusteringStateConsistencyReportForClientRoutes", ((RoutingTableImpl) XMPPServer.getInstance().getRoutingTable()).clusteringStateConsistencyReportForClientRoutes());
-    pageContext.setAttribute("clusteringStateConsistencyReportForIncomingServerSessions", ((SessionManager) XMPPServer.getInstance().getSessionManager()).clusteringStateConsistencyReportForIncomingServerSessions());
+    pageContext.setAttribute("clusteringStateConsistencyReportForIncomingServerSessions", ((SessionManager) XMPPServer.getInstance().getSessionManager()).clusteringStateConsistencyReportForIncomingServerSessionInfos());
     pageContext.setAttribute("clusteringStateConsistencyReportForSessionInfos", ((SessionManager) XMPPServer.getInstance().getSessionManager()).clusteringStateConsistencyReportForSessionInfos());
     pageContext.setAttribute("clusteringStateConsistencyReportForUsersSession", ((RoutingTableImpl) XMPPServer.getInstance().getRoutingTable()).clusteringStateConsistencyReportForUsersSessions());
     pageContext.setAttribute("clusteringStateConsistencyReportForMucRoomsAndOccupant", XMPPServer.getInstance().getMultiUserChatManager().clusteringStateConsistencyReportForMucRoomsAndOccupant());


### PR DESCRIPTION
Code that facilitates working with incoming server sessions previously depended on two caches. The 'second' cache stored 'validatedDomains' information. This comment was added:

> Content is stored in a clustered cache so that even in the case of the node hosting the sessions is lost we can still have access to this info to be able to perform proper clean up logic

We now know that in case of an incident that involves losing a cluster node, the content of caches cannot be depended on (instead, local copies of cached data needs to be maintained).

This commit removes the second cache, replacing it with a construct that keeps 'validatedDomains' info in both the primary cache, as well as locally-stored data.