### PR TITLE
OF-2414: Where appropriate, send a stream error before closing a stream.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,16 @@
 
 package org.jivesoftware.openfire;
 
-import java.io.Closeable;
-import java.net.UnknownHostException;
-import java.security.cert.Certificate;
-
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.session.LocalSession;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
 import org.xmpp.packet.Packet;
+import org.xmpp.packet.StreamError;
 
 import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.net.UnknownHostException;
+import java.security.cert.Certificate;
 
 /**
  * Represents a connection on the server.
@@ -158,6 +158,21 @@ public interface Connection extends Closeable {
      */
     @Override
     void close();
+
+    /**
+     * Close this session including associated socket connection, optionally citing a
+     * stream error. The events for closing the session are:
+     * <ul>
+     *      <li>Set closing flag to prevent redundant shutdowns.
+     *      <li>Close the socket.
+     *      <li>Notify all listeners that the channel is shut down.
+     * </ul>
+     *
+     * Not all implementations use the same order of events.
+     *
+     * @param error If non-null, the end-stream tag will be preceded with this error.
+     */
+    void close(@Nullable final StreamError error);
 
     /**
      * Notification message indicating that the server is being shutdown. Implementors

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,10 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
-import org.xmpp.packet.IQ;
-import org.xmpp.packet.Message;
-import org.xmpp.packet.Packet;
-import org.xmpp.packet.Presence;
+import org.xmpp.packet.*;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -972,7 +969,7 @@ public class HttpSession extends LocalClientSession {
         sentElements.add(delivered);
     }
 
-    private void closeSession() {
+    private void closeSession(@Nullable final StreamError error) {
         try {
             // There generally should not be a scenario where there are pending connections, as well as pending elements
             // to deliver, as when a new connection becomes available while there are pending elements, those will be
@@ -1080,6 +1077,24 @@ public class HttpSession extends LocalClientSession {
     }
 
     /**
+     * Creates an empty BOSH 'body' element that including a 'terminate' type attribute (that, in BOSH, signifies the
+     * end of a session), sets the 'condition' attribute to 'remote-stream-error' (to signal that an XMPP error is
+     * transported), and includes the error in the body.
+     *
+     * @param error The error to be included in the body.
+     * @return The string representation of a BOSH 'body' element.
+     */
+    @Nonnull
+    protected String createRemoteStreamErrorBody(@Nonnull final StreamError error)
+    {
+        final Element body = DocumentHelper.createElement( QName.get( "body", "http://jabber.org/protocol/httpbind" ) );
+        body.addAttribute("type", "terminate");
+        body.addAttribute("condition", "remote-stream-error");
+        body.add(error.getElement());
+        return body.asXML();
+    }
+
+    /**
      * Creets a BOSH 'body' element that represents a 'session restart' event, including the stream features that are
      * available to this session.
      *
@@ -1118,8 +1133,8 @@ public class HttpSession extends LocalClientSession {
         }
 
         @Override
-        public void closeVirtualConnection() {
-            ((HttpSession) session).closeSession();
+        public void closeVirtualConnection(@Nullable final StreamError error) {
+            ((HttpSession) session).closeSession(error);
         }
 
         @Override
@@ -1139,7 +1154,7 @@ public class HttpSession extends LocalClientSession {
 
         @Override
         public void systemShutdown() {
-            close();
+            close(new StreamError(StreamError.Condition.system_shutdown));
         }
 
         @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,9 @@ import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.jivesoftware.openfire.spi.ConnectionType;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.Packet;
+import org.xmpp.packet.StreamError;
 
+import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -169,9 +171,11 @@ public class ClientSessionConnection extends VirtualConnection {
      * nothing. But if the server originated the request to close the connection then we need
      * to send to the Connection Manager a packet letting him know that the Client Session needs
      * to be terminated.
+     *
+     * @param error If non-null, this error will be sent to the peer before the connection is disconnected.
      */
     @Override
-    public void closeVirtualConnection() {
+    public void closeVirtualConnection(@Nullable final StreamError error) {
         // Figure out who requested the connection to be closed
         StreamID streamID = session.getStreamID();
         if (multiplexerManager.getClientSession(connectionManagerName, streamID) == null) {
@@ -191,6 +195,10 @@ public class ClientSessionConnection extends VirtualConnection {
                         "http://jabber.org/protocol/connectionmanager");
                 child.addAttribute("id", streamID.getID());
                 child.addElement("close");
+                if (error != null) {
+                    // Note that this is ignored by all Connection Manager implementations at the time of writing.
+                    child.add(error.getElement());
+                }
                 multiplexerSession.process(closeRequest);
             }
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,6 @@
  */
 
 package org.jivesoftware.openfire.net;
-
-import java.io.IOException;
-import java.net.Socket;
-import java.util.List;
 
 import org.dom4j.Element;
 import org.dom4j.io.XMPPPacketReader;
@@ -37,13 +33,11 @@ import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
-import org.xmpp.packet.IQ;
-import org.xmpp.packet.JID;
-import org.xmpp.packet.Message;
-import org.xmpp.packet.PacketError;
-import org.xmpp.packet.Presence;
-import org.xmpp.packet.Roster;
-import org.xmpp.packet.StreamError;
+import org.xmpp.packet.*;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.List;
 
 /**
  * A SocketReader creates the appropriate {@link Session} based on the defined namespace in the
@@ -353,15 +347,10 @@ public abstract class SocketReader implements Runnable {
      * closing the connection a stream error will be sent to the entity.
      */
     void closeNeverSecuredConnection() {
-        // Set the not_authorized error
-        StreamError error = new StreamError(StreamError.Condition.not_authorized);
-        // Deliver stanza
-        connection.deliverRawText(error.toXML());
-        // Close the underlying connection
-        connection.close();
+        // Send a stream error and close the underlying connection.
+        connection.close(new StreamError(StreamError.Condition.not_authorized, "TLS is mandatory, but was not established."));
         // Log a warning so that admins can track this case from the server side
-        Log.warn("TLS was required by the server and connection was never secured. " +
-                "Closing connection : " + connection);
+        Log.warn("TLS was required by the server and connection was never secured. Closing connection: {}", connection);
     }
 
     private IQ getIQ(Element doc) {
@@ -432,16 +421,10 @@ public abstract class SocketReader implements Runnable {
             sb.append("xmlns=\"").append(xpp.getNamespace(null)).append("\" ");
             sb.append("xmlns:stream=\"").append(xpp.getNamespace("stream")).append("\" ");
             sb.append("version=\"1.0\">");
-            // Set the host_unknown error
-            StreamError error = new StreamError(StreamError.Condition.host_unknown);
-            sb.append(error.toXML());
-            // Deliver stanza
-            connection.deliverRawText(sb.toString());
-            // Close the underlying connection
-            connection.close();
+            // Send the host_unknown error and close the underlying connection
+            connection.close(new StreamError(StreamError.Condition.host_unknown, "The 'to' attribute does not specify an XMPP domain entity served by this service."));
             // Log a warning so that admins can track this cases from the server side
-            Log.warn("Closing session due to incorrect hostname in stream header. Host: " + host +
-                    ". Connection: " + connection);
+            Log.warn("Closing session due to incorrect hostname in stream header. Host: {}. Connection: {}", host, connection);
         }
 
         // Create the correct session based on the sent namespace. At this point the server
@@ -461,15 +444,10 @@ public abstract class SocketReader implements Runnable {
             sb.append("xmlns=\"").append(xpp.getNamespace(null)).append("\" ");
             sb.append("xmlns:stream=\"").append(xpp.getNamespace("stream")).append("\" ");
             sb.append("version=\"1.0\">");
-            // Include the bad-namespace-prefix in the response
-            StreamError error = new StreamError(StreamError.Condition.bad_namespace_prefix);
-            sb.append(error.toXML());
-            connection.deliverRawText(sb.toString());
-            // Close the underlying connection
-            connection.close();
+            // Include the bad-namespace-prefix in the response and close the underlying connection.
+            connection.close(new StreamError(StreamError.Condition.bad_namespace_prefix, "The namespace used in the request does not identify functionality that can be provided by this endpoint."));
             // Log a warning so that admins can track this cases from the server side
-            Log.warn("Closing session due to bad_namespace_prefix in stream header. Prefix: " +
-                    xpp.getNamespace(null) + ". Connection: " + connection);
+            Log.warn("Closing session due to bad_namespace_prefix in stream header. Prefix: {}. Connection: {}", xpp.getNamespace(null), connection);
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -426,15 +426,10 @@ public abstract class StanzaHandler {
      */
     private boolean negotiateTLS() {
         if (connection.getTlsPolicy() == Connection.TLSPolicy.disabled) {
-            // Set the not_authorized error
-            StreamError error = new StreamError(StreamError.Condition.not_authorized);
-            // Deliver stanza
-            connection.deliverRawText(error.toXML());
-            // Close the underlying connection
-            connection.close();
+            // Send a not_authorized error and close the underlying connection
+            connection.close(new StreamError(StreamError.Condition.not_authorized, "A request to negotiate TLS is denied, as TLS has been disabled by configuration."));
             // Log a warning so that admins can track this case from the server side
-            Log.warn("TLS requested by initiator when TLS was never offered by server. " +
-                    "Closing connection : " + connection);
+            Log.warn("TLS requested by initiator when TLS was never offered by server. Closing connection: {}", connection);
             return false;
         }
         // Client requested to secure the connection using TLS. Negotiate TLS.
@@ -609,15 +604,10 @@ public abstract class StanzaHandler {
      * closing the connection a stream error will be sent to the entity.
      */
     void closeNeverSecuredConnection() {
-        // Set the not_authorized error
-        StreamError error = new StreamError(StreamError.Condition.not_authorized);
-        // Deliver stanza
-        connection.deliverRawText(error.toXML());
-        // Close the underlying connection
-        connection.close();
+        // Send a stream error and close the underlying connection.
+        connection.close(new StreamError(StreamError.Condition.not_authorized, "TLS is mandatory, but was established."));
         // Log a warning so that admins can track this case from the server side
-        Log.warn("TLS was required by the server and connection was never secured. " +
-                "Closing connection : " + connection);
+        Log.warn("TLS was required by the server and connection was never secured. Closing connection: {}", connection);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,6 @@
 
 package org.jivesoftware.openfire.net;
 
-import java.security.cert.Certificate;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.ConnectionCloseListener;
 import org.jivesoftware.openfire.PacketDeliverer;
@@ -29,8 +24,13 @@ import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.util.LocaleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xmpp.packet.StreamError;
 
 import javax.annotation.Nullable;
+import java.security.cert.Certificate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Abstract implementation of the Connection interface that models abstract connections. Abstract
@@ -182,6 +182,16 @@ public abstract class VirtualConnection implements Connection {
      */
     @Override
     public void close() {
+    }
+
+    /**
+     * Closes the session, the virtual connection and notifies listeners that the connection
+     * has been closed.
+     *
+     * @param error If non-null, the end-stream tag will be preceded with this error.
+     */
+    @Override
+    public void close(@Nullable final StreamError error) {
         if (state.compareAndSet(State.OPEN, State.CLOSED)) {
             
             if (session != null) {
@@ -203,7 +213,7 @@ public abstract class VirtualConnection implements Connection {
             listeners.clear();
 
             try {
-                closeVirtualConnection();
+                closeVirtualConnection(error);
             } catch (Exception e) {
                 Log.error(LocaleUtils.getLocalizedString("admin.error.close") + "\n" + toString(), e);
             }
@@ -242,8 +252,10 @@ public abstract class VirtualConnection implements Connection {
     }
 
     /**
-     * Closes the virtual connection. Subsclasses should indicate what closing a virtual
+     * Closes the virtual connection. Subclasses should indicate what closing a virtual
      * connection means. At this point the session has a CLOSED state.
+     *
+     * @param error If non-null, this error will be sent to the peer before the connection is disconnected.
      */
-    public abstract void closeVirtualConnection();
+    public abstract void closeVirtualConnection(@Nullable final StreamError error);
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -212,12 +212,9 @@ public class LocalClientSession extends LocalSession implements ClientSession {
                 // Do nothing
             }
 
-            Log.debug("LocalClientSession: Closed connection to client attempting to connect from: " + hostAddress);
-            // Include the not-authorized error in the response
-            StreamError error = new StreamError(StreamError.Condition.not_authorized);
-            connection.deliverRawText(error.toXML());
-            // Close the underlying connection
-            connection.close();
+            Log.debug("LocalClientSession: Closed connection to client attempting to connect from: {}", hostAddress);
+            // Include the not-authorized error in the response and close the underlying connection.
+            connection.close(new StreamError(StreamError.Condition.not_authorized));
             return null;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -34,6 +34,7 @@ import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Packet;
+import org.xmpp.packet.StreamError;
 
 import java.io.IOException;
 import java.security.cert.Certificate;
@@ -203,8 +204,8 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
             return session;
         }
         catch (Exception e) {
-            Log.error("Error establishing connection from remote server:" + connection, e);
-            connection.close();
+            Log.error("Error establishing connection from remote server: {}", connection, e);
+            connection.close(new StreamError(StreamError.Condition.internal_server_error));
             return null;
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -365,7 +365,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                         }
                         else if (connection.getTlsPolicy() == Connection.TLSPolicy.required) {
                             log.debug("I have no StartTLS yet I must TLS");
-                            connection.close();
+                            connection.close(new StreamError(StreamError.Condition.not_authorized, "TLS is mandatory, but was not established."));
                             return null;
                         }
                         // Check if we are going to try server dialback (XMPP 1.0)
@@ -375,7 +375,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
                             OutgoingServerSocketReader newSocketReader = new OutgoingServerSocketReader(reader);
                             if (method.authenticateDomain(newSocketReader, id)) {
                                 log.debug( "Successfully authenticated the connection with dialback!" );
-                                StreamID streamID = new BasicStreamIDFactory().createStreamID(id);
+                                StreamID streamID = BasicStreamIDFactory.createStreamID(id);
                                 LocalOutgoingServerSession session = new LocalOutgoingServerSession(domainPair.getLocal(), connection, newSocketReader, streamID);
                                 connection.init(session);
                                 // Set the remote domain name as the address of the session.
@@ -399,7 +399,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
             log.debug( "Something went wrong so close the connection and try server dialback over a plain connection" );
             if (connection.getTlsPolicy() == Connection.TLSPolicy.required) {
                 log.debug("I have no StartTLS yet I must TLS");
-                connection.close();
+                connection.close(new StreamError(StreamError.Condition.not_authorized, "TLS is mandatory, but was not established."));
                 return null;
             }
             connection.close();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,6 @@
 
 package org.jivesoftware.openfire.session;
 
-import java.net.UnknownHostException;
-import java.security.cert.Certificate;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import javax.net.ssl.SSLSession;
-
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.StreamID;
@@ -38,6 +30,14 @@ import org.jivesoftware.util.LocaleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.*;
+
+import javax.net.ssl.SSLSession;
+import java.net.UnknownHostException;
+import java.security.cert.Certificate;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * The session represents a connection between the server and a client (c2s) or
@@ -188,7 +188,7 @@ public abstract class LocalSession implements Session {
             Log.debug("Reattaching session with address {} and streamID {} using connection from session with address {} and streamID {}.", this.address, this.streamID, connectionProvider.getAddress(), connectionProvider.getStreamID());
             if (this.conn != null && !this.conn.isClosed())
             {
-                this.conn.close();
+                this.conn.close(new StreamError(StreamError.Condition.conflict, "The stream previously served over this connection is resumed on a new connection."));
             }
             this.conn = connectionProvider.releaseConnection();
             this.conn.reinit(this);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015-2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.streammanagement;
 
 import org.dom4j.Element;
@@ -338,7 +353,7 @@ public class StreamManager {
             Log.debug("Existing session {} of '{}' is not detached; detaching.", otherSession.getStreamID(), fullJid);
             Connection oldConnection = otherSession.getConnection();
             otherSession.setDetached();
-            oldConnection.close();
+            oldConnection.close(new StreamError(StreamError.Condition.conflict, "The stream previously served over this connection is resumed on a new connection."));
         }
         Log.debug("Attaching to other session '{}' of '{}'.", otherSession.getStreamID(), fullJid);
         // If we're all happy, re-attach the connection from the pre-existing session to the new session, discarding the old session.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,11 @@
  */
 package org.jivesoftware.openfire.websocket;
 
-import java.net.InetSocketAddress;
-
 import org.dom4j.Namespace;
-import org.jivesoftware.openfire.*;
+import org.jivesoftware.openfire.PacketDeliverer;
+import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.net.VirtualConnection;
-import org.jivesoftware.openfire.nio.OfflinePacketDeliverer;
 import org.jivesoftware.openfire.session.LocalClientSession;
 import org.jivesoftware.openfire.session.LocalSession;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
@@ -33,6 +31,7 @@ import org.xmpp.packet.Packet;
 import org.xmpp.packet.StreamError;
 
 import javax.annotation.Nullable;
+import java.net.InetSocketAddress;
 
 /**
  * Following the conventions of the BOSH implementation, this class extends {@link VirtualConnection}
@@ -56,9 +55,9 @@ public class WebSocketConnection extends VirtualConnection
     }
 
     @Override
-    public void closeVirtualConnection()
+    public void closeVirtualConnection(@Nullable final StreamError error)
     {
-        socket.closeSession();
+        socket.closeSession(error);
     }
 
     @Override
@@ -78,8 +77,7 @@ public class WebSocketConnection extends VirtualConnection
 
     @Override
     public void systemShutdown() {
-        deliverRawText(new StreamError(StreamError.Condition.system_shutdown).toXML());
-        close();
+        close(new StreamError(StreamError.Condition.system_shutdown));
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import org.xmpp.packet.PacketError;
 import org.xmpp.packet.StreamError;
 
+import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
 import java.io.IOException;
 import java.io.StringReader;
@@ -154,8 +155,12 @@ public class XmppWebSocket {
     }
 
     void closeSession() {
+        closeSession(null);
+    }
+
+    void closeSession(@Nullable final StreamError error) {
         if (isWebSocketOpen()) {
-            closeStream(null);
+            closeStream(error);
         }
         if (xmppSession != null) {
             if (!xmppSession.getStreamManager().getResume()) {


### PR DESCRIPTION
When a stream is being closed, it's often helpful to signal why this happens, especially when the stream is closed due to an error.

This commit adds stream errors in various places where such context is desirable.

The API to close a connection has been modified to be able to include an optional stream error. This replaces an older structure where a stream error is first sent manually, followed by a call to the 'close' API. With this change, only one attempt to send data is made instead of two (one for the stream error, and another one for the end-stream tag).

As there's an API change, we'd better not include this change in a patch release.