### PR TITLE
Upgrade log4j to 2.16.0 for CVE-2021-4428

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <mina.version>2.1.3</mina.version>
         <bouncycastle.version>1.68</bouncycastle.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
Upgrading log4j to 2.15.0 was unfortunately not enough per https://issues.apache.org/jira/browse/LOG4J2-3221

This should further address the CVE-2021-44228 "LogJam" vulnerability.