### PR TITLE
OF-2325: Prevent endless loop when peer closes during TLS handshake

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
@@ -237,7 +237,7 @@ public class TLSStreamHandler {
                     throw ex;
                 }
 
-                return initialHSComplete;
+                throw new SSLHandshakeException( "The peer closed the connection during the TLS handshake." );
             }
 
             needIO: while (initialHSStatus == HandshakeStatus.NEED_UNWRAP) {


### PR DESCRIPTION
When a peer closes the connection while performing an initial TLS handshake, a problem occurs if the state of the handshake remains 'not complete': the code in TLSStreamHandler#start() will loop until the handshake is complete. Subsequent iterations will read nothing, which repeats indefinitely. This can drain the available CPU resources.

Instead, throwing an exception will force the invoker to give up.