### PR TITLE
OF-2360 Move plugin / OF version retrieval to ClusterManager

### DIFF
--- a/xmppserver/changelog.html
+++ b/xmppserver/changelog.html
@@ -162,6 +162,13 @@ hr {
     
     <div id="pageBody">
 
+<h2>(Next version) <span style="font-weight: normal;">(release date)</span></h2>
+
+<h2>Improvement</h2>
+<ul>
+    <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2360">OF-2360</a>] - Plugin version information accessible through cluster manager</li>
+</ul>
+
 <h2>4.7.0 Beta -- <span style="font-weight: normal;">December 3, 2021</span></h2>
 
 <h2>Bug</h2>

--- a/xmppserver/changelog.html
+++ b/xmppserver/changelog.html
@@ -162,13 +162,6 @@ hr {
     
     <div id="pageBody">
 
-<h2>(Next version) <span style="font-weight: normal;">(release date)</span></h2>
-
-<h2>Improvement</h2>
-<ul>
-    <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2360">OF-2360</a>] - Plugin version information accessible through cluster manager</li>
-</ul>
-
 <h2>4.7.0 Beta -- <span style="font-weight: normal;">December 3, 2021</span></h2>
 
 <h2>Bug</h2>

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterManager.java
@@ -510,7 +510,7 @@ public class ClusterManager {
     public static Map<NodeID, String> findRemotePluginsWithDifferentVersion(final String pluginName) {
         final Map<String, Map<NodeID, String>> allPluginVersions = getPluginAndOpenfireVersions();
 
-        if (allPluginVersions.containsKey(pluginName)) {
+        if (!allPluginVersions.containsKey(pluginName)) {
             return null;
         }
 


### PR DESCRIPTION
Logic for clusterwide fetching of plugin versions was previously located in a jsp. This PR moves that logic to the cluster manager, so it becomes available for reuse.

Furthermore a new method is introduced that detects version discrepancies of plugins between the local and other nodes. This will be useful for (at least) improving the monitoring plugin.