### PR TITLE
OF-400: Log an error when saving a MUCRoom with a subject > 100 chars

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
@@ -404,6 +404,12 @@ public class MUCPersistenceManager {
      * @param room The room to save its configuration.
      */
     public static void saveToDB(MUCRoom room) {
+        // OF-400: Subjects can't be longer than 100 characters in the database. Invokers should truncate longer subjects (or reject them with an error).
+        if (room.getSubject() != null && room.getSubject().length() > 100) {
+            Log.error("Unable to store subject for room '{}' as it has more than 100 characters.", room.getName());
+            return;
+        }
+        
         Log.debug("Attempting to save room '{}' to the database.", room.getName());
         Connection con = null;
         PreparedStatement pstmt = null;


### PR DESCRIPTION
In addition to #2086

Adds another clear logging point when the subject is too long. This might not be all of them, but this is called by the Openfire REST API Plugin.