### PR TITLE
OF-2368: Improve MUC ghost user detection

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -155,6 +156,7 @@ public class CacheFactory {
         cacheNames.put("JID Domain-parts", "jidDomainprep");
         cacheNames.put("JID Resource-parts", "jidResourceprep");
         cacheNames.put("Sequences", "sequences");
+        cacheNames.put("MUC Service Pings Sent", "mucPings");
 
         cacheProps.put(PROPERTY_PREFIX_CACHE + "dnsRecords" + PROPERTY_SUFFIX_SIZE, 128 * 1024L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "dnsRecords" + PROPERTY_SUFFIX_MAX_LIFE_TIME, 1000 * 60L);
@@ -238,7 +240,8 @@ public class CacheFactory {
         cacheProps.put(PROPERTY_PREFIX_CACHE + "publishedItems" + PROPERTY_SUFFIX_MAX_LIFE_TIME, JiveConstants.MINUTE * 15);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "sequences" + PROPERTY_SUFFIX_SIZE, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "sequences" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
-
+        cacheProps.put(PROPERTY_PREFIX_CACHE + "mucPings" + PROPERTY_SUFFIX_SIZE, -1L);
+        cacheProps.put(PROPERTY_PREFIX_CACHE + "mucPings" + PROPERTY_SUFFIX_MAX_LIFE_TIME, JiveConstants.MINUTE * 10);
 
         // The JID-based classes (wrappers for Caffeine caches) take their default values from whatever is hardcoded in the JID implementation.
         cacheProps.put(PROPERTY_PREFIX_CACHE + "jidNodeprep" + PROPERTY_SUFFIX_SIZE, JID.NODEPREP_CACHE.policy().eviction().get().getMaximum() );


### PR DESCRIPTION
This commit combines approaches introduced by OF-910 and OF-2209 to detect a 'ghost user' in MUC.

Per OF-910, any Presence or Message stanza that contains an error is considered indicative of a ghost.

Per OF-2209, an IQ 'Ping' is used to determine ghosts.

Unlike the original solution for OF-2209, not all IQ error responses should be considered as indicative of a ghost. Firstly, the IQ error must be in response to an IQ Ping that was sent by the service itself. Furthermore, 'service-unavailable' and 'feature-not-implemented' can be considered as responses sent by a client (that does not support the IQ Ping protocol).

Finally, this commit adds a kick of users that have been pinged, but for which no response has been received at all.