### PR TITLE
OF-2518: Attempt to load favicon over HTTPS

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/FaviconServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/FaviconServlet.java
@@ -213,7 +213,6 @@ public class FaviconServlet extends HttpServlet {
         return bytes;
     }
 
-    @SuppressWarnings("lgtm[java/ssrf]")
     private byte[] getImage(@Nonnull final String host) {
         final Set<URI> urls = new HashSet<>();
 


### PR DESCRIPTION
This adds an additional attempt to load the favicon. With this, both HTTPS and HTTP are attempted.

Additionally, the URL that's used is now being constructed through a builder, which should further reduce the attack vector of using 'user-provided input'.