### PR TITLE
OF-2355 Update log4j to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <mina.version>2.1.3</mina.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
Another one in few days, to fix https://nvd.nist.gov/vuln/detail/CVE-2021-44832.
- https://logging.apache.org/log4j/2.x/security.html

CVE-2021-4104
CVE-2021-44228
CVE-2021-44832
CVE-2021-45046
CVE-2021-45105