### PR TITLE
Update MINA to 2.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
         <jetty.version>9.4.43.v20210629</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
-        <mina.version>2.1.3</mina.version>
+        <mina.version>2.1.5</mina.version>
         <bouncycastle.version>1.68</bouncycastle.version>
         <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.16.0</log4j.version>


### PR DESCRIPTION
To fix https://nvd.nist.gov/vuln/detail/CVE-2021-41973.