### PR TITLE
OF-2390: Redefine MUC ghost detection timing defaults

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1418,6 +1418,7 @@ muc.tasks.conversation.logging=Conversation Logging
 muc.tasks.maxbatchsize=Maximum batch size
 muc.tasks.maxbatchinterval=Maximum batch time (millis)
 muc.tasks.batchgrace=Maximum wait for new batch content (millis)
+muc.tasks.pingtime_short=Checking if users are still connected after they have been idle for this amount of minutes has a significant chance of removing users that are in fact not disconnected. Consider increasing the amount of time.
 
 # Muc cache Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -2459,7 +2459,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
             }
         }
         value = MUCPersistenceManager.getProperty(chatServiceName, "tasks.user.ping");
-        userIdlePing = Duration.ofMinutes(8);
+        userIdlePing = Duration.ofMinutes(60);
         if (value != null) {
             try {
                 final long millis = Long.parseLong(value);


### PR DESCRIPTION
With this new default settings, there's a lot less risk of Openfire incorrectly identifying occupants that are XEP-0198-detached as MUC ghosts.