### PR TITLE
OF-2289: Do not use Interner<String>

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutManager.java
@@ -19,11 +19,13 @@ import java.util.Date;
 
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
+import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.util.SystemProperty;
 import org.jivesoftware.util.cache.Cache;
 import org.jivesoftware.util.cache.CacheFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xmpp.packet.JID;
 
 /**
  * The LockOutManager manages the LockOutProvider configured for this server, caches knowledge of
@@ -40,7 +42,7 @@ import org.slf4j.LoggerFactory;
  */
 public class LockOutManager {
 
-    private static final Interner<String> userBaseMutex = Interners.newWeakInterner();
+    private static final Interner<JID> userBaseMutex = Interners.newWeakInterner();
 
     public static final SystemProperty<Class> LOCKOUT_PROVIDER = SystemProperty.Builder.ofType(Class.class)
         .setKey("provider.lockout.className")
@@ -219,7 +221,7 @@ public class LockOutManager {
         LockOutFlag flag = lockOutCache.get(username);
         // If ID wan't found in cache, load it up and put it there.
         if (flag == null) {
-            synchronized (userBaseMutex.intern(username)) {
+            synchronized (userBaseMutex.intern(XMPPServer.getInstance().createJID(username, null))) {
                 flag = lockOutCache.get(username);
                 // If group wan't found in cache, load it up and put it there.
                 if (flag == null) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -59,7 +59,7 @@ import javax.annotation.Nonnull;
 @SuppressWarnings({"WeakerAccess", "unused"})
 public final class UserManager {
 
-    private static final Interner<String> userBaseMutex = Interners.newWeakInterner();
+    private static final Interner<JID> userBaseMutex = Interners.newWeakInterner();
 
     public static final SystemProperty<Class> USER_PROVIDER = SystemProperty.Builder.ofType(Class.class)
         .setKey("provider.user.className")
@@ -271,7 +271,7 @@ public final class UserManager {
         username = username.trim().toLowerCase();
         User user = userCache.get(username);
         if (user == null) {
-            synchronized (userBaseMutex.intern(username)) {
+            synchronized (userBaseMutex.intern(XMPPServer.getInstance().createJID(username, null))) {
                 user = userCache.get(username);
                 if (user == null) {
                     user = provider.loadUser(username);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
@@ -20,12 +20,14 @@ import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import org.dom4j.Element;
 import org.jivesoftware.database.DbConnectionManager;
+import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.util.AlreadyExistsException;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.NotFoundException;
 import org.jivesoftware.util.SAXReaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xmpp.packet.JID;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -42,7 +44,7 @@ public class DefaultVCardProvider implements VCardProvider {
 
     private static final Logger Log = LoggerFactory.getLogger(DefaultVCardProvider.class);
 
-    private static final Interner<String> userBaseMutex = Interners.newWeakInterner();
+    private static final Interner<JID> userBaseMutex = Interners.newWeakInterner();
     
     private static final String LOAD_PROPERTIES =
         "SELECT vcard FROM ofVCard WHERE username=?";
@@ -55,7 +57,7 @@ public class DefaultVCardProvider implements VCardProvider {
 
     @Override
     public Element loadVCard(String username) {
-        synchronized (userBaseMutex.intern(username)) {
+        synchronized (userBaseMutex.intern(XMPPServer.getInstance().createJID(username, null))) {
             Connection con = null;
             PreparedStatement pstmt = null;
             ResultSet rs = null;

--- a/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
+++ b/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
@@ -1,6 +1,7 @@
 package org.jivesoftware;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -28,6 +29,8 @@ import org.jivesoftware.openfire.user.UserAlreadyExistsException;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.openfire.user.UserProvider;
 import org.jivesoftware.util.JiveGlobals;
+import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.JID;
 
@@ -80,6 +83,10 @@ public final class Fixtures {
             return jid.getDomain().equals(XMPP_DOMAIN);
         }).when(xmppServer).isLocal(any(JID.class));
 
+        doAnswer(invocationOnMock -> new JID(invocationOnMock.getArgument(0), XMPP_DOMAIN, invocationOnMock.getArgument(1)))
+            .when(xmppServer).createJID(any(String.class), nullable(String.class));
+        doAnswer(invocationOnMock -> new JID(invocationOnMock.getArgument(0), XMPP_DOMAIN, invocationOnMock.getArgument(1), invocationOnMock.getArgument(2)))
+            .when(xmppServer).createJID(any(String.class), nullable(String.class), any(Boolean.class));
         doReturn(mockXMPPServerInfo()).when(xmppServer).getServerInfo();
         doReturn(mockIQRouter()).when(xmppServer).getIQRouter();
 

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/user/UserManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/user/UserManagerTest.java
@@ -70,7 +70,8 @@ public class UserManagerTest {
         userManager = new UserManager(xmppServer);
         userManager.createUser(USER_ID, "change me", "Test User Name", "test-email@example.com");
         userManager.createUser(USER_ID_2, "change me", "Test User Name 2", "test-email-2@example.com");
-        
+
+        XMPPServer.setInstance(xmppServer);
     }
     
     @Test


### PR DESCRIPTION
com.google.common.collect.Interner is not safe when used with Strings: as with String.intern(), an equal string value could end up being used as a mutex for unrelated code blocks (introducing the risk of deadlocks between code blocks that have no functional relation).

When an Interner instance is used with anohter immutable type, the generated mutexes are local to the Interner instance. This allows, for example, for the same JID value to be used with two different Interner instances, without the resulting mutexes influencing each-other.

This commit replaces all occurrances of Interner<String>.