### PR TITLE
CI: add Java 17

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 1.8, 11 ]
+        java: [ 1.8, 11, 17 ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Java 17 is the latest LTS release of Java. Openfire should build successfully with it.

This commit adds Java 17 to the matrix of builds that Github's CI workflow performs.
