### PR TITLE
OF-2537: Advertise support for pubsub's 'multi-item' feature

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -664,6 +664,8 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
             features.add("http://jabber.org/protocol/pubsub#subscription-options");
             // Publishing options are supported.
             features.add("http://jabber.org/protocol/pubsub#publish-options");
+            // Clients are allowed to set persist_items to true, and max_items to a value higher than 1, so this service can support multiple items.
+            features.add("http://jabber.org/protocol/pubsub#multi-items");
         }
         else if (name == null) {
             // Answer the features of a given node


### PR DESCRIPTION
XEP-0060 defines, amongst many others, the 'multi-items' service discovery feature.

This feature can be advertised by a pubsub service, when clients are allowed to configure a node in such a way that it can accept more-than-one item, by:

- setting `persist_items` to `true`
- setting `max_items` to a value higher than 1.

Openfire supports allows for both. It can/should advertise the feature `http://jabber.org/protocol/pubsub#multi-items` on its pubsub services.