### PR TITLE
OF-2470: Protect against NPE from IQ stanza with no child elements

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -421,7 +421,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                                 lock.unlock();
                             }
                         }
-                    } else if (IQMUCvCardHandler.PROPERTY_ENABLED.getValue() && packet instanceof IQ && ((IQ) packet).isResponse() && ((IQ) packet).getChildElement().getNamespaceURI().equals(IQMUCvCardHandler.NAMESPACE)) {
+                    } else if (IQMUCvCardHandler.PROPERTY_ENABLED.getValue() && packet instanceof IQ && ((IQ) packet).isResponse() && (((IQ) packet).getChildElement() != null) && ((IQ) packet).getChildElement().getNamespaceURI().equals(IQMUCvCardHandler.NAMESPACE)) {
                         Log.trace( "Stanza is a VCard response stanza." );
                         processVCardResponse((IQ) packet);
                     } else {


### PR DESCRIPTION
Claude and Dele isolatedf a case where a Jitsi client sends an IQ Result stanza with no child elements, causing an NPE in a new feature introduced in Openfire 4.7.2.
This defends against it. I can't see any other instances of this risk in this class.

Cherrypick for 4.7