### PR TITLE
OF-2556: Record namespace prefixes sent on root XML element

### DIFF
--- a/xmppserver/src/main/java/org/dom4j/io/XMPPPacketReader.java
+++ b/xmppserver/src/main/java/org/dom4j/io/XMPPPacketReader.java
@@ -82,14 +82,15 @@ public class XMPPPacketReader {
 
     /**
      * Retrieves a collection of namespaces declared in the current element that the parser is on, that are not defined
-     * in {@link #IGNORED_NAMESPACE_ON_STANZA}
+     * in {@link #IGNORED_NAMESPACE_ON_STANZA}, and that are not the default namespace (the namespaces returned all have
+     * a defined prefix).
      *
      * @param xpp the parser
      * @return A collection of namespaces
-     * @throws XmlPullParserException
+     * @throws XmlPullParserException On any problem thrown by the XML parser.
      */
     @Nonnull
-    public static Set<Namespace> getNamespacesOnCurrentElement(XmlPullParser xpp) throws XmlPullParserException
+    public static Set<Namespace> getPrefixedNamespacesOnCurrentElement(XmlPullParser xpp) throws XmlPullParserException
     {
         final Set<Namespace> results = new HashSet<>();
         final int nsStart = xpp.getNamespaceCount(xpp.getDepth()-1);

--- a/xmppserver/src/main/java/org/dom4j/io/XMPPPacketReader.java
+++ b/xmppserver/src/main/java/org/dom4j/io/XMPPPacketReader.java
@@ -16,10 +16,13 @@ import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
 
+import javax.annotation.Nonnull;
 import java.io.*;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * <p><code>XMPPPacketReader</code> is a Reader of DOM4J documents that
@@ -75,6 +78,30 @@ public class XMPPPacketReader {
 
     public XMPPPacketReader(DocumentFactory factory) {
         this.factory = factory;
+    }
+
+    /**
+     * Retrieves a collection of namespaces declared in the current element that the parser is on, that are not defined
+     * in {@link #IGNORED_NAMESPACE_ON_STANZA}
+     *
+     * @param xpp the parser
+     * @return A collection of namespaces
+     * @throws XmlPullParserException
+     */
+    @Nonnull
+    public static Set<Namespace> getNamespacesOnCurrentElement(XmlPullParser xpp) throws XmlPullParserException
+    {
+        final Set<Namespace> results = new HashSet<>();
+        final int nsStart = xpp.getNamespaceCount(xpp.getDepth()-1);
+        final int nsEnd = xpp.getNamespaceCount(xpp.getDepth());
+        for (int i = nsStart; i < nsEnd; i++) {
+            final String prefix = xpp.getNamespacePrefix(i);
+            final String ns = xpp.getNamespaceUri(i);
+            if (prefix != null && !XMPPPacketReader.IGNORED_NAMESPACE_ON_STANZA.contains(ns)) {
+                results.add(Namespace.get(prefix, ns));
+            }
+        }
+        return results;
     }
 
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
@@ -16,16 +16,20 @@
 
 package org.jivesoftware.openfire;
 
+import org.dom4j.Namespace;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.session.LocalSession;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
 import org.xmpp.packet.Packet;
 import org.xmpp.packet.StreamError;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.net.UnknownHostException;
 import java.security.cert.Certificate;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents a connection on the server.
@@ -33,7 +37,17 @@ import java.security.cert.Certificate;
  * @author Iain Shigeoka
  */
 public interface Connection extends Closeable {
-    
+
+    /**
+     * When a connection is used to transmit an XML data, the root element of that data can define XML namespaces other
+     * than the ones that are default (eg: 'jabber:client', 'jabber:server', etc). For an XML parser to be able to parse
+     * stanzas or other elements that are defined in that namespace (eg: are prefixed), these namespaces are recorded
+     * here.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2556">Issue OF-2556</a>
+     */
+    Set<Namespace> additionalNamespaces = new HashSet<>();
+
     /**
      * Verifies that the connection is still live. Typically this is done by
      * sending a whitespace character between packets.
@@ -367,6 +381,33 @@ public interface Connection extends Closeable {
      * @return The desired configuration for the connection (never null).
      */
     ConnectionConfiguration getConfiguration();
+
+    /**
+     * When a connection is used to transmit an XML data, the root element of that data can define XML namespaces other
+     * than the ones that are default (eg: 'jabber:client', 'jabber:server', etc). For an XML parser to be able to parse
+     * stanzas or other elements that are defined in that namespace (eg: are prefixed), these namespaces are recorded
+     * here.
+     *
+     * @return A collection that contains all non-default namespaces that the peer defined when last opening a new stream.
+     */
+    @Nonnull
+    default Set<Namespace> getAdditionalNamespaces() {
+        return additionalNamespaces;
+    }
+
+    /**
+     * When a connection is used to transmit an XML data, the root element of that data can define XML namespaces other
+     * than the ones that are default (eg: 'jabber:client', 'jabber:server', etc). For an XML parser to be able to parse
+     * stanzas or other elements that are defined in that namespace (eg: are prefixed), these namespaces are recorded
+     * here.
+     *
+     * @param additionalNamespaces A collection that contains all non-default namespaces that the peer defined when last
+     *                            opening a new stream.
+     */
+    default void setAdditionalNamespaces(@Nonnull final Set<Namespace> additionalNamespaces) {
+        this.additionalNamespaces.clear();
+        this.additionalNamespaces.addAll(additionalNamespaces);
+    }
 
     /**
      * Enumeration of possible compression policies required to interact with the server.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.session;
 
+import org.dom4j.io.XMPPPacketReader;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.StreamID;
@@ -217,6 +218,9 @@ public class LocalClientSession extends LocalSession implements ClientSession {
             connection.close(new StreamError(StreamError.Condition.not_authorized));
             return null;
         }
+
+        // Retrieve list of namespaces declared in current element (OF-2556)
+        connection.setAdditionalNamespaces(XMPPPacketReader.getNamespacesOnCurrentElement(xpp));
 
         // Default language is English ("en").
         Locale language = Locale.forLanguageTag("en");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -220,7 +220,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
         }
 
         // Retrieve list of namespaces declared in current element (OF-2556)
-        connection.setAdditionalNamespaces(XMPPPacketReader.getNamespacesOnCurrentElement(xpp));
+        connection.setAdditionalNamespaces(XMPPPacketReader.getPrefixedNamespacesOnCurrentElement(xpp));
 
         // Default language is English ("en").
         Locale language = Locale.forLanguageTag("en");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
@@ -78,7 +78,7 @@ public class LocalComponentSession extends LocalSession implements ComponentSess
         Log.debug("LocalComponentSession: [ExComp] Starting registration of new external component for domain: {}", domain);
 
         // Retrieve list of namespaces declared in current element (OF-2556)
-        connection.setAdditionalNamespaces(XMPPPacketReader.getNamespacesOnCurrentElement(xpp));
+        connection.setAdditionalNamespaces(XMPPPacketReader.getPrefixedNamespacesOnCurrentElement(xpp));
 
         // Default answer header in case of an error
         StringBuilder sb = new StringBuilder();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.openfire.session;
 
+import org.dom4j.io.XMPPPacketReader;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.PacketException;
 import org.jivesoftware.openfire.SessionManager;
@@ -75,6 +76,9 @@ public class LocalComponentSession extends LocalSession implements ComponentSess
         boolean allowMultiple = xpp.getAttributeValue("", "allowMultiple") != null;
 
         Log.debug("LocalComponentSession: [ExComp] Starting registration of new external component for domain: {}", domain);
+
+        // Retrieve list of namespaces declared in current element (OF-2556)
+        connection.setAdditionalNamespaces(XMPPPacketReader.getNamespacesOnCurrentElement(xpp));
 
         // Default answer header in case of an error
         StringBuilder sb = new StringBuilder();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
@@ -68,7 +68,7 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
         String domain = xpp.getAttributeValue("", "to");
 
         // Retrieve list of namespaces declared in current element (OF-2556)
-        connection.setAdditionalNamespaces(XMPPPacketReader.getNamespacesOnCurrentElement(xpp));
+        connection.setAdditionalNamespaces(XMPPPacketReader.getPrefixedNamespacesOnCurrentElement(xpp));
 
         Log.debug("LocalConnectionMultiplexerSession: [ConMng] Starting registration of new connection manager for domain: " + domain);
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
@@ -17,6 +17,7 @@
 package org.jivesoftware.openfire.session;
 
 import org.dom4j.Element;
+import org.dom4j.io.XMPPPacketReader;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.StreamID;
@@ -65,6 +66,9 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
     public static LocalConnectionMultiplexerSession createSession(String serverName, XmlPullParser xpp, Connection connection)
             throws XmlPullParserException {
         String domain = xpp.getAttributeValue("", "to");
+
+        // Retrieve list of namespaces declared in current element (OF-2556)
+        connection.setAdditionalNamespaces(XMPPPacketReader.getNamespacesOnCurrentElement(xpp));
 
         Log.debug("LocalConnectionMultiplexerSession: [ConMng] Starting registration of new connection manager for domain: " + domain);
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -118,7 +118,7 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
         }
 
         // Retrieve list of namespaces declared in current element (OF-2556)
-        connection.setAdditionalNamespaces(XMPPPacketReader.getNamespacesOnCurrentElement(xpp));
+        connection.setAdditionalNamespaces(XMPPPacketReader.getPrefixedNamespacesOnCurrentElement(xpp));
 
         try {
             // Get the stream ID for the new session

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -116,7 +116,10 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
         if (toDomain == null) {
             toDomain = serverName;
         }
-        
+
+        // Retrieve list of namespaces declared in current element (OF-2556)
+        connection.setAdditionalNamespaces(XMPPPacketReader.getNamespacesOnCurrentElement(xpp));
+
         try {
             // Get the stream ID for the new session
             StreamID streamID = SessionManager.getInstance().nextStreamID();


### PR DESCRIPTION
XMPP connections take the form of an XML document, starting with a 'stream' root element.

Openfire processes the direct child elements as if they were individual documents (for reasons beyond the scope of this issue). In that approach, any namespaces defined in the original root element are lost.

Generally, this isn't much of an issue, as a default namespace is assumed/used that is specific to the connection type. However, if the root element defined _other_ issues, that information is lost.

Defining additional namespaces is allowed in XML/XMPP, but isn't typically used. If it were, we would have hit problems long ago. There is one known application of this, which is Dialback (refactoring Openfire's S2S server to use MINA as part of OF-1112 is how this issue was found).

Openfire should be able to XML-parse child elements of the root 'stream' tags, if those child elements use a prefix that refers to a namespace defined on that root element.

This commit achieves that, by recording such declarations in the `Connection` representation over which they were sent. When such declarations are found, each stanza that is processed is wrapped in dummy root element, on which those definitions are placed, prioer to XML parsing. After parsing, the root element is discarded again.