### PR TITLE
OF-2487: More atomicly replace XMLProperties files

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
@@ -821,29 +821,14 @@ public class XMLProperties {
             return false;
         }
 
-        // No errors occurred, so delete the main file.
-        // Delete the old file so we can replace it.
+        // No errors occurred, so replace the main file.
         try {
-            Files.deleteIfExists(file);
-        } catch (final IOException e) {
-            Log.error("Error deleting existing property file {}: ", tempFile, e);
-            return false;
-        }
-        // Copy new contents to the file.
-        try {
-            Files.copy(tempFile, file, StandardCopyOption.REPLACE_EXISTING);
+            Files.move(tempFile, file, StandardCopyOption.REPLACE_EXISTING);
         } catch (final Exception e) {
-            Log.error("Error copying new property file from {} to {}:", tempFile, file, e);
-            // There were errors so abort replacing the old property file.
+            Log.error("Error moving new property file from {} to {}:", tempFile, file, e);
             return false;
         }
 
-        // If no errors, delete the temp file.
-        try {
-            Files.deleteIfExists(tempFile);
-        } catch (IOException e) {
-            Log.error("Error deleting temp file {}", tempFile, e);
-        }
         return true;
     }
 


### PR DESCRIPTION
When updating XMLProperties files (`openfire.xml`, `security.xml`), do not:
- create a new temp file
- remove the old file
- copy temp file to the location of the old file
- remove the temp file file

Instead, do this more atomicly, as such:
- create a new temp file
- move temp file to replace to old file

There will leave Openfire in a more consistent state if somewhere along the line, things go wrong. Also, it reduces code a bit.