### PR TITLE
OF-2351: Update log4j to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <mina.version>2.1.3</mina.version>
         <bouncycastle.version>1.68</bouncycastle.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <log4j.version>2.13.3</log4j.version>
+        <log4j.version>2.15.0</log4j.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
This addresses the CVE-2021-44228 "LogJam" vulnerability.