### PR TITLE
OF-2426: Refactor Group implementation

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupAdminAdded.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupAdminAdded.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.openfire.commands.event;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dom4j.Element;
 import org.jivesoftware.openfire.commands.AdHocCommand;
 import org.jivesoftware.openfire.commands.SessionData;
@@ -26,9 +27,7 @@ import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
 import org.xmpp.packet.JID;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Notifies the that a admin was added to the group. It can be used by user providers to notify Openfire of the
@@ -58,48 +57,44 @@ public class GroupAdminAdded extends AdHocCommand {
 
         Map<String, List<String>> data = sessionData.getData();
 
-        // Get the group name
-        String groupname;
-        try {
-            groupname = get(data, "groupName", 0);
-        }
-        catch (NullPointerException npe) {
-            note.addAttribute("type", "error");
-            note.setText("Group name required parameter.");
-            return;
+        // Input validation
+        final Set<String> inputValidationErrors = new HashSet<>();
+
+        Group group = null;
+        final String groupName = get(data, "groupName", 0);
+        if (StringUtils.isBlank(groupName)) {
+            inputValidationErrors.add("The parameter 'groupName' is required, but is missing.");
+        } else {
+            try {
+                group = GroupManager.getInstance().getGroup(groupName);
+            } catch (GroupNotFoundException e) {
+                inputValidationErrors.add("The group '" + groupName + "' does not exist.");
+            }
         }
 
         final String wasMemberValue = get(data, "wasMember", 0);
-        if (wasMemberValue == null) {
-            note.addAttribute("type", "error");
-            note.setText("WasMember required parameter.");
-            return;
+        if (StringUtils.isBlank(wasMemberValue)) {
+            inputValidationErrors.add("The parameter 'wasMember' is required, but is missing.");
         }
         final boolean wasMember = "1".equals(wasMemberValue) || Boolean.parseBoolean(wasMemberValue);
 
         JID admin;
-        try {
-            // Get the admin
-            String adminValue = get(data, "admin", 0);
-            admin = new JID(adminValue);
-        }
-        catch (NullPointerException npe) {
-            note.addAttribute("type", "error");
-            note.setText("Admin required parameter.");
+        final String adminValue = get(data, "admin", 0);
+        if (StringUtils.isBlank(adminValue)) {
+            inputValidationErrors.add("The parameter 'admin' is required, but is missing.");
             return;
-        }
-        catch (IllegalArgumentException e) {
-            note.addAttribute("type", "error");
-            note.setText("Admin value needs to be a JID.");
-            return;
+        } else {
+            try {
+                admin = new JID(adminValue);
+            } catch (IllegalArgumentException e) {
+                inputValidationErrors.add("The value for parameter 'admin' should be a valid JID, but '" + adminValue + "' is not.");
+                return;
+            }
         }
 
-        final Group group;
-        try {
-            group = GroupManager.getInstance().getGroup(groupname);
-        } catch (GroupNotFoundException e) {
+        if (!inputValidationErrors.isEmpty()) {
             note.addAttribute("type", "error");
-            note.setText("Group not found.");
+            note.setText(StringUtils.join(inputValidationErrors, " "));
             return;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupAdminRemoved.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupAdminRemoved.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import org.dom4j.Element;
 import org.jivesoftware.openfire.commands.AdHocCommand;
 import org.jivesoftware.openfire.commands.SessionData;
 import org.jivesoftware.openfire.component.InternalComponentManager;
-import org.jivesoftware.openfire.event.GroupEventDispatcher;
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.group.GroupManager;
 import org.jivesoftware.openfire.group.GroupNotFoundException;
@@ -28,7 +27,6 @@ import org.xmpp.forms.FormField;
 import org.xmpp.packet.JID;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,36 +69,34 @@ public class GroupAdminRemoved extends AdHocCommand {
             return;
         }
 
-        // Creates event params.
-        Map<String, Object> params = null;
-
+        JID admin;
         try {
-
             // Get the admin
-            String admin = get(data, "admin", 0);
-
-            // Adds the admin
-            params = new HashMap<>();
-            params.put("admin", admin);
+            String adminValue = get(data, "admin", 0);
+            admin = new JID(adminValue);
         }
         catch (NullPointerException npe) {
             note.addAttribute("type", "error");
             note.setText("Admin required parameter.");
             return;
         }
+        catch (IllegalArgumentException e) {
+            note.addAttribute("type", "error");
+            note.setText("Admin value needs to be a JID.");
+            return;
+        }
 
-        // Sends the event
-        Group group;
+        final Group group;
         try {
-            group = GroupManager.getInstance().getGroup(groupname, true);
-
-            // Fire event.
-            GroupEventDispatcher.dispatchEvent(group, GroupEventDispatcher.EventType.admin_removed, params);
-
+            group = GroupManager.getInstance().getGroup(groupname);
         } catch (GroupNotFoundException e) {
             note.addAttribute("type", "error");
             note.setText("Group not found.");
+            return;
         }
+
+        // Perform post-processing (cache updates and event notifications).
+        GroupManager.getInstance().adminRemovedPostProcess(group, admin);
 
         // Answer that the operation was successful
         note.addAttribute("type", "info");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupCreated.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupCreated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import org.dom4j.Element;
 import org.jivesoftware.openfire.commands.AdHocCommand;
 import org.jivesoftware.openfire.commands.SessionData;
 import org.jivesoftware.openfire.component.InternalComponentManager;
-import org.jivesoftware.openfire.event.GroupEventDispatcher;
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.group.GroupManager;
 import org.jivesoftware.openfire.group.GroupNotFoundException;
@@ -74,15 +73,14 @@ public class GroupCreated extends AdHocCommand {
         Group group;
         try {
             group = GroupManager.getInstance().getGroup(groupname, true);
-
-            // Fire event.
-            Map<String, Object> params = Collections.emptyMap();
-            GroupEventDispatcher.dispatchEvent(group, GroupEventDispatcher.EventType.group_created, params);
-
         } catch (GroupNotFoundException e) {
             note.addAttribute("type", "error");
             note.setText("Group not found.");
+            return;
         }
+
+        // Perform post-processing (cache updates and event notifications).
+        GroupManager.getInstance().createGroupPostProcess(group);
 
         // Answer that the operation was successful
         note.addAttribute("type", "info");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupDeleting.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupDeleting.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.openfire.commands.event;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dom4j.Element;
 import org.jivesoftware.openfire.commands.AdHocCommand;
 import org.jivesoftware.openfire.commands.SessionData;
@@ -26,9 +27,7 @@ import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
 import org.xmpp.packet.JID;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Notifies the that a group is being deleted. It can be used by user providers to notify Openfire of the
@@ -58,24 +57,24 @@ public class GroupDeleting extends AdHocCommand {
 
         Map<String, List<String>> data = sessionData.getData();
 
-        // Get the group name
-        String groupname;
-        try {
-            groupname = get(data, "groupName", 0);
-        }
-        catch (NullPointerException npe) {
-            note.addAttribute("type", "error");
-            note.setText("Group name required parameter.");
-            return;
+        // Input validation
+        final Set<String> inputValidationErrors = new HashSet<>();
+
+        Group group = null;
+        final String groupName = get(data, "groupName", 0);
+        if (StringUtils.isBlank(groupName)) {
+            inputValidationErrors.add("The parameter 'groupName' is required, but is missing.");
+        } else {
+            try {
+                group = GroupManager.getInstance().getGroup(groupName);
+            } catch (GroupNotFoundException e) {
+                inputValidationErrors.add("The group '" + groupName + "' does not exist.");
+            }
         }
 
-        // Sends the event
-        Group group;
-        try {
-            group = GroupManager.getInstance().getGroup(groupname, true);
-        } catch (GroupNotFoundException e) {
+        if (!inputValidationErrors.isEmpty()) {
             note.addAttribute("type", "error");
-            note.setText("Group not found.");
+            note.setText(StringUtils.join(inputValidationErrors, " "));
             return;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberAdded.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberAdded.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import org.dom4j.Element;
 import org.jivesoftware.openfire.commands.AdHocCommand;
 import org.jivesoftware.openfire.commands.SessionData;
 import org.jivesoftware.openfire.component.InternalComponentManager;
-import org.jivesoftware.openfire.event.GroupEventDispatcher;
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.group.GroupManager;
 import org.jivesoftware.openfire.group.GroupNotFoundException;
@@ -28,7 +27,6 @@ import org.xmpp.forms.FormField;
 import org.xmpp.packet.JID;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,36 +69,42 @@ public class GroupMemberAdded extends AdHocCommand {
             return;
         }
 
-        // Creates event params.
-        Map<String, Object> params = null;
-        
+        final String wasAdminValue = get(data, "wasAdmin", 0);
+        if (wasAdminValue == null) {
+            note.addAttribute("type", "error");
+            note.setText("WasAdmin required parameter.");
+            return;
+        }
+        final boolean wasAdmin = "1".equals(wasAdminValue) || Boolean.parseBoolean(wasAdminValue);
+
+        JID member;
         try {
-
             // Get the member
-            String member = get(data, "member", 0);
-
-            // Adds the member
-            params = new HashMap<>();
-            params.put("member", member);
+            String memberValue = get(data, "member", 0);
+            member = new JID(memberValue);
         }
         catch (NullPointerException npe) {
             note.addAttribute("type", "error");
             note.setText("Member required parameter.");
             return;
         }
+        catch (IllegalArgumentException e) {
+            note.addAttribute("type", "error");
+            note.setText("Member value needs to be a JID.");
+            return;
+        }
 
-        // Sends the event
-        Group group;
+        final Group group;
         try {
-            group = GroupManager.getInstance().getGroup(groupname, true);
-
-            // Fire event.
-            GroupEventDispatcher.dispatchEvent(group, GroupEventDispatcher.EventType.member_added, params);
-
+            group = GroupManager.getInstance().getGroup(groupname);
         } catch (GroupNotFoundException e) {
             note.addAttribute("type", "error");
             note.setText("Group not found.");
+            return;
         }
+
+        // Perform post-processing (cache updates and event notifications).
+        GroupManager.getInstance().memberAddedPostProcess(group, member, wasAdmin);
 
         // Answer that the operation was successful
         note.addAttribute("type", "info");
@@ -128,6 +132,12 @@ public class GroupMemberAdded extends AdHocCommand {
         field.setType(FormField.Type.text_single);
         field.setLabel("Member");
         field.setVariable("member");
+        field.setRequired(true);
+
+        field = form.addField();
+        field.setType(FormField.Type.boolean_type);
+        field.setLabel("Was this user previously an admin?");
+        field.setVariable("wasAdmin");
         field.setRequired(true);
 
         // Add the form to the command

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberAdded.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberAdded.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.openfire.commands.event;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dom4j.Element;
 import org.jivesoftware.openfire.commands.AdHocCommand;
 import org.jivesoftware.openfire.commands.SessionData;
@@ -26,9 +27,7 @@ import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
 import org.xmpp.packet.JID;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Notifies the that a member was added to the group. It can be used by user providers to notify Openfire of the
@@ -58,48 +57,44 @@ public class GroupMemberAdded extends AdHocCommand {
 
         Map<String, List<String>> data = sessionData.getData();
 
-        // Get the group name
-        String groupname;
-        try {
-            groupname = get(data, "groupName", 0);
-        }
-        catch (NullPointerException npe) {
-            note.addAttribute("type", "error");
-            note.setText("Group name required parameter.");
-            return;
+        // Input validation
+        final Set<String> inputValidationErrors = new HashSet<>();
+
+        Group group = null;
+        final String groupName = get(data, "groupName", 0);
+        if (StringUtils.isBlank(groupName)) {
+            inputValidationErrors.add("The parameter 'groupName' is required, but is missing.");
+        } else {
+            try {
+                group = GroupManager.getInstance().getGroup(groupName);
+            } catch (GroupNotFoundException e) {
+                inputValidationErrors.add("The group '" + groupName + "' does not exist.");
+            }
         }
 
         final String wasAdminValue = get(data, "wasAdmin", 0);
-        if (wasAdminValue == null) {
-            note.addAttribute("type", "error");
-            note.setText("WasAdmin required parameter.");
-            return;
+        if (StringUtils.isBlank(wasAdminValue)) {
+            inputValidationErrors.add("The parameter 'wasAdmin' is required, but is missing.");
         }
         final boolean wasAdmin = "1".equals(wasAdminValue) || Boolean.parseBoolean(wasAdminValue);
 
         JID member;
-        try {
-            // Get the member
-            String memberValue = get(data, "member", 0);
-            member = new JID(memberValue);
-        }
-        catch (NullPointerException npe) {
-            note.addAttribute("type", "error");
-            note.setText("Member required parameter.");
+        final String memberValue = get(data, "member", 0);
+        if (StringUtils.isBlank(memberValue)) {
+            inputValidationErrors.add("The parameter 'member' is required, but is missing.");
             return;
-        }
-        catch (IllegalArgumentException e) {
-            note.addAttribute("type", "error");
-            note.setText("Member value needs to be a JID.");
-            return;
+        } else {
+            try {
+                member = new JID(memberValue);
+            } catch (IllegalArgumentException e) {
+                inputValidationErrors.add("The value for parameter 'member' should be a valid JID, but '" + memberValue + "' is not.");
+                return;
+            }
         }
 
-        final Group group;
-        try {
-            group = GroupManager.getInstance().getGroup(groupname);
-        } catch (GroupNotFoundException e) {
+        if (!inputValidationErrors.isEmpty()) {
             note.addAttribute("type", "error");
-            note.setText("Group not found.");
+            note.setText(StringUtils.join(inputValidationErrors, " "));
             return;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberRemoved.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberRemoved.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.openfire.commands.event;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dom4j.Element;
 import org.jivesoftware.openfire.commands.AdHocCommand;
 import org.jivesoftware.openfire.commands.SessionData;
@@ -26,9 +27,7 @@ import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
 import org.xmpp.packet.JID;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Notifies the that a member was removed from the group. It can be used by user providers to notify Openfire of the
@@ -58,40 +57,38 @@ public class GroupMemberRemoved extends AdHocCommand {
 
         Map<String, List<String>> data = sessionData.getData();
 
-        // Get the group name
-        String groupname;
-        try {
-            groupname = get(data, "groupName", 0);
-        }
-        catch (NullPointerException npe) {
-            note.addAttribute("type", "error");
-            note.setText("Group name required parameter.");
-            return;
+        // Input validation
+        final Set<String> inputValidationErrors = new HashSet<>();
+
+        Group group = null;
+        final String groupName = get(data, "groupName", 0);
+        if (StringUtils.isBlank(groupName)) {
+            inputValidationErrors.add("The parameter 'groupName' is required, but is missing.");
+        } else {
+            try {
+                group = GroupManager.getInstance().getGroup(groupName);
+            } catch (GroupNotFoundException e) {
+                inputValidationErrors.add("The group '" + groupName + "' does not exist.");
+            }
         }
 
         JID member;
-        try {
-            // Get the member
-            String memberValue = get(data, "member", 0);
-            member = new JID(memberValue);
-        }
-        catch (NullPointerException npe) {
-            note.addAttribute("type", "error");
-            note.setText("Member required parameter.");
+        final String memberValue = get(data, "member", 0);
+        if (StringUtils.isBlank(memberValue)) {
+            inputValidationErrors.add("The parameter 'member' is required, but is missing.");
             return;
-        }
-        catch (IllegalArgumentException e) {
-            note.addAttribute("type", "error");
-            note.setText("Member value needs to be a JID.");
-            return;
+        } else {
+            try {
+                member = new JID(memberValue);
+            } catch (IllegalArgumentException e) {
+                inputValidationErrors.add("The value for parameter 'member' should be a valid JID, but '" + memberValue + "' is not.");
+                return;
+            }
         }
 
-        final Group group;
-        try {
-            group = GroupManager.getInstance().getGroup(groupname);
-        } catch (GroupNotFoundException e) {
+        if (!inputValidationErrors.isEmpty()) {
             note.addAttribute("type", "error");
-            note.setText("Group not found.");
+            note.setText(StringUtils.join(inputValidationErrors, " "));
             return;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/AbstractGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/AbstractGroupProvider.java
@@ -53,21 +53,21 @@ public abstract class AbstractGroupProvider implements GroupProvider {
 
     private static final String GROUPLIST_CONTAINERS =
             "SELECT groupName from ofGroupProp " +
-            "WHERE name='sharedRoster.groupList' " +
+            "WHERE name='" + Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY + "' " +
             "AND (propValue LIKE ? OR (groupName = ? AND (propValue IS NULL OR LTRIM(propValue) = '') ))"; // using Ltrim instead of trim, as the latter wasn't supported in SQL Server prior to 2017.
     private static final String PUBLIC_GROUPS_SQL =
             "SELECT groupName from ofGroupProp " +
-            "WHERE name='sharedRoster.showInRoster' " +
-            "AND propValue='everybody'";
+            "WHERE name='" + Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY + "' " +
+            "AND propValue='" + SharedGroupVisibility.everybody.getDbValue() + "'";
     private static final String GROUPS_FOR_PROP =
             "SELECT groupName from ofGroupProp " +
             "WHERE name=? " +
             "AND propValue=?";
     private static final String LOAD_SHARED_GROUPS =
-            "SELECT groupName FROM ofGroupProp WHERE name='sharedRoster.showInRoster' " +
-            "AND propValue IS NOT NULL AND propValue <> 'nobody'";
+            "SELECT groupName FROM ofGroupProp WHERE name='" + Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY + "' " +
+            "AND propValue IS NOT NULL AND propValue <> '" + SharedGroupVisibility.nobody.getDbValue() + "'";
     private static final String HAS_SHARED_GROUPS_PARTIAL =
-            "WHERE EXISTS (SELECT 1 FROM ofGroupProp WHERE name='sharedRoster.showInRoster' AND propValue IS NOT NULL AND propValue <> 'nobody')";
+            "WHERE EXISTS (SELECT 1 FROM ofGroupProp WHERE name='" + Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY + "' AND propValue IS NOT NULL AND propValue <> '" + SharedGroupVisibility.nobody.getDbValue() + "')";
     private static final String LOAD_PROPERTIES =
             "SELECT name, propValue FROM ofGroupProp WHERE groupName=?";
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupPropertyMap.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupPropertyMap.java
@@ -210,7 +210,7 @@ public class DefaultGroupPropertyMap<K,V> extends PersistableMap<K,V> {
         public void remove() {
             delegate.remove();
             if (current instanceof String) {
-                deleteProperty((String)current, null); // FIXME by not providing the original value, some event handlers may not be able to handle this.
+                deleteProperty((String)current, null); // FIXME OF-2430 by not providing the original value, some event handlers may not be able to handle this.
             }
             current = null;
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupPropertyMap.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupPropertyMap.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 public class DefaultGroupPropertyMap<K,V> extends PersistableMap<K,V> {
 
-    private static final long serialVersionUID = -7501088917416583815L;
+    private static final long serialVersionUID = 3128889631577167040L;
     private static final Logger logger = LoggerFactory.getLogger(DefaultGroupPropertyMap.class);
 
     // moved from {@link Group} as these are specific to the default provider

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupPropertyMap.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupPropertyMap.java
@@ -112,7 +112,7 @@ public class DefaultGroupPropertyMap<K,V> extends PersistableMap<K,V> {
         final Map<K,V> originalMap = new HashMap<>(this); // copy to be used by event handling.
         super.clear();
 
-        // Ignore all entries that are not strings.
+        // Create a copy of all to-be-deleted string values (to be sent to event listeners).
         final Map<String, String> map = originalMap.entrySet().stream()
             .filter(entry -> entry.getValue() instanceof String && entry.getKey() instanceof String)
             .collect(Collectors.toMap(entry -> (String)entry.getKey(), entry -> (String)entry.getValue()));
@@ -568,6 +568,8 @@ public class DefaultGroupPropertyMap<K,V> extends PersistableMap<K,V> {
 
     /**
      * Delete all properties from the database for the current group
+     *
+     * @param originalMap The properties of the group prior to the removal.
      */
     private synchronized void deleteAllProperties(final Map<String,String> originalMap) {
         Connection con = null;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/Group.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/Group.java
@@ -51,6 +51,10 @@ public class Group implements Cacheable, Externalizable {
 
     private static final Logger Log = LoggerFactory.getLogger(Group.class);
 
+    public static final String SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY = "sharedRoster.showInRoster";
+    public static final String SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY = "sharedRoster.displayName";
+    public static final String SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY = "sharedRoster.groupList";
+
     private transient GroupProvider provider;
     private transient GroupManager groupManager;
     private transient PersistableMap<String, String> properties;
@@ -244,9 +248,9 @@ public class Group implements Cacheable, Externalizable {
      */
     public void shareWithNobody() {
         final PersistableMap<String, String> properties = getProperties();
-        properties.put("sharedRoster.showInRoster", "nobody");
-        properties.put("sharedRoster.displayName", "");
-        properties.put("sharedRoster.groupList", "");
+        properties.put(SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY, SharedGroupVisibility.nobody.getDbValue());
+        properties.put(SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY, "");
+        properties.put(SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY, "");
     }
 
     /**
@@ -258,9 +262,9 @@ public class Group implements Cacheable, Externalizable {
      */
     public void shareWithEverybody(@Nonnull final String displayName) {
         final PersistableMap<String, String> properties = getProperties();
-        properties.put("sharedRoster.showInRoster", "everybody");
-        properties.put("sharedRoster.displayName", displayName);
-        properties.remove("sharedRoster.groupList");
+        properties.put(SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY, SharedGroupVisibility.everybody.getDbValue());
+        properties.put(SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY, displayName);
+        properties.remove(SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY);
     }
 
     /**
@@ -272,9 +276,9 @@ public class Group implements Cacheable, Externalizable {
      */
     public void shareWithUsersInSameGroup(@Nonnull final String displayName) {
         final PersistableMap<String, String> properties = getProperties();
-        properties.put("sharedRoster.showInRoster", "onlyGroup");
-        properties.put("sharedRoster.displayName", displayName);
-        properties.put("sharedRoster.groupList", "");
+        properties.put(SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY, SharedGroupVisibility.usersOfGroups.getDbValue());
+        properties.put(SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY, displayName);
+        properties.put(SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY, "");
     }
 
     /**
@@ -287,9 +291,9 @@ public class Group implements Cacheable, Externalizable {
      */
     public void shareWithUsersInGroups(@Nonnull final List<String> groupNames, @Nonnull final String displayName) {
         final PersistableMap<String, String> properties = getProperties();
-        properties.put("sharedRoster.showInRoster", "onlyGroup");
-        properties.put("sharedRoster.displayName", displayName);
-        properties.put("sharedRoster.groupList", String.join(",", groupNames));
+        properties.put(SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY, SharedGroupVisibility.usersOfGroups.getDbValue());
+        properties.put(SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY, displayName);
+        properties.put(SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY, String.join(",", groupNames));
     }
 
     /**
@@ -304,7 +308,7 @@ public class Group implements Cacheable, Externalizable {
      */
     @Nullable
     public String getSharedDisplayName() {
-        return getProperties().get("sharedRoster.displayName");
+        return getProperties().get(SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY);
     }
 
     /**
@@ -319,7 +323,7 @@ public class Group implements Cacheable, Externalizable {
      */
     @Nullable
     public SharedGroupVisibility getSharedWith() {
-        final String value = getProperties().get("sharedRoster.showInRoster");
+        final String value = getProperties().get(SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY);
         if (value == null) {
             return null;
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/Group.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/Group.java
@@ -24,7 +24,6 @@ import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.openfire.event.GroupEventDispatcher;
 import org.jivesoftware.util.PersistableMap;
 import org.jivesoftware.util.cache.CacheSizes;
 import org.jivesoftware.util.cache.Cacheable;
@@ -167,18 +166,11 @@ public class Group implements Cacheable, Externalizable {
         }
         try {
             String originalName = this.name;
-            GroupJID originalJID = getJID();
             provider.setName(originalName, name);
             this.name = name;
             this.jid = null; // rebuilt when needed
 
-            // Fire event.
-            Map<String, Object> params = new HashMap<>();
-            params.put("type", "nameModified");
-            params.put("originalValue", originalName);
-            params.put("originalJID", originalJID);
-            GroupEventDispatcher.dispatchEvent(this, GroupEventDispatcher.EventType.group_modified,
-                    params);
+            groupManager.renameGroupPostProcess(this, originalName);
         }
         catch (GroupAlreadyExistsException e) {
             Log.error("Failed to change group name; group already exists");
@@ -217,12 +209,8 @@ public class Group implements Cacheable, Externalizable {
             String originalDescription = this.description;
             provider.setDescription(name, description);
             this.description = description;
-            // Fire event.
-            Map<String, Object> params = new HashMap<>();
-            params.put("type", "descriptionModified");
-            params.put("originalValue", originalDescription);
-            GroupEventDispatcher.dispatchEvent(this,
-                    GroupEventDispatcher.EventType.group_modified, params);
+
+            groupManager.redescribeGroupPostProcess(this, originalDescription);
         }
         catch (Exception e) {
             Log.error(e.getMessage(), e);
@@ -504,18 +492,12 @@ public class Group implements Cacheable, Externalizable {
                     iter.remove();
                     // Remove the group user from the backend store.
                     provider.deleteMember(name, user);
-                    // Fire event.
+
+                    // Perform post-processing (cache updates and event notifications).
                     if (adminCollection) {
-                        Map<String, String> params = new HashMap<>();
-                        params.put("admin", user.toString());
-                        GroupEventDispatcher.dispatchEvent(Group.this,
-                                GroupEventDispatcher.EventType.admin_removed, params);
-                    }
-                    else {
-                        Map<String, String> params = new HashMap<>();
-                        params.put("member", user.toString());
-                        GroupEventDispatcher.dispatchEvent(Group.this,
-                                GroupEventDispatcher.EventType.member_removed, params);
+                        groupManager.adminRemovedPostProcess(Group.this, user);
+                    } else {
+                        groupManager.memberRemovedPostProcess(Group.this, user);
                     }
                 }
             };
@@ -559,28 +541,13 @@ public class Group implements Cacheable, Externalizable {
 
                 }
 
-                // Fire event.
-                Map<String, String> params = new HashMap<>();
+                // Perform post-processing (cache updates and event notifications).
                 if (adminCollection) {
-                    params.put("admin", user.toString());
-                    if (alreadyGroupUser) {
-                        params.put("member", user.toString());
-                        GroupEventDispatcher.dispatchEvent(Group.this,
-                                    GroupEventDispatcher.EventType.member_removed, params);
-                    }
-                    GroupEventDispatcher.dispatchEvent(Group.this,
-                                GroupEventDispatcher.EventType.admin_added, params);
+                    groupManager.adminAddedPostProcess(Group.this, user, alreadyGroupUser);
+                } else {
+                    groupManager.memberAddedPostProcess(Group.this, user, alreadyGroupUser);
                 }
-                else {
-                    params.put("member", user.toString());
-                    if (alreadyGroupUser) {
-                        params.put("admin", user.toString());
-                        GroupEventDispatcher.dispatchEvent(Group.this,
-                                    GroupEventDispatcher.EventType.admin_removed, params);
-                    }
-                    GroupEventDispatcher.dispatchEvent(Group.this,
-                                GroupEventDispatcher.EventType.member_added, params);
-                }
+
                 // If the user was a member that became an admin or vice versa then remove the
                 // user from the other collection
                 if (alreadyGroupUser) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -1007,11 +1007,11 @@ public class GroupManager {
     private void propertyChangePostProcess(final Group group, final String key, final String originalValue)
     {
         switch (key) {
-            case "sharedRoster.showInRoster": {
+            case Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY: {
                 clearGroupNameCache();
 
                 // Check to see if the definition of people to which the shared group is shared has changed
-                final String newValue = group.getProperties().get("sharedRoster.showInRoster");
+                final String newValue = group.getProperties().get(Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY);
                 if (!StringUtils.equals(originalValue, newValue)) {
                     if ("everybody".equals(originalValue) || "everybody".equals(newValue)) {
                         evictCachedUserSharedGroups();
@@ -1020,9 +1020,9 @@ public class GroupManager {
                 break;
             }
 
-            case "sharedRoster.groupList": {
+            case Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY: {
                 // Check to see if the list of groups to which the shared group is shared has changed
-                final String newValue = group.getProperties().get("sharedRoster.groupList");
+                final String newValue = group.getProperties().get(Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY);
 
                 if (!StringUtils.equals(originalValue, newValue)) {
                     evictCachedUsersForGroup(group);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/SharedGroupVisibility.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/SharedGroupVisibility.java
@@ -53,6 +53,11 @@ public enum SharedGroupVisibility {
     }
 
     @Nonnull
+    public String getDbValue() {
+        return dbValue;
+    }
+
+    @Nonnull
     public static SharedGroupVisibility fromDatabaseValue(@Nullable final String dbValue) {
         if (dbValue == null) {
             return nobody;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
@@ -239,7 +239,7 @@ public class LdapGroupProvider extends AbstractGroupProvider {
 
     @Override
     public Collection<String> search(String key, String value) {
-        if (key.equals("sharedRoster.displayName")){
+        if (key.equals(Group.SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY)){
             return super.search(key,value);
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/Roster.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/Roster.java
@@ -312,10 +312,10 @@ public class Roster implements Cacheable, Externalizable {
             for (String groupDisplayName : groups) {
                 Collection<Group> groupsWithProp = GroupManager
                         .getInstance()
-                        .search("sharedRoster.displayName", groupDisplayName);
+                        .search(Group.SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY, groupDisplayName);
                 for ( Group group : groupsWithProp )
                 {
-                    String showInRoster = group.getProperties().get( "sharedRoster.showInRoster" );
+                    String showInRoster = group.getProperties().get(Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY);
                     if ( showInRoster != null && !showInRoster.equals( "nobody" ) )
                     {
                         throw new SharedGroupException( "Cannot add an item to a shared group" );

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItem.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItem.java
@@ -451,7 +451,7 @@ public class RosterItem implements Cacheable, Externalizable {
                     // Check now if there is a group whose display name matches the requested group
                     Collection<Group> groupsWithProp = GroupManager
                             .getInstance()
-                            .search("sharedRoster.displayName", groupName);
+                            .search(Group.SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY, groupName);
                     Iterator<Group> itr = groupsWithProp.iterator();
                     while(itr.hasNext()) {
                         Group group = itr.next();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
@@ -354,8 +354,8 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
         String originalValue = (String) params.get("originalValue");
 
 
-        if ("sharedRoster.showInRoster".equals(keyChanged)) {
-            String currentValue = group.getProperties().get("sharedRoster.showInRoster");
+        if (Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY.equals(keyChanged)) {
+            String currentValue = group.getProperties().get(Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY);
             // Nothing has changed so do nothing.
             if (currentValue.equals(originalValue)) {
                 return;
@@ -389,8 +389,8 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
                 }
             });
         }
-        else if ("sharedRoster.groupList".equals(keyChanged)) {
-            String currentValue = group.getProperties().get("sharedRoster.groupList");
+        else if (Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY.equals(keyChanged)) {
+            String currentValue = group.getProperties().get(Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY);
             // Nothing has changed so do nothing.
             if (currentValue.equals(originalValue)) {
                 return;
@@ -422,8 +422,8 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
                 }
             });
         }
-        else if ("sharedRoster.displayName".equals(keyChanged)) {
-            String currentValue = group.getProperties().get("sharedRoster.displayName");
+        else if (Group.SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY.equals(keyChanged)) {
+            String currentValue = group.getProperties().get(Group.SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY);
             // Nothing has changed so do nothing.
             if (currentValue.equals(originalValue)) {
                 return;

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/AbstractGroupProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/AbstractGroupProviderTest.java
@@ -1449,7 +1449,7 @@ public class AbstractGroupProviderTest extends DBTestCase {
     public void testSearchByKeyAndValueReturnsGroup() throws Exception {
         final DefaultGroupProvider provider = new DefaultGroupProvider();
         provider.createGroup("Test Group A").shareWithNobody();
-        final Collection<String> result = provider.search("sharedRoster.showInRoster", "nobody");
+        final Collection<String> result = provider.search(Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY, SharedGroupVisibility.nobody.getDbValue());
         assertEquals(1, result.size());
         assertTrue(result.contains("Test Group A"));
     }
@@ -1464,7 +1464,7 @@ public class AbstractGroupProviderTest extends DBTestCase {
     public void testSearchByKeyAndValueReturnsNothingForInvalidValue() throws Exception {
         final DefaultGroupProvider provider = new DefaultGroupProvider();
         provider.createGroup("Test Group A").shareWithNobody();
-        final Collection<String> result = provider.search("sharedRoster.showInRoster", "Invalid Value");
+        final Collection<String> result = provider.search(Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY, "Invalid Value");
         assertEquals(0, result.size());
     }
 
@@ -1472,7 +1472,7 @@ public class AbstractGroupProviderTest extends DBTestCase {
         final DefaultGroupProvider provider = new DefaultGroupProvider();
         provider.createGroup("Test Group A").shareWithNobody();
         provider.createGroup("Test Group B").shareWithNobody();
-        final Collection<String> result = provider.search("sharedRoster.showInRoster", "nobody");
+        final Collection<String> result = provider.search(Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY, SharedGroupVisibility.nobody.getDbValue());
         assertEquals(2, result.size());
         assertTrue(result.contains("Test Group A"));
         assertTrue(result.contains("Test Group B"));
@@ -1482,7 +1482,7 @@ public class AbstractGroupProviderTest extends DBTestCase {
         final DefaultGroupProvider provider = new DefaultGroupProvider();
         provider.createGroup("Test Group A").shareWithNobody();
         provider.createGroup("Test Group B").shareWithNobody();
-        final Collection<String> result = provider.search("sharedRoster.groupList", "");
+        final Collection<String> result = provider.search(Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY, "");
         assertEquals(2, result.size());
         assertTrue(result.contains("Test Group A"));
         assertTrue(result.contains("Test Group B"));
@@ -1495,12 +1495,12 @@ public class AbstractGroupProviderTest extends DBTestCase {
         PersistableMap<String,String> result =  provider.loadProperties(a);
 
         assertEquals(3, result.size());
-        assertTrue(result.containsKey("sharedRoster.displayName"));
-        assertEquals("", result.get("sharedRoster.displayName"));
-        assertTrue(result.containsKey("sharedRoster.groupList"));
-        assertEquals("", result.get("sharedRoster.groupList"));
-        assertTrue(result.containsKey("sharedRoster.showInRoster"));
-        assertEquals("nobody", result.get("sharedRoster.showInRoster"));
+        assertTrue(result.containsKey(Group.SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY));
+        assertEquals("", result.get(Group.SHARED_ROSTER_DISPLAY_NAME_PROPERTY_KEY));
+        assertTrue(result.containsKey(Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY));
+        assertEquals("", result.get(Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY));
+        assertTrue(result.containsKey(Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY));
+        assertEquals(SharedGroupVisibility.nobody.getDbValue(), result.get(Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY));
     }
 
     public void testLoadPropertiesReturnsNoPropertiesForNewGroup() throws Exception {

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.group;
+
+import org.dbunit.DBTestCase;
+import org.dbunit.PropertiesBasedJdbcDatabaseTester;
+import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.xml.XmlDataSet;
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.database.DbConnectionManager;
+import org.jivesoftware.database.DefaultConnectionProvider;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.event.GroupEventDispatcher;
+import org.jivesoftware.util.cache.CacheFactory;
+import org.xmpp.packet.JID;
+
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Unit tests that verify the functionality of {@link GroupManager}.
+ *
+ * Implementation-wise, this class extends for DBTestCase, which is as JUnit 3 derivative. Practically, this means that
+ * Junit 4 annotations in this class will be ignored.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class GroupManagerNoMockTest extends DBTestCase
+{
+    public static final String DRIVER = "org.hsqldb.jdbcDriver";
+    public static final String URL;
+    public static final String USERNAME = "sa";
+    public static final String PASSWORD = "";
+
+    static {
+        final URL location = AbstractGroupProvider.class.getResource("/datasets/openfire.script");
+        final String fileLocation = location.toString().substring(0, location.toString().lastIndexOf("/")+1) + "openfire";
+        URL = "jdbc:hsqldb:"+fileLocation+";ifexists=true";
+
+        // Setup database configuration of DBUnit.
+        System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_DRIVER_CLASS, DRIVER );
+        System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_CONNECTION_URL, URL );
+        System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_USERNAME, USERNAME );
+        System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_PASSWORD, PASSWORD );
+    }
+
+    public void setUp() throws Exception
+    {
+        // Ensure that DB-Unit's setUp is called!
+        super.setUp();
+
+        // Initialize Openfire's cache framework.
+        CacheFactory.initialize();
+
+        // Mock the XMPPServer implementation that's used internally.
+        Fixtures.clearExistingProperties();
+        XMPPServer.setInstance(Fixtures.mockXMPPServer());
+
+        // Ensure that Openfire caches are reset before each test to avoid tests to affect each-other.
+        Arrays.stream(CacheFactory.getAllCaches()).forEach(Map::clear);
+
+        // Wire the database connection provider used by the GroupProvider.
+        final DefaultConnectionProvider conProvider = new DefaultConnectionProvider();
+        conProvider.setDriver(DRIVER);
+        conProvider.setServerURL(URL);
+        conProvider.setUsername(USERNAME);
+        conProvider.setPassword(PASSWORD);
+        DbConnectionManager.setConnectionProvider(conProvider);
+    }
+
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        // Reset static fields after use (to not confuse other test classes).
+        // TODO: this ideally goes in a static @AfterClass method, but that's not supported in JUnit 3.
+        for (String fieldName : Arrays.asList("INSTANCE", "provider")) {
+            final Field field = GroupManager.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(null, null);
+            field.setAccessible(false);
+        }
+
+        final Field field = GroupEventDispatcher.class.getDeclaredField("listeners");
+        field.setAccessible(true);
+        ((List)field.get(null)).clear();
+        field.setAccessible(false);
+    }
+
+    @Override
+    protected IDataSet getDataSet() throws Exception {
+        // This dataset restores the state of the database to one that does not contain any groups (or metadata for
+        // groups) between each test.
+        return new XmlDataSet(getClass().getResourceAsStream("/datasets/clean.xml"));
+    }
+
+    /**
+     * Asserts that a simple test group that is created by the provider can be retrieved again in good order.
+     */
+    public void testCreateGroup() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+        final DefaultGroupProvider provider = new DefaultGroupProvider();
+
+        // Execute system under test.
+        final Group group = groupManager.createGroup("Test Group");
+        group.setDescription("This is test group.");
+        group.getMembers().add(new JID("john@example.org"));
+        group.getMembers().add(new JID("jack@example.org"));
+        group.getAdmins().add(new JID("jane@example.org"));
+
+        // Verify results.
+        final Group result = provider.getGroup("Test Group");
+        assertNotNull(result);
+        assertEquals("Test Group", result.getName());
+        assertEquals("This is test group.", result.getDescription());
+        assertEquals(2, result.getMembers().size());
+        assertTrue(result.getMembers().contains(new JID("john@example.org")));
+        assertTrue(result.getMembers().contains(new JID("jack@example.org")));
+        assertEquals(1, result.getAdmins().size());
+        assertTrue(result.getAdmins().contains(new JID("jane@example.org")));
+        assertEquals(3, result.getAll().size());
+        assertTrue(result.getAll().contains(new JID("john@example.org")));
+        assertTrue(result.getAll().contains(new JID("jack@example.org")));
+        assertTrue(result.getAll().contains(new JID("jane@example.org")));
+    }
+
+    /**
+     * Asserts that a with no name cannot be created
+     */
+    public void testCreateGroupWithEmptyNameThrows() throws Exception
+    {
+        final String GROUP_NAME = "";
+        final GroupManager groupManager = GroupManager.getInstance();
+        assertThrows(GroupNameInvalidException.class, ()-> groupManager.createGroup(GROUP_NAME));
+    }
+
+    /**
+     * Asserts that two groups with the same name cannot be created
+     */
+    public void testCreateGroupWithDuplicateNameThrows() throws Exception
+    {
+        final String GROUP_NAME = "Test Group A";
+        final GroupManager groupManager = GroupManager.getInstance();
+        groupManager.createGroup(GROUP_NAME);
+        assertThrows(GroupAlreadyExistsException.class, ()-> groupManager.createGroup(GROUP_NAME));
+    }
+
+    /**
+     * Asserts that a group can be created, removed and recreated again, with the same name.
+     */
+    public void testRecreateGroup() throws Exception
+    {
+        final String GROUP_NAME = "Test Group A";
+        final GroupManager groupManager = GroupManager.getInstance();
+        final Group group = groupManager.createGroup(GROUP_NAME);
+        groupManager.deleteGroup(group);
+        groupManager.createGroup(GROUP_NAME);
+    }
+
+    /**
+     * Reproduces an issue where adding a member to a group that does not exist would cause the group to be added
+     * to a cache, making it appear that this group exists.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2426">Group cache can contain ghost entries</a>
+     */
+    public void testAddMemberToDeletedGroup() throws Exception
+    {
+        // Setup test fixture
+        final String GROUP_NAME = "Test Group A";
+        final GroupManager groupManager = GroupManager.getInstance();
+        final Group group = groupManager.createGroup(GROUP_NAME);
+        groupManager.deleteGroup(group);
+
+        // Execute system under test.
+        group.getMembers().add(new JID("test@example.org"));
+
+        // Verify results.
+        assertThrows(GroupNotFoundException.class, ()-> groupManager.getGroup(GROUP_NAME));
+    }
+
+    /**
+     * Verifies that a group can be retrieved based on the name that it was created with.
+     */
+    public void testGetGroupByName() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+        groupManager.createGroup("test");
+
+        // Execute system under test.
+        final Group result = groupManager.getGroup("test");
+
+        // Verify result.
+        assertNotNull(result);
+        assertEquals("test", result.getName());
+    }
+
+    /**
+     * Verifies that a {@link GroupManager#getGroupCount()} returns the correct count of groups when no groups
+     * are present.
+     */
+    public void testGroupCountEmpty() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+
+        // Execute system under test.
+        final int result = groupManager.getGroupCount();
+
+        // Verify result.
+        assertEquals(0, result);
+    }
+
+    /**
+     * Verifies that a {@link GroupManager#getGroupCount()} returns the correct count of groups when one group
+     * is present.
+     */
+    public void testGroupCountOne() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+        groupManager.createGroup("Test Group");
+
+        // Execute system under test.
+        final int result = groupManager.getGroupCount();
+
+        // Verify result.
+        assertEquals(1, result);
+    }
+
+    /**
+     * Verifies that a {@link GroupManager#getGroupCount()} returns the correct count of groups when multiple
+     * groups are present.
+     */
+    public void testGroupCountMultiple() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+        groupManager.createGroup("Test Group A");
+        groupManager.createGroup("Test Group B");
+
+        // Execute system under test.
+        final int result = groupManager.getGroupCount();
+
+        // Verify result.
+        assertEquals(2, result);
+    }
+
+    /**
+     * Verifies that {@link GroupManager#deleteGroup(Group)} deletes a shared group, such that it cannot be retrieved
+     */
+    public void testDeleteGroupShared() throws Exception {
+        final JID needle = new JID("jane@example.org");
+        final GroupManager groupManager = GroupManager.getInstance();
+        final Group groupA = groupManager.createGroup("Test Group A");
+        groupA.shareWithEverybody("Users in group A");
+        groupManager.createGroup("Test Group B");
+
+        groupManager.deleteGroup(groupA);
+        final Collection<Group> result = groupManager.getSharedGroups(needle.getNode());
+
+        assertEquals(0, result.size());
+    }
+}

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
@@ -60,6 +60,7 @@ public class GroupManagerTest {
     public static void beforeClass() throws Exception {
         Fixtures.reconfigureOpenfireHome();
         groupCache = CacheFactory.createCache("Group");
+        groupCache.clear();
         JiveGlobals.setProperty("provider.group.className", TestGroupProvider.class.getName());
     }
 
@@ -82,6 +83,8 @@ public class GroupManagerTest {
             field.set(null, null);
             field.setAccessible(false);
         }
+
+        groupCache.clear();
     }
 
     @Test


### PR DESCRIPTION
Reduce complexity by centralizing the responsiblity of dispatching events to event listeners and cache updates.

Avoid using the event listener mechanism that's also being provided to users of this API in the implementation itself.

As a byproduct of the latter, this fixes OF-2426: an event dispatched by the implementation no longer re-populates the cache unexpectedly.