### PR TITLE
OF-2499: No longer serialize MUC history with room

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
  * database.
  *
  * @author Gaston Dombiak
+ * @author Guus der Kinderen, guus@goodbytes.nl
  */
 @JiveID(JiveConstants.MUC_ROOM)
 public class MUCRoom implements GroupEventListener, Externalizable, Result, Cacheable {
@@ -369,7 +370,7 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
         this.canChangeNickname = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.canChangeNickname", true);
         this.registrationEnabled = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.registrationEnabled", true);
         // TODO Allow to set the history strategy from the configuration form?
-        roomHistory = new MUCRoomHistory(this, new HistoryStrategy(mucService.getHistoryStrategy()));
+        roomHistory = new MUCRoomHistory(this, new HistoryStrategy(getJID(), mucService.getHistoryStrategy()));
         this.iqOwnerHandler = new IQOwnerHandler(this);
         this.iqAdminHandler = new IQAdminHandler(this);
         this.fmucHandler = new FMUCHandler(this);
@@ -1322,6 +1323,8 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
 
         // Remove the room from the DB if the room was persistent
         MUCPersistenceManager.deleteFromDB(this);
+        // Remove the history of the room from memory (preventing it to pop up in a new room by the same name).
+        roomHistory.purge();
         // Fire event that the room has been destroyed
         MUCEventDispatcher.roomDestroyed(getRole().getRoleAddress());
     }
@@ -3635,7 +3638,7 @@ public class MUCRoom implements GroupEventListener, Externalizable, Result, Cach
         String subdomain = ExternalizableUtil.getInstance().readSafeUTF(in);
         mucService = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(subdomain);
         if (mucService == null) throw new IllegalArgumentException("MUC service not found for subdomain: " + subdomain);
-        roomHistory = new MUCRoomHistory(this, new HistoryStrategy(mucService.getHistoryStrategy()));
+        roomHistory = new MUCRoomHistory(this, new HistoryStrategy(getJID(), mucService.getHistoryStrategy()));
 
         this.iqOwnerHandler = new IQOwnerHandler(this);
         this.iqAdminHandler = new IQAdminHandler(this);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
@@ -41,6 +41,7 @@ import java.util.*;
  * joining and leaving times.
  * 
  * @author Gaston Dombiak
+ * @author Guus der Kinderen, guus@goodbytes.nl
  */
 public final class MUCRoomHistory implements Externalizable {
     private static final Logger Log = LoggerFactory.getLogger(MUCRoomHistory.class);
@@ -176,7 +177,7 @@ public final class MUCRoomHistory implements Externalizable {
             // payload initialized as XML string from DB
             try {
                 Element element = SAXReaderUtil.readRootElement(stanza);
-                for (Element child : (List<Element>)element.elements()) {
+                for (Element child : element.elements()) {
                     Namespace ns = child.getNamespace();
                     if (ns == null || ns.getURI().equals("jabber:client") || ns.getURI().equals("jabber:server")) {
                         continue;
@@ -185,10 +186,10 @@ public final class MUCRoomHistory implements Externalizable {
                     if (!child.getText().isEmpty()) {
                         added.setText(child.getText());
                     }
-                    for (Attribute attr : (List<Attribute>)child.attributes()) {
+                    for (Attribute attr : child.attributes()) {
                         added.addAttribute(attr.getQName(), attr.getValue());
                     }
-                    for (Element el : (List<Element>)child.elements()) {
+                    for (Element el : child.elements()) {
                         added.add(el.createCopy());
                     }
                 }
@@ -227,6 +228,14 @@ public final class MUCRoomHistory implements Externalizable {
             delayInformation.addAttribute("from", getRoom().getRole().getRoleAddress().toString());
         }
         historyStrategy.addMessage(message);
+    }
+
+    /**
+     * Removes all history that is maintained for this instance.
+     */
+    public void purge()
+    {
+        historyStrategy.purge();
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
@@ -215,6 +215,7 @@ public class LocalMUCRoomManager
             Log.trace("Removing room '{}' of service '{}'", roomName, serviceName);
             final MUCRoom room = ROOM_CACHE.remove(roomName);
             if (room != null) {
+                room.getRoomHistory().purge();
                 GroupEventDispatcher.removeListener(room);
             }
             localRooms.remove(roomName);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
+import javax.annotation.Nonnull;
 import java.math.BigInteger;
 import java.sql.*;
 import java.util.Date;
@@ -310,34 +311,7 @@ public class MUCPersistenceManager {
 
             // Recreate the history only for the rooms that have the conversation logging
             // enabled
-            if (room.isLogEnabled()) {
-                pstmt = con.prepareStatement(LOAD_HISTORY);
-                // Reload the history, using "muc.history.reload.limit" (days); defaults to 2
-                int reloadLimitDays = JiveGlobals.getIntProperty(MUC_HISTORY_RELOAD_LIMIT, 2);
-                long from = System.currentTimeMillis() - (BigInteger.valueOf(86400000).multiply(BigInteger.valueOf(reloadLimitDays))).longValue();
-                pstmt.setString(1, StringUtils.dateToMillis(new Date(from)));
-                pstmt.setLong(2, room.getID());
-                rs = pstmt.executeQuery();
-
-                while (rs.next()) {
-                    String senderJID = rs.getString("sender");
-                    String nickname = rs.getString("nickname");
-                    Date sentDate = new Date(Long.parseLong(rs.getString("logTime").trim()));
-                    String subject = rs.getString("subject");
-                    String body = rs.getString("body");
-                    String stanza = rs.getString("stanza");
-                    room.getRoomHistory().addOldMessage(senderJID, nickname, sentDate, subject, body, stanza);
-                }
-            }
-            DbConnectionManager.fastcloseStmt(rs, pstmt);
-
-            // If the room does not include the last subject in the history then recreate one if
-            // possible
-            if (!room.getRoomHistory().hasChangedSubject() && room.getSubject() != null &&
-                    room.getSubject().length() > 0) {
-                room.getRoomHistory().addOldMessage(room.getRole().getRoleAddress().toString(),
-                        null, room.getModificationDate(), room.getSubject(), null, null);
-            }
+            loadHistory(room);
 
             pstmt = con.prepareStatement(LOAD_AFFILIATIONS);
             pstmt.setLong(1, room.getID());
@@ -759,6 +733,66 @@ public class MUCPersistenceManager {
         }
 
         return rooms;
+    }
+
+    /**
+     * Load or reload the room history for a particular room from the database into memory.
+     *
+     * Invocation of this method will replace exising room history that's stored in memory (if any) with a freshly set
+     * of messages obtained from the database.
+     *
+     * @param room The room for which to load message history from the database into memory.
+     * @throws SQLException
+     */
+    public static void loadHistory(@Nonnull final MUCRoom room) throws SQLException
+    {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        try {
+            if (room.isLogEnabled()) {
+                con = DbConnectionManager.getConnection();
+                pstmt = con.prepareStatement(LOAD_HISTORY);
+
+                // Reload the history, using "muc.history.reload.limit" (days) if present
+                long from = 0;
+                String reloadLimit = JiveGlobals.getProperty(MUC_HISTORY_RELOAD_LIMIT);
+                if (reloadLimit != null) {
+                    // if the property is defined, but not numeric, default to 2 (days)
+                    int reloadLimitDays = JiveGlobals.getIntProperty(MUC_HISTORY_RELOAD_LIMIT, 2);
+                    Log.warn("MUC history reload limit set to " + reloadLimitDays + " days");
+                    from = System.currentTimeMillis() - (BigInteger.valueOf(86400000).multiply(BigInteger.valueOf(reloadLimitDays))).longValue();
+                }
+
+                pstmt.setString(1, StringUtils.dateToMillis(new Date(from)));
+                pstmt.setLong(2, room.getID());
+                rs = pstmt.executeQuery();
+
+                // When reloading history, make sure that the old data is removed from memory before re-adding it.
+                room.getRoomHistory().purge();
+
+                while (rs.next()) {
+                    String senderJID = rs.getString("sender");
+                    String nickname = rs.getString("nickname");
+                    Date sentDate = new Date(Long.parseLong(rs.getString("logTime").trim()));
+                    String subject = rs.getString("subject");
+                    String body = rs.getString("body");
+                    String stanza = rs.getString("stanza");
+                    room.getRoomHistory().addOldMessage(senderJID, nickname, sentDate, subject, body, stanza);
+                }
+            }
+
+            // If the room does not include the last subject in the history then recreate one if
+            // possible
+            if (!room.getRoomHistory().hasChangedSubject() && room.getSubject() != null &&
+                room.getSubject().length() > 0) {
+                room.getRoomHistory().addOldMessage(room.getRole().getRoleAddress().toString(),
+                    null, room.getModificationDate(), room.getSubject(), null, null);
+            }
+        } finally {
+            DbConnectionManager.closeConnection(rs, pstmt, con);
+        }
     }
 
     private static void loadHistory(Long serviceID, Map<Long, MUCRoom> rooms) throws SQLException {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -82,6 +82,7 @@ import java.util.stream.Stream;
  * abandoned rooms won't be loaded into memory when the Multi-User Chat service starts up.</p>
  *
  * @author Gaston Dombiak
+ * @author Guus der Kinderen, guus@goodbytes.nl
  */
 public class MultiUserChatServiceImpl implements Component, MultiUserChatService,
     ServerItemsProvider, DiscoInfoProvider, DiscoItemsProvider, XMPPServerListener, ClusterEventListener
@@ -310,7 +311,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
             this.chatDescription = LocaleUtils.getLocalizedString("muc.service-name");
         }
         this.isHidden = isHidden;
-        historyStrategy = new HistoryStrategy(null);
+        historyStrategy = new HistoryStrategy(getAddress(), null);
 
         localMUCRoomManager = new LocalMUCRoomManager(this);
         occupantManager = new OccupantManager(this);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -2680,6 +2680,9 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
 
         final int preloadDays = MUCPersistenceManager.getIntProperty(chatServiceName, "preload.days", 30);
         if (preloadDays > 0) {
+            if (ClusterManager.isClusteringEnabled()) {
+                Log.warn("Preloading MUC rooms when clustering is enabled can lead to a lot of duplicated database overhead. Consider disabling MUC room preloading.");
+            }
             // Load all the persistent rooms to memory
             final Instant cutoff = Instant.now().minus(Duration.ofDays(preloadDays));
             for (final MUCRoom room : MUCPersistenceManager.loadRoomsFromDB(this, Date.from(cutoff))) {

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -25,10 +25,7 @@ import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginClassLoader;
 import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.openfire.session.RemoteSessionLocatorImpl;
-import org.jivesoftware.util.InitializationException;
-import org.jivesoftware.util.JiveGlobals;
-import org.jivesoftware.util.PropertyEventDispatcher;
-import org.jivesoftware.util.PropertyEventListener;
+import org.jivesoftware.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
@@ -150,6 +147,7 @@ public class CacheFactory {
         cacheNames.put("JID Domain-parts", "jidDomainprep");
         cacheNames.put("JID Resource-parts", "jidResourceprep");
         cacheNames.put("Sequences", "sequences");
+        cacheNames.put("MUC History", "mucHistory");
         cacheNames.put("MUC Service Pings Sent", "mucPings");
 
         cacheProps.put(PROPERTY_PREFIX_CACHE + "dnsRecords" + PROPERTY_SUFFIX_SIZE, 128 * 1024L);
@@ -236,6 +234,8 @@ public class CacheFactory {
         cacheProps.put(PROPERTY_PREFIX_CACHE + "publishedItems" + PROPERTY_SUFFIX_MAX_LIFE_TIME, Duration.ofMinutes(15).toMillis());
         cacheProps.put(PROPERTY_PREFIX_CACHE + "sequences" + PROPERTY_SUFFIX_SIZE, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "sequences" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
+        cacheProps.put(PROPERTY_PREFIX_CACHE + "mucHistory" + PROPERTY_SUFFIX_SIZE, -1L);
+        cacheProps.put(PROPERTY_PREFIX_CACHE + "mucHistory" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "mucPings" + PROPERTY_SUFFIX_SIZE, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "mucPings" + PROPERTY_SUFFIX_MAX_LIFE_TIME, Duration.ofMinutes(30).toMillis());
 

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/muc/HistoryStrategyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/muc/HistoryStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,14 +107,14 @@ public class HistoryStrategyTest
     {
         final Message h1 = new Message();
         h1.setFrom(new JID("test" + StringUtils.randomString(4) + "@example.org"));
-        h1.setFrom(new JID("foo" + StringUtils.randomString(4) + "@example.org"));
+        h1.setTo(new JID("foo" + StringUtils.randomString(4) + "@example.org"));
         h1.setType(Message.Type.groupchat);
         h1.setBody("This is a historic message that is used in a unit test. Some random value to make text unique: " + StringUtils.randomString(10) );
         h1.addChildElement("delay", "urn:xmpp:delay").addAttribute("stamp", "2");
 
         final Message h2 = new Message();
         h2.setFrom(new JID("bar" + StringUtils.randomString(4) + "@example.org"));
-        h2.setFrom(new JID("foobar" +StringUtils.randomString(4)+ "@example.org"));
+        h2.setTo(new JID("foobar" +StringUtils.randomString(4)+ "@example.org"));
         h2.setType(Message.Type.groupchat);
         h2.setBody("This is another historic message that is used in a unit test. Some random value to make text unique: " + StringUtils.randomString(10));
         h2.addChildElement("delay", "urn:xmpp:delay").addAttribute("stamp", "1");
@@ -125,19 +125,20 @@ public class HistoryStrategyTest
 
         final Message subject = new Message();
         subject.setFrom(new JID("bar" + StringUtils.randomString(4) + "@example.org"));
-        subject.setFrom(new JID("foobar" +StringUtils.randomString(4)+ "@example.org"));
+        subject.setTo(new JID("foobar" +StringUtils.randomString(4)+ "@example.org"));
         subject.setType(Message.Type.groupchat);
         subject.setBody("This is a subject message that is used in a unit test. Some random value to make text unique: " + StringUtils.randomString(10));
         subject.addChildElement("delay", "urn:xmpp:delay").addAttribute("stamp", "4");
 
         final HistoryStrategy result = new HistoryStrategy(); // Set all fields to a non-default value, for a more specific test!
         populateField(result, "type", HistoryStrategy.Type.all);
-        populateField(result, "history", history);
+        populateField(result, "roomJID", new JID("test" + StringUtils.randomString(4) + "@example.org"));
         populateField(result, "maxNumber", new Random().nextInt(10000));
         populateField(result, "parent", null);
         populateField(result, "roomSubject", subject);
         populateField(result, "contextPrefix", "test prefix");
         populateField(result, "contextSubdomain", "test subdomain");
+        history.forEach(result::addMessage);
 
         return result;
     }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/muc/MUCRoomTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/muc/MUCRoomTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ import java.time.Instant;
 import java.util.*;
 
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
@@ -130,7 +129,7 @@ public class MUCRoomTest {
         populateField(input, "startTime", Instant.now().minus(Duration.ofDays(4)).toEpochMilli());
         populateField(input, "endTime", Instant.now().minus(Duration.ofHours(23)).toEpochMilli());
         populateField(input, "isDestroyed", true);
-        populateField(input, "roomHistory", new MUCRoomHistory(input, new HistoryStrategy(null)));
+        populateField(input, "roomHistory", new MUCRoomHistory(input, new HistoryStrategy(new JID("test-room-name", mockService.getServiceDomain(),null), null)));
         populateField(input, "lockedTime", Instant.now().minus(Duration.ofMinutes(141)).toEpochMilli());
         populateField(input, "owners", owners);
         populateField(input, "admins", admins);


### PR DESCRIPTION
As suggested in a 'TODO' comment in code, this replaces the MUC history that is stored inline with each MUC room, with a cache lookup.

This change intends to result in a performance boost, as retrieving/storing MUC rooms from a cache (and serializing them between cluster nodes) no longer includes the history. The data associated with history is typically very large (~50kb for 25 messages), but changes a lot less often than the room itself.