### PR TITLE
OF-2479: Allow clients that do websockets without the required XMPP framing

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1786,6 +1786,7 @@ system_property.xmpp.taskengine.threadpool.size.max=The maximum number of thread
 system_property.xmpp.taskengine.threadpool.keepalive=The number of threads in the thread pool that is used to execute tasks of Openfire's TaskEngine is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
 system_property.xmpp.muc.allowpm.blockall=Toggles whether to block all packets from users or just messages if they do not have permission to send private messages.
 system_property.abstractGroupProvider.shared.recursive=Toggles whether shared groups recursively resolve groups that they are shared with, or limit themselves to their immediate shared groups only.
+system_property.xmpp.websocket.stream-substitution-enabled=Controls if 'stream' elements that are sent over websockets are renamed to 'open' and 'close' where appropriate. Useful to allow certain non-compliant clients (eg: Tsung) to connect.
 
 # Server properties Page
 


### PR DESCRIPTION
This basically is a hack to get Tsung to connect to Openfire over websockets.

The functionality introduced here is switched off by default. If enabled, it replaces `stream` element names with `open` and `close` where appropriate, to conform to 'XMPP framing' as described in https://datatracker.ietf.org/doc/html/rfc7395#section-3.3