### PR TITLE
OF-2511: Prevent loading unused historic messages for MUC rooms.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
@@ -246,7 +246,7 @@ public class HistoryStrategy implements Externalizable {
         if (!MUC_HISTORY_CACHE.containsKey(roomJID)) {
             try {
                 final MUCRoom room = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(roomJID).getChatRoom(roomJID.getNode());
-                MUCPersistenceManager.loadHistory(room);
+                MUCPersistenceManager.loadHistory(room, getMaxNumber());
             } catch (Exception e) {
                 Log.error("Unable to load history for room {} from database.", roomJID, e);
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
@@ -289,6 +289,15 @@ public final class MUCRoomHistory implements Externalizable {
         return historyStrategy.isSubjectChangeRequest(message);
     }
 
+    /**
+     * Returns the maximum number of messages that is kept in history for this room, or -1 when there is no such limit.
+     *
+     * @return The maximum amount of historic messages to keep for this room, or -1.
+     */
+    public int getMaxMessages() {
+        return historyStrategy.getType() == HistoryStrategy.Type.number ? historyStrategy.getMaxNumber() : -1;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;


### PR DESCRIPTION
Typically, rooms are configured to retain only 25 message of history, to be sent to clients that join a room (note that this does _not_ relate at all to MAM).

When loading a room from the database, Openfire should not load _all_ messages from the database, but only the ones that are potentially going to be sent to clients. For rooms which a large history, this saves a considerable amount of resources.

This commit uses somewhat of a hack that is based on database driver functionality (skipping ahead in the resultset), as opposed to modifying the SQL query that is used to obtain the records. Such modification would likely depend on non-standardized SQL staments (TOP / LIMIT / ROWNUM), which would introduce the need for database-vendor specific code.