### PR TITLE
OF-2524: Improving speed of loading MUC history from database

### DIFF
--- a/distribution/src/database/openfire_db2.sql
+++ b/distribution/src/database/openfire_db2.sql
@@ -265,6 +265,7 @@ CREATE TABLE ofMucConversationLog (
   body                CLOB,
   stanza              CLOB
 );
+CREATE INDEX ofMucConvLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
 CREATE INDEX ofMucConvLog_time_idx ON ofMucConversationLog (logTime);
 CREATE INDEX ofMucConvLog_msg_id ON ofMucConversationLog (messageID);
 
@@ -391,7 +392,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 34);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_hsqldb.sql
+++ b/distribution/src/database/openfire_hsqldb.sql
@@ -257,6 +257,7 @@ CREATE TABLE ofMucConversationLog (
   body                LONGVARCHAR   NULL,
   stanza             LONGVARCHAR    NULL
 );
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
 CREATE INDEX ofMucConversationLog_time_idx ON ofMucConversationLog (logTime);
 CREATE INDEX ofMucConversationLog_msg_id ON ofMucConversationLog (messageID);
 
@@ -377,7 +378,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 34);
 
 // Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -246,6 +246,7 @@ CREATE TABLE ofMucConversationLog (
   subject             VARCHAR(255)  NULL,
   body                TEXT          NULL,
   stanza                TEXT          NULL,
+  INDEX ofMucConversationLog_roomtime_idx (roomID, logTime),
   INDEX ofMucConversationLog_time_idx (logTime),
   INDEX ofMucConversationLog_msg_id (messageID)
 );
@@ -367,7 +368,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 34);
 
 # Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -254,6 +254,7 @@ CREATE TABLE ofMucConversationLog (
   body                VARCHAR2(4000) NULL,
   stanza                VARCHAR2(4000) NULL
 );
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
 CREATE INDEX ofMucConversationLog_time_idx ON ofMucConversationLog (logTime);
 CREATE INDEX ofMucConversationLog_msg_id ON ofMucConversationLog (messageID);
 
@@ -375,7 +376,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 34);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -262,6 +262,7 @@ CREATE TABLE ofMucConversationLog (
   body                TEXT           NULL,
   stanza                TEXT           NULL
 );
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
 CREATE INDEX ofMucConversationLog_time_idx ON ofMucConversationLog (logTime);
 CREATE INDEX ofMucConversationLog_msg_id ON ofMucConversationLog (messageID);
 
@@ -383,7 +384,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 34);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -260,6 +260,7 @@ CREATE TABLE ofMucConversationLog (
   body                NTEXT          NULL,
   stanza                NTEXT          NULL
 );
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
 CREATE INDEX ofMucConversationLog_time_idx ON ofMucConversationLog (logTime);
 CREATE INDEX ofMucConversationLog_msg_id ON ofMucConversationLog (messageID);
 
@@ -380,7 +381,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 33);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 34);
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -259,6 +259,7 @@ CREATE TABLE ofMucConversationLog (
   body                TEXT           NULL,
   stanza                TEXT           NULL
 )
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime)
 CREATE INDEX ofMucConversationLog_time_idx ON ofMucConversationLog (logTime)
 CREATE INDEX ofMucConversationLog_msg_id ON ofMucConversationLog (messageID)
 
@@ -380,7 +381,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1)
 INSERT INTO ofID (idType, id) VALUES (26, 2)
 INSERT INTO ofID (idType, id) VALUES (27, 1)
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 33)
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 34)
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/upgrade/34/openfire_db2.sql
+++ b/distribution/src/database/upgrade/34/openfire_db2.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ofMucConvLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
+
+UPDATE ofVersion SET version = 34 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/34/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/34/openfire_hsqldb.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
+
+UPDATE ofVersion SET version = 34 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/34/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/34/openfire_mysql.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
+
+UPDATE ofVersion SET version = 34 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/34/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/34/openfire_oracle.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
+
+UPDATE ofVersion SET version = 34 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/34/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/34/openfire_postgresql.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
+
+UPDATE ofVersion SET version = 34 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/34/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/34/openfire_sqlserver.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
+
+UPDATE ofVersion SET version = 34 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/34/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/34/openfire_sybase.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
+
+UPDATE ofVersion SET version = 34 WHERE name = 'openfire';

--- a/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
@@ -68,7 +68,7 @@ public class SchemaManager {
     /**
      * Current Openfire database schema version.
      */
-    private static final int DATABASE_VERSION = 33;
+    private static final int DATABASE_VERSION = 34;
 
     /**
      * Checks the Openfire database schema to ensure that it's installed and up to date.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Externalizable;
 import java.io.IOException;
@@ -167,9 +168,51 @@ public final class MUCRoomHistory implements Externalizable {
      * @param subject the subject included in the message.
      * @param body the body of the message.
      * @param stanza the stanza to add
+     * @deprecated Replaced by a combination of {@link #parseHistoricMessage} and {@link #addOldMessages}. Less overhead when adding more than one message.
      */
+    @Deprecated // Remove in Openfire 4.8.0 or later.
     public void addOldMessage(String senderJID, String nickname, Date sentDate, String subject,
-            String body, String stanza)
+            String body, String stanza) {
+        final Message message = parseHistoricMessage(senderJID, nickname, sentDate, subject, body, stanza);
+        historyStrategy.addMessage(message);
+    }
+
+    /**
+     * Add message(s) to the history of the chat room.
+     *
+     * The messages will likely come from the database when loading the room history from the database.
+     * @param oldMessages The messages to add to the history
+     */
+    public void addOldMessages(@Nonnull final List<Message> oldMessages) {
+        addOldMessages(oldMessages.toArray(new Message[0]));
+    }
+
+    /**
+     * Add message(s) to the history of the chat room.
+     *
+     * The messages will likely come from the database when loading the room history from the database.
+     * @param oldMessages The messages to add to the history
+     */
+    public void addOldMessages(@Nonnull final Message... oldMessages) {
+        historyStrategy.addMessage(oldMessages);
+    }
+
+    /**
+     * Creates a new message, representing a message that was exchanged in a chat room in the past, based on the
+     * provided information.
+     *
+     * This information will likely come from the database when loading the room history from the database.
+     *
+     * @param senderJID the sender's JID of the message.
+     * @param nickname the sender's nickname of the message.
+     * @param sentDate the date when the message was sent to the room.
+     * @param subject the subject included in the message.
+     * @param body the body of the message.
+     * @param stanza the stanza to add
+     * @return A historic chat message.
+     */
+    public Message parseHistoricMessage(String senderJID, String nickname, Date sentDate, String subject,
+                                        String body, String stanza)
     {
         Message message = new Message();
         message.setType(Message.Type.groupchat);
@@ -227,7 +270,7 @@ public final class MUCRoomHistory implements Externalizable {
             // Set the Room JID as the "from" attribute
             delayInformation.addAttribute("from", getRoom().getRole().getRoleAddress().toString());
         }
-        historyStrategy.addMessage(message);
+        return message;
     }
 
     /**


### PR DESCRIPTION
Two changes (see individual commit messages for details):
- add all messages to the history in one batch, to prevent repeated acquiring and releasing of a (cluster-wide) lock
- add database index to speed up query to retrieve messages from the database.