### PR TITLE
bump install4j maven plugin to latest release

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -81,7 +81,7 @@
                     <plugin>
                         <groupId>org.sonatype.install4j</groupId>
                         <artifactId>install4j-maven-plugin</artifactId>
-                        <version>1.1.1</version>
+                        <version>1.1.2</version>
 
                         <executions>
                             <execution>


### PR DESCRIPTION
The 1.1.2 version is 5 years newer than 1.1.1, so it has to be better, right?