### PR TITLE
OF-2523: Do not re-use stream ID as the default resource ID

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -129,8 +129,7 @@ public abstract class LocalSession implements Session {
         conn = connection;
         this.streamID = streamID;
         this.serverName = serverName;
-        String id = streamID.getID();
-        this.address = new JID(null, serverName, id, true);
+        this.address = new JID(null, serverName, UUID.randomUUID().toString(), true);
         this.sessionManager = SessionManager.getInstance();
         this.streamManager = new StreamManager(this);
         this.language = language;


### PR DESCRIPTION
Let's decouple the stream ID and resource identifier that's used by default. This should help make both less predictable.