### PR TITLE
OF-2543: When retrieving pubsub items, always include payload

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/LeafNode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/LeafNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -360,16 +360,14 @@ public class LeafNode extends Node {
     }
 
     /**
-     * Sends an IQ result with the list of items published to the node. Item ID and payload
-     * may be included in the result based on the node configuration.
+     * Sends an IQ result with the list of items published to the node. Item ID and payload are always included.
+     * Should only be used for use-cases described in section "6.5 Retrieve Items from a Node" from XEP-0060 (as
+     * opposed to processing of notifications or service discovery, which are allowed to discard payloads).
      *
      * @param originalRequest the IQ packet sent by a subscriber (or anyone) to get the node items.
      * @param publishedItems the list of published items to send to the subscriber.
-     * @param forceToIncludePayload true if the item payload should be include if one exists. When
-     *        false the decision is up to the node.
      */
-    void sendPublishedItems(IQ originalRequest, List<PublishedItem> publishedItems,
-            boolean forceToIncludePayload) {
+    void sendPublishedItems(IQ originalRequest, List<PublishedItem> publishedItems) {
         IQ result = IQ.createResultIQ(originalRequest);
         Element pubsubElem = result.setChildElement("pubsub", "http://jabber.org/protocol/pubsub");
         Element items = pubsubElem.addElement("items");
@@ -380,10 +378,7 @@ public class LeafNode extends Node {
             if (isItemRequired()) {
                 item.addAttribute("id", publishedItem.getID());
             }
-            if ((forceToIncludePayload || isPayloadDelivered()) &&
-                    publishedItem.getPayload() != null) {
-                item.add(publishedItem.getPayload().createCopy());
-            }
+            item.add(publishedItem.getPayload().createCopy());
         }
         // Send the result
         getService().send(result);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -1105,6 +1105,10 @@ public class PubSubEngine
         router.route(reply);
     }
 
+    /**
+     * Retrieves published items. Should only be used for use-cases described in section "6.5 Retrieve Items from a Node"
+     * from XEP-0060 (as opposed to processing of notifications or service discovery, which are allowed to discard payloads).
+     */
     private void getPublishedItems(PubSubService service, IQ iq, Element itemsElement) {
         String nodeID = itemsElement.attributeValue("node");
         String subID = itemsElement.attributeValue("subid");
@@ -1184,7 +1188,6 @@ public class PubSubEngine
 
         LeafNode leafNode = (LeafNode) node;
         // Get list of items to send to the user
-        boolean forceToIncludePayload = false;
         List<PublishedItem> items;
         String max_items = itemsElement.attributeValue("max_items");
         int recentItems = 0;
@@ -1211,9 +1214,6 @@ public class PubSubEngine
             }
             else {
                 items = new ArrayList<>();
-                // Indicate that payload should be included (if exists) no matter
-                // the node configuration
-                forceToIncludePayload = true;
                 // Get the items as requested by the user
                 for (Iterator it = requestedItems.iterator(); it.hasNext();) {
                     Element element = (Element) it.next();
@@ -1238,7 +1238,7 @@ public class PubSubEngine
         }
 
         // Send items to the user
-        leafNode.sendPublishedItems(iq, items, forceToIncludePayload);
+        leafNode.sendPublishedItems(iq, items);
     }
 
     private void createNode(PubSubService service, IQ iq, Element childElement, Element createElement, DataForm publishOptions) {


### PR DESCRIPTION
The pubsub node configuration option `pubsub#deliver_payloads` is defined in XEP-0060 to control if payloads are included in pubsub notification events. Openfire should not use it to determine if payloads are to be included when answering item retrievals (those should _always_ have payloads, if they exist on the item).