### PR TITLE
OF-2469: fix NPE on admin console (pubsub config)

### DIFF
--- a/xmppserver/src/main/webapp/pubsub-node-configuration.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-configuration.jsp
@@ -69,7 +69,7 @@
         <meta name="extraParams" content="username=${admin:urlEncode(owner.node)}&nodeID=${admin:urlEncode(node.nodeID)}" />
     </c:when>
     <c:otherwise>
-        <meta name="subPageID" content="pubsub-node-details"/>
+        <meta name="subPageID" content="pubsub-node-configuration"/>
         <meta name="extraParams" content="nodeID=${admin:urlEncode(node.nodeID)}"/>
     </c:otherwise>
 </c:choose>


### PR DESCRIPTION
This fixes a NullPointerException that was shown when someone looked at the configuration of a Pubsub node in Openfire's Admin Console.