### PR TITLE
OF-2314 Kill s2s local connection if it already exists elsewhere in the cluster

### DIFF
--- a/runAioxmppIntegrationTests
+++ b/runAioxmppIntegrationTests
@@ -89,10 +89,10 @@ function setUpAioxmppEnvironment {
     	git clone -b devel https://github.com/horazont/aioxmpp "${AIOXMPPDIR}"
     	pushd "${AIOXMPPDIR}"
 	fi
-    which pip3
-	pip3 install setuptools
-    pip3 install nose
-    pip3 install -e .
+	python3.9 -m pip install setuptools
+	python3.9 -m pip install pytest
+	python3.9 -m pip install pytest-cov
+	python3.9 -m pip install -e .
     cat >"${AIOXMPPCONFIG}" <<EOL
 [global]
 provisioner=aioxmpp.e2etest.provision.AnonymousProvisioner
@@ -141,7 +141,7 @@ function runTests {
     which python3.9
 	if [ -d output ]; then rm -Rf output; fi
     mkdir output
-    python3.9 -m aioxmpp.e2etest --e2etest-config="${AIOXMPPCONFIG}" --e2etest-only -e 'test_set_topic' -e 'test_publish_and_purge' -e 'test_publish_multiple_and_get_by_id' tests 2>&1 | tee output/aioxmpp.test.output.txt
+    python3.9 -m pytest -p aioxmpp.e2etest --e2etest-config="${AIOXMPPCONFIG}" --e2etest-only -k 'not test_set_topic and not test_publish_and_purge and not test_publish_multiple_and_get_by_id' tests 2>&1 | tee output/aioxmpp.test.output.txt
 	if [ ${PIPESTATUS[0]} -ne 0 ]; then false; fi;
     popd
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1646,9 +1646,13 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             if (route instanceof LocalOutgoingServerSession) {
                 // Terminating the connection should also trigger the OutgoingServerSessionListener#onConnectionClose in SessionManagerImpl.
                 // That will result in the s2s connection actually being removed from the LocalRoutingTable.
-                LocalOutgoingServerSession.class.cast(route).close();
+                try {
+                    LocalOutgoingServerSession.class.cast(route).close();
+                } catch (Exception e) {
+                    Log.warn("Failed to terminate the local s2s connection for " + localServerRouteToRemove + ".", e);
+                }
             } else {
-                Log.warn("We can't terminate the local s2s connection for {} because it is a {} instead of a LocalOutgoingServerSession.", localServerRouteToRemove, route.getClass());
+                Log.warn("Failed to terminate the local s2s connection for {} because it is a {} instead of a LocalOutgoingServerSession.", localServerRouteToRemove, route.getClass());
             }
         }
 


### PR DESCRIPTION
If multiple nodes have similar s2s connections before joining together in a cluster, the local s2s connections were allowed to keep existing on both nodes. That's actually not allowed, or at least not at this moment. This PR kills the s2s connection on the node that is considered to be 'joining' the cluster.