### PR TITLE
OF-2413: Ensure that connections are closed, when no error occurs.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -182,6 +182,7 @@ public abstract class VirtualConnection implements Connection {
      */
     @Override
     public void close() {
+        close(null);
     }
 
     /**


### PR DESCRIPTION
The fix (which as of yet is unreleased) for OF-2413 introduces a bug, where a call to close() doesn't do anything anymore.

This bug is introduced in commit 257806e4ce061462de782d69fe5afeabdcdc9264, which was merged in the main branch of the Openfire repository with pull request https://github.com/igniterealtime/Openfire/pull/2026. No releases have been made from that branch, since this issue was introduced. By merging this change prior to the next release of the main branch (expected to be v4.8.0), the bug can be fixed before it was ever released.