### PR TITLE
Update apache commons-text from 1.6 to 1.10.0

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -371,7 +371,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.6</version>
+            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
Fixes OF-2529

Updates Apache commons-text in Openfire to prevent it incorrectly appearing as vulnerable to CVE-2022-42889, even though it isn't, since we don't use the affected portions of the library.