### PR TITLE
OF-2354: Allow whitespace around comma-separated string values for list

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
@@ -119,7 +119,7 @@ public final class SystemProperty<T> {
         if (StringUtils.isEmpty(value)) {
             return Stream.empty();
         }
-        final List<String> strings = Arrays.asList(value.split(","));
+        final List<String> strings = Arrays.asList(value.trim().split("[\\s,]+"));
         Stream<Object> stream = strings.stream()
             .map(singleValue -> FROM_STRING.get(systemProperty.collectionType).apply(singleValue, systemProperty))
             .filter(Objects::nonNull);

--- a/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
@@ -526,6 +526,48 @@ public class SystemPropertyTest {
     }
 
     @Test
+    public void willCreateAListOfCommaSeparatedString() {
+        final String key = "a csv list property";
+
+        final SystemProperty<List<String>> property = SystemProperty.Builder.ofType(List.class)
+            .setKey(key)
+            .setDefaultValue(Collections.emptyList())
+            .setDynamic(true)
+            .buildList(String.class);
+
+        JiveGlobals.setProperty(key, "3,2,1");
+        assertThat(property.getValue(), is(Arrays.asList("3", "2", "1")));
+    }
+
+    @Test
+    public void willCreateAListOfCommaWhitespaceSeparatedString() {
+        final String key = "a whitespace csv list property";
+
+        final SystemProperty<List<String>> property = SystemProperty.Builder.ofType(List.class)
+            .setKey(key)
+            .setDefaultValue(Collections.emptyList())
+            .setDynamic(true)
+            .buildList(String.class);
+
+        JiveGlobals.setProperty(key, " 3, 2, 1 ");
+        assertThat(property.getValue(), is(Arrays.asList("3", "2", "1")));
+    }
+
+    @Test
+    public void willCreateAListOfCommaWhitespaceSeparatedString2() {
+        final String key = "another whitespace csv list property";
+
+        final SystemProperty<List<String>> property = SystemProperty.Builder.ofType(List.class)
+            .setKey(key)
+            .setDefaultValue(Collections.emptyList())
+            .setDynamic(true)
+            .buildList(String.class);
+
+        JiveGlobals.setProperty(key, "1 , 2 , 3");
+        assertThat(property.getValue(), is(Arrays.asList("1", "2", "3")));
+    }
+
+    @Test
     public void willCreateASetOfStringProperties() {
         final String key = "a set property";
 


### PR DESCRIPTION
When reading a comma-separated string to be parsed as a list of strings, whitespace surrounding the comma's should be ignored.

eg: "user@example.org, user@example.com" should be parsed as two values that contain no whitespace.