### PR TITLE
Bump down default log level

### DIFF
--- a/distribution/src/resources/log4j2.xml
+++ b/distribution/src/resources/log4j2.xml
@@ -33,7 +33,7 @@
         <!-- OF-506: Jetty INFO messages are generally not useful. Ignore them by default. -->
         <Logger name="org.eclipse.jetty" level="warn"/>
 
-        <Root level="all">
+        <Root level="info">
             <AppenderRef ref="openfire"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
Having a verbose log level is convenient for development, but should not be the default level.