### PR TITLE
OF-2423: Improve removal of client sessions from cache

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1077,7 +1077,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             lockA.lock();
             try {
                 clientRoute = anonymousUsersCache.remove(address);
-                anonymous = true;
+                if (clientRoute != null) {
+                    anonymous = true;
+                }
             }
             finally {
                 lockA.unlock();


### PR DESCRIPTION
Prior to this, the failure to identify a client session as a (regular) user session resulted in the session being assumed an anonymous user session. When a session is removed twice (which should not occur, but does occur with websockets for some reason), this causes a second client route to be removed from the cache.

This commit ensures that a session is indeed an anonymous session before assuming that it is.

For websockets, a warning will still be logged, as there are still two attempts to remove the session. Optimizing this is the subject of another issue: OF-2485