### PR TITLE
OF-2355: Update log4j to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <mina.version>2.1.3</mina.version>
         <bouncycastle.version>1.68</bouncycastle.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
To fix https://nvd.nist.gov/vuln/detail/CVE-2021-45105. Fixes OF-2355