### PR TITLE
OF-2484 truncate last update instant to millis

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
@@ -169,7 +169,8 @@ public class UpdateManager extends BasicModule {
                                 }
                             }
                             // Keep track of the last time we checked for updates.
-                            final Instant lastUpdate = Instant.now();
+                            // Openfire SystemProperties store as truncated to millis
+                            final Instant lastUpdate = Instant.now().truncatedTo(ChronoUnit.MILLIS);
                             LAST_UPDATE_CHECK.setValue(lastUpdate);
                             // As an extra precaution, make sure that that the value
                             // we just set is saved. If not, return to make sure that


### PR DESCRIPTION
Openfire property `update.lastCheck` stores as a truncated to millis value, so we should truncate the last check instant before doing a comparison against the stored property.