### PR TITLE
OF-2525: Deprecate non-persisting XMLProperties API

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1257,14 +1257,15 @@ public class JiveGlobals {
                     openfireProperties = new XMLProperties(home + File.separator + getConfigName());
                 }
                 catch (IOException ioe) {
-                    Log.error(ioe.getMessage());
+                    Log.error("Unable to load default Openfire properties from: {}{}{}", home, File.separator, getConfigName(), ioe);
                     failedLoading = true;
                 }
             }
             // create a default/empty XML properties set (helpful for unit testing)
             if (openfireProperties == null) {
-                try { 
-                    openfireProperties = new XMLProperties();
+                try {
+                    Log.warn("Default properties have not been loaded from file. Using a non-persisting dummy properties object.");
+                    openfireProperties = XMLProperties.getNonPersistedInstance();
                 } catch (IOException e) {
                     Log.error("Failed to setup default openfire properties", e);
                 }            	
@@ -1299,14 +1300,15 @@ public class JiveGlobals {
                     }
                 }
                 catch (IOException ioe) {
-                    Log.error(ioe.getMessage());
+                    Log.error("Unable to load default security properties from: {}{}{}", home, File.separator, getConfigName(), ioe);
                     failedLoading = true;
                 }
             }
             // create a default/empty XML properties set (helpful for unit testing)
             if (securityProperties == null) {
-                try { 
-                    securityProperties = new XMLProperties();
+                try {
+                    Log.warn("Security properties have not been loaded from file. Using a non-persisting dummy properties object.");
+                    securityProperties = XMLProperties.getNonPersistedInstance();
                 } catch (IOException e) {
                     Log.error("Failed to setup default security properties", e);
                 }            	

--- a/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
@@ -23,6 +23,7 @@ import org.dom4j.io.SAXReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
@@ -65,32 +66,67 @@ public class XMLProperties {
     private final Map<String, Optional<String>> propertyCache = new HashMap<>();
 
     /**
-     * Creates a new empty XMLPropertiesTest object.
+     * Creates a new empty XMLProperties object. The object will only have an empty root element.
+     *
+     * Note that an instance created by this constructor cannot be used to persist changes (as it is not backed by a file).
+     *
+     * @throws IOException if an exception occurs initializing the properties
+     * @return an XMLProperties instance that is empty
+     */
+    public static XMLProperties getNonPersistedInstance() throws IOException {
+        return new XMLProperties();
+    }
+
+    /**
+     * Creates a new empty XMLProperties object.
+     *
+     * Note that an instance created by this constructor cannot be used to persist changes (as it is not backed by a file).
      *
      * @throws IOException if an error occurs loading the properties.
+     * @deprecated replaced by {@link #getNonPersistedInstance()}
      */
+    @Deprecated // Make 'private' in or after Openfire 4.8.0.
     public XMLProperties() throws IOException {
         file = null;
         document = buildDoc(new StringReader("<root />"));
     }
 
     /**
-     * Creates a new XMLPropertiesTest object.
+     * Creates a new XMLProperties object.
      *
      * @param fileName the full path the file that properties should be read from
      *                 and written to.
      * @throws IOException if an error occurs loading the properties.
+     * @deprecated use XMLProperties(Path) instead
      */
+    @Deprecated // Remove in or after Openfire 4.8.0
     public XMLProperties(String fileName) throws IOException {
         this(Paths.get(fileName));
     }
 
     /**
-     * Loads XML properties from a stream.
+     * Creates a new XMLProperties object with content loaded from a stream.
+     *
+     * Note that an instance created by this constructor cannot be used to persist changes (as it is not backed by a file).
      *
      * @param in the input stream of XML.
      * @throws IOException if an exception occurs when reading the stream.
+     * @return an XMLProperties instance populated with data from the stream.
      */
+    public static XMLProperties getNonPersistedInstance(@Nonnull final InputStream in) throws IOException {
+        return new XMLProperties(in);
+    }
+
+    /**
+     * Loads XML properties from a stream.
+     *
+     * Note that an instance created by this constructor cannot be used to persist changes (as it is not backed by a file).
+     *
+     * @param in the input stream of XML.
+     * @throws IOException if an exception occurs when reading the stream.
+     * @deprecated replaced by {@link #getNonPersistedInstance(InputStream)}
+     */
+    @Deprecated // Make 'private' in or after Openfire 4.8.0.
     public XMLProperties(InputStream in) throws IOException {
         file = null;
         try (Reader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
@@ -99,7 +135,7 @@ public class XMLProperties {
     }
 
     /**
-     * Creates a new XMLPropertiesTest object.
+     * Creates a new XMLProperties object.
      *
      * @param file the file that properties should be read from and written to.
      * @throws IOException if an error occurs loading the properties.
@@ -805,7 +841,7 @@ public class XMLProperties {
      */
     private boolean saveProperties() {
         if (file == null) {
-            Log.error("Unable to save XML properties; no file specified");
+            Log.error("Unable to save XML properties", new IllegalStateException("No file specified"));
             return false;
         }
 

--- a/xmppserver/src/test/java/org/jivesoftware/util/XMLPropertiesTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/XMLPropertiesTest.java
@@ -28,7 +28,7 @@ public class XMLPropertiesTest {
     @Test
     public void testAttributes() throws Exception {
         String xml = "<root><foo></foo></root>";
-        XMLProperties props = new XMLProperties(new ByteArrayInputStream(xml.getBytes()));
+        XMLProperties props = XMLProperties.getNonPersistedInstance(new ByteArrayInputStream(xml.getBytes()));
         assertNull(props.getAttribute("foo","bar"));
         xml = "<root><foo bar=\"test123\"></foo></root>";
         props = new XMLProperties(new ByteArrayInputStream(xml.getBytes()));
@@ -37,7 +37,7 @@ public class XMLPropertiesTest {
 
     @Test
     public void testGetProperty() throws Exception {
-        XMLProperties props = new XMLProperties(getClass().getResourceAsStream("XMLProperties.test01.xml"));
+        XMLProperties props = XMLProperties.getNonPersistedInstance(getClass().getResourceAsStream("XMLProperties.test01.xml"));
         assertEquals("123", props.getProperty("foo.bar"));
         assertEquals("456", props.getProperty("foo.bar.baz"));
         assertNull(props.getProperty("foo"));
@@ -46,7 +46,7 @@ public class XMLPropertiesTest {
 
     @Test
     public void testGetChildPropertiesIterator() throws Exception {
-        XMLProperties props = new XMLProperties(getClass().getResourceAsStream("XMLProperties.test02.xml"));
+        XMLProperties props = XMLProperties.getNonPersistedInstance(getClass().getResourceAsStream("XMLProperties.test02.xml"));
         String[] names = {"a","b","c","d"};
         String[] values = {"1","2","3","4"};
         String[] children = props.getChildrenProperties("foo.bar");
@@ -62,7 +62,7 @@ public class XMLPropertiesTest {
     @Test
     public void testGetPropertyWithXMLEntity() throws Exception {
         String xml = "<root><foo>foo&amp;bar</foo></root>";
-        XMLProperties props = new XMLProperties(new ByteArrayInputStream(xml.getBytes()));
+        XMLProperties props = XMLProperties.getNonPersistedInstance(new ByteArrayInputStream(xml.getBytes()));
         assertEquals("foo&bar", props.getProperty("foo"));
     }
 }


### PR DESCRIPTION
This aims to prevent accidental usage of XMLProperties instances that cannot persist changes. This is achieved by deprecating all constructors that create such an instance, replacing them with an aptly named static method.