### PR TITLE
OF-2486: Ensure mediated MUC invite has a 'from'.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -2452,10 +2452,9 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
                 }
             }
             Element frag = message.addChildElement("x", "http://jabber.org/protocol/muc#user");
-            // ChatUser will be null if the room itself (i.e. via admin console) made the request
-            if (senderRole.getUserAddress() != null) {
-                frag.addElement("invite").addAttribute("from", senderRole.getUserAddress().toBareJID());
-            }
+            // ChatUser will be null if the room itself (i.e. via admin console) made the request. In that case, use the room JID. See OF-2486.
+            final JID from = senderRole.getUserAddress() != null ? senderRole.getUserAddress() : getJID();
+            frag.addElement("invite").addAttribute("from", from.toBareJID());
             if (reason != null && reason.length() > 0) {
                 Element invite = frag.element("invite");
                 if (invite == null) {


### PR DESCRIPTION
XEP-0045 mandates a 'from' attribute on the 'invite' element, used for mediated invitations. This aught to be the address of the inviter. In some scenarios, there is not an identifiable XMPP entity that is the inviter (eg: when an invitation is generated through the admin console or REST api). In such cases, this commit will use the bare JID of the room itself as the invitation. Reasoning that it can be thought of as the inviter, and having at least some value is less likely to break clients that expect the attribute to be present.