### PR TITLE
OF-2340: send stanzas that are 'responses' through PacketRouter, not RoutingTable

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -458,7 +458,7 @@ public class IQRouter extends BasicModule {
             return;
         }
         // Route the error packet to the original sender of the IQ.
-        routingTable.routePacket(reply.getTo(), reply, true);
+        XMPPServer.getInstance().getPacketRouter().route(reply);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStrategy.java
@@ -96,7 +96,8 @@ public class OfflineMessageStrategy extends BasicModule implements ServerFeature
                 result.setTo(message.getFrom());
                 result.setFrom(message.getTo());
                 result.setError(PacketError.Condition.service_unavailable);
-                XMPPServer.getInstance().getRoutingTable().routePacket(message.getFrom(), result, true);
+
+                XMPPServer.getInstance().getPacketRouter().route(result);
                 return;
             }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
@@ -404,12 +404,10 @@ public class FileTransferProxy extends BasicModule
     public void process(Packet packet) throws UnauthorizedException, PacketException {
         // Check if the packet is a disco request or a packet with namespace iq:register
         if (packet instanceof IQ) {
-            if (handleIQ((IQ) packet)) {
-                // Do nothing
-            }
-            else {
-                IQ reply = IQ.createResultIQ((IQ) packet);
-                reply.setChildElement(((IQ) packet).getChildElement().createCopy());
+            final IQ iq = (IQ) packet;
+            if (!handleIQ(iq) && iq.isRequest()) {
+                IQ reply = IQ.createResultIQ(iq);
+                reply.setChildElement(iq.getChildElement().createCopy());
                 reply.setError(PacketError.Condition.feature_not_implemented);
                 router.route(reply);
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -551,6 +551,9 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
      */
     private void sendErrorPacket( Packet packet, PacketError.Condition error, String message )
     {
+        if (packet.getError() != null) {
+            Log.debug("Avoid generating an error in response to a stanza that itself has an error (to avoid the chance of entering an endless back-and-forth of exchanging errors). Suppress sending an {} error (with message '{}') in response to: {}", error, message, packet);
+        }
         if ( packet instanceof IQ )
         {
             IQ reply = IQ.createResultIQ((IQ) packet);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -553,6 +553,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     {
         if (packet.getError() != null) {
             Log.debug("Avoid generating an error in response to a stanza that itself has an error (to avoid the chance of entering an endless back-and-forth of exchanging errors). Suppress sending an {} error (with message '{}') in response to: {}", error, message, packet);
+            return;
         }
         if ( packet instanceof IQ )
         {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -386,16 +386,9 @@ public class OutgoingSessionPromise {
                 TaskEngine.getInstance().submit(() -> {
                     try
                     {
-                        final ClientSession session = SessionManager.getInstance().getSession( reply.getTo() );
-                        InterceptorManager.getInstance().invokeInterceptors( reply, session, false, false );
-                        routingTable.routePacket( reply.getTo(), reply, true );
-                        InterceptorManager.getInstance().invokeInterceptors( reply, session, false, true );
+                        XMPPServer.getInstance().getPacketRouter().route( reply );
                     }
-                    catch ( PacketRejectedException ex )
-                    {
-                        Log.debug( "Reply got rejected by an interceptor: {}", reply, ex );
-                    }
-                    catch ( Exception e )
+                    catch (Exception e)
                     {
                         Log.warn( "An exception occurred while trying to returning a remote-server-not-found error (for domain '{}') to the original sender. Original packet: {}", domainPair.getRemote(), packet, e );
                     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -713,7 +713,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                 }
                 else if (packet instanceof Presence) {
                     if (((Presence)packet).getType() == Presence.Type.error) {
-                        Log.debug("Double-bounce of presence: {}", packet.toXML());
+                        Log.debug("Avoid generating an error in response to a stanza that itself is an error (to avoid the chance of entering an endless back-and-forth of exchanging errors). Suppress sending an {} error in response to: {}", PacketError.Condition.remote_server_not_found, packet);
                         return;
                     }
                     Presence reply = new Presence();
@@ -726,7 +726,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                 }
                 else if (packet instanceof Message) {
                     if (((Message)packet).getType() == Message.Type.error){
-                        Log.debug("Double-bounce of message: {}", packet.toXML());
+                        Log.debug("Avoid generating an error in response to a stanza that itself is an error (to avoid the chance of entering an endless back-and-forth of exchanging errors). Suppress sending an {} error in response to: {}", PacketError.Condition.remote_server_not_found, packet);
                         return;
                     }
                     Message reply = new Message();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -692,7 +692,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
 
     private void returnErrorToSenderAsync(Packet packet) {
         TaskEngine.getInstance().submit(() -> {
-            RoutingTable routingTable = XMPPServer.getInstance().getRoutingTable();
+            final PacketRouter packetRouter = XMPPServer.getInstance().getPacketRouter();
             if (packet.getError() != null) {
                 Log.debug("Possible double bounce: {}", packet.toXML());
             }
@@ -709,7 +709,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                     reply.setChildElement(((IQ) packet).getChildElement().createCopy());
                     reply.setType(IQ.Type.error);
                     reply.setError(PacketError.Condition.remote_server_not_found);
-                    routingTable.routePacket(reply.getTo(), reply, true);
+                    packetRouter.route(reply);
                 }
                 else if (packet instanceof Presence) {
                     if (((Presence)packet).getType() == Presence.Type.error) {
@@ -722,7 +722,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                     reply.setFrom(packet.getTo());
                     reply.setType(Presence.Type.error);
                     reply.setError(PacketError.Condition.remote_server_not_found);
-                    routingTable.routePacket(reply.getTo(), reply, true);
+                    packetRouter.route(reply);
                 }
                 else if (packet instanceof Message) {
                     if (((Message)packet).getType() == Message.Type.error){
@@ -736,7 +736,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                     reply.setType(Message.Type.error);
                     reply.setThread(((Message)packet).getThread());
                     reply.setError(PacketError.Condition.remote_server_not_found);
-                    routingTable.routePacket(reply.getTo(), reply, true);
+                    packetRouter.route(reply);
                 }
             }
             catch (Exception e) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -422,6 +422,10 @@ public abstract class LocalSession implements Session {
             // http://xmpp.org/extensions/xep-0016.html#protocol-error
             if (packet instanceof Message) {
                 // For message stanzas, the server SHOULD return an error, which SHOULD be <service-unavailable/>.
+                if (((Message)packet).getType() == Message.Type.error){
+                    Log.debug("Avoid generating an error in response to a stanza that itself is an error (to avoid the chance of entering an endless back-and-forth of exchanging errors). Suppress sending an {} error in response to: {}", PacketError.Condition.service_unavailable, packet);
+                    return;
+                }
                 Message message = (Message) packet;
                 Message result = message.createCopy();
                 result.setTo(message.getFrom());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -425,8 +425,9 @@ public abstract class LocalSession implements Session {
                 Message message = (Message) packet;
                 Message result = message.createCopy();
                 result.setTo(message.getFrom());
+                result.setFrom(message.getTo());
                 result.setError(PacketError.Condition.service_unavailable);
-                XMPPServer.getInstance().getRoutingTable().routePacket(message.getFrom(), result, true);
+                XMPPServer.getInstance().getPacketRouter().route(result);
             } else if (packet instanceof IQ) {
                 // For IQ stanzas of type "get" or "set", the server MUST return an error, which SHOULD be <service-unavailable/>.
                 // IQ stanzas of other types MUST be silently dropped by the server.
@@ -434,7 +435,7 @@ public abstract class LocalSession implements Session {
                 if (iq.getType() == IQ.Type.get || iq.getType() == IQ.Type.set) {
                     IQ result = IQ.createResultIQ(iq);
                     result.setError(PacketError.Condition.service_unavailable);
-                    XMPPServer.getInstance().getRoutingTable().routePacket(iq.getFrom(), result, true);
+                    XMPPServer.getInstance().getPacketRouter().route(result);
                 }
             }
         }


### PR DESCRIPTION
In various places in the code, Openfire generates a response to a stanza, to be delivered back to the sender of the original stanza. Typically, this involves errors, such as delivery errors.

Some of the existing code uses the RoutingTable to deliver these stanzas. This works, but bypasses a lot of checks and flags (as well as the interceptors). For "new" stanzas, it's more appropriate to use PacketRouter, as this will more closely resemble the normal stanza processing.