### PR TITLE
server can reply with message error stanza with error information

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
@@ -179,6 +179,10 @@ public class MessageRouter extends BasicModule {
                 reply.setTo(session.getAddress());
                 reply.setFrom(packet.getTo());
                 reply.setType(packet.getType());
+                if(packet.getError()!= null){
+                    PacketError packetError = packet.getError();
+                    reply.setError(new PacketError(packetError.getCondition(), packetError.getType(), packetError.getText()));
+                }
                 reply.setThread(packet.getThread());
                 reply.setBody(e.getRejectionMessage());
                 session.process(reply);


### PR DESCRIPTION
Currently, If we reject packet from any Message Interceptor, we can't set error information. As we have access of packet but in PacketRejectionException handling, we create a copy of reply. 
So added this feature, so that if packet contains any error info added by any Intercepted, it should be saved in reply packet too and sent to client.