### PR TITLE
OF-2483: Delay restart of admin console when truststore content is changed

### DIFF
--- a/xmppserver/src/main/webapp/import-truststore-certificate.jsp
+++ b/xmppserver/src/main/webapp/import-truststore-certificate.jsp
@@ -8,6 +8,8 @@
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
+<%@ page import="org.jivesoftware.openfire.container.AdminConsolePlugin" %>
+<%@ page import="java.time.Duration" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -69,6 +71,10 @@
         {
             try
             {
+                // When updating certificates through the admin console, do not immediately restart the website, as that
+                // is very likely to lock out the administrator that is performing the changes.
+                ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+
                 // Import certificate
                 trustStoreConfig.installCertificate( alias, certificate );
 

--- a/xmppserver/src/main/webapp/security-truststore.jsp
+++ b/xmppserver/src/main/webapp/security-truststore.jsp
@@ -11,6 +11,8 @@
 <%@ page import="java.util.Set" %>
 <%@ page import="java.security.cert.X509Certificate" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
+<%@ page import="org.jivesoftware.openfire.container.AdminConsolePlugin" %>
+<%@ page import="java.time.Duration" %>
 <%@ taglib uri="admin" prefix="admin" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -76,6 +78,11 @@
             {
                 try
                 {
+                    // When updating certificates through the admin console, do not cause changes to restart the website, as
+                    // that is very likely to log out the administrator that is performing the changes. As the keystore change
+                    // event is async, this line disables restarting the plugin for a few minutes.
+                    ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+
                     trustStore.delete( alias );
 
                     // Log the event


### PR DESCRIPTION
This mimics similar behavior introduced by OF-2212 for the identity store. When the trust store is modified by an administrator, restarting the admin console immediately is undesirable, as it kicks out the admin that is busy applying changes.