### PR TITLE
OF-2473: Prevent websocket deadlock

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
@@ -34,6 +34,7 @@ import org.jivesoftware.util.TaskEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.management.ObjectName;
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -384,7 +385,12 @@ public class HttpSessionManager {
         }
     }
 
-    protected void execute(Runnable runnable) {
+    /**
+     * Executes a Runnable in the thread pool that is used for processing stanzas received over BOSH.
+     *
+     * @param runnable The task to run
+     */
+    public void execute(@Nonnull final Runnable runnable) {
         this.stanzaWorkerPool.execute(runnable);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
@@ -132,35 +132,36 @@ public class XmppWebSocket {
     @OnWebSocketError
     public void onError(Throwable error)
     {
-        Log.error("Error detected; session: " + wsSession, error);
+        Log.error("Error detected; session: {}", wsSession, error);
 
         // Handle asynchronously, to prevent deadlocks. See OF-2473.
         HttpBindManager.getInstance().getSessionManager().execute(() -> {
-            try {
-                Log.debug("Attempting to close session on which an error occurred.");
-                closeStream(new StreamError(StreamError.Condition.internal_server_error));
-                if (wsSession != null) {
-                    wsSession.disconnect();
+            synchronized (this) {
+                try {
+                    Log.debug("Attempting to close session on which an error occurred.");
+                    if (isWebSocketOpen()) {
+                        closeStream(new StreamError(StreamError.Condition.internal_server_error));
+                    }
+                } catch (Exception e) {
+                    Log.error("Error disconnecting websocket", e);
+                } finally {
+                    wsSession = null;
                 }
-            } catch ( Exception e ) {
-                Log.error("Error disconnecting websocket", e);
-            } finally {
-                wsSession = null;
             }
         });
     }
 
     // local (package) visibility
 
-    boolean isWebSocketOpen() {
+    synchronized boolean isWebSocketOpen() {
         return wsSession != null && wsSession.isOpen();
     }
 
-    boolean isWebSocketSecure() {
+    synchronized boolean isWebSocketSecure() {
         return wsSession != null && wsSession.isSecure();
     }
 
-    void closeWebSocket()
+    synchronized void closeWebSocket()
     {
         if (isWebSocketOpen())
         {
@@ -174,8 +175,10 @@ public class XmppWebSocket {
     }
 
     void closeSession(@Nullable final StreamError error) {
-        if (isWebSocketOpen()) {
-            closeStream(error);
+        synchronized (this) {
+            if (isWebSocketOpen()) {
+                closeStream(error);
+            }
         }
         if (xmppSession != null) {
             if (!xmppSession.getStreamManager().getResume()) {
@@ -196,7 +199,7 @@ public class XmppWebSocket {
      *
      * @param packet XML to be sent to client
      */
-    void deliver(String packet)
+    synchronized void deliver(String packet)
     {
         if (isWebSocketOpen())
         {
@@ -366,7 +369,7 @@ public class XmppWebSocket {
         deliver(sb.toString());
     }
 
-    private void closeStream(StreamError streamError)
+    private synchronized void closeStream(StreamError streamError)
     {
         if (isWebSocketOpen()) {
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
@@ -98,7 +98,13 @@ public class XmppWebSocket {
     public void onClose(int statusCode, String reason)
     {
         // Handle asynchronously, to prevent deadlocks. See OF-2473.
-        HttpBindManager.getInstance().getSessionManager().execute(this::closeSession);
+        HttpBindManager.getInstance().getSessionManager().execute(() -> {
+            try {
+                closeSession();
+            } catch (Throwable t) {
+                Log.warn("An exception occurred while trying to process @OnWebSocketClose for session {}.", wsSession, t);
+            }
+        });
     }
 
     @OnWebSocketMessage


### PR DESCRIPTION
Jetty's websocket implementation invokes `@OnWebSocketError` and `@OnWebSocketClose` annotated methods when certain erroneous conditions occur. These invocations happen synchronously.

As a result, a 'close' operation is called synchronously to the processing of the original request, which can happen under guard of a mutex. This leads to the 'close' implementation being called while a mutex is held that is intended to be held only while inbound data is being processed. This has lead to deadlocks.

An example scenario is when a websocket request arrives that asks to close the connection. Sometimes (presumably if the per immediately disconnects the connection, rather than waiting for an answer), returning a response fails ('EOF'). This then triggers error handling.

This commit makes the `@OnWebSocketError` and `@OnWebSocketClose` methods be asynchronous, to ensure that its processing is decoupled from the inbound data that might have tirggered their invocation.