### PR TITLE
Prevent CodeQL from running on Dependabot pushes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,6 +3,8 @@ name: "CodeQL"
 on:
   push:
     branches: "**"
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     branches: "**"
   schedule:


### PR DESCRIPTION
This prevents a failure that logs this error: "Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events."