### PR TITLE
OF-2365: Pubsub - limit notifications to eligible (parent) subscribers.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/LeafNode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/LeafNode.java
@@ -282,7 +282,12 @@ public class LeafNode extends Node {
         // Get affiliates that are subscribed to a parent in the hierarchy of parent nodes
         for (CollectionNode parentNode : getParents()) {
             for (NodeSubscription subscription : parentNode.getSubscriptions()) {
-                affiliatesToNotify.add(subscription.getAffiliate());
+                // OF-2365: Prevent sending notifications to subscribers that are not allowed to access this node.
+                if (parentNode.getAccessModel().canAccessItems(this, subscription.getOwner(), subscription.getJID() )
+                    && accessModel.canAccessItems(this, subscription.getOwner(), subscription.getJID()))
+                {
+                    affiliatesToNotify.add(subscription.getAffiliate());
+                }
             }
         }
 


### PR DESCRIPTION
When sending notifications to subscribers of a parent collection node, only include those that match the applicable AccessModel.