### PR TITLE
Run the unit tests in isolation

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -52,6 +52,8 @@
                                 <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
                             </systemPropertyVariables>
                             <argLine>@{argLine} -Duser.language=us -Duser.country=US</argLine>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -163,6 +165,8 @@
                         <log4j.configurationFile>${project.build.directory}/test-classes/log4j2-test-mvn.xml</log4j.configurationFile>
                     </systemPropertyVariables>
                     <argLine>-Duser.language=us -Duser.country=US</argLine>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Openfire's internals have many statics that are hard to 'unset'. As a result, unit tests are very likely to affect one another.

To prevent this kind of interaction, this commit configures the unit test execution to happen in isolation, using a new for for every test.

This trades execution speed for reliability.