### PR TITLE
OF-2398: Admin console: add visual indication of MUC room being locked

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1299,6 +1299,8 @@ muc.room.edit.form.modified=Last Modified
 muc.room.edit.form.change_room=Change the room settings of this room using the form below
 muc.room.edit.form.persistent_room=Use the form below to create a new persistent room. The new room \
         will be immediately available.
+muc.room.edit.form.warning.room_is_locked=This room is locked since {0}. It is likely in process of being created. \
+  Users cannot join the room, until the room owner unlocks the room. 
 muc.room.edit.form.error_created_id=Error creating the room. A room with the request ID already exists.
 muc.room.edit.form.error_created_privileges=Error creating the room. You do not have enough \
         privileges to create rooms.
@@ -1365,6 +1367,7 @@ muc.room.summary.destroy=Destroy
 muc.room.summary.no_room_in_group=No rooms in the Group Chat service.
 muc.room.summary.alt_persistent=Room is persistent
 muc.room.summary.alt_temporary=Room is temporary
+muc.room.summary.alt_locked=Room is locked (it is likely in process of being created).
 muc.room.summary.service=Service
 
 # MUC service summary Page

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -690,6 +690,8 @@ muc.room.edit.form.modified=Laatst aangepast
 muc.room.edit.form.change_room=Verander de instellingen van deze gespreksruimte via het onderstaande formulier
 muc.room.edit.form.persistent_room=Gebruik het onderstaande formulier om een nieuwe, permanente gespreksruimte aan te maken. \
         De nieuwe gespreksruimte is onmiddelijk beschikbaar.
+muc.room.edit.form.warning.room_is_locked=Deze gespreksruimte is op slot sinds {0}. De ruimte wordt op dit moment \
+        waarschijnlijk nog aangemaakt. Gebruikers kunnen de ruimte niet betreden, voordat een eigenaar de ruimte ontsluit. 
 muc.room.edit.form.error_created_id=Fout bij het aanmaken van de gespreksruimte. Een gespreksruimte met hetzelfde ID bestaat reeds.
 muc.room.edit.form.error_created_privileges=Fout bij het aanmaken van de gespreksruimte. U hebt geen \
         toelating om gespreksruimtes aan te maken.
@@ -751,6 +753,7 @@ muc.room.summary.destroy=Vernietigen
 muc.room.summary.no_room_in_group=De chatdienst bevat geen gespreksruimtes.
 muc.room.summary.alt_persistent=Wanneer iedereen de gespreksruimte heeft verlaten blijft de ruimte bestaan
 muc.room.summary.alt_temporary=De gespreksruimte is tijdelijk
+muc.room.summary.alt_locked=De gespreksruimte zit op slot (het wordt waarschijnlijk nog aangemaakt).
 
 # Muc tasks Page
 

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -432,6 +432,16 @@
         </c:when>
     </c:choose>
 
+    <c:if test="${room.locked}">
+        <admin:infobox type="warning">
+            <fmt:message key="muc.room.edit.form.warning.room_is_locked">
+                <fmt:param>
+                    <fmt:formatDate value="${room.lockedDate}" type="both" dateStyle="medium" timeStyle="short"/>
+                </fmt:param>
+            </fmt:message>
+        </admin:infobox>
+    </c:if>
+
     <c:choose>
         <c:when test="${not create}">
             <p>

--- a/xmppserver/src/main/webapp/muc-room-summary.jsp
+++ b/xmppserver/src/main/webapp/muc-room-summary.jsp
@@ -193,10 +193,14 @@
                 <% } %>
         </td>
         <td width="1%" align="center">
-            <nobr><%= room.getOccupantsCount() %>
-            <% if (room.getMaxUsers() > 0 ) { %>
-                / <%= room.getMaxUsers() %>
-            <% } %></nobr>
+            <% if (room.isLocked()) {%>
+            <img src="images/lock.gif" width="16" height="16" border="0" alt="<fmt:message key="muc.room.summary.alt_locked" />">
+            <% } else { %>
+                <nobr><%= room.getOccupantsCount() %>
+                <% if (room.getMaxUsers() > 0 ) { %>
+                    / <%= room.getMaxUsers() %>
+                <% } %></nobr>
+            <% } %>
         </td>
         <td width="1%" align="center">
             <a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), "UTF-8") %>"


### PR DESCRIPTION
MUC rooms can be 'locked', which typically occurs when they are initially being created and configured. When a MUC room is 'locked', it cannot be entered by users.

The Openfire admin console should make it possible for an administrator to see if a room is locked.

This commit replaces the value in the 'users' column on the room summary page with a 'lock' icon, and displays a warning on the room settings page, when the room is locked.

![image](https://user-images.githubusercontent.com/4253898/155488237-64280c21-5d52-48fd-902b-be7b3dcdb62a.png)
![image](https://user-images.githubusercontent.com/4253898/155488325-95ebc0c5-8319-49a8-a937-44a509396819.png)
