### PR TITLE
OF-113: Limit lenght of group name/description to database restrictions

### DIFF
--- a/xmppserver/src/main/webapp/group-create.jsp
+++ b/xmppserver/src/main/webapp/group-create.jsp
@@ -228,7 +228,7 @@
             <label for="gname"><fmt:message key="group.create.group_name" /></label> *
         </td>
         <td width="99%">
-            <input type="text" name="name" size="30" maxlength="75"
+            <input type="text" name="name" size="30" maxlength="50"
              value="<%= ((name != null) ? StringUtils.escapeForXML(name) : "") %>" id="gname">
         </td>
     </tr>
@@ -253,7 +253,7 @@
             <label for="gdesc"><fmt:message key="group.create.label_description" /></label>
         </td>
         <td width="99%">
-            <textarea name="description" cols="30" rows="3" id="gdesc"
+            <textarea name="description" cols="30" rows="3" maxlength="255" id="gdesc"
              ><%= ((description != null) ? StringUtils.escapeHTMLTags(description) : "") %></textarea>
         </td>
     </tr>

--- a/xmppserver/src/main/webapp/group-edit.jsp
+++ b/xmppserver/src/main/webapp/group-edit.jsp
@@ -424,7 +424,7 @@
                     <label for="gname"><fmt:message key="group.create.group_name" /></label> *
                 </td>
                 <td width="99%">
-                    <input type="text" name="name" size="75" maxlength="75" value="${fn:escapeXml(group.name)}" id="gname" ${webManager.groupManager.readOnly ? 'readonly' : ''} />
+                    <input type="text" name="name" size="50" maxlength="50" value="${fn:escapeXml(group.name)}" id="gname" ${webManager.groupManager.readOnly ? 'readonly' : ''} />
                 </td>
             </tr>
             <c:if test="${not empty errors['name'] or not empty errors['alreadyExists']}">
@@ -443,7 +443,7 @@
                     <label for="gdesc"><fmt:message key="group.create.label_description" /></label>
                 </td>
                 <td width="99%">
-                    <textarea name="description" cols="75" rows="3" id="gdesc" ${webManager.groupManager.readOnly ? 'readonly' : ''}><c:out value="${group.description}"/></textarea>
+                    <textarea name="description" cols="75" rows="3" maxlength="255" id="gdesc" ${webManager.groupManager.readOnly ? 'readonly' : ''}><c:out value="${group.description}"/></textarea>
                 </td>
             </tr>
             <c:if test="${not empty errors['description']}">


### PR DESCRIPTION
The database allows for up to 50 characters for a group name, and up to 255 for a description. The admin panel should not allow the end-user to provide longer values.