### PR TITLE
OF-2320: Restore ability to obtain MUC vcard

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
@@ -57,7 +57,14 @@ public class DefaultVCardProvider implements VCardProvider {
 
     @Override
     public Element loadVCard(String username) {
-        synchronized (userBaseMutex.intern(XMPPServer.getInstance().createJID(username, null))) {
+        final JID mutex;
+        if (username.contains("@")) {
+            // OF-2320: VCards are used for MUC rooms, to store their avatar. For this usecase, the 'username' is actually a (bare) JID value representing the room.
+            mutex = new JID(username);
+        } else {
+            mutex = XMPPServer.getInstance().createJID(username, null);
+        }
+        synchronized (userBaseMutex.intern(mutex)) {
             Connection con = null;
             PreparedStatement pstmt = null;
             ResultSet rs = null;


### PR DESCRIPTION
With the changes of OF-2289, the mutex value was expected to be a username. For MUC rooms, a bare JID is used. Using that as the node-part for a new JID causes problems.