### PR TITLE
OF-2424: Assert when LocalSession is null

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/LocalSessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/LocalSessionManager.java
@@ -134,18 +134,19 @@ class LocalSessionManager {
 
             for (LocalSession session : sessions) {
                 try {
-                    // Notify connected client that the server is being shut down
-                    if (!session.isDetached()) {
-                        session.getConnection().systemShutdown();
+                    // Notify connected client that the server is being shut down.
+                    final Connection connection = session.getConnection();
+                    if (connection != null) { // The session may have been detached.
+                        connection.systemShutdown();
                     }
                 }
                 catch (Throwable t) {
-                    // Ignore.
+                    Log.debug("Error while sending system shutdown to session {}", session, t);
                 }
             }
         }
         catch (Exception e) {
-            // Ignore.
+            Log.debug("Error while sending system shutdown to sessions", e);
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -468,11 +468,10 @@ public class SessionManager extends BasicModule implements ClusterEventListener
 
         final PacketDeliverer backupDeliverer = ClientConnectionHandler.BACKUP_PACKET_DELIVERY_ENABLED.getValue() ? new OfflinePacketDeliverer() : null;
         final HttpSession.HttpVirtualConnection vConnection = new HttpSession.HttpVirtualConnection(connection.getRemoteAddr(), backupDeliverer, ConnectionType.SOCKET_C2S);
-        HttpSession session = new HttpSession(vConnection, serverName, id, connection.getRequestId(), connection.getPeerCertificates(), language, wait, hold, isSecure,
+        final HttpSession session = new HttpSession(vConnection, serverName, id, connection.getRequestId(), connection.getPeerCertificates(), language, wait, hold, isSecure,
                                               maxPollingInterval, maxRequests, maxPause, defaultInactivityTimeout, majorVersion, minorVersion);
-        Connection conn = session.getConnection();
-        conn.init(session);
-        conn.registerCloseListener(clientSessionListener, session);
+        vConnection.init(session);
+        vConnection.registerCloseListener(clientSessionListener, session);
         localSessionManager.getPreAuthenticatedSessions().put(session.getAddress().getResource(), session);
         connectionsCounter.incrementAndGet();
         return session;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
@@ -360,20 +360,21 @@ public class HttpSessionManager {
             for (HttpSession session : sessionMap.values()) {
                 try {
                     Duration lastActive = Duration.between(session.getLastActivity(), currentTime);
+                    String hostAddress = session.getConnection() != null ? session.getConnection().getHostAddress() : "(not available)";
                     if( !lastActive.isNegative() && !lastActive.isZero() && HttpBindManager.LOG_HTTPBIND_ENABLED.getValue()) {
                         Log.info("Session {} was last active {} ago: {} from IP {} " +
                                 " currently on rid {}",
                                 session.getStreamID(),
                                 lastActive,
                                 session.getAddress(), // JID
-                                session.getConnection().getHostAddress(),
+                                hostAddress,
                                 session.getLastAcknowledged()); // RID
                     }
                     if (lastActive.compareTo(session.getInactivityTimeout()) > 0) {
                         Log.info("Closing idle session {}: {} from IP {}",
                                 session.getStreamID(),
                                 session.getAddress(),
-                                session.getConnection().getHostAddress());
+                                hostAddress);
                         session.close();
                     }
                 } catch (Exception e) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
@@ -105,7 +105,7 @@ public class ComponentStanzaHandler extends StanzaHandler {
                             subdomain = extraDomain;
                         }
                         InternalComponentManager.getInstance().addComponent(subdomain, component);
-                        session.getConnection().registerCloseListener( handback -> InternalComponentManager.getInstance().removeComponent( subdomain, (ComponentSession.ExternalComponent) handback ), component );
+                        componentSession.getConnection().registerCloseListener( handback -> InternalComponentManager.getInstance().removeComponent( subdomain, (ComponentSession.ExternalComponent) handback ), component );
                         // Send confirmation that the new domain has been registered
                         connection.deliverRawText("<bind/>");
                     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/AnonymousSaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/AnonymousSaslServer.java
@@ -1,12 +1,13 @@
 package org.jivesoftware.openfire.sasl;
 
-import javax.security.sasl.Sasl;
-import javax.security.sasl.SaslException;
-import javax.security.sasl.SaslServer;
-
+import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.session.LocalClientSession;
 import org.jivesoftware.openfire.session.LocalSession;
 import org.jivesoftware.util.SystemProperty;
+
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
 
 /**
  * Implementation of the SASL ANONYMOUS mechanism.
@@ -57,7 +58,9 @@ public class AnonymousSaslServer implements SaslServer
         }
 
         // Verify that client can connect from his IP address.
-        final boolean forbidAccess = !LocalClientSession.isAllowedAnonymous( session.getConnection() );
+        final Connection connection = session.getConnection();
+        assert connection != null; // While the peer is performing a SASL negotiation, the connection can't be null.
+        final boolean forbidAccess = !LocalClientSession.isAllowedAnonymous(connection);
         if ( forbidAccess )
         {
             throw new SaslException( "Authentication failed" );

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ExternalClientSaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ExternalClientSaslServer.java
@@ -68,6 +68,7 @@ public class ExternalClientSaslServer implements SaslServer
         complete = true;
 
         final Connection connection = session.getConnection();
+        assert connection != null; // While the peer is performing a SASL negotiation, the connection can't be null.
         Certificate[] peerCertificates = connection.getPeerCertificates();
         if ( peerCertificates == null || peerCertificates.length < 1 )
         {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -931,12 +931,12 @@ public class LocalClientSession extends LocalSession implements ClientSession {
     public String toString()
     {
         String peerAddress = "(not available)";
-        if ( getConnection() != null ) {
-        try {
-            peerAddress = getConnection().getHostAddress();
-        } catch ( UnknownHostException e ) {
-            Log.debug( "Unable to determine address for peer of local client session.", e );
-        }
+        if (getConnection() != null) {
+            try {
+                peerAddress = getConnection().getHostAddress();
+            } catch (UnknownHostException e) {
+                Log.debug("Unable to determine address for peer of local client session.", e);
+            }
         }
         return this.getClass().getSimpleName() +"{" +
             "address=" + getAddress() +

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
@@ -34,6 +34,7 @@ import org.xmpp.packet.JID;
 import org.xmpp.packet.Packet;
 import org.xmpp.packet.StreamError;
 
+import javax.annotation.Nonnull;
 import java.util.*;
 
 /**
@@ -171,6 +172,29 @@ public class LocalComponentSession extends LocalSession implements ComponentSess
     public String getAvailableStreamFeatures() {
         // Nothing special to add
         return null;
+    }
+
+    @Override
+    public void setDetached() {
+        throw new UnsupportedOperationException("Stream management is not supported for components.");
+    }
+
+    @Override
+    public void reattach(LocalSession connectionProvider, long h) {
+        throw new UnsupportedOperationException("Stream management is not supported for components.");
+    }
+
+    /**
+     * Returns the connection associated with this Session.
+     *
+     * @return The connection for this session
+     */
+    @Nonnull
+    @Override
+    public Connection getConnection() {
+        final Connection connection = super.getConnection();
+        assert connection != null; // Openfire does not implement stream management for external component sessions. Therefor, the connection cannot be null.
+        return connection;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
@@ -38,6 +38,7 @@ import org.xmpp.packet.JID;
 import org.xmpp.packet.Packet;
 import org.xmpp.packet.StreamError;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Locale;
 
@@ -188,6 +189,29 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
             return "<compression xmlns=\"http://jabber.org/features/compress\"><method>zlib</method></compression>";
         }
         return null;
+    }
+
+    @Override
+    public void setDetached() {
+        throw new UnsupportedOperationException("Stream management is not supported for multiplexers.");
+    }
+
+    @Override
+    public void reattach(LocalSession connectionProvider, long h) {
+        throw new UnsupportedOperationException("Stream management is not supported for multiplexers.");
+    }
+
+    /**
+     * Returns the connection associated with this Session.
+     *
+     * @return The connection for this session
+     */
+    @Nonnull
+    @Override
+    public Connection getConnection() {
+        final Connection connection = super.getConnection();
+        assert connection != null; // Openfire does not implement stream management for multiplex connections. Therefor, the connection cannot be null.
+        return connection;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalServerSession.java
@@ -5,6 +5,7 @@ import org.jivesoftware.openfire.StreamID;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.xmpp.packet.Packet;
 
+import javax.annotation.Nonnull;
 import java.util.Locale;
 
 /**
@@ -48,6 +49,31 @@ public class LocalServerSession extends LocalSession implements ServerSession {
         return null;
     }
 
+    @Override
+    public void setDetached() {
+        // TODO Implement stream management for s2s (OF-2425). Remove this override when it is.
+        throw new UnsupportedOperationException("Stream management is not supported for server-to-server connections");
+    }
+
+    @Override
+    public void reattach(LocalSession connectionProvider, long h) {
+        // TODO Implement stream management for s2s (OF-2425). Remove this override when it is.
+        throw new UnsupportedOperationException("Stream management is not supported for server-to-server connections");
+    }
+
+    /**
+     * Returns the connection associated with this Session.
+     *
+     * @return The connection for this session
+     */
+    @Nonnull
+    @Override
+    public Connection getConnection() {
+        final Connection connection = super.getConnection();
+        // valid only as long as stream management for s2s is not implemented (OF-2425). Remove this override when it is.
+        assert connection != null; // Openfire does not implement stream management for s2s (OF-2425). Therefor, the connection cannot be null.
+        return connection;
+    }
 
     @Override
     public boolean isUsingServerDialback() {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.*;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
 import java.net.UnknownHostException;
 import java.security.cert.Certificate;
@@ -229,15 +230,13 @@ public abstract class LocalSession implements Session {
     /**
      * Returns the connection associated with this Session.
      *
+     * Note that null can be returned, for example when the session is detached.
+     *
      * @return The connection for this session
      */
+    @Nullable
     public Connection getConnection() {
-        Connection connection = conn;
-        if (connection == null)
-        {
-            Log.error("Attempt to read connection of detached session with address {} and streamID {}: ", this.address, this.streamID, new IllegalStateException());
-            }
-        return connection;
+        return conn;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/LocalRoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/LocalRoutingTable.java
@@ -138,18 +138,18 @@ class LocalRoutingTable {
                     LocalSession session = (LocalSession) route;
                     try {
                         // Notify connected client that the server is being shut down
-                        if (!session.isDetached()) {
+                        if (session.getConnection() != null) { // Can occur if a session is 'detached'.
                             session.getConnection().systemShutdown();
                         }
                     }
                     catch (Throwable t) {
-                        // Ignore.
+                        Log.debug("A throwable was thrown while trying to send the close stream header to a session.", t);
                     }
                 }
             }
         }
         catch (Exception e) {
-            // Ignore.
+            Log.debug("An exception was thrown while trying to send the close stream header to a session.", e);
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -128,7 +128,14 @@ public class StreamManager {
     public StreamManager(LocalSession session) {
         String address;
         try {
-            address = session.getConnection().getHostAddress();
+            final Connection connection = session.getConnection();
+            if (connection != null) {
+                address = connection.getHostAddress();
+            } else {
+                // This smells: Why would a stream manager be created for a session without a connection (which typically is a session that is already detached)?
+                LoggerFactory.getLogger(StreamManager.class).warn("Connection is null for session: {}", session.getAddress());
+                address = null;
+            }
         }
         catch ( UnknownHostException e )
         {
@@ -353,6 +360,7 @@ public class StreamManager {
             Log.debug("Existing session {} of '{}' is not detached; detaching.", otherSession.getStreamID(), fullJid);
             Connection oldConnection = otherSession.getConnection();
             otherSession.setDetached();
+            assert oldConnection != null; // If the other session is not detached, the connection can't be null.
             oldConnection.close(new StreamError(StreamError.Condition.conflict, "The stream previously served over this connection is resumed on a new connection."));
         }
         Log.debug("Attaching to other session '{}' of '{}'.", otherSession.getStreamID(), fullJid);
@@ -561,7 +569,9 @@ public class StreamManager {
         Element resumed = new DOMElement(QName.get("resumed", namespace));
         resumed.addAttribute("previd", StringUtils.encodeBase64( session.getAddress().getResource() + "\0" + session.getStreamID().getID()));
         resumed.addAttribute("h", Long.toString(serverProcessedStanzas.get()));
-        session.getConnection().deliverRawText(resumed.asXML());
+        final Connection connection = session.getConnection();
+        assert connection != null; // While the client is resuming a session, the connection on which the session is resumed can't be null.
+        connection.deliverRawText(resumed.asXML());
         Log.debug("Resuming session: Ack for {}", h);
         processClientAcknowledgement(h);
         Log.debug("Processing remaining unacked stanzas");
@@ -577,7 +587,7 @@ public class StreamManager {
                                 delayInformation.addAttribute("stamp", XMPPDateTimeFormat.format(unacked.timestamp));
                                 delayInformation.addAttribute("from", serverAddress.toBareJID());
                             }
-                            session.getConnection().deliver(m);
+                            connection.deliver(m);
                         } else if (unacked.packet instanceof Presence) {
                             Presence p = (Presence) unacked.packet;
                             if (p.getExtension("delay", "urn:xmpp:delay") == null) {
@@ -585,9 +595,9 @@ public class StreamManager {
                                 delayInformation.addAttribute("stamp", XMPPDateTimeFormat.format(unacked.timestamp));
                                 delayInformation.addAttribute("from", serverAddress.toBareJID());
                             }
-                            session.getConnection().deliver(p);
+                            connection.deliver(p);
                         } else {
-                            session.getConnection().deliver(unacked.packet);
+                            connection.deliver(unacked.packet);
                         }
                     } catch (UnauthorizedException e) {
                         Log.warn("Caught unauthorized exception, which seems worrying: ", e);


### PR DESCRIPTION
Under certain circumstances (notably, when a session is detached), a session's connection can be null.

This commit adds assertions to identify the null-ability of a sessin's connection, and ensures that a null connection is not attempted to be used in a context where it is assumed to be non-null.