### PR TITLE
OF-2488: Reduce log level sevierty of DNS lookup failure

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/DNSUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/DNSUtil.java
@@ -240,7 +240,7 @@ public class DNSUtil {
                 LOOKUP_CACHE.put(lookup, CacheableOptional.of(new WeightedHostAddress[0])); // Empty result (different from negative result!)
                 result = new WeightedHostAddress[0];
             } catch (NamingException e) {
-                logger.error("DNS SRV lookup failed for '{}'", lookup, e);
+                logger.info("DNS SRV lookup was unsuccessful for '{}': {}", lookup, e.getMessage());
                 LOOKUP_CACHE.put(lookup, CacheableOptional.of(null)); // Negative result cache (different from empty result!)
                 result = new WeightedHostAddress[0];
             }


### PR DESCRIPTION
When a particular DNS SRV record doesn't exist, there is no need to log this on level ERROR with a stack trace. The administrator of Openfire is unlikely to be able to fix this, while it occurs all the time.