### PR TITLE
allow Openfire to operate as a gateway for XMPP traffic

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerSocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerSocketReader.java
@@ -23,6 +23,7 @@ import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.event.ServerSessionEventDispatcher;
 import org.jivesoftware.openfire.interceptor.PacketRejectedException;
 import org.jivesoftware.openfire.session.LocalIncomingServerSession;
+import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParserException;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerSocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerSocketReader.java
@@ -205,6 +205,6 @@ public class ServerSocketReader extends SocketReader {
 
     @Override
     boolean validateHost() {
-        return true;
+        return JiveGlobals.getBooleanProperty("xmpp.server.validate.host",true);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
@@ -77,7 +77,7 @@ public class ServerStanzaHandler extends StanzaHandler {
 
     @Override
     boolean validateHost() {
-        return true;
+        return JiveGlobals.getBooleanProperty("xmpp.server.validate.host",true);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -497,7 +497,7 @@ public class ServerDialback {
             log.debug( "Unable to validate domain: Remote domain is not allowed to establish a connection to this server." );
             return false;
         }
-        else if (isHostUnknown(recipient)) {
+        else if (validateHost() && isHostUnknown(recipient)) {
             dialbackError(recipient, remoteDomain, new PacketError(PacketError.Condition.item_not_found, PacketError.Type.cancel, "Service not hosted here"));
             log.debug( "Unable to validate domain: recipient not recognized as a local domain." );
             return false;
@@ -645,6 +645,10 @@ public class ServerDialback {
         }
         return host_unknown;
     }
+    
+    private boolean validateHost() {
+       return JiveGlobals.getBooleanProperty("xmpp.server.validate.host",true); 
+    }
 
     private VerifyResult sendVerifyKey(String key, StreamID streamID, String recipient, String remoteDomain, Writer writer, XMPPPacketReader reader, Socket socket, boolean skipTLS, boolean directTLS) throws IOException, XmlPullParserException, RemoteConnectionFailedException {
         final Logger log = LoggerFactory.getLogger( Log.getName() + "[Acting as Receiving Server: Verify key with AS: " + remoteDomain + " for OS: " + recipient + " (id " + streamID + ")]" );
@@ -757,7 +761,7 @@ public class ServerDialback {
                         // condition is sent to the Originating Server
                         throw new RemoteConnectionFailedException("Invalid ID");
                     }
-                    else if (isHostUnknown( doc.attributeValue( "to" ) )) {
+                    else if (validateHost() && isHostUnknown( doc.attributeValue( "to" ) )) {
                         // Include the host-unknown stream error condition in the response
                         writer.write(new StreamError(StreamError.Condition.host_unknown).toXML());
                         writer.write("</stream:stream>");


### PR DESCRIPTION
If Openfire does not validate that the messages it receives are addressed to its domain, then it will go ahead and forward messages to the target servers and it will effectively operate as a gateway for XMPP traffic.

This PR makes this validation configurable by setting system property "xmpp.server.validate.host" to "false" (default is "true"). The name of this property is similar to property "xmpp.client.validate.host", used by ClientStanzaHandler.
