### PR TITLE
OF-2495: Websocket onError handler prevents earlier data to be processed

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
@@ -288,15 +288,19 @@ public class XmppWebSocket {
                         router = new SessionPacketRouter(xmppSession);
                     }
                 }
-                router.route(stanza);
+                HttpBindManager.getInstance().getSessionManager().execute(() -> {
+                    try {
+                        router.route(stanza);
+                    }  catch (UnknownStanzaException use) {
+                        Log.warn("Received invalid stanza: " + stanza.asXML());
+                        sendPacketError(stanza, PacketError.Condition.bad_request);
+                    }
+                });
             } else {
                 // require authentication
                 Log.warn("Not authorized: " + stanza.asXML());
                 sendPacketError(stanza, PacketError.Condition.not_authorized);
             }
-        } catch (UnknownStanzaException use) {
-            Log.warn("Received invalid stanza: " + stanza.asXML());
-            sendPacketError(stanza, PacketError.Condition.bad_request);
         } catch (Exception ex) {
             Log.error("Failed to process incoming stanza: " + stanza.asXML(), ex);
             closeStream(new StreamError(StreamError.Condition.internal_server_error));


### PR DESCRIPTION
This commit ensures that the handling of the onError event is done in the same thread pool as that is using data. This should help ensure that those events are handled in roughly the same order. This in turn prevents data that has been supplied previously from going unprocessed, because the onError handler is executed 'early'.