### PR TITLE
OF-2539: Improve naming of threads

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Channel.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Channel.java
@@ -18,10 +18,12 @@ package org.jivesoftware.openfire;
 
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.util.LocaleUtils;
+import org.jivesoftware.util.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.Packet;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -64,7 +66,7 @@ public class Channel<T extends Packet> {
         this.name = name;
         this.channelHandler = channelHandler;
 
-        executor = new ThreadPoolExecutor(1, 8, 15, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>());
+        executor = new ThreadPoolExecutor(1, 8, 15, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(), new NamedThreadFactory("Channel-" + name + "-", Executors.defaultThreadFactory(), false, Thread.NORM_PRIORITY));
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdGroupProvider.java
@@ -30,6 +30,7 @@ import org.jivesoftware.openfire.group.AbstractGroupProvider;
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.group.GroupNotFoundException;
 import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.NamedThreadFactory;
 import org.jivesoftware.util.cache.Cache;
 import org.jivesoftware.util.cache.CacheFactory;
 import org.slf4j.Logger;
@@ -51,7 +52,9 @@ public class CrowdGroupProvider extends AbstractGroupProvider {
     private static final String USER_MEMBERSHIP_CACHE_NAME = "crowdUserMembership";
 
     private static final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-    private static final ScheduledExecutorService crowdGroupSync = Executors.newSingleThreadScheduledExecutor();
+    private static final ScheduledExecutorService crowdGroupSync = Executors.newSingleThreadScheduledExecutor(
+        new NamedThreadFactory("CrowdGroupSync-", Executors.defaultThreadFactory(), false, Thread.NORM_PRIORITY)
+    );
     private static final CrowdManager manager = CrowdManager.getInstance();
 
     private static List<String> groups = new ArrayList<>();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdUserProvider.java
@@ -27,6 +27,7 @@ import org.jivesoftware.openfire.user.UserAlreadyExistsException;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.openfire.user.UserProvider;
 import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +48,9 @@ public class CrowdUserProvider implements UserProvider {
         SEARCH_FIELD_USERNAME, SEARCH_FIELD_NAME, SEARCH_FIELD_EMAIL));
     
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-    private final ScheduledExecutorService crowdUserSync = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService crowdUserSync = Executors.newSingleThreadScheduledExecutor(
+        new NamedThreadFactory("CrowdUserSync-", Executors.defaultThreadFactory(), false, Thread.NORM_PRIORITY)
+    );
     
     private Map<String, org.jivesoftware.openfire.crowd.jaxb.User> usersCache = new TreeMap<>();
     private List<org.jivesoftware.openfire.crowd.jaxb.User> users = new ArrayList<>();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreWatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreWatcher.java
@@ -1,5 +1,6 @@
 package org.jivesoftware.openfire.keystore;
 
+import org.jivesoftware.util.NamedThreadFactory;
 import org.jivesoftware.util.SystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +38,9 @@ public class CertificateStoreWatcher
 
     private WatchService storeWatcher;
 
-    private final ExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    private final ExecutorService executorService = Executors.newSingleThreadScheduledExecutor(
+        new NamedThreadFactory("CertstoreWatcher-", Executors.defaultThreadFactory(), false, Thread.NORM_PRIORITY)
+    );
 
     public CertificateStoreWatcher()
     {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -60,6 +60,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -1571,7 +1572,8 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         }
 
         // A thread pool is used to broadcast concurrently, as well as to limit the execution time of this service.
-        final ExecutorService service = Executors.newFixedThreadPool( Math.min( localOccupants.size(), 10 ) );
+        final ThreadFactory threadFactory = new NamedThreadFactory("MUC-Shutdown-", Executors.defaultThreadFactory(), false, Thread.NORM_PRIORITY);
+        final ExecutorService service = Executors.newFixedThreadPool( Math.min( localOccupants.size(), 10 ), threadFactory );
 
         // Queue all tasks in the executor service.
         for ( final OccupantManager.Occupant localOccupant : localOccupants )

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -36,6 +36,7 @@ import org.jivesoftware.openfire.interceptor.PacketRejectedException;
 import org.jivesoftware.openfire.session.*;
 import org.jivesoftware.openfire.spi.RoutingTableImpl;
 import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.NamedThreadFactory;
 import org.jivesoftware.util.SystemProperty;
 import org.jivesoftware.util.TaskEngine;
 import org.jivesoftware.util.cache.Cache;
@@ -130,6 +131,7 @@ public class OutgoingSessionPromise {
         threadPool = new ThreadPoolExecutor(QUEUE_MIN_THREADS.getValue(), QUEUE_MAX_THREADS.getValue(),
                         QUEUE_THREAD_TIMEOUT.getValue().toMillis(), TimeUnit.MILLISECONDS,
                         new LinkedBlockingQueue<>(QUEUE_SIZE.getValue()),
+                        new NamedThreadFactory("S2SOutgoingPromise-", Executors.defaultThreadFactory(), false, Thread.NORM_PRIORITY),
                         new ThreadPoolExecutor.CallerRunsPolicy());
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
@@ -80,7 +80,8 @@ public final class SAXReaderUtil
                                                             PARSER_SERVICE_CORE_POOL_SIZE.getValue(),
                                                             PARSER_SERVICE_MAX_POOL_SIZE.getValue(),
                                                             PARSER_SERVICE_KEEP_ALIVE_TIME.getValue().toMillis(), TimeUnit.MILLISECONDS,
-                                                            new SynchronousQueue<>());
+                                                            new SynchronousQueue<>(),
+                                                            new NamedThreadFactory("saxReaderUtil-", Executors.defaultThreadFactory(), false, Thread.NORM_PRIORITY));
 
     static
     {


### PR DESCRIPTION
This overrides the default name (pool-x-thread-y) used for threads generated by an executor service to something that is more identifiable. Should not introduce functional changes.