### PR TITLE
OF-2381: Fixes for MUC 'ghost user' and 'idle user' detection

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -2111,7 +2111,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         synchronized (this) {
             // Cancel the existing task because the timeout has changed
             if (userTimeoutTask != null) {
-                userTimeoutTask.cancel();
+                TaskEngine.getInstance().cancelScheduledTask(userTimeoutTask);
             }
 
             // Create a new task and schedule it with the new timeout

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/OccupantManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/OccupantManager.java
@@ -645,12 +645,12 @@ public class OccupantManager implements MUCEventListener
 
         @Override
         public String toString() {
-            return "Occupant{" +
-                "roomName='" + roomName + '\'' +
-                ", nickname='" + nickname + '\'' +
-                ", realJID=" + realJID +
-                ", lastActive=" + lastActive +
-                '}';
+            return "Occupant " +
+                "'" + nickname + '\'' +
+                " of room '" + roomName + '\'' +
+                " (real JID '" + realJID +
+                "', last active " + lastActive +
+                ")";
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -241,7 +241,7 @@ public class CacheFactory {
         cacheProps.put(PROPERTY_PREFIX_CACHE + "sequences" + PROPERTY_SUFFIX_SIZE, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "sequences" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "mucPings" + PROPERTY_SUFFIX_SIZE, -1L);
-        cacheProps.put(PROPERTY_PREFIX_CACHE + "mucPings" + PROPERTY_SUFFIX_MAX_LIFE_TIME, JiveConstants.MINUTE * 10);
+        cacheProps.put(PROPERTY_PREFIX_CACHE + "mucPings" + PROPERTY_SUFFIX_MAX_LIFE_TIME, JiveConstants.MINUTE * 30);
 
         // The JID-based classes (wrappers for Caffeine caches) take their default values from whatever is hardcoded in the JID implementation.
         cacheProps.put(PROPERTY_PREFIX_CACHE + "jidNodeprep" + PROPERTY_SUFFIX_SIZE, JID.NODEPREP_CACHE.policy().eviction().get().getMaximum() );


### PR DESCRIPTION
A 'ghost' occupant (one that is no longer reachable) should be detected by an IQ ping (or routing issues), which is now tied to the 'Check if users are still connected after they have been idle for X minutes' in the admin console (defaults to 'enabled', 8 minutes)

Removing an 'inactive' user (in context of the 'Kick users after they have been idle for Y minutes' admin console setting) should _not_ take into account Ghost detection, as the original intent of this feature appears to relate to connected, but otherwise inactive users.

Kicking a 'ghost' that fails to respond to an IQ Ping should be tied to the IQ Ping request/response (and not, as previously implemented, by detecting continued inactivity for some period after a Ping request should have been sent).

Kicking an occupant doesn't require an additional broadcast. This only duplicates presence stanzas in the room.

The interval with which checks are executed should be tied to the maximum allowed idleness (to prevent cases where Openfire checks once per day for users that have been inactive for longer than one minute, for example).