### PR TITLE
OF-2462: Do not skip stringprep in S2S

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1681,6 +1681,7 @@ system_property.xmpp.client.idle.ping=Set to true to ping idle clients, otherwis
 system_property.xmpp.client.version-query.enabled=Send a version request query to clients when they connect.
 system_property.xmpp.client.version-query.delay=After this amount of time has passed since a new client connection has been accepted, a version request is being sent to the peer.
 system_property.xmpp.server.rewrite.replace-missing-to=If the server receives a message or IQ stanza with no 'to' attribute, set the 'to' attribute to the bare JID representation of the 'from' attribute value.
+system_property.xmpp.server.incoming.skip-jid-validation=Controls if JIDs that are in the addresses of stanzas supplied by remote domains are validated.
 system_property.xmpp.server.outgoing.max.threads=Minimum amount of threads in the thread pool that is used to establish outbound server-to-server connections. 
 system_property.xmpp.server.outgoing.min.threads=Maximum amount of threads in the thread pool that is used to establish outbound server-to-server connections
 system_property.xmpp.server.outgoing.threads-timeout=Amount of time after which idle, surplus threads are removed from the thread pool that is used to establish outbound server-to-server connections.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
@@ -23,6 +23,7 @@ import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.openfire.session.LocalIncomingServerSession;
 import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.SystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
@@ -47,6 +48,15 @@ import org.xmpp.packet.*;
 public class ServerStanzaHandler extends StanzaHandler {
 
     private static final Logger Log = LoggerFactory.getLogger(ServerStanzaHandler.class);
+
+    /**
+     * Controls if JIDs that are in the addresses of stanzas supplied by remote domains are validated.
+     */
+    public static final SystemProperty<Boolean> SKIP_JID_VALIDATION = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("xmpp.server.incoming.skip-jid-validation")
+        .setDefaultValue(false)
+        .setDynamic(true)
+        .build();
 
     public ServerStanzaHandler(PacketRouter router, Connection connection) {
         super(router, connection);
@@ -82,8 +92,7 @@ public class ServerStanzaHandler extends StanzaHandler {
 
     @Override
     boolean validateJIDs() {
-        // TODO Should we trust other servers???
-        return false;
+        return !SKIP_JID_VALIDATION.getValue();
     }
 
     @Override


### PR DESCRIPTION
Openfire should not assume that JIDs in stanzas supplied by remote domains are stringprepped. It should apply stringprepping itself.

The property `xmpp.server.incoming.skip-jid-validation` can be used to control this behavior.