### PR TITLE
OF-2508: Nodeprep room name when creating through Ad-hoc command

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/muc/CreateMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/muc/CreateMUCRoom.java
@@ -93,6 +93,7 @@ public class CreateMUCRoom extends AdHocCommand {
             note.setText("Room name must be specified.");
             return;
         }
+        roomname = JID.nodeprep(roomname);
         JID admin = admins.iterator().next();
 
         boolean isPersistent;


### PR DESCRIPTION
Openfire provides an ad-hoc command that can be used to create a room. Openfire must ensure that room name values provided through that command are properly normalized (nodeprepped).