### PR TITLE
LGTM: ignore insecure-cookie when unsetting the cookie.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/CookieUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/CookieUtils.java
@@ -64,6 +64,7 @@ public class CookieUtils {
      * @param response the servlet response.
      * @param cookie the cookie object to be deleted.
      */
+    @SuppressWarnings("lgtm[java/insecure-cookie]") // We're explicitly setting an empty cookie to remove things.
     public static void deleteCookie(HttpServletRequest request, HttpServletResponse response,
             Cookie cookie)
     {


### PR DESCRIPTION
As long as we're exposing the admin console on a non-HTTPS endpoint (our port 9090), we will have a need to set cookies on an unsecure endpoint. This raises (rightfully) the LGTM 'insecure-cookie' alert, as Insecure cookies may be sent in cleartext, which makes them vulnerable to interception.

However, LGTM also raises this alert when we remove the cookie (which we do by setting an immediately-expired cookie with no data). The alert can be suppressed for that one.