### PR TITLE
OF-2409: Fix casing of CSS identifier

### DIFF
--- a/xmppserver/src/main/webapp/decorators/main.jsp
+++ b/xmppserver/src/main/webapp/decorators/main.jsp
@@ -98,7 +98,7 @@
                 <div id="jive-logo">
                     <a href="/index.jsp"><img src="/images/login_logo.gif" alt="Openfire" width="179" height="53" /></a>
                 </div>
-                <div id="jive-userstatus">
+                <div id="jive-userStatus">
                     <%= AdminConsole.getAppName() %> <%= AdminConsole.getVersionString() %>, build <%= AdminConsole.getGitSHAString() %><br/>
                     <fmt:message key="admin.logged_in_as"><fmt:param value="<strong>${usernameHtmlEscaped}</strong>"/></fmt:message> - <a href="<%= path %>/index.jsp?logout=true"><%= LocaleUtils.getLocalizedString("global.logout") %></a><br/>
                     <fmt:message key="admin.clustering.status"/> -

--- a/xmppserver/src/main/webapp/decorators/setup.jsp
+++ b/xmppserver/src/main/webapp/decorators/setup.jsp
@@ -131,7 +131,7 @@
                 <div id="jive-logo">
                     <a href="/index.jsp"><img src="/images/login_logo.gif" alt="Openfire" width="179" height="53" /></a>
                 </div>
-                <div id="jive-userstatus">
+                <div id="jive-userStatus">
                     <%= AdminConsole.getAppName() %> <%= AdminConsole.getVersionString() %>, build <%= AdminConsole.getGitSHAString() %><br/>
                 </div>
                 <div id="jive-nav">


### PR DESCRIPTION
In OF-2409, the DOCTYPE of the admin pages has changed to HTML 5. This apparently has the side-effect that CSS identifiers have become case sensitive.

The change in this commit fixes the issue of the build/login/clustering status information block to move back to the top-right corner of each page.