### PR TITLE
OF-2527: Default to millisecond-precision in log4j

### DIFF
--- a/distribution/src/resources/log4j2.xml
+++ b/distribution/src/resources/log4j2.xml
@@ -8,7 +8,7 @@
           -->
         <RollingFile name="openfire" fileName="${sys:openfireHome}/logs/openfire.log" filePattern="${sys:openfireHome}/logs/openfire.log-%i">
             <PatternLayout>
-                <Pattern>%d{yyyy.MM.dd HH:mm:ss} %highlight{%-5p} [%t]: %c - %msg{nolookups}%n</Pattern>
+                <Pattern>%d{yyyy.MM.dd HH:mm:ss.SSS} %highlight{%-5p} [%t]: %c - %msg{nolookups}%n</Pattern>
             </PatternLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="100 MB"/>


### PR DESCRIPTION
Fixes OF-2527.

Changes the log4j2.xml configuration to default to using milliseconds in the Openfire log file.