### PR TITLE
Upgrade Jetty to 9.4.48.v20220622

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -122,7 +122,7 @@
         <!-- Versions -->
         <openfire.version>4.8.0-SNAPSHOT</openfire.version>
         <!-- Note; the following jetty.version should be identical to the jetty.version in xmppserver/pom.xml -->
-        <jetty.version>9.4.43.v20210629</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 
         <!-- Versions -->
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
-        <jetty.version>9.4.43.v20210629</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <mina.version>2.2.1</mina.version>
         <bouncycastle.version>1.70</bouncycastle.version>


### PR DESCRIPTION
Includes latest security fixes.

Draft to see how CI handles it. If it looks viable, will Jira and give it a real test.