### PR TITLE
OF-2349: Show default value for property on admin console

### DIFF
--- a/xmppserver/src/main/webapp/system-properties.jsp
+++ b/xmppserver/src/main/webapp/system-properties.jsp
@@ -314,6 +314,16 @@ ${listPager.jumpToPageForm}
         </tr>
         <tr valign="top">
             <td>
+                <label for="defaultPropertyValue">
+                    <fmt:message key="server.properties.default"/>:
+                </label>
+            </td>
+            <td>
+                <span id="defaultPropertyValue"></span>
+            </td>
+        </tr>
+        <tr valign="top">
+            <td>
                 <fmt:message key="server.properties.encryption"/>:
             </td>
             <td>
@@ -368,6 +378,10 @@ ${listPager.jumpToPageForm}
         } else {
             valueField.value = imgObject.parentNode.parentNode.childNodes[3].childNodes[1].textContent;
         }
+
+        var defaultValueField = document.getElementById("defaultPropertyValue");
+        defaultValueField.innerText = imgObject.parentNode.parentNode.childNodes[5].childNodes[0].textContent.trim();
+
         document.getElementById(encrypted ? "editPropertyEncryptTrue" : "editPropertyEncryptFalse").checked = true;
         document.getElementById("newPropertyTitle").style.display = "none";
         document.getElementById("editPropertyTitle").style.display = "";


### PR DESCRIPTION
The system property page shows default values for each property, but the space for that is limited. Longer values are abbreviated, which makes it hard to determine exactly what their content is.

This commit adds the full default value in the 'edit' form.

![image](https://user-images.githubusercontent.com/4253898/144470291-5441271d-4a4f-44c4-9100-669dfc8f75bd.png)
