### PR TITLE
OF-2341 / OF-2342: Process S2S 'bounces' async to prevent deadlocks

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -398,7 +398,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
             } else if (packet instanceof Message) {
                 final Message msg = (Message) packet;
                 if (msg.getType() == Message.Type.error) {
-                    // Bounced message, drop user.
+                    Log.info("Received a message stanza of type error from {}. Removing this user from all chat rooms.", packet.getFrom());
                     removeChatUser(packet.getFrom());
                     Log.trace( "Done processing Message stanza." );
                     return;
@@ -406,7 +406,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
             } else if (packet instanceof Presence) {
                 final Presence pres = (Presence) packet;
                 if (pres.getType() == Presence.Type.error) {
-                    // Bounced presence, drop user.
+                    Log.info("Received a presence stanza of type error from {}. Removing this user from all chat rooms.", packet.getFrom());
                     removeChatUser(packet.getFrom());
                     Log.trace( "Done processing Presence stanza." );
                     return;


### PR DESCRIPTION
When a stanza addressed to a remote domain cannot be processed, it is 'bounced'. Processing of these bounces has been a factor in at least two recent deadlocks on the Ignite domain.

This commit attempts to alleviate the problem by making the processing of the 'bounce' be asynchronous to the process that leads up to sending to original stanza (that was bounced). This decoupling allows locks/mutexes kept by the 'supplying' code flow to be released, before the 'bounce' is being processed (which arguably is a completely new stanza which needs not be processed under the original locks/mutexes anyway).