### PR TITLE
OF-2528: Migrate set-output to use $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -103,10 +103,10 @@ jobs:
       - name: check branch ${{ github.ref }} is either main or a version number
         id: check-branch
         run: |
-          if [[ ${{ github.ref }} == 'refs/heads/main' || ${{ github.ref }} =~ refs\/heads\/[0-9]+\.[0-9]+ ]]; then
-            echo "::set-output name=is_publishable_branch::true"
+          if [[ ${{ github.ref }} == 'refs/heads/main' || ${{ github.ref }} =~ refs\/heads\/[0-9]+\.[0-9]+ ]]; then            
+            echo "is_publishable_branch=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=is_publishable_branch::false"
+            echo "is_publishable_branch=false" >> $GITHUB_OUTPUT
           fi
 
   connectivity:
@@ -213,7 +213,7 @@ jobs:
             DOCKERHUB_SECRET: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
             echo "is_DOCKERHUB_SECRET_set: ${{ env.DOCKERHUB_SECRET != '' }}"
-            echo "::set-output name=is_DOCKERHUB_SECRET_set::${{ env.DOCKERHUB_SECRET != '' }}"
+            echo "is_DOCKERHUB_SECRET_set=${{ env.DOCKERHUB_SECRET != '' }}" >> $GITHUB_OUTPUT
 
 
   publish-docker:

--- a/.github/workflows/macos-release-artifact.yml
+++ b/.github/workflows/macos-release-artifact.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           set -x
           version=$(echo ${{ github.ref }} | cut -d '/' -f3 | cut -c 2- | sed 's/\./_/g')
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
           echo "version is '$version'"
 
       - name: Get release


### PR DESCRIPTION
Fixes #2528

Remove use of deprecated 'set-output' function in Github Actions.