### PR TITLE
OF-2444: Deadlock in BOSH implementation

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -160,7 +160,13 @@ public class HttpSession extends LocalClientSession {
     // FIXME: OF-2445: Prevent elements to be scheduled for delivery in #pendingElements after the session is closed (as they would never be delivered).
     private final ConcurrentLinkedQueue<Deliverable> pendingElements = new ConcurrentLinkedQueue<>();
 
-    private final List<Delivered> sentElements = new ArrayList<>();
+    /**
+     * A list of data that has been delivered, for potential future retransmission.
+     *
+     * The size of this collection is limited. It will contain only the last few transmitted elements.
+     */
+    @GuardedBy("itself")
+    private final List<Delivered> sentElements = new ArrayList<>(); // FIXME: OF-2446 Use a more appropriate data type than ArrayList.
 
     private Instant lastPoll = Instant.EPOCH;
     private Duration inactivityTimeout;
@@ -661,13 +667,14 @@ public class HttpSession extends LocalClientSession {
      * @return previously delivered data when found.
      */
     @Nullable
-    @GuardedBy("connectionQueue")
     private Delivered retrieveDeliverable(final long rid) {
         Delivered result = null;
-        for (Delivered delivered : sentElements) {
-            if (delivered.getRequestID() == rid) {
-                result = delivered;
-                break;
+        synchronized (sentElements) {
+            for (Delivered delivered : sentElements) {
+                if (delivered.getRequestID() == rid) {
+                    result = delivered;
+                    break;
+                }
             }
         }
         return result;
@@ -967,11 +974,13 @@ public class HttpSession extends LocalClientSession {
 
         // Keep track of data that has been delivered, for potential future retransmission.
         final Delivered delivered = new Delivered(deliverable, connection.getRequestId());
-        while (sentElements.size() > maxRequests) {
-            sentElements.remove(0);
-        }
+        synchronized (sentElements) {
+            while (sentElements.size() > maxRequests) {
+                sentElements.remove(0);
+            }
 
-        sentElements.add(delivered);
+            sentElements.add(delivered);
+        }
     }
 
     private void closeSession(@Nullable final StreamError error) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -662,24 +662,22 @@ public class HttpSession extends LocalClientSession {
      * Attempts to find data that was previously sent back to the client, using a particular request ID. This is
      * expected to be used to process requests for retransmission.
      *
-     * The implementation only holds a limited amount of data. It will return null when no data that matches the ID can
-     * be found.
+     * The implementation only holds a limited amount of data. It will return an empty Optional when no data that
+     * matches the ID can be found.
      *
      * @param rid The request ID for which to find previously delivered data.
      * @return previously delivered data when found.
      */
-    @Nullable
-    private Delivered retrieveDeliverable(final long rid) {
-        Delivered result = null;
+    @Nonnull
+    private Optional<Delivered> retrieveDeliverable(final long rid) {
         synchronized (sentElements) {
             for (Delivered delivered : sentElements) {
                 if (delivered.getRequestID() == rid) {
-                    result = delivered;
-                    break;
+                    return Optional.of(delivered);
                 }
             }
         }
-        return result;
+        return Optional.empty();
     }
 
     /**
@@ -811,12 +809,12 @@ public class HttpSession extends LocalClientSession {
     private void redeliver(@Nonnull final HttpConnection connection) throws HttpBindException, IOException, HttpConnectionClosedException
     {
         Log.debug("Session {} requesting a retransmission for rid {}", getStreamID(), connection.getRequestId());
-        final Delivered deliverable = retrieveDeliverable(connection.getRequestId());
-        if (deliverable == null) {
+        final Optional<Delivered> deliverable = retrieveDeliverable(connection.getRequestId());
+        if (!deliverable.isPresent()) {
             Log.warn("Deliverable unavailable for " + connection.getRequestId() + " in session " + getStreamID());
             throw new HttpBindException("Unexpected RID error.", BoshBindingError.itemNotFound);
         }
-        connection.deliverBody(asBodyText(deliverable.deliverables), true);
+        connection.deliverBody(asBodyText(deliverable.get().deliverables), true);
     }
 
     private enum OveractivityType {
@@ -946,9 +944,9 @@ public class HttpSession extends LocalClientSession {
             return;
         }
 
-        final HttpConnection connection = getConnectionReadyForOutboundDelivery();
+        final Optional<HttpConnection> connection = getConnectionReadyForOutboundDelivery();
 
-        if (connection == null) {
+        if (!connection.isPresent()) {
             Log.trace("Immediate delivery of pending data to the client on session {} was requested, but no connection is available. The data ({} deliverables) will be re-queued.", getStreamID(), deliverables.size());
             // place pending deliverables back on queue. // FIXME: if other threads have placed pending elements, this will cause a re-order, which might be undesirable.
             pendingElements.addAll(deliverables);
@@ -958,7 +956,7 @@ public class HttpSession extends LocalClientSession {
         // OF-2444: deliver asynchronously, to avoid deadlocking issues.
         HttpBindManager.getInstance().getSessionManager().execute(() -> {
             try {
-                deliver(connection, deliverables, true);
+                deliver(connection.get(), deliverables, true);
             } catch (HttpConnectionClosedException e) {
                 /* Connection was closed, try the next one. Indicates a (concurrency?) bug. */
                 Log.warn("Iterating over a connection that was closed for session {}. Openfire will recover from this problem, but it should not occur in the first place.", getStreamID(), e);
@@ -977,20 +975,20 @@ public class HttpSession extends LocalClientSession {
      *
      * @return A connection that is ready to be responded to.
      */
-    @Nullable
-    private HttpConnection getConnectionReadyForOutboundDelivery()
+    @Nonnull
+    private Optional<HttpConnection> getConnectionReadyForOutboundDelivery()
     {
-        HttpConnection connection = null;
         synchronized (connectionQueue) {
             // The connection queue is ordered. No need to iterate further than the first element.
             if (!connectionQueue.isEmpty()) {
-                connection = connectionQueue.peek();
+                final HttpConnection connection = connectionQueue.peek();
                 assert !connection.isClosed();
 
                 // We can only use connections that have a sequential request ID.
                 if (connection.getRequestId() <= lastSequentialRequestID) {
                     Log.trace("Got a connection that is ready for outbound delivery of session {}. The connection's RID is {}. The last sequential RID was: {}", getStreamID(), connection.getRequestId(), lastSequentialRequestID);
-                    connection = connectionQueue.poll();
+                    connectionQueue.poll(); // remove it.
+                    return Optional.of(connection);
                 } else {
                     Log.trace("Trying to get a connection that is ready for outbound delivery of session {}, but the first connection in the connection queue isn't the next connection that needs to be responded to. It's RID is {}, while the last sequential RID was {}.", getStreamID(), connection.getRequestId(), lastSequentialRequestID);
                 }
@@ -998,7 +996,7 @@ public class HttpSession extends LocalClientSession {
                 Log.trace("Trying to get a connection that is ready for outbound delivery of session {}, but the connection queue is currently empty. The last sequential RID was {}", getStreamID(), lastSequentialRequestID);
             }
         }
-        return connection;
+        return Optional.empty();
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -175,7 +175,6 @@ public class HttpSession extends LocalClientSession {
     private Instant lastPoll = Instant.EPOCH;
     private Duration inactivityTimeout;
 
-    @GuardedBy("connectionQueue")
     private Instant lastActivity;
 
     @GuardedBy("connectionQueue")
@@ -501,6 +500,7 @@ public class HttpSession extends LocalClientSession {
 
             // Check for retransmission.
             if (rid <= lastAnsweredRequestID) {
+                Log.debug("Request {} on session {} appears to be a request for redelivery, as the last answered RID is {}", rid, getStreamID(), lastAnsweredRequestID);
                 redeliver(connection);
                 return;
             }
@@ -606,8 +606,8 @@ public class HttpSession extends LocalClientSession {
                     if (connectionQueue.remove(connection) || !connection.isClosed()) {
                         Log.warn("Discovered a 'complete' event for a BOSH connection that has not been consumed (for session {} with Request ID {}, was closed: {}). This likely is a bug in Openfire.", streamID, rid, connection.isClosed());
                     }
-                    lastActivity = Instant.now();
                 }
+                lastActivity = Instant.now();
                 SessionEventDispatcher.dispatchEvent( HttpSession.this, SessionEventDispatcher.EventType.connection_closed, connection, context );
             }
 
@@ -651,6 +651,7 @@ public class HttpSession extends LocalClientSession {
                 if (Log.isTraceEnabled()) {
                     Log.trace("Session {} Request ID {}, event start: {}", streamID, rid, asyncEvent);
                 }
+                lastActivity = Instant.now();
             }
         });
 
@@ -706,33 +707,39 @@ public class HttpSession extends LocalClientSession {
             // Note that this queue will automatically order its entities.
             connectionQueue.add(connection);
 
+            lastActivity = Instant.now();
+
             final Iterator<HttpConnection> iter = connectionQueue.iterator();
             while (iter.hasNext()) {
                 final HttpConnection queuedConnection = iter.next();
                 assert !queuedConnection.isClosed();
 
                 final long queuedRequestID = queuedConnection.getRequestId();
-                if (queuedRequestID <= lastSequentialRequestID) {
-                    Log.warn("Detected a queued connection (for session {}) with a request ID ({}) that is not higher than the last sequential request ID ({}). This likely is a bug in Openfire.", streamid, queuedRequestID, lastSequentialRequestID);
+                if (queuedRequestID <= lastSequentialRequestID)
+                {
+                    // The request body (inbound data) for this request will already have been processed, but the connection remains queued, waiting to be used to send outbound data.
+                    Log.trace("Detected a queued connection (for session {}) with a request ID ({}) that is not higher than the last sequential request ID ({}). This connection is waiting to be used to deliver outbound data back to the client.", streamid, queuedRequestID, lastSequentialRequestID);
                     continue;
                 }
                 if (queuedRequestID == lastSequentialRequestID + 1)
                 {
-                    // There is a new connection available for consumption.
-                    lastSequentialRequestID = queuedRequestID;
-
+                    Log.debug("Detected a queued connection (for session {}) with request ID ({}) that is exactly one higher than the last sequential request ID ({}). This inbound data on this connection will now be processed, after which the connection can be used to send outbound data back to the client.", streamid, queuedRequestID, lastSequentialRequestID);
                     // The data that was provided by the client can now be processed by the server.
-                    sendPendingPackets(queuedConnection.getInboundDataQueue()); // FIXME: OF-2444: This should not be done while holding the lock on connectionQueue, as it leads to deadlocks!
+                    // The below sends this data asynchronously.
+                    sendPendingPackets(queuedConnection.getInboundDataQueue());
 
                     // Evaluate edge-cases.
                     if (queuedConnection.isTerminate()) {
+                        Log.debug("Connection (for session {}) with request ID ({}) is a request to terminate.", getStreamID(), queuedRequestID);
                         iter.remove(); // This connection will be consumed here.
                         queuedConnection.deliverBody(createEmptyBody(true), true);
                         close();
                     } else if (queuedConnection.isRestart()) {
+                        Log.debug("Connection (for session {}) with request ID ({}) is a request to restart.", getStreamID(), queuedRequestID);
                         iter.remove(); // This connection has now been fully consumed.
                         queuedConnection.deliverBody(createSessionRestartResponse(), true);
                     } else if (queuedConnection.getPause() != null && queuedConnection.getPause().compareTo(getMaxPause()) <= 0) {
+                        Log.debug("Connection (for session {}) with request ID ({}) is a request to pause (for {}).", getStreamID(), queuedRequestID, queuedConnection.getPause());
                         iter.remove(); // This connection will be consumed by this block. It should not be processed by the 'pause' method.
                         pause(queuedConnection.getPause()); // TODO: OF-2449: shouldn't we error when the requested pause is higher than the allowed maximum?
                         connection.deliverBody(createEmptyBody(false), true); // FIXME: OF-2450: Deliver an empty body on queuedConnection, not connection.
@@ -741,6 +748,10 @@ public class HttpSession extends LocalClientSession {
                         // At least one new connection has become available, and can be used to return data to the client.
                         aConnectionAvailableForDelivery = true;
                     }
+
+                    // There is a new connection available for consumption.
+                    lastSequentialRequestID = queuedRequestID;
+
                     // Note that when this connection fills a gap in the sequence, other connections might already be
                     // available that have the 'next' Request ID value. We need to keep iterating.
                 } else {
@@ -761,13 +772,8 @@ public class HttpSession extends LocalClientSession {
             }
 
             if (isPollingSession() || aConnectionAvailableForDelivery) {
-                // In a thread-safe manner, create a copy of all elements that are currently pending.
-                final List<Deliverable> toProcessElements = drainPendingElements();
-                if (!toProcessElements.isEmpty()) {
-                    lastActivity = Instant.now();
-                    SessionEventDispatcher.dispatchEvent(this, SessionEventDispatcher.EventType.connection_opened, connection, context); // TODO is this the right place to dispatch this event?
-                    deliver(toProcessElements);
-                }
+                SessionEventDispatcher.dispatchEvent(this, SessionEventDispatcher.EventType.connection_opened, connection, context); // TODO is this the right place to dispatch this event?
+                tryImmediateDelivery();
             }
 
             // When a new connection has become available, older connections need to be released (allowing the client to
@@ -920,40 +926,79 @@ public class HttpSession extends LocalClientSession {
      *
      * @param deliverable data to be delivered.
      */
-    private void deliver(@Nonnull final List<Deliverable> deliverable) {
-        boolean delivered = false;
+    private void deliver(@Nonnull final List<Deliverable> deliverable)
+    {
+        pendingElements.addAll(deliverable); // ConcurrentLinkedQueue.addAll is not guaranteed to be atomic. We don't need that, as long as the insertion/iteration order is guaranteed. I'm not sure if it is (but I assume so).
+        tryImmediateDelivery();
+    }
+
+    /**
+     * Tries to deliver all data that is queued to be sent to the client, if data has been queued and a connection is
+     * available for delivery.
+     *
+     * When no data is queued for delivery, or when no connection is available, an invocation does nothing.
+     */
+    private void tryImmediateDelivery()
+    {
+        final List<Deliverable> deliverables = drainPendingElements();
+        if (deliverables.isEmpty()) {
+            Log.trace("Immediate delivery of pending data to the client on session {} was requested, but no data is pending.", getStreamID());
+            return;
+        }
+
+        final HttpConnection connection = getConnectionReadyForOutboundDelivery();
+
+        if (connection == null) {
+            Log.trace("Immediate delivery of pending data to the client on session {} was requested, but no connection is available. The data ({} deliverables) will be re-queued.", getStreamID(), deliverables.size());
+            // place pending deliverables back on queue. // FIXME: if other threads have placed pending elements, this will cause a re-order, which might be undesirable.
+            pendingElements.addAll(deliverables);
+            return;
+        }
+
+        // OF-2444: deliver asynchronously, to avoid deadlocking issues.
+        HttpBindManager.getInstance().getSessionManager().execute(() -> {
+            try {
+                deliver(connection, deliverables, true);
+            } catch (HttpConnectionClosedException e) {
+                /* Connection was closed, try the next one. Indicates a (concurrency?) bug. */
+                Log.warn("Iterating over a connection that was closed for session {}. Openfire will recover from this problem, but it should not occur in the first place.", getStreamID(), e);
+                // place pending deliverables back on queue. // FIXME: if other threads have placed pending elements, this will cause a re-order, which might be undesirable.
+                pendingElements.addAll(deliverables);
+            } catch (IOException e) {
+                Log.warn("An unexpected exception occurred while iterating over connections for session {}. Openfire will attempt to recover by ignoring this connection.", getStreamID(), e);
+                // place pending deliverables back on queue. // FIXME: if other threads have placed pending elements, this will cause a re-order, which might be undesirable.
+                pendingElements.addAll(deliverables);
+            }
+        });
+    }
+
+    /**
+     * Returns a connection that can be used to deliver data to the client, if such a connection is currently available.
+     *
+     * @return A connection that is ready to be responded to.
+     */
+    @Nullable
+    private HttpConnection getConnectionReadyForOutboundDelivery()
+    {
+        HttpConnection connection = null;
         synchronized (connectionQueue) {
-            while (!connectionQueue.isEmpty()) {
-                final HttpConnection connection = connectionQueue.peek();
+            // The connection queue is ordered. No need to iterate further than the first element.
+            if (!connectionQueue.isEmpty()) {
+                connection = connectionQueue.peek();
                 assert !connection.isClosed();
 
-                try {
-                    // We can only use connections that have a sequential request ID.
-                    if (connection.getRequestId() <= lastSequentialRequestID) {
-                        connectionQueue.poll();
-                        deliver(connection, deliverable, true); // TODO OF-2444 move this out from under the connectionQueue mutex maybe?
-                        delivered = true;
-                    }
-
-                    // The connection queue is ordered. No need to iterate further;
-                    break;
+                // We can only use connections that have a sequential request ID.
+                if (connection.getRequestId() <= lastSequentialRequestID) {
+                    Log.trace("Got a connection that is ready for outbound delivery of session {}. The connection's RID is {}. The last sequential RID was: {}", getStreamID(), connection.getRequestId(), lastSequentialRequestID);
+                    connection = connectionQueue.poll();
+                } else {
+                    Log.trace("Trying to get a connection that is ready for outbound delivery of session {}, but the first connection in the connection queue isn't the next connection that needs to be responded to. It's RID is {}, while the last sequential RID was {}.", getStreamID(), connection.getRequestId(), lastSequentialRequestID);
                 }
-                catch (HttpConnectionClosedException e) {
-                    /* Connection was closed, try the next one. Indicates a (concurrency?) bug. */
-                    StreamID streamID = getStreamID();
-                    Log.warn("Iterating over a connection that was closed for session " + streamID +
-                            ". Openfire will recover from this problem, but it should not occur in the first place.");
-                } catch (IOException e) {
-                    StreamID streamID = getStreamID();
-                    Log.warn("An unexpected exception occurred while iterating over connections for session " + streamID +
-                            ". Openfire will attempt to recover by ignoring this connection.", e);
-                }
+            } else {
+                Log.trace("Trying to get a connection that is ready for outbound delivery of session {}, but the connection queue is currently empty. The last sequential RID was {}", getStreamID(), lastSequentialRequestID);
             }
         }
-        if (!delivered) {
-            Log.debug("Unable to immediately deliver a stanza on session {}. It is being queued instead).", getStreamID());
-            pendingElements.addAll(deliverable); // ConcurrentLinkedQueue.addAll is not guaranteed to be atomic. We don't need that, as long as the insertion/iteration order is guaranteed. I'm not sure if it is (but I assume so).
-        }
+        return connection;
     }
 
     /**
@@ -963,12 +1008,14 @@ public class HttpSession extends LocalClientSession {
      * @param deliverable The data to be delivered.
      * @param async should the invocation block until the data has been delivered?
      */
-    @GuardedBy("connectionQueue")
     private void deliver(@Nonnull final HttpConnection connection, @Nonnull final List<Deliverable> deliverable, final boolean async)
         throws HttpConnectionClosedException, IOException
     {
+        Log.trace("Delivering {} deliverables to the client on session {}, using connection with RID {}", deliverable.size(), getStreamID(), connection.getRequestId());
         connection.deliverBody(asBodyText(deliverable), async);
         lastAnsweredRequestID = connection.getRequestId();
+
+        lastActivity = Instant.now();
 
         // Keep track of data that has been delivered, for potential future retransmission.
         final Delivered delivered = new Delivered(deliverable, connection.getRequestId());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -779,7 +779,7 @@ public class HttpSession extends LocalClientSession {
                 final HttpConnection openConnection = connectionQueue.peek();
                 assert openConnection != null;
                 if (openConnection.getRequestId() > lastSequentialRequestID) {
-                    break; // There's a gap.
+                    break; // There's a gap. As described above, connections must be used in sequence, without jumping the queue.
                 }
 
                 // Consume this connection.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -58,7 +58,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.stream.Collectors;
 
 /**
  * A session represents a series of interactions with an XMPP client sending packets using the HTTP
@@ -150,8 +149,13 @@ public class HttpSession extends LocalClientSession {
      */
     private final X509Certificate[] sslCertificates;
 
+    /**
+     * Collection of client connections on which a BOSH request has been made, but have not been responded to.
+     *
+     * The connections in the queue will be ordered by their requestId value.
+     */
     @GuardedBy("itself")
-    private final List<HttpConnection> connectionQueue = new LinkedList<>();
+    private final PriorityQueue<HttpConnection> connectionQueue = new PriorityQueue<>((o1, o2) -> (int) (o1.getRequestId() - o2.getRequestId()));
 
     /**
      * A thread-safe collection (using a weakly consistent iterator) that contains stanzas that could not immediately be
@@ -183,8 +187,6 @@ public class HttpSession extends LocalClientSession {
     private boolean lastResponseEmpty;
 
     private final SessionPacketRouter router = new SessionPacketRouter(this);
-
-    private static final Comparator<HttpConnection> connectionComparator = (o1, o2) -> (int) (o1.getRequestId() - o2.getRequestId());
 
     public HttpSession(HttpVirtualConnection vConnection, String serverName,
                        StreamID streamID, long requestId, X509Certificate[] sslCertificates, Locale language,
@@ -373,10 +375,11 @@ public class HttpSession extends LocalClientSession {
     public void pause(Duration duration) {
         // Respond immediately to all pending requests
         synchronized (connectionQueue) {
-            for (HttpConnection toClose : connectionQueue) {
-                if (!toClose.isClosed()) {
-                    toClose.close();
-                }
+            final Iterator<HttpConnection> iter = connectionQueue.iterator();
+            while (iter.hasNext()) {
+                final HttpConnection toClose = iter.next();
+                toClose.close();
+                iter.remove();
             }
         }
         setInactivityTimeout(duration);
@@ -392,13 +395,8 @@ public class HttpSession extends LocalClientSession {
     public Instant getLastActivity() {
         synchronized (connectionQueue) {
             if (!connectionQueue.isEmpty()) {
-                for (HttpConnection connection : connectionQueue) {
-                    // The session is currently active, set the last activity to the current time.
-                    if (!(connection.isClosed())) {
-                        lastActivity = Instant.now();
-                        break;
-                    }
-                }
+                // The session is currently active, set the last activity to the current time.
+                lastActivity = Instant.now();
             }
             return lastActivity;
         }
@@ -513,26 +511,24 @@ public class HttpSession extends LocalClientSession {
              * deliverable on the new connection. This is under the assumption that a connection has been dropped,
              * and re-requested before jetty has realised.
              */
-            // TODO is there overlap with the retransmission logic above? Can this be simplified?
-            for (HttpConnection queuedConnection : connectionQueue) {
+            final Iterator<HttpConnection> iter = connectionQueue.iterator();
+            while (iter.hasNext()) {
+                final HttpConnection queuedConnection = iter.next();
                 if (queuedConnection.getRequestId() == rid) {
                     Log.debug("Found previous connection in queue with rid {}", rid);
-                    if(queuedConnection.isClosed()) {
-                        Log.debug("It's closed - copying deliverables");
 
-                        Delivered deliverable = retrieveDeliverable(rid);
-                        if (deliverable == null) {
-                            Log.warn("In session {} deliverable unavailable for {}", streamid, rid);
-                            throw new HttpBindException("Unexpected RID error.", BoshBindingError.itemNotFound);
-                        }
-                        connection.deliverBody(asBodyText(deliverable.deliverables), true);
-                    } else {
-                        Log.debug("For session {} queued connection is still open - calling close() on the old connection (as the new connection will replace it).", streamid);
+                    // Note that the old connection is removed here, but the new connection will not be added back before the mutex is released. This leaves
+                    // room for another thread to try and consume a connection before this connection has been restored. This should be safe, as the consumer
+                    // should not be allowed to consume a connection with a RID that, compared to the previously consumed RID, leaves a 'gap'. In that case,
+                    // the to-be-delivered data is expected to be queued, which will be picked up as soon as this connection (for which the RID 'fills the gap',
+                    // is being processed by org.jivesoftware.openfire.http.HttpSession.processConnection.
+                    iter.remove();
 
-                        // TODO implement section 14.3 of XEP 0124 instead of this!
-                        deliver(queuedConnection, Collections.singletonList(new Deliverable("")), true);
-                        connection.close();
-                    }
+                    assert !queuedConnection.isClosed();
+                    Log.debug("For session {} queued connection is still open - calling close() on the old connection (as the new connection will replace it).", streamid);
+                    // TODO: OF-2447: implement section 14.3 of XEP 0124 instead of this!
+                    deliver(queuedConnection, Collections.singletonList(new Deliverable("")), true);
+                    connection.close(); // FIXME: OF-2448: As the intention is for the new connection to replace the old connection, the new connection should not be closed, I think.
                     break;
                 }
             }
@@ -607,7 +603,9 @@ public class HttpSession extends LocalClientSession {
                     Log.trace("Session {} Request ID {}, event complete: {}", streamID, rid, asyncEvent);
                 }
                 synchronized (connectionQueue) {
-                    connectionQueue.remove(connection);
+                    if (connectionQueue.remove(connection) || !connection.isClosed()) {
+                        Log.warn("Discovered a 'complete' event for a BOSH connection that has not been consumed (for session {} with Request ID {}, was closed: {}). This likely is a bug in Openfire.", streamID, rid, connection.isClosed());
+                    }
                     lastActivity = Instant.now();
                 }
                 SessionEventDispatcher.dispatchEvent( HttpSession.this, SessionEventDispatcher.EventType.connection_closed, connection, context );
@@ -623,6 +621,8 @@ public class HttpSession extends LocalClientSession {
                     // If onTimeout does not result in a complete(), the container falls back to default behavior.
                     // This is why this body is to be delivered in a non-async fashion.
                     synchronized (connectionQueue) {
+                        // Consume the connection that is timing out, by removing it from the queue and sending data to it.
+                        connectionQueue.remove(connection);
                         deliver(connection, Collections.singletonList(new Deliverable("")), false);
                         setLastResponseEmpty(true);
                     }
@@ -640,6 +640,7 @@ public class HttpSession extends LocalClientSession {
                 }
                 Log.warn("For session {} an unhandled AsyncListener error occurred: ", streamID, asyncEvent.getThrowable());
                 synchronized (connectionQueue) {
+                    // There was an error with a connection. Make sure it cannot be consumed again.
                     connectionQueue.remove(connection);
                 }
                 SessionEventDispatcher.dispatchEvent( HttpSession.this, SessionEventDispatcher.EventType.connection_closed, connection, context );
@@ -702,36 +703,39 @@ public class HttpSession extends LocalClientSession {
         // connection arrives that 'fills the gap' (and be used only _after_ that connection gets used).
         boolean aConnectionAvailableForDelivery = false;
         synchronized (connectionQueue) {
+            // Note that this queue will automatically order its entities.
             connectionQueue.add(connection);
 
-            // Order the connection queue, and determine if the sequence of consecutive request IDs can be updated.
-            connectionQueue.sort(connectionComparator);
+            final Iterator<HttpConnection> iter = connectionQueue.iterator();
+            while (iter.hasNext()) {
+                final HttpConnection queuedConnection = iter.next();
+                assert !queuedConnection.isClosed();
 
-            for (final HttpConnection queuedConnection : connectionQueue) {
                 final long queuedRequestID = queuedConnection.getRequestId();
                 if (queuedRequestID <= lastSequentialRequestID) {
+                    Log.warn("Detected a queued connection (for session {}) with a request ID ({}) that is not higher than the last sequential request ID ({}). This likely is a bug in Openfire.", streamid, queuedRequestID, lastSequentialRequestID);
                     continue;
                 }
                 if (queuedRequestID == lastSequentialRequestID + 1)
                 {
                     // There is a new connection available for consumption.
                     lastSequentialRequestID = queuedRequestID;
-                    if (queuedConnection.isClosed()) {
-                        continue; // Unsure if this can happen - perhaps at edge-cases involving time-outs?
-                    }
 
                     // The data that was provided by the client can now be processed by the server.
-                    sendPendingPackets(queuedConnection.getInboundDataQueue());
+                    sendPendingPackets(queuedConnection.getInboundDataQueue()); // FIXME: OF-2444: This should not be done while holding the lock on connectionQueue, as it leads to deadlocks!
 
                     // Evaluate edge-cases.
                     if (queuedConnection.isTerminate()) {
+                        iter.remove(); // This connection will be consumed here.
                         queuedConnection.deliverBody(createEmptyBody(true), true);
                         close();
                     } else if (queuedConnection.isRestart()) {
+                        iter.remove(); // This connection has now been fully consumed.
                         queuedConnection.deliverBody(createSessionRestartResponse(), true);
                     } else if (queuedConnection.getPause() != null && queuedConnection.getPause().compareTo(getMaxPause()) <= 0) {
-                        pause(queuedConnection.getPause()); // TODO shouldn't we error when the requested pause is higher than the allowed maximum?
-                        connection.deliverBody(createEmptyBody(false), true);
+                        iter.remove(); // This connection will be consumed by this block. It should not be processed by the 'pause' method.
+                        pause(queuedConnection.getPause()); // TODO: OF-2449: shouldn't we error when the requested pause is higher than the allowed maximum?
+                        connection.deliverBody(createEmptyBody(false), true); // FIXME: OF-2450: Deliver an empty body on queuedConnection, not connection.
                         setLastResponseEmpty(true);
                     } else {
                         // At least one new connection has become available, and can be used to return data to the client.
@@ -753,7 +757,7 @@ public class HttpSession extends LocalClientSession {
                 // Note that the code leading up to here checks if the Request ID of the new connection 'fits in the window',
                 // which means that for polling sessions, the request ID must have been a sequential one, which in turn should
                 // guarantee that 'a new connection is now available for delivery').
-                assert aConnectionAvailableForDelivery;
+                assert aConnectionAvailableForDelivery; // FIXME: OF-2451: the edge-cases evaluated above make this assertion not necessarily true.
             }
 
             if (isPollingSession() || aConnectionAvailableForDelivery) {
@@ -768,17 +772,18 @@ public class HttpSession extends LocalClientSession {
 
             // When a new connection has become available, older connections need to be released (allowing the client to
             // send more data if it needs to).
-            final List<HttpConnection> openConnections = connectionQueue.stream()
-                .filter(c -> !c.isClosed())
-                .filter(c -> c.getRequestId() <= lastSequentialRequestID)
-                .sorted(connectionComparator)
-                .collect(Collectors.toList());
-
-            while( openConnections.size() > hold) {
+            while (!connectionQueue.isEmpty() && connectionQueue.size() > hold) {
                 if (Log.isTraceEnabled()) {
-                    Log.trace("Stream {}: releasing oldest connection (rid {}), as the amount of open connections ({}) is higher than the requested amount to hold ({}).", streamid, rid, openConnections.size(), hold);
+                    Log.trace("Stream {}: releasing oldest connection (rid {}), as the amount of open connections ({}) is higher than the requested amount to hold ({}).", streamid, rid, connectionQueue.size(), hold);
                 }
-                final HttpConnection openConnection = openConnections.remove(0);
+                final HttpConnection openConnection = connectionQueue.peek();
+                assert openConnection != null;
+                if (openConnection.getRequestId() > lastSequentialRequestID) {
+                    break; // There's a gap.
+                }
+
+                // Consume this connection.
+                connectionQueue.poll();
                 openConnection.deliverBody(createEmptyBody(false), true);
             }
         }
@@ -825,18 +830,11 @@ public class HttpSession extends LocalClientSession {
      *         protocol.
      */
     private void checkOveractivity(HttpConnection connection) throws HttpBindException {
-        int pendingConnections = 0;
+        int pendingConnections;
         OveractivityType overactivity = OveractivityType.NONE;
 
         synchronized (connectionQueue) {
-            for (HttpConnection conn : connectionQueue) {
-                if (!conn.isClosed()) {
-                    pendingConnections++;
-                    if (Log.isDebugEnabled()) {
-                        Log.debug("For session {} and origin rid {} an open connection is pending with rid {}", getStreamID(), connection.getRequestId(), conn.getRequestId());
-                    }
-                }
-            }
+            pendingConnections = connectionQueue.size();
         }
 
         Instant time = Instant.now();
@@ -925,15 +923,15 @@ public class HttpSession extends LocalClientSession {
     private void deliver(@Nonnull final List<Deliverable> deliverable) {
         boolean delivered = false;
         synchronized (connectionQueue) {
-            for (HttpConnection connection : connectionQueue) {
-                // We can only use connections that have not been used yet.
-                if (connection.isClosed()) {
-                    continue;
-                }
+            while (!connectionQueue.isEmpty()) {
+                final HttpConnection connection = connectionQueue.peek();
+                assert !connection.isClosed();
+
                 try {
                     // We can only use connections that have a sequential request ID.
                     if (connection.getRequestId() <= lastSequentialRequestID) {
-                        deliver(connection, deliverable, true);
+                        connectionQueue.poll();
+                        deliver(connection, deliverable, true); // TODO OF-2444 move this out from under the connectionQueue mutex maybe?
                         delivered = true;
                     }
 
@@ -993,22 +991,22 @@ public class HttpSession extends LocalClientSession {
             // open connections in this method.
             synchronized (connectionQueue) {
                 boolean isFirst = true;
-                for (HttpConnection toClose : connectionQueue) {
+                while (!connectionQueue.isEmpty()) {
+                    final HttpConnection toClose = connectionQueue.poll();
+                    assert !toClose.isClosed();
                     try {
                         // XEP-0124, section 13: "The connection manager SHOULD acknowledge the session termination on
                         // the oldest connection with an HTTP 200 OK containing a <body/> element of the type
                         // 'terminate'. On all other open connections, the connection manager SHOULD respond with an
                         // HTTP 200 OK containing an empty <body/> element.
-                        if (!toClose.isClosed()) {
-                            final String body;
-                            if (isFirst) {
-                                isFirst = false;
-                                body = this.createEmptyBody(true);
-                            } else {
-                                body = null;
-                            }
-                            toClose.deliverBody(body, true);
+                        final String body;
+                        if (isFirst) {
+                            isFirst = false;
+                            body = this.createEmptyBody(true);
+                        } else {
+                            body = null;
                         }
+                        toClose.deliverBody(body, true);
                     } catch (HttpConnectionClosedException e) {
                         // Probably benign.
                         Log.debug("Closing an already closed connection.", e);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -57,6 +57,7 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 /**
@@ -152,8 +153,12 @@ public class HttpSession extends LocalClientSession {
     @GuardedBy("itself")
     private final List<HttpConnection> connectionQueue = new LinkedList<>();
 
-    @GuardedBy("connectionQueue")
-    private final List<Deliverable> pendingElements = new ArrayList<>();
+    /**
+     * A thread-safe collection (using a weakly consistent iterator) that contains stanzas that could not immediately be
+     * delivered to the peer.
+     */
+    // FIXME: OF-2445: Prevent elements to be scheduled for delivery in #pendingElements after the session is closed (as they would never be delivered).
+    private final ConcurrentLinkedQueue<Deliverable> pendingElements = new ConcurrentLinkedQueue<>();
 
     private final List<Delivered> sentElements = new ArrayList<>();
 
@@ -746,11 +751,14 @@ public class HttpSession extends LocalClientSession {
                 assert aConnectionAvailableForDelivery;
             }
 
-            if (isPollingSession() || (aConnectionAvailableForDelivery && !pendingElements.isEmpty())) {
-                lastActivity = Instant.now();
-                SessionEventDispatcher.dispatchEvent( this, SessionEventDispatcher.EventType.connection_opened, connection, context ); // TODO is this the right place to dispatch this event?
-                deliver(pendingElements);
-                pendingElements.clear();
+            if (isPollingSession() || aConnectionAvailableForDelivery) {
+                // In a thread-safe manner, create a copy of all elements that are currently pending.
+                final List<Deliverable> toProcessElements = drainPendingElements();
+                if (!toProcessElements.isEmpty()) {
+                    lastActivity = Instant.now();
+                    SessionEventDispatcher.dispatchEvent(this, SessionEventDispatcher.EventType.connection_opened, connection, context); // TODO is this the right place to dispatch this event?
+                    deliver(toProcessElements);
+                }
             }
 
             // When a new connection has become available, older connections need to be released (allowing the client to
@@ -938,11 +946,10 @@ public class HttpSession extends LocalClientSession {
                             ". Openfire will attempt to recover by ignoring this connection.", e);
                 }
             }
-
-            if (!delivered) {
-                Log.debug("Unable to immediately deliver a stanza on session {}. It is being queued instead).", getStreamID());
-                pendingElements.addAll( deliverable );
-            }
+        }
+        if (!delivered) {
+            Log.debug("Unable to immediately deliver a stanza on session {}. It is being queued instead).", getStreamID());
+            pendingElements.addAll(deliverable); // ConcurrentLinkedQueue.addAll is not guaranteed to be atomic. We don't need that, as long as the insertion/iteration order is guaranteed. I'm not sure if it is (but I assume so).
         }
     }
 
@@ -1003,11 +1010,11 @@ public class HttpSession extends LocalClientSession {
                         Log.debug("An unexpected exception occurred while closing a session.", e);
                     }
                 }
+            }
 
-                for (Deliverable deliverable : pendingElements) {
-                    failDelivery(deliverable.getPackets());
-                }
-                pendingElements.clear();
+            final List<Deliverable> toProcessElements = drainPendingElements();
+            for (Deliverable deliverable : toProcessElements) {
+                failDelivery(deliverable.getPackets());
             }
         } finally { // ensure the session is removed from the session map
             SessionEventDispatcher.dispatchEvent( this, SessionEventDispatcher.EventType.session_closed, null, null );
@@ -1113,6 +1120,24 @@ public class HttpSession extends LocalClientSession {
         }
 
         return response.asXML();
+    }
+
+    /**
+     * Removes all elements that are queued to be delivered to the peer from the queue and returns them as an
+     * unmodifiable collection.
+     *
+     * @return An unmodifiable list of elements that are to be sent to the peer.
+     */
+    @Nonnull
+    private List<Deliverable> drainPendingElements()
+    {
+        final List<Deliverable> result = new LinkedList<>();
+        final Iterator<Deliverable> iter = pendingElements.iterator(); // Weakly consistent iterator.
+        while (iter.hasNext()) {
+            result.add(iter.next());
+            iter.remove();
+        }
+        return Collections.unmodifiableList(result);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -1058,7 +1058,7 @@ public class HttpSession extends LocalClientSession {
         builder.append("<body xmlns='http://jabber.org/protocol/httpbind' ack='")
             .append(getLastAcknowledged()).append("'>");
 
-        setLastResponseEmpty(elements.size() == 0);
+        setLastResponseEmpty(elements.isEmpty());
         for (Deliverable child : elements) {
             builder.append(child.getDeliverable());
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -324,8 +324,7 @@ public class HttpSession extends LocalClientSession {
     }
 
     /**
-     * Sets the time, in seconds, after which this session will be considered inactive and be be
-     * terminated.
+     * Sets the time, in seconds, after which this session will be considered inactive and be terminated.
      *
      * @param inactivityTimeout the time, in seconds, after which this session will be considered
      * inactive and be terminated.
@@ -470,9 +469,9 @@ public class HttpSession extends LocalClientSession {
      * @param body the body element that was sent containing the request for a new session.
      * @param context the context of the asynchronous servlet call leading up to this method call.
      *
-     * @throws org.jivesoftware.openfire.http.HttpBindException for several reasons: if the encoding inside of an auth packet is
-     * not recognized by the server, or if the packet type is not recognized.
-     * @throws org.jivesoftware.openfire.http.HttpConnectionClosedException if the session is no longer available.
+     * @throws HttpBindException for several reasons: if the encoding inside an auth packet is not recognized by the
+     *                           server, or if the packet type is not recognized.
+     * @throws HttpConnectionClosedException if the session is no longer available.
      * @throws IOException if an input or output exception occurred
      */
     public void forwardRequest(HttpBindBody body, AsyncContext context)
@@ -541,7 +540,7 @@ public class HttpSession extends LocalClientSession {
     }
 
     /**
-     * This methods sends any pending packets in the session. If no packets are
+     * This method sends any pending packets in the session. If no packets are
      * pending, this method simply returns. The method is internally synchronized
      * to avoid simultaneous sending operations on this Session. If two
      * threads try to run this method simultaneously, the first one will trigger
@@ -582,8 +581,7 @@ public class HttpSession extends LocalClientSession {
      *
      * @param body the body element that was sent containing the request for a new session.
      * @param context the context of the asynchronous servlet call leading up to this method call.
-     * @return the created {@link org.jivesoftware.openfire.http.HttpConnection} which represents
-     *         the connection.
+     * @return the created {@link HttpConnection} which represents the connection.
      */
     @Nonnull
     synchronized HttpConnection createConnection(@Nonnull final HttpBindBody body, @Nonnull final AsyncContext context)
@@ -692,7 +690,7 @@ public class HttpSession extends LocalClientSession {
         }
 
         // Note that connections can be expected to arrive 'out of order'. The implementation should only use a connection
-        // that has a request ID value that's exactly one higher than the last request ID value in the 'gapless' sequence
+        // that has a request ID value that's exactly one higher than the last request ID value in the 'gap-less' sequence
         // of request IDs. When a connection is being processed that has a higher value, it should go unused until another
         // connection arrives that 'fills the gap' (and be used only _after_ that connection gets used).
         boolean aConnectionAvailableForDelivery = false;
@@ -745,7 +743,7 @@ public class HttpSession extends LocalClientSession {
             // Request ID of the new connection 'fits in the window'
 
             if (isPollingSession()) {
-                // Note that the code leading up to this checks if the Request ID of the new connection 'fits in the window',
+                // Note that the code leading up to here checks if the Request ID of the new connection 'fits in the window',
                 // which means that for polling sessions, the request ID must have been a sequential one, which in turn should
                 // guarantee that 'a new connection is now available for delivery').
                 assert aConnectionAvailableForDelivery;
@@ -780,7 +778,7 @@ public class HttpSession extends LocalClientSession {
     }
 
     /**
-     * Attempts to processes a request for redelivery of data that was sent earlier.
+     * Attempts to process a request for redelivery of data that was sent earlier.
      *
      * This method is expected to be called with a connection that has a request ID that was already processed before.
      *
@@ -812,7 +810,7 @@ public class HttpSession extends LocalClientSession {
     /**
      * Check that the client SHOULD NOT make more simultaneous requests than specified
      * by the 'requests' attribute in the connection manager's Session Creation Response.
-     * However the client MAY make one additional request if it is to pause or terminate a session.
+     * However, the client MAY make one additional request if it is to pause or terminate a session.
      *
      * @see <a href="http://www.xmpp.org/extensions/xep-0124.html#overactive">overactive</a>
      * @param connection the new connection.
@@ -855,7 +853,7 @@ public class HttpSession extends LocalClientSession {
                         " with rid " + connection.getRequestId() +
                         " lastResponseEmpty = " + lastResponseEmpty  +
                         " overactivity = " + overactivity +
-                        " deltaFromlastPoll = " + deltaFromLastPoll +
+                        " deltaFromLastPoll = " + deltaFromLastPoll +
                         " isPollingSession() = " + localIsPollingSession +
                         " maxRequests = " + maxRequests +
                         " pendingConnections = " + pendingConnections);
@@ -989,7 +987,7 @@ public class HttpSession extends LocalClientSession {
                 for (HttpConnection toClose : connectionQueue) {
                     try {
                         // XEP-0124, section 13: "The connection manager SHOULD acknowledge the session termination on
-                        // the oldest connection with a HTTP 200 OK containing a <body/> element of the type
+                        // the oldest connection with an HTTP 200 OK containing a <body/> element of the type
                         // 'terminate'. On all other open connections, the connection manager SHOULD respond with an
                         // HTTP 200 OK containing an empty <body/> element.
                         if (!toClose.isClosed()) {
@@ -1050,7 +1048,7 @@ public class HttpSession extends LocalClientSession {
      * usage of this method is to generate data that can be included in HTTP responses returned to the client.
      *
      * @param elements The data to be transformed (can be empty).
-     * @return The text representation (wrapped in a body element) of the the provided elements.
+     * @return The text representation (wrapped in a body element) of the provided elements.
      */
     @Nonnull
     private String asBodyText(@Nonnull final List<Deliverable> elements) {
@@ -1102,7 +1100,7 @@ public class HttpSession extends LocalClientSession {
     }
 
     /**
-     * Creets a BOSH 'body' element that represents a 'session restart' event, including the stream features that are
+     * Creates a BOSH 'body' element that represents a 'session restart' event, including the stream features that are
      * available to this session.
      *
      * @return The string representation of a BOSH 'body' element for a 'session restart'.
@@ -1242,9 +1240,9 @@ public class HttpSession extends LocalClientSession {
                 if (Namespace.NO_NAMESPACE.equals(packet.getElement().getNamespace())) {
                     // use string-based operation here to avoid cascading xmlns wonkery
                     StringBuilder packetXml = new StringBuilder(packet.toXML());
-                    final int noslash = packetXml.indexOf( ">" );
+                    final int noSlash = packetXml.indexOf( ">" );
                     final int slash = packetXml.indexOf( "/>" );
-                    final int insertAt = ( noslash - 1 == slash ? slash : noslash );
+                    final int insertAt = ( noSlash - 1 == slash ? slash : noSlash );
                     packetXml.insert( insertAt, " xmlns=\"jabber:client\"");
                     stanzas.add(packetXml.toString());
                 } else {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
@@ -64,7 +64,7 @@ public class HttpSessionManager {
     private SessionManager sessionManager;
     private final Map<String, HttpSession> sessionMap = new ConcurrentHashMap<>();
     private TimerTask inactivityTask;
-    private ThreadPoolExecutor sendPacketPool;
+    private ThreadPoolExecutor stanzaWorkerPool;
     private final SessionListener sessionListener = new SessionListener() {
         @Override
         public void sessionClosed(HttpSession session) {
@@ -81,7 +81,7 @@ public class HttpSessionManager {
     /**
      * Starts the services used by the HttpSessionManager.
      *
-     * (Re)creates and configures a pooled executor to handle async routing for incoming packets with a configurable
+     * (Re)creates and configures a pooled executor to handle async routing for stanzas with a configurable
      * (through property "xmpp.httpbind.worker.threads") amount of threads; also uses an unbounded task queue and
      * configurable ("xmpp.httpbind.worker.timeout") keep-alive.
      *
@@ -94,16 +94,16 @@ public class HttpSessionManager {
 
         this.sessionManager = SessionManager.getInstance();
 
-        sendPacketPool = new ThreadPoolExecutor(MIN_POOL_SIZE.getValue(), MAX_POOL_SIZE.getValue(), POOL_KEEP_ALIVE.getValue().getSeconds(), TimeUnit.SECONDS,
+        stanzaWorkerPool = new ThreadPoolExecutor(MIN_POOL_SIZE.getValue(), MAX_POOL_SIZE.getValue(), POOL_KEEP_ALIVE.getValue().getSeconds(), TimeUnit.SECONDS,
                 new LinkedBlockingQueue<>(), // unbounded task queue
                 new NamedThreadFactory( "httpbind-worker-", true, null, Thread.currentThread().getThreadGroup(), null )
         );
 
         if (JMXManager.isEnabled()) {
-            final ThreadPoolExecutorDelegateMBean mBean = new ThreadPoolExecutorDelegate(sendPacketPool);
+            final ThreadPoolExecutorDelegateMBean mBean = new ThreadPoolExecutorDelegate(stanzaWorkerPool);
             workerThreadPoolObjectName = JMXManager.tryRegister(mBean, ThreadPoolExecutorDelegateMBean.BASE_OBJECT_NAME + "bosh");
         }
-        sendPacketPool.prestartCoreThread();
+        stanzaWorkerPool.prestartCoreThread();
 
         // Periodically check for Sessions that need a cleanup.
         inactivityTask = new HttpSessionReaper();
@@ -166,7 +166,7 @@ public class HttpSessionManager {
             session.close();
         }
         sessionMap.clear();
-        sendPacketPool.shutdown();
+        stanzaWorkerPool.shutdown();
     }
 
     /**
@@ -384,6 +384,6 @@ public class HttpSessionManager {
     }
 
     protected void execute(Runnable runnable) {
-        this.sendPacketPool.execute(runnable);
+        this.stanzaWorkerPool.execute(runnable);
     }
 }


### PR DESCRIPTION
The changes in this PR should lead to a fix for a BOSH related deadlock in Openfire 4.7.0 and 4.7.1, as described in [OF-2444](https://igniterealtime.atlassian.net/browse/OF-2444). When the PR was created, this wasn't yet achieved. I have created the PR as a draft for that reason.

My goal is to incrementally reduce complexity and, in particular, the usage of locks in the `HttpSession` class. In particular, I believe that the deadlock described in OF-2444 is prevented when the processing of inbound data (provided by a BOSH request) no longer occurs under guard of the lock represented by the `connectionQueue` field.

This PR builds up to a refactoring that would allow for that change to become possible.

The refactoring is sufficiently complex that I would welcome feedback on my approach while I'm making process. That is why I'm creating this PR, prior to it being ready. I am doing my best to make each commit in this PR to be a isolated change, which hopefully facilitates reviewing things.

As an aside, while trying to refactor the code, I am running into what I believe to be other issues. I am raising new JIRA issues as I go along. Fixes might be included in this PR, but until they are included, I have left TODO and FIXME comments that reference the JIRA issues.

So far, I think these I have identified these issues:
- https://igniterealtime.atlassian.net/browse/OF-2445
- https://igniterealtime.atlassian.net/browse/OF-2446
- https://igniterealtime.atlassian.net/browse/OF-2447
- https://igniterealtime.atlassian.net/browse/OF-2448
- https://igniterealtime.atlassian.net/browse/OF-2449
- https://igniterealtime.atlassian.net/browse/OF-2450
- https://igniterealtime.atlassian.net/browse/OF-2451