### PR TITLE
OF-2490: Better handle PEP requests to non-local/non-registered users

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -479,7 +479,7 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
     }
 
     /**
-     * Process an IQ set stanza that was addressed to the a node/user.
+     * Process an IQ set stanza that was addressed to a node/user.
      *
      * @param packet The stanza to process.
      * @return A response (can be null).
@@ -487,6 +487,16 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
     private IQ handleIQRequestToUser(IQ packet)
     {
         final JID jidTo = packet.getTo().asBareJID();
+
+        // Only service local, registered users.
+        if (!UserManager.getInstance().isRegisteredUser(jidTo, false)) {
+            Log.debug("Rejected IQ request from '{}' to the PEP service of '{}' that is not a local, registered user.", packet.getFrom(), packet.getTo());
+            final IQ reply = IQ.createResultIQ(packet);
+            reply.setChildElement(packet.getChildElement().createCopy());
+            reply.setError(new PacketError(PacketError.Condition.item_not_found, PacketError.Condition.item_not_found.getDefaultType(), "PEP service does not exist. Only local, registered users have a PEP service."));
+            return reply;
+        }
+
         final PEPService pepService = pepServiceManager.getPEPService(jidTo);
         pepServiceManager.process(pepService, packet);
         return null;


### PR DESCRIPTION
Only local, registered users of Openfire have a PEP service. Other users do not. When a client tries to interact with such a non-existing PEP service, the current behavior of Openfire is to very verbosely log this as an (unexpected) error.

This code tries to properly handle this scenario, by returning a nice error back to the requestee, and logging it less verbosely.