### PR TITLE
OF-2474: IP-based access control for the admin console

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -491,6 +491,8 @@ tab.server.descr=Click to manage server settings
         sidebar.server-logs.descr=Click to view server logs
         sidebar.manage-updates=Manage Updates
         sidebar.manage-updates.descr=Click to manage server or plugins updates
+        sidebar.admin-console-access=Admin Console Access
+        sidebar.admin-console-access.descr=Click to configure admin console access
         sidebar.server-email=Email Settings
         sidebar.server-email.descr=Click to configure email settings
         sidebar.server-sms=SMS Settings
@@ -1708,6 +1710,9 @@ system_property.provider.vcard.className=The class to use to provide vCard handl
 system_property.usermanager.remote-disco-info-timeout-seconds=The maximum time the UserManager should wait, in seconds, for the a remote server to respond to a disco#info request to confirm the presence of a user
 system_property.provider.userproperty.className=The class to use to provide user properties
 system_property.xmpp.auth.sasl.external.client.suppress-matching-realmname=Ignore the realm of a SASL EXTERNAL provided username if it matches the XMPP domain name.
+system_property.adminConsole.access.ip-blocklist=List of IP addresses that are not allowed to access the admin console.
+system_property.adminConsole.access.ip-allowlist=List of IP addresses that are allowed to access the admin console. When empty, this list is ignored.
+system_property.adminConsole.access.ignore-excludes=Controls if IP Access lists are applied to excluded URLs.
 system_property.adminConsole.servlet-request-authenticator=The class to use to authenticate requests made to the admin console. If not supplied, normal username/password authentication will be used.
 system_property.adminConsole.siteMinderHeader=The name of the HTTP header that will contain the CA SiteMinder/Single Sign-On authenticated user, if available.
 system_property.adminConsole.forwarded.enabled=Enable / Disable parsing a 'X-Forwarded-For' style HTTP header of Admin Console requests.
@@ -3184,6 +3189,20 @@ plugin.admin.updating = Updating
 plugin.admin.failed.minserverversion=The version of the plugin that is installed requires Openfire {0} or later versions!
 plugin.admin.failed.priortoserverversion=The version of the plugin that is installed is no longer compatible with Openfire {0} and later versions!
 
+# System Admin Console access
+system.admin.console.access.title=Admin Console Access
+system.admin.console.access.info=Use this page to control what network devices have access to the admin console.
+system.admin.console.access.success=Settings were successfully saved.
+system.admin.console.access.iplists.title=Network access control
+system.admin.console.access.iplists.warning=When you exclude the IP address that you are currently using ({0}) when applying changes on this page, you will be locked out of the admin console!
+system.admin.console.access.iplists.blocklist.info=Any IP address that appears on the Blocklist will not be allowed to access the admin console. This list always takes presedence over the Allowlist.
+system.admin.console.access.iplists.blocklist.label=Blocklist
+system.admin.console.access.iplists.blocklist.invalid-hint=One or more of the values that you provided for the Blocklist was not valid. These values need to be IPv4 addresses: {0}
+system.admin.console.access.iplists.allowlist.info=When the Allowlist is <em>not empty</em>, only IP addresses that is are on the Allowlist will be allowed to access the admin console.
+system.admin.console.access.iplists.allowlist.label=Allowlist
+system.admin.console.access.iplists.allowlist.invalid-hint=One or more of the values that you provided for the Allowlist was not valid. These values need to be IPv4 addresses: {0}
+system.admin.console.access.iplists.ignore-excludes.info=By default, access control is not applied to 'excluded' pages (such as the login page). This can be overridden here.
+system.admin.console.access.iplists.ignore-excludes.label=Apply access control to 'excluded' pages.
 # System Email
 
 system.email.title=Email Settings

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -3194,13 +3194,13 @@ system.admin.console.access.title=Admin Console Access
 system.admin.console.access.info=Use this page to control what network devices have access to the admin console.
 system.admin.console.access.success=Settings were successfully saved.
 system.admin.console.access.iplists.title=Network access control
-system.admin.console.access.iplists.warning=When you exclude the IP address that you are currently using ({0}) when applying changes on this page, you will be locked out of the admin console!
+system.admin.console.access.iplists.warning=When you exclude the IP address that you are currently using (which appears to be {0}) when applying changes on this page, you will be locked out of the admin console!
 system.admin.console.access.iplists.blocklist.info=Any IP address that appears on the Blocklist will not be allowed to access the admin console. This list always takes presedence over the Allowlist.
 system.admin.console.access.iplists.blocklist.label=Blocklist
-system.admin.console.access.iplists.blocklist.invalid-hint=One or more of the values that you provided for the Blocklist was not valid. These values need to be IPv4 addresses: {0}
+system.admin.console.access.iplists.blocklist.invalid-hint=None of your changes have been saved. One or more of the values that you provided for the Blocklist was not valid. These values need to be IPv4 addresses: {0}
 system.admin.console.access.iplists.allowlist.info=When the Allowlist is <em>not empty</em>, only IP addresses that is are on the Allowlist will be allowed to access the admin console.
 system.admin.console.access.iplists.allowlist.label=Allowlist
-system.admin.console.access.iplists.allowlist.invalid-hint=One or more of the values that you provided for the Allowlist was not valid. These values need to be IPv4 addresses: {0}
+system.admin.console.access.iplists.allowlist.invalid-hint=None of your changes have been saved. One or more of the values that you provided for the Allowlist was not valid. These values need to be IPv4 addresses: {0}
 system.admin.console.access.iplists.ignore-excludes.info=By default, access control is not applied to 'excluded' pages (such as the login page). This can be overridden here.
 system.admin.console.access.iplists.ignore-excludes.label=Apply access control to 'excluded' pages.
 # System Email

--- a/xmppserver/src/main/resources/admin-sidebar.xml
+++ b/xmppserver/src/main/resources/admin-sidebar.xml
@@ -48,6 +48,11 @@
                   url="logviewer.jsp"
                   description="${sidebar.server-logs.descr}"/>
 
+            <!-- Admin Console Access -->
+            <item id="system-admin-console-access" name="${sidebar.admin-console-access}"
+                  url="system-admin-console-access.jsp"
+                  description="${sidebar.admin-console-access.descr}"/>
+
             <!-- Email -->
             <item id="system-email" name="${sidebar.server-email}"
                   url="system-email.jsp"

--- a/xmppserver/src/main/webapp/system-admin-console-access.jsp
+++ b/xmppserver/src/main/webapp/system-admin-console-access.jsp
@@ -1,0 +1,173 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ page errorPage="error.jsp" %>
+<%@ page import="org.jivesoftware.util.StringUtils" %>
+<%@ page import="org.jivesoftware.util.CookieUtils" %>
+<%@ page import="org.jivesoftware.util.ParamUtils" %>
+<%@ page import="java.util.*" %>
+<%@ page import="java.util.regex.Pattern" %>
+<%@ page import="org.jivesoftware.admin.AuthCheckFilter" %>
+
+<%@ taglib uri="admin" prefix="admin" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
+<% webManager.init(request, response, session, application, out ); %>
+
+<%  final Map<String, String> errors = new HashMap<>();
+
+    // Get parameters
+    final String blockedIPs = request.getParameter("blockedIPs");
+    final String allowedIPs = request.getParameter("allowedIPs");
+    final boolean ignoreExcludes= ParamUtils.getBooleanParameter( request, "ignore-excludes" );
+
+    boolean save = ParamUtils.getParameter(request, "save") != null;
+    boolean success = ParamUtils.getBooleanParameter(request, "success");
+
+    // Handle a save
+    Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+    String csrfParam = ParamUtils.getParameter(request, "csrf");
+
+    if (save) {
+        if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
+            save = false;
+            errors.put("csrf", "CSRF Failure!");
+        }
+    }
+    csrfParam = StringUtils.randomString(15);
+    CookieUtils.setCookie(request, response, "csrf", csrfParam, -1);
+    pageContext.setAttribute("csrf", csrfParam);
+
+    if (save) {
+        // do validation
+        final Pattern pattern = Pattern.compile("(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\." +
+            "(?:(?:\\*|25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){2}" +
+            "(?:\\*|25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)");
+
+        final Set<String> blockedSet = new HashSet<>();
+        for (final String address : blockedIPs.split("[,\\s]+") ) {
+            if (!address.isEmpty()) {
+                if (pattern.matcher(address).matches()) {
+                    blockedSet.add(address);
+                } else {
+                    if (errors.containsKey("invalid-blocklist-ips")) {
+                        errors.put("invalid-blocklist-ips", errors.get("invalid-blocklist-ips") + ", " + address);
+                    } else {
+                        errors.put("invalid-blocklist-ips", address);
+                    }
+                }
+            }
+        }
+        final Set<String> allowedSet = new HashSet<>();
+        for (final String address : allowedIPs.split("[,\\s]+") ) {
+            if (!address.isEmpty()) {
+                if (pattern.matcher(address).matches()) {
+                    allowedSet.add(address);
+                } else {
+                    if (errors.containsKey("invalid-allowlist-ips")) {
+                        errors.put("invalid-allowlist-ips", errors.get("invalid-allowlist-ips") + ", " + address);
+                    } else {
+                        errors.put("invalid-allowlist-ips", address);
+                    }
+                }
+            }
+        }
+
+        if (errors.isEmpty()) {
+            AuthCheckFilter.IP_ACCESS_BLOCKLIST.setValue(blockedSet);
+            AuthCheckFilter.IP_ACCESS_ALLOWLIST.setValue(allowedSet);
+            AuthCheckFilter.IP_ACCESS_IGNORE_EXCLUDES.setValue(ignoreExcludes);
+
+            // Log the event
+            webManager.logEvent("Updated Admin Console access configuration.", "Blocklist = " + String.join(", ", blockedSet) +"\nAllowlist = " + String.join(", ", allowedSet)+"\nignore excludes = "+ignoreExcludes);
+            response.sendRedirect("system-admin-console-access.jsp?success=true");
+            return;
+        }
+    }
+
+    pageContext.setAttribute("errors", errors);
+    pageContext.setAttribute("success", errors.isEmpty() && success);
+    pageContext.setAttribute("blockedIPs", String.join(", ", AuthCheckFilter.IP_ACCESS_BLOCKLIST.getValue()));
+    pageContext.setAttribute("allowedIPs", String.join(", ", AuthCheckFilter.IP_ACCESS_ALLOWLIST.getValue()));
+    pageContext.setAttribute("ignoreExcludes", AuthCheckFilter.IP_ACCESS_IGNORE_EXCLUDES.getValue());
+
+%>
+
+<html>
+<head>
+    <title><fmt:message key="system.admin.console.access.title"/></title>
+    <meta name="pageID" content="system-admin-console-access"/>
+</head>
+<body>
+
+<admin:infobox type="warning">
+    <fmt:message key="system.admin.console.access.iplists.warning">
+        <!-- When AdminConsolePlugin.ADMIN_CONSOLE_FORWARDED is set, this will also show any X-Forwarded-For value. -->
+        <fmt:param><c:out value="${pageContext.request.remoteAddr}"/></fmt:param>
+    </fmt:message>
+</admin:infobox>
+
+<c:choose>
+    <c:when test="${not empty errors}">
+        <c:forEach var="err" items="${errors}">
+            <admin:infobox type="error">
+                <c:choose>
+                    <c:when test="${err.key eq 'csrf'}"><fmt:message key="global.csrf.failed" /></c:when>
+                    <c:when test="${err.key eq 'invalid-blocklist-ips'}"><fmt:message key="system.admin.console.access.iplists.blocklist.invalid-hint"><fmt:param><c:out value="${err.value}"/></fmt:param></fmt:message></c:when>
+                    <c:when test="${err.key eq 'invalid-allowlist-ips'}"><fmt:message key="system.admin.console.access.iplists.allowlist.invalid-hint"><fmt:param><c:out value="${err.value}"/></fmt:param></fmt:message></c:when>
+                    <c:otherwise>
+                        <c:if test="${not empty err.value}">
+                            <fmt:message key="admin.error"/>: <c:out value="${err.value}"/>
+                        </c:if>
+                        (<c:out value="${err.key}"/>)
+                    </c:otherwise>
+                </c:choose>
+            </admin:infobox>
+        </c:forEach>
+    </c:when>
+    <c:when test="${success}">
+        <admin:infobox type="success">
+            <fmt:message key="system.admin.console.access.success" />
+        </admin:infobox>
+    </c:when>
+</c:choose>
+
+<p>
+    <fmt:message key="system.admin.console.access.info"/>
+</p>
+
+<fmt:message key="system.admin.console.access.iplists.title" var="iplists_boxtitle"/>
+<admin:contentBox title="${iplists_boxtitle}">
+
+    <form action="system-admin-console-access.jsp" method="post">
+        <input type="hidden" name="csrf" value="${csrf}">
+
+        <p><fmt:message key="system.admin.console.access.iplists.blocklist.info" /></p>
+        <table cellpadding="3" cellspacing="0" border="0">
+            <tr>
+                <td valign='top'><b><label for="blockedIPs"><fmt:message key="system.admin.console.access.iplists.blocklist.label" /></label></b></td>
+                <td><textarea name="blockedIPs" id="blockedIPs" cols="40" rows="3"><c:if test="${not empty blockedIPs}"><c:out value="${blockedIPs}"/></c:if></textarea></td>
+            </tr>
+        </table>
+
+        <p><fmt:message key="system.admin.console.access.iplists.allowlist.info" /></p>
+        <table cellpadding="3" cellspacing="0" border="0">
+            <tr>
+                <td valign='top'><b><label for="allowedIPs"><fmt:message key="system.admin.console.access.iplists.allowlist.label" /></label></b></td>
+                <td><textarea name="allowedIPs" id="allowedIPs" cols="40" rows="3"><c:if test="${not empty allowedIPs}"><c:out value="${allowedIPs}"/></c:if></textarea></td>
+            </tr>
+        </table>
+
+        <p><fmt:message key="system.admin.console.access.iplists.ignore-excludes.info" /></p>
+        <p>
+            <input type="checkbox" name="ignore-excludes" id="ignore-excludes" ${ignoreExcludes ? "checked" : ""}>
+            <label for="ignore-excludes"><fmt:message key="system.admin.console.access.iplists.ignore-excludes.label" /></label>
+        </p>
+
+        <input type="submit" name="save" value="<fmt:message key="global.save_settings" />">
+    </form>
+</admin:contentBox>
+
+</body>
+</html>

--- a/xmppserver/src/main/webapp/system-admin-console-access.jsp
+++ b/xmppserver/src/main/webapp/system-admin-console-access.jsp
@@ -20,7 +20,7 @@
     // Get parameters
     final String blockedIPs = request.getParameter("blockedIPs");
     final String allowedIPs = request.getParameter("allowedIPs");
-    final boolean ignoreExcludes= ParamUtils.getBooleanParameter( request, "ignore-excludes" );
+    final boolean ignoreExcludes = ParamUtils.getBooleanParameter(request, "ignore-excludes");
 
     boolean save = ParamUtils.getParameter(request, "save") != null;
     boolean success = ParamUtils.getBooleanParameter(request, "success");
@@ -88,9 +88,9 @@
 
     pageContext.setAttribute("errors", errors);
     pageContext.setAttribute("success", errors.isEmpty() && success);
-    pageContext.setAttribute("blockedIPs", String.join(", ", AuthCheckFilter.IP_ACCESS_BLOCKLIST.getValue()));
-    pageContext.setAttribute("allowedIPs", String.join(", ", AuthCheckFilter.IP_ACCESS_ALLOWLIST.getValue()));
-    pageContext.setAttribute("ignoreExcludes", AuthCheckFilter.IP_ACCESS_IGNORE_EXCLUDES.getValue());
+    pageContext.setAttribute("blockedIPs", errors.isEmpty() ? String.join(", ", AuthCheckFilter.IP_ACCESS_BLOCKLIST.getValue()) : blockedIPs);
+    pageContext.setAttribute("allowedIPs", errors.isEmpty() ? String.join(", ", AuthCheckFilter.IP_ACCESS_ALLOWLIST.getValue()) : allowedIPs);
+    pageContext.setAttribute("ignoreExcludes", errors.isEmpty() ? AuthCheckFilter.IP_ACCESS_IGNORE_EXCLUDES.getValue() : ignoreExcludes);
 
 %>
 

--- a/xmppserver/src/main/webapp/system-admin-console-access.jsp
+++ b/xmppserver/src/main/webapp/system-admin-console-access.jsp
@@ -80,7 +80,7 @@
             AuthCheckFilter.IP_ACCESS_IGNORE_EXCLUDES.setValue(ignoreExcludes);
 
             // Log the event
-            webManager.logEvent("Updated Admin Console access configuration.", "Blocklist = " + String.join(", ", blockedSet) +"\nAllowlist = " + String.join(", ", allowedSet)+"\nignore excludes = "+ignoreExcludes);
+            webManager.logEvent("Updated Admin Console access configuration.", "Blocklist = {" + String.join(", ", blockedSet) + "}\nAllowlist = {" + String.join(", ", allowedSet) + "}\nIgnore excludes = " + ignoreExcludes);
             response.sendRedirect("system-admin-console-access.jsp?success=true");
             return;
         }


### PR DESCRIPTION
This adds an 'allow' and 'block' list of IP(v4) addresses, that controls access to the admin console.

A third property is added that can be used to configure if these lists should also be applied when accessing pages that are otherwise 'excluded' from access control by the AuthCheckFilter.

An admin console page has been added to easily configure the new properties.

![image](https://user-images.githubusercontent.com/4253898/179985872-26db48c6-5b30-4fa3-a95d-59d996b18665.png)
