### PR TITLE
OF-2322: Ensure outgoing queue is emptied before routing newer stanzas

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -208,6 +208,19 @@ public class OutgoingSessionPromise implements RoutableChannelHandler {
         }
     }
 
+    /**
+     * Checks if an outgoing session is in process of being created, which includes both establishment of the (possibly
+     * authenticated) connection as well as delivery of all queued stanzas.
+     *
+     * @param domain The domain to check
+     * @return true if an outgoing session is currently being created, otherwise false.
+     */
+    public boolean isPending(JID domain) {
+        synchronized (domainBasedMutex.intern(domain)) {
+            return packetsProcessors.containsKey(domain) && !packetsProcessors.get(domain).isDone();
+        }
+    }
+
     private class PacketsProcessor implements Runnable
     {
         private final Logger Log = LoggerFactory.getLogger( PacketsProcessor.class );

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -604,7 +604,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         boolean routed = false;
         DomainPair pair = new DomainPair(packet.getFrom().getDomain(), jid.getDomain());
         NodeID nodeID = serversCache.get(pair);
-        if (nodeID != null) {
+        if (nodeID != null && !OutgoingSessionPromise.getInstance().isPending(new JID(jid.getDomain()))) {
             if (server.getNodeID().equals(nodeID)) {
                 // This is a route to a remote server connected from this node
                 try {


### PR DESCRIPTION
The existing code is based around a route of last resort, the
OutgoingSessionPromise, which builds a helper - the PacketsProcessor - and
creates the new session. The PacketsProcessors operate from within a thread
pool, and thus have contended execution time.

As new packets arrives from onward transmission during the session setup, the
PacketsProcessor queues them for retransmission. However, the act of session
creation also creates the outgoing route, meaning that later packets will
bypass the queue, and be transmitted out of order.

This should give the impression of a randomly reordered set of stanzas, but
would in fact be two consecutive sequences of ordered stanzas which are
interleaved, hence if the two sequences are A-E, F-J, one might see:

A, B, F, G, C, H, I, D, J, E

The fix here is two ensure that all packets are queued until the queue itself
is empty.