### PR TITLE
OF-2533: AdminConsole's IP access should allow ranges

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -3209,12 +3209,14 @@ system.admin.console.access.iplists.title=Network access control
 system.admin.console.access.iplists.warning=When you exclude the IP address that you are currently using (which appears to be {0}) when applying changes on this page, you will be locked out of the admin console!
 system.admin.console.access.iplists.blocklist.info=Any IP address that appears on the Blocklist will not be allowed to access the admin console. This list always takes presedence over the Allowlist.
 system.admin.console.access.iplists.blocklist.label=Blocklist
-system.admin.console.access.iplists.blocklist.invalid-hint=None of your changes have been saved. One or more of the values that you provided for the Blocklist was not valid. These values need to be IPv4 addresses: {0}
+system.admin.console.access.iplists.blocklist.invalid-hint=None of your changes have been saved. One or more of the values that you provided for the Blocklist was not valid. These values need to be IPv4 or IPv6 addresses or address ranges: {0}
 system.admin.console.access.iplists.allowlist.info=When the Allowlist is <em>not empty</em>, only IP addresses that is are on the Allowlist will be allowed to access the admin console.
 system.admin.console.access.iplists.allowlist.label=Allowlist
-system.admin.console.access.iplists.allowlist.invalid-hint=None of your changes have been saved. One or more of the values that you provided for the Allowlist was not valid. These values need to be IPv4 addresses: {0}
+system.admin.console.access.iplists.allowlist.invalid-hint=None of your changes have been saved. One or more of the values that you provided for the Allowlist was not valid. These values need to be IPv4 or IPv6 addresses or address ranges: {0}
 system.admin.console.access.iplists.ignore-excludes.info=By default, access control is not applied to 'excluded' pages (such as the login page). This can be overridden here.
 system.admin.console.access.iplists.ignore-excludes.label=Apply access control to 'excluded' pages.
+system.admin.console.access.iplists.help=This values in the lists on this page are separated by comma's and whitespace. They can contain IP addresses (both v4 and v6) as well as IP address ranges. Ranges can use CIDR-notation (eg: "192.168.0.0/16"), or be dash separated (eg: "192.168.0.0-192.168.255.255"). When using dash separation, be careful not to include any whitespace characters in the range! Do not use []-notation for IPv6.
+
 # System Email
 
 system.email.title=Email Settings

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -449,6 +449,11 @@
             <artifactId>guava</artifactId>
             <version>30.1-jre</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.jgonian</groupId>
+            <artifactId>commons-ip-math</artifactId>
+            <version>1.32</version>
+        </dependency>
         <!-- Test Scope -->
         <dependency>
             <groupId>junit</groupId>

--- a/xmppserver/src/main/webapp/system-admin-console-access.jsp
+++ b/xmppserver/src/main/webapp/system-admin-console-access.jsp
@@ -118,6 +118,7 @@
     pageContext.setAttribute("blockedIPs", errors.isEmpty() ? String.join(", ", AuthCheckFilter.IP_ACCESS_BLOCKLIST.getValue()) : blockedIPs);
     pageContext.setAttribute("allowedIPs", errors.isEmpty() ? String.join(", ", AuthCheckFilter.IP_ACCESS_ALLOWLIST.getValue()) : allowedIPs);
     pageContext.setAttribute("ignoreExcludes", errors.isEmpty() ? AuthCheckFilter.IP_ACCESS_IGNORE_EXCLUDES.getValue() : ignoreExcludes);
+    pageContext.setAttribute("formattedRemoteAddress", AuthCheckFilter.removeBracketsFromIpv6Address(pageContext.getRequest().getRemoteAddr()));
 
 %>
 
@@ -131,7 +132,7 @@
 <admin:infobox type="warning">
     <fmt:message key="system.admin.console.access.iplists.warning">
         <!-- When AdminConsolePlugin.ADMIN_CONSOLE_FORWARDED is set, this will also show any X-Forwarded-For value. -->
-        <fmt:param><c:out value="${pageContext.request.remoteAddr}"/></fmt:param>
+        <fmt:param><c:out value="${formattedRemoteAddress}"/></fmt:param>
     </fmt:message>
 </admin:infobox>
 

--- a/xmppserver/src/test/java/org/jivesoftware/admin/AuthCheckFilterTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/admin/AuthCheckFilterTest.java
@@ -1,9 +1,7 @@
 package org.jivesoftware.admin;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -488,6 +486,66 @@ public class AuthCheckFilterTest {
             // Tear down test fixture.
             AuthCheckFilter.removeExclude(request.getRequestURI().substring(1));
         }
+    }
+
+    @Test
+    public void stripBracketsIpv6() throws Exception {
+        // Setup test fixture.
+        final String input = "[0:0:0:0:0:0:0:1]";
+
+        // Execute system under test.
+        final String result = AuthCheckFilter.removeBracketsFromIpv6Address(input);
+
+        // Verify result.
+        assertEquals("0:0:0:0:0:0:0:1", result);
+    }
+
+    @Test
+    public void stripBracketsIpv6NoBrackets() throws Exception {
+        // Setup test fixture.
+        final String input = "0:0:0:0:0:0:0:1";
+
+        // Execute system under test.
+        final String result = AuthCheckFilter.removeBracketsFromIpv6Address(input);
+
+        // Verify result.
+        assertEquals(input, result);
+    }
+
+    @Test
+    public void stripBracketsIpv4() throws Exception {
+        // Setup test fixture.
+        final String input = "[192.168.0.1]";
+
+        // Execute system under test.
+        final String result = AuthCheckFilter.removeBracketsFromIpv6Address(input);
+
+        // Verify result.
+        assertEquals(input, result); // Should only strip brackets from IPv6, not IPv4.
+    }
+
+    @Test
+    public void stripBracketsNonIP() throws Exception {
+        // Setup test fixture.
+        final String input = "[Foo Bar]";
+
+        // Execute system under test.
+        final String result = AuthCheckFilter.removeBracketsFromIpv6Address(input);
+
+        // Verify result.
+        assertEquals(input, result); // Should only strip brackets from IPv6, nothing else.
+    }
+
+    @Test
+    public void stripBracketsNonIPNoBrackets() throws Exception {
+        // Setup test fixture.
+        final String input = "Foo Bar";
+
+        // Execute system under test.
+        final String result = AuthCheckFilter.removeBracketsFromIpv6Address(input);
+
+        // Verify result.
+        assertEquals(input, result); // Should only strip brackets from IPv6, nothing else.
     }
 
     public static class AdminUserServletAuthenticatorClass implements ServletRequestAuthenticator {


### PR DESCRIPTION
This adds to the new IP-based access control for the admin console that was introduced in 4.8 via OF-2474 / https://github.com/igniterealtime/Openfire/pull/2074

Now, IP _ranges_ can also be used (eg, 192.168.2.0/24).

Also improved IPv6 support