### PR TITLE
create macos github action job for releases

### DIFF
--- a/.github/workflows/macos-release-artifact.yml
+++ b/.github/workflows/macos-release-artifact.yml
@@ -1,0 +1,60 @@
+name: Openfire Mac Artifact
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    name: Build Openfire from source
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        java: [ 1.8 ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - id: get-id
+        name: Compute needed variables
+        run: |
+          set -x
+          id=$(echo ${{ github.repository }} | cut -d- -f2)
+          echo "::set-output name=id::$id"
+          echo "id is '$id'"
+          tag=$(echo ${{ github.ref }} | cut -d '/' -f3)
+          echo "::set-output name=tag::$tag"
+          echo "tag is '$tag'"
+          version=$(echo ${{ github.ref }} | cut -d '/' -f3 | cut -c 2- | sed 's/\./_/g')
+          echo "::set-output name=version::$version"
+          echo "version is '$version'"
+          rel_id=$(curl -sL https://api.github.com/repos/${{github.repository}}/releases | jq -r --arg TAG "$tag" '.[] | select(.tag_name==$TAG) | .id')
+          echo ::set-output name=rel_id::$rel_id
+          echo "rel_id is '$rel_id'"
+
+      - name: Cache Maven repository
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-java${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-java${{ matrix.java }}-maven-
+            ${{ runner.os }}-
+      - name: Build with Maven
+        run: mvn -B package -Pcoverage --file pom.xml
+      - name: Build Artifact
+        run: |
+          bash build/osx/build_dmg.sh
+      - name: Conditionally Push Artifact to Github Release
+        uses: actions/upload-release-asset@v1
+        if: ${{ contains(github.repository, 'igniterealtime/') && github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.get-id.outputs.rel_id }}/assets?name=openfire_${{ steps.get-id.outputs.version }}.dmg
+          asset_path: distribution/build/osx/Openfire.dmg
+          asset_name: openfire_${{ steps.get-id.outputs.version }}.dmg
+          asset_content_type: application/octet-stream
+


### PR DESCRIPTION
Motivation: I want to remove the ancient mac on my desktop that just runs an Ignite Realtime bamboo agent :)

This PR creates a Github Action on MacOS that:
- builds openfire
- creates the DMG artifact
- conditionally uploads it to github when releases are made

I made a [fake release](https://github.com/akrherz/Openfire/releases/tag/v9.9.6) within my fork to hopefully test that this upload works.