### PR TITLE
OF-2446: Use a more efficient List implementation for HttpSession's sentElements

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -170,7 +170,7 @@ public class HttpSession extends LocalClientSession {
      * The size of this collection is limited. It will contain only the last few transmitted elements.
      */
     @GuardedBy("itself")
-    private final List<Delivered> sentElements = new ArrayList<>(); // FIXME: OF-2446 Use a more appropriate data type than ArrayList.
+    private final LinkedList<Delivered> sentElements = new LinkedList<>();
 
     private Instant lastPoll = Instant.EPOCH;
     private Duration inactivityTimeout;
@@ -1027,7 +1027,7 @@ public class HttpSession extends LocalClientSession {
         final Delivered delivered = new Delivered(deliverable, connection.getRequestId());
         synchronized (sentElements) {
             while (sentElements.size() > maxRequests) {
-                sentElements.remove(0);
+                sentElements.poll();
             }
 
             sentElements.add(delivered);


### PR DESCRIPTION
The code is using this List as a queue. Using an ArrayList for this isn't very efficient. A LinkedList (or any Queue) is expected to perform better.