### PR TITLE
OF-2369: Do not do outbound S2S when inbound disabled.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
@@ -1,6 +1,8 @@
 package org.jivesoftware.openfire.net;
 
 import org.jivesoftware.openfire.server.RemoteServerManager;
+import org.jivesoftware.openfire.session.ConnectionSettings;
+import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +55,16 @@ public class SocketUtil
             final String realHostname = remoteHost.getHost();
             final int realPort = remoteHost.getPort();
             final boolean directTLS = remoteHost.isDirectTLS();
+
+            if (!JiveGlobals.getBooleanProperty(ConnectionSettings.Server.ENABLE_OLD_SSLPORT, true) && directTLS) {
+                Log.debug("Skipping directTLS host, as we're ourselves not accepting directTLS S2S");
+                continue;
+            }
+
+            if (!JiveGlobals.getBooleanProperty(ConnectionSettings.Server.SOCKET_ACTIVE, true) && !directTLS) {
+                Log.debug("Skipping non direct TLS host, as we're ourselves not accepting non direct S2S");
+                continue;
+            }
 
             try
             {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/RemoteServerManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/RemoteServerManager.java
@@ -114,7 +114,8 @@ public class RemoteServerManager {
     public static boolean canAccess(String domain) {
         // If s2s is disabled then it is not possible to send packets to remote servers or
         // receive packets from remote servers
-        if (!JiveGlobals.getBooleanProperty(ConnectionSettings.Server.SOCKET_ACTIVE, true)) {
+        if (!JiveGlobals.getBooleanProperty(ConnectionSettings.Server.SOCKET_ACTIVE, true)
+            && !JiveGlobals.getBooleanProperty(ConnectionSettings.Server.ENABLE_OLD_SSLPORT, true)) {
             return false;
         }
 


### PR DESCRIPTION
When Openfire is configured to not allow inbound S2S of a particular flavor (direct or non-direct TLS) do not try to establish outbound S2S of the same type.

This effectively makes an outbound S2S attempt impossible when Openfire is configured to not accept any inbound S2S.