### PR TITLE
Update dependencies

### DIFF
--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -1,24 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-   <suppress> <!-- Ignore Openfire for the search jar, else dependency-check picks up every Openfire CVE since Openfire v1.7.2-->
+   <suppress>
       <notes><![CDATA[
-   file name: search.jar: search-1.7.2.jar
+      Ignore Openfire for the search jar, else dependency-check picks up every Openfire CVE since Openfire v1.7.2
+        file name: search.jar: search-1.7.2.jar
    ]]>      </notes>
       <packageUrl regex="true">^pkg:maven/org\.igniterealtime\.openfire\.plugins/search@.*$</packageUrl>
       <cpe>cpe:/a:igniterealtime:openfire</cpe>
    </suppress>
    <suppress>
       <notes><![CDATA[
+      Ignore Openfire for the search jar, else dependency-check picks up every Openfire CVE since Openfire v1.7.2
    file name: search.jar: search-1.7.2.jar
    ]]>      </notes>
       <packageUrl regex="true">^pkg:maven/org\.igniterealtime\.openfire\.plugins/search@.*$</packageUrl>
       <cpe>cpe:/a:ignite_realtime:openfire</cpe>
    </suppress>
-   <suppress> <!-- Ignore tag_project:tag - it's an MP3 tagging tool, and nothing to do with Apache Taglibs -->
+   <suppress>
       <notes><![CDATA[
+      Ignore tag_project:tag - it's an MP3 tagging tool, and nothing to do with Apache Taglibs.
    file name: taglibs-standard-impl-1.2.5.jar
    ]]>      </notes>
       <packageUrl regex="true">^pkg:maven/org\.apache\.taglibs/taglibs\-standard\-impl@.*$</packageUrl>
       <cpe>cpe:/a:tag_project:tag</cpe>
    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Ignore a CVE related to JDom2 when setExpandEntities is enabled. JDom2 is used by Rome, which doesn't use this feature, so is immune.
+        https://github.com/rometools/rome/issues/469
+   file name: jdom2-2.0.6.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jdom/jdom2@.*$</packageUrl>
+        <cve>CVE-2021-33813</cve>
+    </suppress>
 </suppressions>

--- a/build/ci/updater/pom.xml
+++ b/build/ci/updater/pom.xml
@@ -67,12 +67,12 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.21</version>
+      <version>8.0.27</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.14</version>
+      <version>42.2.19</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.jtds</groupId>
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>7.2.2.jre8</version>
+      <version>7.4.1.jre8</version>
     </dependency>
   </dependencies>
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -122,7 +122,7 @@
         <!-- Versions -->
         <openfire.version>4.7.0-SNAPSHOT</openfire.version>
         <!-- Note; the following jetty.version should be identical to the jetty.version in xmppserver/pom.xml -->
-        <jetty.version>9.4.35.v20201120</jetty.version>
+        <jetty.version>9.4.43.v20210629</jetty.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>6.0.4</version>
+                        <version>6.2.2</version>
                         <configuration>
                             <suppressionFiles>
                                 <suppressionFile>.dependency-check-suppressions.xml</suppressionFile>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 
         <!-- Versions -->
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
-        <jetty.version>9.4.39.v20210325</jetty.version>
+        <jetty.version>9.4.43.v20210629</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <mina.version>2.1.3</mina.version>
         <bouncycastle.version>1.68</bouncycastle.version>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -428,7 +428,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.21</version>
+            <version>8.0.27</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -341,7 +341,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.6.0</version>
+            <version>2.9.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
Fixes a bunch of CVEs.
Doesn't touch Mina.
Suppresses one false positive from JDOM2, which is included by Rome for RSS, but isn't used in a way that could expose the problem.