### PR TITLE
OF-2428: Allow MUC occupants to request each-other's VCards

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -1390,6 +1390,10 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
      * If the system property xmpp.muc.allowpm.blockall is set to true, this will block all private packets
      * However, if this property is false (by default) then it will allow non-message private packets.
      *
+     * If the system property xmpp.muc.vcard.enabled is set to true, then IQ requests that are VCard requests for
+     * occupants of the MUC room are processed differently to allow for VCards to be requested from the home server of
+     * the occupant. See {@link MultiUserChatServiceImpl#processVCardResponse(IQ)} for details.
+     *
      * @param packet The packet to send.
      * @param senderRole the role of the user that is trying to send a public message.
      * @throws NotFoundException If the user is sending a packet to a room JID that does not exist.
@@ -1431,6 +1435,21 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
         // Sending the stanza will modify it. Make sure that the event listeners that are triggered after sending
         // the stanza don't get the 'real' address from the recipient.
         final Packet immutable = stanza.createCopy();
+
+        // If this is a VCard request, then the intended recipient's home server (possibly not this instance of Openfire) needs
+        // to answer on behalf of the intended recipient. See {@link MultiUserChatServiceImpl#processVCardResponse(IQ)} for details.
+        if (IQMUCvCardHandler.PROPERTY_ENABLED.getValue() && stanza instanceof IQ && ((IQ)stanza).getType() == IQ.Type.get) {
+            final IQ request = (IQ)stanza;
+            if (IQMUCvCardHandler.NAMESPACE.equals(request.getChildElement().getNamespaceURI())) {
+                // Build request from the requestor's room nickname (to have the response be delivered through the MUC room) to the home user of the intended recipient.
+                final JID bareJID = occupants.get(0).getUserAddress().asBareJID();
+                Log.debug("Sending VCard request to occupant {}'s real JID ('{}') to answer VCard request of {}", resource, bareJID, request.getFrom());
+                request.setTo(bareJID);
+
+                XMPPServer.getInstance().getPacketRouter().route(request);
+                return;
+            }
+        }
 
         // Forward it to each occupant.
         for (final MUCRole occupant : occupants) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -421,6 +421,9 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                                 lock.unlock();
                             }
                         }
+                    } else if (IQMUCvCardHandler.PROPERTY_ENABLED.getValue() && packet instanceof IQ && ((IQ) packet).isResponse() && ((IQ) packet).getChildElement().getNamespaceURI().equals(IQMUCvCardHandler.NAMESPACE)) {
+                        Log.trace( "Stanza is a VCard response stanza." );
+                        processVCardResponse((IQ) packet);
                     } else {
                         Log.trace( "Stanza is a regular MUC stanza." );
                         processRegularStanza(packet);
@@ -547,7 +550,74 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     }
 
     /**
-     * This method does all stanz routing in the chat server for 'regular' MUC stanzas. Packet routing is actually very
+     * Processes a VCard response stanza that is supposedly sent to an occupant of a room as a result of that occupant
+     * having requested the VCard of another occupant earlier.
+     *
+     * VCard processing in MUC rooms depends on a bit of a hack: most clients of requestees cannot process a request for
+     * a VCard themselves (see XEP-0054). Instead, the request is rerouted to the bare JID of the requestee, which is
+     * responded to by its home server. {@link MUCRoom#sendPrivatePacket(Packet, MUCRole)} implements this rerouting.
+     * The response from the home server is then processed by this method. It needs special care as its 'from' address
+     * is a bare JID (and thus not directly related to a single occupant).
+     *
+     * @param response An IQ stanza that should be a response to an earlier VCard request.
+     */
+    public void processVCardResponse(@Nonnull final IQ response)
+    {
+        if (!response.isResponse()) {
+            throw new IllegalArgumentException("IQ must be a response, but is of type: " + response.getType());
+        }
+
+        // Name of the room that the stanza is addressed to.
+        final String roomName = response.getTo().getNode();
+
+        if ( roomName == null )
+        {
+            // Packets to the groupchat service (as opposed to a specific room on the service). This should not occur
+            // (should be handled by MultiUserChatServiceImpl instead).
+            Log.warn(LocaleUtils.getLocalizedString("muc.error.not-supported") + " " + response);
+            return;
+        }
+
+        StanzaIDUtil.ensureUniqueAndStableStanzaID(response, response.getTo().asBareJID());
+
+        final Lock lock = getChatRoomLock(roomName);
+        lock.lock();
+        try {
+            // Get the room, if one exists.
+            @Nullable MUCRoom room = getChatRoom(roomName);
+
+            // Determine if this sender (responding to the VCard request) has a pre-existing role in the addressed room.
+            // VCards responses are sent by servers on behalf of the user, so have a bare JID in the 'from' address.
+            // This cannot be uniquely matched to a single occupant. In case that they are with multiple occupants in
+            // the room, we will use the role with the most liberal permissions.
+            MUCRole preExistingRole;
+            if (room == null) {
+                preExistingRole = null;
+            } else {
+                try {
+                    preExistingRole = room.getOccupantsByBareJID(response.getFrom().asBareJID())
+                        .stream()
+                        .min(Comparator.comparingInt(o -> o.getRole().getValue()))
+                        .orElse(null);
+                } catch (UserNotFoundException e) {
+                    preExistingRole = null;
+                }
+            }
+            Log.debug("Preexisting role for user {} in room {} (that currently {} exist): {}", response.getFrom(), roomName, room == null ? "does not" : "does", preExistingRole == null ? "(none)" : preExistingRole);
+
+            process(response, room, preExistingRole);
+
+            // Ensure that other cluster nodes see any changes (unlikely to have occurred here, but better safe than sorry) that might have been applied.
+            if (room != null) {
+                syncChatRoom(room);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * This method does all stanza routing in the chat server for 'regular' MUC stanzas. Packet routing is actually very
      * simple:
      *
      * <ul>
@@ -568,7 +638,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         {
             // Packets to the groupchat service (as opposed to a specific room on the service). This should not occur
             // (should be handled by MultiUserChatServiceImpl instead).
-            Log.warn(LocaleUtils.getLocalizedString("muc.error.not-supported") + " " + packet.toString());
+            Log.warn(LocaleUtils.getLocalizedString("muc.error.not-supported") + " " + packet);
             if ( packet instanceof IQ && ((IQ) packet).isRequest() )
             {
                 sendErrorPacket(packet, PacketError.Condition.feature_not_implemented, "Unable to process stanza.");


### PR DESCRIPTION
This implements a hack that redirects IQ requests from one MUC occupant to another to the bare JID of the occupant, rather than the full JID. This allows the home server of the occupant (rather than its client) to process the request. This is in-line with how XEP-0054 defines how VCards should be requested.