### PR TITLE
OF-400: Truncate MUC subjects longer than 100 characters

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -2372,6 +2372,11 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
             MUCRole.Role.moderator == role.getRole()) {
             // Set the new subject to the room
             subject = packet.getSubject();
+            // OF-400: Openfire only supports 100 characters for the subject. Truncate, if longer.
+            if (subject != null && subject.length() > 100) {
+                Log.info("Subject for room '{}' was changed by '{}' to a value that is longer than the maximum allowable 100 characters. The subject was truncated to fit.", name, role.getUserAddress());
+                subject = subject.substring(0, 97) + "...";
+            }
             MUCPersistenceManager.updateRoomSubject(this);
             // Notify all the occupants that the subject has changed
             packet.setFrom(role.getRoleAddress());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
@@ -927,6 +927,12 @@ public class MUCPersistenceManager {
             return;
         }
 
+        // OF-400: Subjects can't be longer than 100 characters in the database. Invokers should truncate longer subjects (or reject them with an error).
+        if (room.getSubject() != null && room.getSubject().length() > 100) {
+            Log.error("Unable to store subject for room '{}' as it has more than 100 characters.", room.getName());
+            return;
+        }
+
         Connection con = null;
         PreparedStatement pstmt = null;
         try {


### PR DESCRIPTION
Openfire's database support only 100 characters for a MUC room subject.

To prevent database errors, this commit truncates subjects that are longer than this.