### PR TITLE
OF-2358: When room is destroyed, consider that room might be gone

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1119,7 +1119,10 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
 
             // This is for clustering scenarios where one node could already have cleaned up the clustered cache,
             // but the local node still needs to process the 'unavailable' presence of the leaving occupant.
-            preExistingRole = localMUCRoomManager.getLocalRooms().get(roomName).getOccupantByFullJID(packet.getFrom());
+            final MUCRoom localRoom = localMUCRoomManager.getLocalRooms().get(roomName);
+            if (localRoom != null) {
+                preExistingRole = localRoom.getOccupantByFullJID(packet.getFrom());
+            }
 
             if (preExistingRole == null) {
                 Log.debug("Silently ignoring user '{}' leaving a room that it has no role in '{}' (was the room just destroyed)?", packet.getFrom(), roomName);


### PR DESCRIPTION
In MUC code that deals with room destruction, the 'room' instance is considered 'nullable' (in other words: it might not be there anymore).

The same code has a fall-back routine that intends to deal with cluster-related events. Prior to this commit, this unconditionally assumes that a local copy of the room will be present.

The former seems to contradictd the latter. This commit adds a null-check to the latter.