### PR TITLE
OF-264 Add group selection field in Create New User page

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -2785,6 +2785,7 @@ user.create.invalid_email=Invalid email.
 user.create.invalid_password=Invalid password.
 user.create.invalid_match_password=Passwords don&#39;t match.
 user.create.invalid_password_confirm=Invalid password confirmation.
+user.create.invalid_group=Invalid group.
 user.create.created_success=New user created successfully.
 user.create.new_user=Create New User
 user.create.username=Username
@@ -2797,6 +2798,7 @@ user.create.create=Create User
 user.create.create_another=Create &amp; Create Another
 user.create.isadmin=Is Administrator?
 user.create.admin_info=Grants admin access to Openfire
+user.create.group=Group
 
 # User delete Page
 

--- a/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
+++ b/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
@@ -1735,6 +1735,7 @@ user.create.invalid_email=Neplatný email.
 user.create.invalid_password=Neplatné heslo.
 user.create.invalid_match_password=Hesla nesouhlasí.
 user.create.invalid_password_confirm=Neplatné potvrzení hesla.
+user.create.invalid_group=Neplatná skupina
 user.create.created_success=Nový uživatel vytvořen úspěšně.
 user.create.new_user=Vytvořit nového uživatele
 user.create.username=Uživatelské jméno
@@ -1745,6 +1746,7 @@ user.create.confirm_pwd=Potvrzení hesla
 user.create.requied=Povinná pole
 user.create.create=Vytvořit uživatele
 user.create.create_another=Vytvořit &amp; vytvořit dalšího
+user.create.group=Skupina
 
 # User delete Page
 

--- a/i18n/src/main/resources/openfire_i18n_de.properties
+++ b/i18n/src/main/resources/openfire_i18n_de.properties
@@ -2252,6 +2252,7 @@ user.create.invalid_email=Ungültige E-Mail.
 user.create.invalid_password=Ungültiges Passwort.
 user.create.invalid_match_password=Passwörter stimmen nicht überein.
 user.create.invalid_password_confirm=Ungültige Passwortbestätigung.
+user.create.invalid_group=Ungültige Gruppe
 user.create.created_success=Neuen Benutzer erfolgreich angelegt.
 user.create.new_user=Neuen Benutzer anlegen
 user.create.username=Benutzername
@@ -2264,6 +2265,7 @@ user.create.create=Benutzer anlegen
 user.create.create_another=Anlegen &amp; weiteren anlegen
 user.create.isadmin=Ist dies ein Administrator?
 user.create.admin_info=Gewährt dem Administrator Zugang zu Openfire
+user.create.group=Gruppe
 
 # User delete Page
 

--- a/i18n/src/main/resources/openfire_i18n_es.properties
+++ b/i18n/src/main/resources/openfire_i18n_es.properties
@@ -2201,6 +2201,7 @@ user.create.invalid_email=Correo Electrónico Inválido.
 user.create.invalid_password=Contraseña Inválida.
 user.create.invalid_match_password=Las contraseñas no coinciden.
 user.create.invalid_password_confirm=Confirmación de contraseña inválida.
+user.create.invalid_group=Grupo Inválido
 user.create.created_success=Nuevo usuario creado con éxito.
 user.create.new_user=Crear Nuevo Usuario
 user.create.username=Usuario
@@ -2213,6 +2214,7 @@ user.create.create=Crear Usuario
 user.create.create_another=Crear y Crear Otro
 user.create.isadmin=¿Es Administrador?
 user.create.admin_info=Permite acceso de administración a Openfire
+user.create.group=Grupo
 
 # User delete Page
 

--- a/i18n/src/main/resources/openfire_i18n_fr.properties
+++ b/i18n/src/main/resources/openfire_i18n_fr.properties
@@ -1396,6 +1396,7 @@ user.create.invalid_email = Email invalide.
 user.create.invalid_password = Mot de Passe invalide.
 user.create.invalid_match_password = Les Mots de passe ne correspondent pas.
 user.create.invalid_password_confirm = Mot de Passe de confirmation invalide.
+user.create.invalid_group = Groupe invalide
 user.create.created_success = Nouvel utilisateur créé avec succès.
 user.create.new_user = Créer un Nouvel Utilisateur
 user.create.username = Pseudo
@@ -1406,6 +1407,8 @@ user.create.confirm_pwd = Mot de Passe de Confirmation
 user.create.requied = Champs requis
 user.create.create = Créer l&#39;Utilisateur
 user.create.create_another = Créer &amp; Créer un Autre
+user.create.group = Groupe
+
 # User delete Page
 user.delete.title = Supprimer Utilisateur
 user.delete.info = Etes-vous sûr de vouloir supprimer cet utilisateur

--- a/i18n/src/main/resources/openfire_i18n_ja_JP.properties
+++ b/i18n/src/main/resources/openfire_i18n_ja_JP.properties
@@ -1719,6 +1719,7 @@ user.create.invalid_email=不適切なメールアドレスです。
 user.create.invalid_password=不適切なパスワードです。
 user.create.invalid_match_password=パスワードが一致しません。
 user.create.invalid_password_confirm=不適切なパスワード確認です。
+user.create.invalid_group=無効なグループ
 user.create.created_success=新規のユーザーが正常に作成されました。
 user.create.new_user=新規ユーザーの作成
 user.create.username=ユーザー名
@@ -1729,6 +1730,7 @@ user.create.confirm_pwd=パスワード確認
 user.create.requied=必須フィールド
 user.create.create=ユーザーを作成
 user.create.create_another=新規作成し、さらにユーザを作成
+user.create.group=グループ
 
 # User delete Page
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1697,6 +1697,7 @@ user.create.invalid_email=Ongeldig email adres.
 user.create.invalid_password=Ongeldig wachtwoord.
 user.create.invalid_match_password=De wachtwoorden komen niet overeen.
 user.create.invalid_password_confirm=Ongeldige bevestiging van het wachtwoord.
+user.create.invalid_group=Ongeldige groep
 user.create.created_success=De gebruiker is succesvol toegevoegd.
 user.create.new_user=Nieuwe gebruiker toevoegen
 user.create.username=Gebruikersnaam
@@ -1707,6 +1708,7 @@ user.create.confirm_pwd=Wachtwoord bevestigen
 user.create.requied=Vereiste velden
 user.create.create=Nieuwe gebruiker toevoegen
 user.create.create_another=Toevoegen &amp; andere toevoegen
+user.create.group=groep
 
 # User delete Page
 

--- a/i18n/src/main/resources/openfire_i18n_pl_PL.properties
+++ b/i18n/src/main/resources/openfire_i18n_pl_PL.properties
@@ -1619,6 +1619,7 @@ user.create.invalid_email=Niepoprawny adres email.
 user.create.invalid_password=Niepoprawne hasło.
 user.create.invalid_match_password=Hasła się nie zgadzają.
 user.create.invalid_password_confirm=Niepoprawne potwierdzenie hasła.
+user.create.invalid_group=Nieprawidłowa grupa
 user.create.created_success=Utworzono nowego użytkownika.
 user.create.new_user=Utwórz nowego uzytkownika
 user.create.username=Identyfikator użytkownika
@@ -1629,6 +1630,7 @@ user.create.confirm_pwd=Potwierdź hasło
 user.create.requied=Pola wymagane
 user.create.create=Utwórz użytkownika
 user.create.create_another=Utwórz i utwórz następnego
+user.create.group=Grupa
 
 # User delete Page
 

--- a/i18n/src/main/resources/openfire_i18n_pt_BR.properties
+++ b/i18n/src/main/resources/openfire_i18n_pt_BR.properties
@@ -1704,6 +1704,7 @@ user.create.invalid_email=E-mail inválido.
 user.create.invalid_password=Senha inválida.
 user.create.invalid_match_password=Senhas não conferem.
 user.create.invalid_password_confirm=Confirmação de senha inválida.
+user.create.invalid_group=Grupo inválido
 user.create.created_success=Novo usuário criado com sucesso.
 user.create.new_user=Criar Novo Usuário
 user.create.username=Nome de Usuário
@@ -1714,6 +1715,7 @@ user.create.confirm_pwd=Confirmar senha
 user.create.requied=Campos requeridos
 user.create.create=Criar Usuário
 user.create.create_another=Criar &amp; Criar Outro
+user.create.group=Grupo
 
 # User delete Page
 

--- a/i18n/src/main/resources/openfire_i18n_pt_PT.properties
+++ b/i18n/src/main/resources/openfire_i18n_pt_PT.properties
@@ -2242,6 +2242,7 @@ user.create.invalid_email=E-mail inválido.
 user.create.invalid_password=Password inválida.
 user.create.invalid_match_password=Passwords não conferem.
 user.create.invalid_password_confirm=Confirmação de password inválida.
+user.create.invalid_group=Grupo inválido.
 user.create.created_success=Novo utilizador criado com sucesso.
 user.create.new_user=Criar Novo Utilizador
 user.create.username=Nome de Utilizador
@@ -2254,6 +2255,7 @@ user.create.create=Criar Utilizador
 user.create.create_another=Criar &amp; Criar Outro
 user.create.isadmin=é Administrador?
 user.create.admin_info=Garante acesso administrativo ao Openfire
+user.create.group=Grupo
 
 # User delete Page
 

--- a/i18n/src/main/resources/openfire_i18n_ru_RU.properties
+++ b/i18n/src/main/resources/openfire_i18n_ru_RU.properties
@@ -1966,6 +1966,7 @@ user.create.invalid_email=Некорректный адрес электронн
 user.create.invalid_password=Некорректный пароль.
 user.create.invalid_match_password=Пароли не совпадают.
 user.create.invalid_password_confirm=Неверное повторение пароля.
+user.create.invalid_group=недопустимая группа
 user.create.created_success=Новый пользователь успешно создан.
 user.create.new_user=Создать нового пользователя
 user.create.username=Имя пользователя
@@ -1978,6 +1979,7 @@ user.create.create=Создать пользователя
 user.create.create_another=Создать &amp; Создать еще
 user.create.isadmin=Администратор?
 user.create.admin_info=Администратору выдается доступ к Openfire
+user.create.group=группа
 
 # Страница удаления пользователя
 

--- a/i18n/src/main/resources/openfire_i18n_sk.properties
+++ b/i18n/src/main/resources/openfire_i18n_sk.properties
@@ -1601,6 +1601,7 @@ user.create.invalid_email=Neplatný email.
 user.create.invalid_password=Neplatné heslo.
 user.create.invalid_match_password=Heslá sa nezhodujú.
 user.create.invalid_password_confirm=Neplatné potvrdenie hesla.
+user.create.invalid_group=Neplatné skupina
 user.create.created_success=Nový používateľ bol úspešne vytvorený.
 user.create.new_user=Vytvoriť nového používateľa
 user.create.username=Meno používateľa
@@ -1611,6 +1612,7 @@ user.create.confirm_pwd=Potvrďte heslo
 user.create.requied=Povinné polia
 user.create.create=Vytvoriť používateľa
 user.create.create_another=Vytvoriť &amp; vytvoriť ďalšieho
+user.create.group=Skupina
 
 # User delete Page
 

--- a/i18n/src/main/resources/openfire_i18n_zh_CN.properties
+++ b/i18n/src/main/resources/openfire_i18n_zh_CN.properties
@@ -1727,6 +1727,7 @@ user.create.invalid_email=无效电子邮件。
 user.create.invalid_password=无效密码。
 user.create.invalid_match_password=密码不匹配。
 user.create.invalid_password_confirm=无效密码确认。
+user.create.invalid_group=无效组
 user.create.created_success=已成功创建新用户。
 user.create.new_user=新建用户
 user.create.username=用户名
@@ -1739,6 +1740,7 @@ user.create.create=创建用户
 user.create.create_another=创建该用户后继续创建用户
 user.create.isadmin=作为管理员
 user.create.admin_info=授予 Openfire 管理权限
+user.create.group=团体
 
 # User delete Page
 

--- a/xmppserver/src/main/webapp/user-create.jsp
+++ b/xmppserver/src/main/webapp/user-create.jsp
@@ -294,6 +294,8 @@
                 (<fmt:message key="user.create.admin_info"/>)
             </td>
         </tr>
+        <% } %>
+        <% if (!webManager.getGroupManager().getGroups().isEmpty()){%>
         <tr>
             <td class="c1">
                 <label for="grouptf"><fmt:message key="user.create.group"/>:</label>
@@ -303,7 +305,7 @@
                        id="grouptf">
             </td>
         </tr>
-        <% } %>
+        <%} %>
         <tr>
 
             <td colspan="2" style="padding-top: 10px;">


### PR DESCRIPTION
Updates the create user page to include an option for assigning a group directly from that first page.

This implementation uses a text field expecting the exact name of a group, could potentially be improved with a dropdown list of available groups.