### PR TITLE
OF-2411: Prevent deadlock in XmlProperties

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1289,15 +1289,14 @@ public class JiveGlobals {
                 try {
                     securityProperties = new XMLProperties(home + File.separator + JIVE_SECURITY_FILENAME);
                     setupPropertyEncryption();
-                    new Thread(() -> {
-                        // Migrate all secure XML properties into the database automatically
-                        for (String propertyName : securityProperties.getAllPropertyNames()) {
-                            if (!propertyName.startsWith(ENCRYPTED_PROPERTY_NAME_PREFIX)) {
-                                setPropertyEncrypted(propertyName, true);
-                                securityProperties.migrateProperty(propertyName);
-                            }
+
+                    // Migrate all secure XML properties into the database automatically
+                    for (String propertyName : securityProperties.getAllPropertyNames()) {
+                        if (!propertyName.startsWith(ENCRYPTED_PROPERTY_NAME_PREFIX)) {
+                            setPropertyEncrypted(propertyName, true);
+                            securityProperties.migrateProperty(propertyName);
                         }
-                    }).start();
+                    }
                 }
                 catch (IOException ioe) {
                     Log.error(ioe.getMessage());

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1289,18 +1289,15 @@ public class JiveGlobals {
                 try {
                     securityProperties = new XMLProperties(home + File.separator + JIVE_SECURITY_FILENAME);
                     setupPropertyEncryption();
-                    TaskEngine.getInstance().schedule(new TimerTask() {
-                        @Override
-                        public void run() {
-                            // Migrate all secure XML properties into the database automatically
-                            for (String propertyName : securityProperties.getAllPropertyNames()) {
-                                if (!propertyName.startsWith(ENCRYPTED_PROPERTY_NAME_PREFIX)) {
-                                    setPropertyEncrypted(propertyName, true);
-                                    securityProperties.migrateProperty(propertyName);
-                                }
+                    new Thread(() -> {
+                        // Migrate all secure XML properties into the database automatically
+                        for (String propertyName : securityProperties.getAllPropertyNames()) {
+                            if (!propertyName.startsWith(ENCRYPTED_PROPERTY_NAME_PREFIX)) {
+                                setPropertyEncrypted(propertyName, true);
+                                securityProperties.migrateProperty(propertyName);
                             }
                         }
-                    }, Duration.ofSeconds(1));
+                    }).start();
                 }
                 catch (IOException ioe) {
                     Log.error(ioe.getMessage());


### PR DESCRIPTION
OF-2377 introduced an updated implementation of the thread-safety module of XmlProperties (the old one wasn't fully thread-safe).

This new implementation causes a very specific problem at startup: When the initial attempt to migrate an XmlProperty is undertaken, TaskEngine is instantiated, which in turn tries to read/write properties (while under lock). This causes a deadlock.

To work around this issue, this commit replaces the usage of TaskEngine with a throw-away thread (that does not use any properties).