### PR TITLE
OF-2319

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1771,7 +1771,7 @@ system_property.xmpp.pep.threadpool.keepalive=The number of threads in the threa
 system_property.xmpp.taskengine.threadpool.size.core=The number of threads to keep in the thread pool that is used to execute tasks of Openfire's TaskEngine, even if they are idle.
 system_property.xmpp.taskengine.threadpool.size.max=The maximum number of threads to allow in the thread pool that is used to execute tasks of Openfire's TaskEngine.
 system_property.xmpp.taskengine.threadpool.keepalive=The number of threads in the thread pool that is used to execute tasks of Openfire's TaskEngine is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
-
+system_property.xmpp.muc.allowpm.blockall=Toggles whether to block all packets from users or just messages if they do not have permission to send private messages.
 # Server properties Page
 
 server.properties.title=System Properties

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -1402,23 +1402,31 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
      * conversation between room occupants or IQ packets when an occupant wants to send IQ packets
      * to other room occupants.
      *
+     * If the system property xmpp.muc.allowpm.blockall is set to true, this will block all private packets
+     * However, if this property is false (by default) then it will allow non-message private packets.
+     *
      * @param packet The packet to send.
      * @param senderRole the role of the user that is trying to send a public message.
      * @throws NotFoundException If the user is sending a packet to a room JID that does not exist.
      * @throws ForbiddenException If a user of this role is not permitted to send private messages in this room.
      */
     public void sendPrivatePacket(Packet packet, MUCRole senderRole) throws NotFoundException, ForbiddenException {
-        switch (senderRole.getRole()) { // intended fall-through
-            case none:
-                throw new ForbiddenException();
-            default:
-            case visitor:
-                if (canSendPrivateMessage().equals( "participants" )) throw new ForbiddenException();
-            case participant:
-                if (canSendPrivateMessage().equals( "moderators" )) throw new ForbiddenException();
-            case moderator:
-                if (canSendPrivateMessage().equals( "none" )) throw new ForbiddenException();
+
+        if (packet instanceof Message || JiveProperties.getInstance().getBooleanProperty("xmpp.muc.allowpm.blockall", false)){
+            //If the packet is a message, check that the user has permissions to send
+            switch (senderRole.getRole()) { // intended fall-through
+                case none:
+                    throw new ForbiddenException();
+                default:
+                case visitor:
+                    if (canSendPrivateMessage().equals( "participants" )) throw new ForbiddenException();
+                case participant:
+                    if (canSendPrivateMessage().equals( "moderators" )) throw new ForbiddenException();
+                case moderator:
+                    if (canSendPrivateMessage().equals( "none" )) throw new ForbiddenException();
+            }
         }
+
         String resource = packet.getTo().getResource();
 
         List<MUCRole> occupants;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -77,6 +77,12 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
         .setChronoUnit(ChronoUnit.MILLIS)
         .build();
 
+    public static SystemProperty<Boolean> ALLOWPM_BLOCKALL = SystemProperty.Builder.ofType( Boolean.class )
+        .setKey("xmpp.muc.allowpm.blockall")
+        .setDefaultValue(false)
+        .setDynamic(true)
+        .build();
+
     /**
      * The service hosting the room.
      */
@@ -1412,7 +1418,7 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
      */
     public void sendPrivatePacket(Packet packet, MUCRole senderRole) throws NotFoundException, ForbiddenException {
 
-        if (packet instanceof Message || JiveProperties.getInstance().getBooleanProperty("xmpp.muc.allowpm.blockall", false)){
+        if (packet instanceof Message || ALLOWPM_BLOCKALL.getValue()){
             //If the packet is a message, check that the user has permissions to send
             switch (senderRole.getRole()) { // intended fall-through
                 case none:


### PR DESCRIPTION
Introduces system property xmpp.muc.allowpm.blockall to toggle whether all packets should be blocked, or just private messages.