### PR TITLE
OF-2557: Show TLS config on each session/connection

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -2057,6 +2057,8 @@ session.details.close=Closed
 session.details.connect=Connected
 session.details.streaming=Streaming
 session.details.authenticated=Authenticated
+session.details.tls_version=TLS Version
+session.details.cipher=Cipher Suite
 session.details.presence=Presence
 session.details.away=Away
 session.details.chat_available=Available to Chat
@@ -2110,7 +2112,7 @@ session.details.show-extended=Show More Details
 # Session row Page
 
 session.row.cliked=Click for more info...
-session.row.cliked_ssl=User is connected via SSL
+session.row.cliked_ssl=User is connected via TLS
 session.row.cliked_kill_session=Click to kill session...
 session.row.confirm_close=Are you sure you want to close this connection?
 
@@ -2157,6 +2159,7 @@ server.session.details.streamid=Stream ID
 server.session.details.authentication=Authentication
 server.session.details.dialback=Dialback
 server.session.details.tlsauth=SASL EXTERNAL
+server.session.details.tls_version=TLS Version
 server.session.details.cipher=Cipher Suite
 server.session.details.incoming_statistics=Packets RX
 server.session.details.outgoing_session=Outgoing Session Details
@@ -2190,6 +2193,8 @@ component.session.remote=Remote
 
 component.session.details.title=External Component Connection Details
 component.session.details.info=Below are details about the session with the external component {0}.
+component.session.details.tls_version=TLS Version
+component.session.details.cipher=Cipher Suite
 
 # General Setup
 
@@ -3824,3 +3829,4 @@ system.cache-details.delete_confirm=Are you sure you want to delete the cache en
 system.cache-details.deleted=The cache entry with key {0} was deleted.
 system.cache-details.key_not_found=The cache entry with key {0} could not be deleted - it may have already expired.
 system.cache-details.cancelled=The request was cancelled and no changes were made to the cache.
+session.row.cliked_ssl=User is connected via TLS

--- a/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
+++ b/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
@@ -1095,7 +1095,7 @@ session.details.remote=Remote
 # Session row Page
 
 session.row.cliked=Klikněte pro více informací...
-session.row.cliked_ssl=Uživatel je připojen přes SSL
+session.row.cliked_ssl=Uživatel je připojen přes TLS
 session.row.cliked_kill_session=Klikněte pro ukončení relace...
 session.row.confirm_close=Jste si jistý(á), že chcete zavřít tuto relaci?
 

--- a/i18n/src/main/resources/openfire_i18n_de.properties
+++ b/i18n/src/main/resources/openfire_i18n_de.properties
@@ -1522,7 +1522,7 @@ session.details.software_version=Software Version
 # Session row Page
 
 session.row.cliked=Für mehr Informationen hier klicken ...
-session.row.cliked_ssl=Benutzer ist über SSL angemeldet
+session.row.cliked_ssl=Benutzer ist über TLS angemeldet
 session.row.cliked_kill_session=Hier klicken um die Sitzung zu beenden ...
 session.row.confirm_close=Sicher dass diese Verbindung beendet werden soll?
 
@@ -3264,3 +3264,5 @@ system.cache-details.deleted=Der Cache-Eintrag mit dem Schlüssel {0} wurde gel�
 system.cache-details.key_not_found=Der Cache-Eintrag mit dem Schlüssel {0} konnte nicht gelöscht werden - er ist \
   möglicherweise bereits abgelaufen.
 system.cache-details.cancelled=Der Request wurde abgebrochen und es wurden keine Änderungen am Cache vorgenommen.
+session.details.cipher=Verschlüsselungs-Suite
+component.session.details.cipher=Verschlüsselungs-Suite

--- a/i18n/src/main/resources/openfire_i18n_es.properties
+++ b/i18n/src/main/resources/openfire_i18n_es.properties
@@ -1474,7 +1474,7 @@ session.details.software_version=Versión de Software
 # Session row Page
 
 session.row.cliked=Presione para más información...
-session.row.cliked_ssl=Usuario conectado por SSL
+session.row.cliked_ssl=Usuario conectado por TLS
 session.row.cliked_kill_session=Presione para cortar la sesión...
 session.row.confirm_close=¿Está seguro que desea cerrar esta conexión?
 
@@ -3195,3 +3195,5 @@ system.cache-details.delete_confirm=¿Está seguro que quiere borrar la entrade 
 system.cache-details.deleted=La entrada de cache con clave{0} fue borrada.
 system.cache-details.key_not_found=La entrada de cache con clave {0} no pudo ser borrada. Pudo haber expirado.
 system.cache-details.cancelled=El pedido fue cancelado y no se hicieron cambios en el cache.
+session.details.cipher=Algoritmo de Cifrado
+component.session.details.cipher=Algoritmo de Cifrado

--- a/i18n/src/main/resources/openfire_i18n_fr.properties
+++ b/i18n/src/main/resources/openfire_i18n_fr.properties
@@ -982,7 +982,7 @@ session.details.local=Local
 session.details.remote=Remote
 # Session row Page
 session.row.cliked = Cliquer pour plus d&#39;info...
-session.row.cliked_ssl = L&#39;Utilisateur est connecté par SSL
+session.row.cliked_ssl=L&#39;Utilisateur est connecté par TLS
 session.row.cliked_kill_session = Cliquer pour clôturer une session...
 session.row.confirm_close = Etes-vous sûr de vouloir clôturer cette connexion ?
 # Session summary Page

--- a/i18n/src/main/resources/openfire_i18n_ja_JP.properties
+++ b/i18n/src/main/resources/openfire_i18n_ja_JP.properties
@@ -1115,7 +1115,7 @@ session.details.remote=Remote
 # Session row Page
 
 session.row.cliked=さらに情報を得る場合にクリックしてください...
-session.row.cliked_ssl=ユーザーはSSL経由で接続しています。
+session.row.cliked_ssl=ユーザーはTLS経由で接続しています。
 session.row.cliked_kill_session=セッションを切断する場合にクリックしてください...
 session.row.confirm_close=このセッションを切断しようとしていますが、よろしいですか?
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1098,7 +1098,7 @@ session.details.show-extended=Toon Meer Details
 # Session row Page
 
 session.row.cliked=Klik hier voor meer informatie...
-session.row.cliked_ssl=Gebruiker is verbonden via SSL
+session.row.cliked_ssl=Gebruiker is verbonden via TLS
 session.row.cliked_kill_session=Klik hier om de sessie te be�ndigen...
 session.row.confirm_close=Wilt u deze verbinding verbreken?
 
@@ -2516,3 +2516,6 @@ ssl.certificates.keystore.no_complete_installed=Het geinstalleerde certificaat o
 certificaat te vervangen door een die dat wel doet of {2}hier{3} om een ondertekend certificaat met bijbehorende\
 private key te installeren.
 group.edit.name=Naam
+server.session.details.tls_version=TLS Versie
+session.details.tls_version=TLS Versie
+component.session.details.tls_version=TLS Versie

--- a/i18n/src/main/resources/openfire_i18n_pl_PL.properties
+++ b/i18n/src/main/resources/openfire_i18n_pl_PL.properties
@@ -1034,7 +1034,7 @@ session.details.remote=Remote
 # Session row Page
 
 session.row.cliked=Kliknij po więcej informacji...
-session.row.cliked_ssl=Użytkownik jest połączony przez SSL
+session.row.cliked_ssl=Użytkownik jest połączony przez TLS
 session.row.cliked_kill_session=Kliknij aby zakończyć sesje...
 session.row.confirm_close=Czy chcesz zakończyć połączenie?
 

--- a/i18n/src/main/resources/openfire_i18n_pt_PT.properties
+++ b/i18n/src/main/resources/openfire_i18n_pt_PT.properties
@@ -1656,7 +1656,7 @@ session.details.remote=Remoto
 # Session row Page
 
 session.row.cliked=Clique para mais informações...
-session.row.cliked_ssl=Utilizador está conectado através de SSL
+session.row.cliked_ssl=Utilizador está conectado através de TLS
 session.row.cliked_kill_session=Clique para desconectar a sessão...
 session.row.confirm_close=Tem certeza que você quer fechar esta ligação?
 
@@ -2964,3 +2964,5 @@ connection-mode.unspecified=unspecified
 ssl.certificates.keystore.no_installed=A certificate for the domain of this server is missing. Click {0}here{1} to generate a self-signed \
   certificate or {2}here{3} to import a signed certificate and its private key.
 group.edit.name=Nome
+session.details.cipher=Grupo de Cifras
+component.session.details.cipher=Grupo de Cifras

--- a/i18n/src/main/resources/openfire_i18n_ru_RU.properties
+++ b/i18n/src/main/resources/openfire_i18n_ru_RU.properties
@@ -1316,7 +1316,7 @@ session.details.connection-type=Тип соединения
 # Страница строки сеанса
 
 session.row.cliked=Нажмите для получения дополнительной информации...
-session.row.cliked_ssl=Пользователь подключен через SSL
+session.row.cliked_ssl=Пользователь подключен через TLS
 session.row.cliked_kill_session=Нажмите, чтобы закрыть сеанс...
 session.row.confirm_close=Вы действительно хотите закрыть это соединение?
 
@@ -2882,3 +2882,5 @@ system.dns.srv.check.label.weight=Вес
 system.dns.srv.check.recordbox.title=Записи DNS SRV
 system.dns.srv.check.recordbox.description=В приведенной ниже таблице перечислены все записи SRV DNS для домена XMPP, которые являются службами этого сервера Openfire. Первая таблица содержит все записи клиент-сервер, а последняя таблица - все записи сервер-сервер.
 group.edit.name=Имя
+session.details.cipher=Cipher Suite
+component.session.details.cipher=Cipher Suite

--- a/i18n/src/main/resources/openfire_i18n_sk.properties
+++ b/i18n/src/main/resources/openfire_i18n_sk.properties
@@ -1073,7 +1073,7 @@ session.details.remote=Remote
 # Session row Page
 
 session.row.cliked=Ďalšie informácie po kliknutí...
-session.row.cliked_ssl=Používateľ je pripojený pomocou SSL
+session.row.cliked_ssl=Používateľ je pripojený pomocou TLS
 session.row.cliked_kill_session=Reláciu ukončíte kliknutím...
 session.row.confirm_close=Ste si istý, že chcete ukončiť túto reláciu?
 

--- a/i18n/src/main/resources/openfire_i18n_zh_CN.properties
+++ b/i18n/src/main/resources/openfire_i18n_zh_CN.properties
@@ -1174,7 +1174,7 @@ session.details.remote=远程
 # Session row Page
 
 session.row.cliked=单击可获得更多信息...
-session.row.cliked_ssl=用户是通过 SSL 连接的
+session.row.cliked_ssl=用户是通过 TLS 连接的
 session.row.cliked_kill_session=单击可杀死会话...
 session.row.confirm_close=确实要关闭此连接吗？
 
@@ -2400,3 +2400,5 @@ connection-mode.plain=纯文本（使用STARTSSL）
 connection-mode.legacy=加密（传统模式）
 connection-mode.unspecified=不指定
 group.edit.name=名称
+session.details.cipher=加密组件
+component.session.details.cipher=加密组件

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
@@ -29,6 +29,7 @@ import java.io.Closeable;
 import java.net.UnknownHostException;
 import java.security.cert.Certificate;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -37,8 +38,7 @@ import java.util.Set;
  * @author Iain Shigeoka
  */
 public interface Connection extends Closeable {
-
-    /**
+/**
      * When a connection is used to transmit an XML data, the root element of that data can define XML namespaces other
      * than the ones that are default (eg: 'jabber:client', 'jabber:server', etc). For an XML parser to be able to parse
      * stanzas or other elements that are defined in that namespace (eg: are prefixed), these namespaces are recorded
@@ -47,7 +47,6 @@ public interface Connection extends Closeable {
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2556">Issue OF-2556</a>
      */
     Set<Namespace> additionalNamespaces = new HashSet<>();
-
     /**
      * Verifies that the connection is still live. Typically this is done by
      * sending a whitespace character between packets.
@@ -206,8 +205,19 @@ public interface Connection extends Closeable {
      * Returns true if this connection is secure.
      *
      * @return true if the connection is secure (e.g. SSL/TLS)
+     * @deprecated Renamed. Use {@link #isEncrypted()} instead.
      */
+    @Deprecated // Remove in Openfire 4.9 or later.
     boolean isSecure();
+
+    /**
+     * Returns true if this connection is encrypted.
+     *
+     * @return true if the connection is encrypted (e.g. uses SSL/TLS)
+     */
+    default boolean isEncrypted() {
+        return isSecure();
+    }
 
     /**
      * Registers a listener for close event notification. Registrations after
@@ -312,9 +322,9 @@ public interface Connection extends Closeable {
 
     /**
      * Returns whether TLS is mandatory, optional or is disabled. When TLS is mandatory clients
-     * are required to secure their connections or otherwise their connections will be closed.
-     * On the other hand, when TLS is disabled clients are not allowed to secure their connections
-     * using TLS. Their connections will be closed if they try to secure the connection. in this
+     * are required to encrypt their connections or otherwise their connections will be closed.
+     * On the other hand, when TLS is disabled clients are not allowed to encrypt their connections
+     * using TLS. Their connections will be closed if they try to encrypt the connection. in this
      * last case.
      *
      * @return whether TLS is mandatory, optional or is disabled.
@@ -323,14 +333,28 @@ public interface Connection extends Closeable {
 
     /**
      * Sets whether TLS is mandatory, optional or is disabled. When TLS is mandatory clients
-     * are required to secure their connections or otherwise their connections will be closed.
-     * On the other hand, when TLS is disabled clients are not allowed to secure their connections
-     * using TLS. Their connections will be closed if they try to secure the connection. in this
+     * are required to encrypt their connections or otherwise their connections will be closed.
+     * On the other hand, when TLS is disabled clients are not allowed to encrypt their connections
+     * using TLS. Their connections will be closed if they try to encrypt the connection. in this
      * last case.
      *
      * @param tlsPolicy whether TLS is mandatory, optional or is disabled.
      */
     void setTlsPolicy(TLSPolicy tlsPolicy);
+
+    /**
+     * Returns the TLS protocol name used by the connection of the session, if any.
+     *
+     * @return a TLS protocol (version) name.
+     */
+    Optional<String> getTLSProtocolName();
+
+    /**
+     * Returns the TLS cipher suite name used by the connection of the session, if any.
+     *
+     * @return cipher suite name.
+     */
+    Optional<String> getCipherSuiteName();
 
     /**
      * Returns the packet deliverer to use when delivering a packet over the socket fails. The
@@ -343,7 +367,7 @@ public interface Connection extends Closeable {
     PacketDeliverer getPacketDeliverer();
 
     /**
-     * Secures the plain connection by negotiating TLS with the other peer. In a server-2-server
+     * Encrypts the plain connection by negotiating TLS with the other peer. In a server-2-server
      * connection the server requesting the TLS negotiation will be the client and the other server
      * will be the server during the TLS negotiation. Therefore, the server requesting the TLS
      * negotiation must pass <code>true</code> in the {@code clientMode} parameter and the server
@@ -354,7 +378,7 @@ public interface Connection extends Closeable {
      *
      * @param clientMode boolean indicating if this entity is a client or a server in the TLS negotiation.
      * @param directTLS boolean indicating if the negotiation is directTLS (true) or startTLS (false).
-     * @throws Exception if an error occured while securing the connection.
+     * @throws Exception if an error occurred while encrypting the connection.
      */
     void startTLS(boolean clientMode, boolean directTLS) throws Exception;
 
@@ -432,13 +456,13 @@ public interface Connection extends Closeable {
     enum TLSPolicy {
 
         /**
-         * TLS is required to interact with the server. Entities that do not secure their
+         * TLS is required to interact with the server. Entities that do not encrypt their
          * connections using TLS will get a stream error and their connections will be closed.
          */
         required,
 
         /**
-         * TLS is optional to interact with the server. Entities may or may not secure their
+         * TLS is optional to interact with the server. Entities may or may not encrypt their
          * connections using TLS.
          */
         optional,

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ConnectionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ConnectionManager.java
@@ -26,14 +26,14 @@ import org.jivesoftware.openfire.spi.ConnectionType;
 public interface ConnectionManager {
 
     /**
-     * The default XMPP port for clients. This port can be used with secured
-     * and unsecured connections. Clients will initially connect using an unsecure
-     * connection and may secure it by using StartTLS.
+     * The default XMPP port for clients. This port can be used with encrypted
+     * and unencrypted connections. Clients will initially connect using an unencrypted
+     * connection and may encrypt it by using StartTLS.
      */
     int DEFAULT_PORT = 5222;
     /**
-     * The default legacy Jabber port for SSL traffic. This old method, and soon
-     * to be deprecated, uses encrypted connections as soon as they are created.
+     * The default legacy Jabber port for Direct TLS traffic. This method uses connections that are encrypted as soon as
+     * they are created.
      */
     int DEFAULT_SSL_PORT = 5223;
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -445,7 +445,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
      * @param language The language to use for the session
      * @param wait The longest time it is permissible to wait for a response.
      * @param hold The maximum number of simultaneous waiting requests.
-     * @param isSecure True if all connections on this session should be secured, and false if they should not.
+     * @param isEncrypted True if all connections on this session should be encrypted, and false if they should not.
      * @param maxPollingInterval The max interval within which a client can send polling requests.
      * @param maxRequests The max number of requests it is permissible for the session to have open at any one time.
      * @param maxPause The maximum length of a temporary session pause (in seconds) that the client MAY request.
@@ -457,7 +457,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
      * @throws UnknownHostException if no IP address for the peer could be found,
      */
     public HttpSession createClientHttpSession(StreamID id, HttpConnection connection, Locale language, Duration wait,
-                                               int hold, boolean isSecure, Duration maxPollingInterval,
+                                               int hold, boolean isEncrypted, Duration maxPollingInterval,
                                                int maxRequests, Duration maxPause, Duration defaultInactivityTimeout,
                                                int majorVersion, int minorVersion)
         throws UnauthorizedException, UnknownHostException
@@ -468,7 +468,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
 
         final PacketDeliverer backupDeliverer = ClientConnectionHandler.BACKUP_PACKET_DELIVERY_ENABLED.getValue() ? new OfflinePacketDeliverer() : null;
         final HttpSession.HttpVirtualConnection vConnection = new HttpSession.HttpVirtualConnection(connection.getRemoteAddr(), backupDeliverer, ConnectionType.SOCKET_C2S);
-        final HttpSession session = new HttpSession(vConnection, serverName, id, connection.getRequestId(), connection.getPeerCertificates(), language, wait, hold, isSecure,
+        final HttpSession session = new HttpSession(vConnection, serverName, id, connection.getRequestId(), connection.getPeerCertificates(), language, wait, hold, isEncrypted,
                                               maxPollingInterval, maxRequests, maxPause, defaultInactivityTimeout, majorVersion, minorVersion);
         vConnection.init(session);
         vConnection.registerCloseListener(clientSessionListener, session);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
@@ -515,26 +515,26 @@ public class AdminConsolePlugin implements Plugin {
                 XMPPServer.getInstance().getServerInfo().getXMPPDomain() :
                 getBindInterface();
         boolean isPlainStarted = false;
-        boolean isSecureStarted = false;
+        boolean isEncryptedStarted = false;
 
         for (Connector connector : adminServer.getConnectors()) {
             if (((ServerConnector) connector).getPort() == adminPort) {
                 isPlainStarted = true;
             }
             else if (((ServerConnector) connector).getPort() == adminSecurePort) {
-                isSecureStarted = true;
+                isEncryptedStarted = true;
             }
 
         }
 
-        if (isPlainStarted && isSecureStarted) {
+        if (isPlainStarted && isEncryptedStarted) {
             log(listening + ":" + System.getProperty("line.separator") +
                     "  http://" + hostname + ":" +
                     adminPort + System.getProperty("line.separator") +
                     "  https://" + hostname + ":" +
                     adminSecurePort);
         }
-        else if (isSecureStarted) {
+        else if (isEncryptedStarted) {
             log(listening + " https://" + hostname + ":" + adminSecurePort);
         }
         else if (isPlainStarted) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpConnection.java
@@ -110,11 +110,19 @@ public class HttpConnection {
     }
 
     /**
+     * @deprecated Renamed. See {@link #isEncrypted()}
+     */
+    @Deprecated // Remove in Openfire 4.9 or later.
+    public boolean isSecure() {
+        return isEncrypted();
+    }
+
+    /**
      * Returns true if this connection is using HTTPS.
      *
      * @return true if this connection is using HTTPS.
      */
-    public boolean isSecure() {
+    public boolean isEncrypted() {
         return context.getRequest().isSecure();
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
@@ -208,7 +208,7 @@ public class HttpSessionManager {
             defaultInactivityTimeout = INACTIVITY_TIMEOUT.getValue();
         }
         HttpSession session = createSession(connection, Locale.forLanguageTag(body.getLanguage()), wait, body.getHold(),
-            connection.isSecure(), POLLING_INTERVAL.getValue(), MAX_REQUESTS.getValue(), MAX_PAUSE.getValue(),
+            connection.isEncrypted(), POLLING_INTERVAL.getValue(), MAX_REQUESTS.getValue(), MAX_PAUSE.getValue(),
             defaultInactivityTimeout, body.getMajorVersion(), body.getMinorVersion());
 
         session.resetInactivityTimeout();
@@ -310,14 +310,14 @@ public class HttpSessionManager {
         .build();
 
     private HttpSession createSession(HttpConnection connection, Locale language, Duration wait,
-                                      int hold, boolean isSecure, Duration maxPollingInterval,
+                                      int hold, boolean isEncrypted, Duration maxPollingInterval,
                                       int maxRequests, Duration maxPause, Duration defaultInactivityTimeout,
                                       int majorVersion, int minorVersion) throws UnauthorizedException, UnknownHostException
     {
         // Create a ClientSession for this user.
         StreamID streamID = SessionManager.getInstance().nextStreamID();
         // Send to the server that a new client session has been created
-        HttpSession session = sessionManager.createClientHttpSession(streamID, connection, language, wait, hold, isSecure,
+        HttpSession session = sessionManager.createClientHttpSession(streamID, connection, language, wait, hold, isEncrypted,
                                                                      maxPollingInterval, maxRequests, maxPause,
                                                                      defaultInactivityTimeout, majorVersion, minorVersion);
         // Register that the new session is associated with the specified stream ID

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
@@ -31,6 +31,7 @@ import org.xmpp.packet.StreamError;
 import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Optional;
 
 /**
  * Represents a connection of a Client Session that was established to a Connection Manager.
@@ -113,6 +114,16 @@ public class ClientSessionConnection extends VirtualConnection {
             // Deliver the wrapped stanza
             multiplexerSession.deliverRawText(sb.toString());
         }
+    }
+
+    @Override
+    public Optional<String> getTLSProtocolName() {
+        return Optional.of("unknown");
+    }
+
+    @Override
+    public Optional<String> getCipherSuiteName() {
+        return Optional.of("unknown");
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -221,7 +221,7 @@ public class SASLAuthentication {
         for (String mech : getSupportedMechanisms()) {
             if (mech.equals("EXTERNAL")) {
                 boolean trustedCert = false;
-                if (session.isSecure()) {
+                if (session.isEncrypted()) {
                     final Connection connection = ( (LocalClientSession) session ).getConnection();
                     assert connection != null; // While the client is performing a SASL negotiation, the connection can't be null.
                     if ( SKIP_PEER_CERT_REVALIDATION_CLIENT.getValue() ) {
@@ -252,7 +252,7 @@ public class SASLAuthentication {
     public static Element getSASLMechanismsElement( LocalIncomingServerSession session )
     {
         final Element result = DocumentHelper.createElement( new QName( "mechanisms", new Namespace( "", SASL_NAMESPACE ) ) );
-        if (session.isSecure()) {
+        if (session.isEncrypted()) {
             final Connection connection   = session.getConnection();
             final TrustStore trustStore   = connection.getConfiguration().getTrustStore();
             final X509Certificate trusted = trustStore.getEndEntityCertificate( session.getConnection().getPeerCertificates() );

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
@@ -256,13 +256,13 @@ public abstract class SocketReader implements Runnable {
      * another thread.
      *
      * @param packet the received packet.
-     * @throws UnauthorizedException if the connection required security but was not secured.
+     * @throws UnauthorizedException if the connection required encryption but was not encrypted.
      */
     protected void processIQ(IQ packet) throws UnauthorizedException {
-        // Ensure that connection was secured if TLS was required
+        // Ensure that connection was encrypted if TLS was required.
         if (connection.getTlsPolicy() == Connection.TLSPolicy.required &&
-                !connection.isSecure()) {
-            closeNeverSecuredConnection();
+                !connection.isEncrypted()) {
+            closeNeverEncryptedConnection();
             return;
         }
         router.route(packet);
@@ -279,13 +279,13 @@ public abstract class SocketReader implements Runnable {
      * another thread.
      *
      * @param packet the received packet.
-     * @throws UnauthorizedException if the connection required security but was not secured.
+     * @throws UnauthorizedException if the connection required encryption but was not encrypted.
      */
     protected void processPresence(Presence packet) throws UnauthorizedException {
-        // Ensure that connection was secured if TLS was required
+        // Ensure that connection was encrypted if TLS was required
         if (connection.getTlsPolicy() == Connection.TLSPolicy.required &&
-                !connection.isSecure()) {
-            closeNeverSecuredConnection();
+                !connection.isEncrypted()) {
+            closeNeverEncryptedConnection();
             return;
         }
         router.route(packet);
@@ -302,13 +302,13 @@ public abstract class SocketReader implements Runnable {
      * another thread.
      *
      * @param packet the received packet.
-     * @throws UnauthorizedException if the connection required security but was not secured.
+     * @throws UnauthorizedException if the connection required encryption but was not encryption.
      */
     protected void processMessage(Message packet) throws UnauthorizedException {
-        // Ensure that connection was secured if TLS was required
+        // Ensure that connection was encrypted if TLS was required
         if (connection.getTlsPolicy() == Connection.TLSPolicy.required &&
-                !connection.isSecure()) {
-            closeNeverSecuredConnection();
+                !connection.isEncrypted()) {
+            closeNeverEncryptedConnection();
             return;
         }
         router.route(packet);
@@ -345,8 +345,19 @@ public abstract class SocketReader implements Runnable {
     /**
      * Close the connection since TLS was mandatory and the entity never negotiated TLS. Before
      * closing the connection a stream error will be sent to the entity.
+     *
+     * @deprecated Renamed. Use {@link #closeNeverEncryptedConnection()} instead.
      */
+    @Deprecated // Remove in Openfire 4.9 or later.
     void closeNeverSecuredConnection() {
+        closeNeverEncryptedConnection();
+    }
+
+    /**
+     * Close the connection since TLS was mandatory and the entity never negotiated TLS. Before
+     * closing the connection a stream error will be sent to the entity.
+     */
+    void closeNeverEncryptedConnection() {
         // Send a stream error and close the underlying connection.
         connection.close(new StreamError(StreamError.Condition.not_authorized, "TLS is mandatory, but was not established."));
         // Log a warning so that admins can track this case from the server side
@@ -394,9 +405,9 @@ public abstract class SocketReader implements Runnable {
      * first packet. A call to next() should result in an START_TAG state with
      * the first packet in the stream.
      *
-     * @throws UnauthorizedException if the connection required security but was not secured.
+     * @throws UnauthorizedException if the connection required encryption but was not encrypted.
      * @throws XmlPullParserException if there was an XML error while creating the session.
-     * @throws IOException if an IO error occured while creating the session.
+     * @throws IOException if an IO error occurred while creating the session.
      */
     protected void createSession()
             throws UnauthorizedException, XmlPullParserException, IOException {
@@ -428,7 +439,7 @@ public abstract class SocketReader implements Runnable {
         }
 
         // Create the correct session based on the sent namespace. At this point the server
-        // may offer the client to secure the connection. If the client decides to secure
+        // may offer the client to encrypt the connection. If the client decides to encrypt
         // the connection then a <starttls> stanza should be received
         else if (!createSession(xpp.getNamespace(null))) {
             // No session was created because of an invalid namespace prefix so answer a stream
@@ -499,7 +510,7 @@ public abstract class SocketReader implements Runnable {
      *
      * @param namespace the namespace sent in the stream element. eg. jabber:client.
      * @return the created session or null.
-     * @throws UnauthorizedException if the connection required security but was not secured.
+     * @throws UnauthorizedException if the connection required encryption but was not encrypted.
      * @throws XmlPullParserException if there was an XML error while creating the session.
      * @throws IOException if an IO error occured while creating the session.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReadingMode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReadingMode.java
@@ -57,11 +57,11 @@ abstract class SocketReadingMode {
     abstract void run();
 
     /**
-     * Tries to secure the connection using TLS. If the connection is secured then reset
-     * the parser to use the new secured reader. But if the connection failed to be secured
+     * Tries to encrypt the connection using TLS. If the connection is encrypted then reset
+     * the parser to use the new encrypted reader. But if the connection failed to be encrypted
      * then send a <failure> stanza and close the connection.
      *
-     * @return true if the connection was secured.
+     * @return true if the connection was encryped.
      */
     protected boolean negotiateTLS() {
         if (socketReader.connection.getTlsPolicy() == Connection.TLSPolicy.disabled) {
@@ -71,7 +71,7 @@ abstract class SocketReadingMode {
             Log.warn("TLS requested by initiator when TLS was never offered by server. Closing connection: {}", socketReader.connection);
             return false;
         }
-        // Client requested to secure the connection using TLS. Negotiate TLS.
+        // Client requested to encrypt the connection using TLS. Negotiate TLS.
         try {
             // This code is only used for s2s
             socketReader.connection.startTLS(false, false);
@@ -116,10 +116,10 @@ abstract class SocketReadingMode {
 
     protected boolean authenticateClient(Element doc) throws DocumentException, IOException,
             XmlPullParserException {
-        // Ensure that connection was secured if TLS was required
+        // Ensure that connection was encrypted if TLS was required
         if (socketReader.connection.getTlsPolicy() == Connection.TLSPolicy.required &&
-                !socketReader.connection.isSecure()) {
-            socketReader.closeNeverSecuredConnection();
+                !socketReader.connection.isEncrypted()) {
+            socketReader.closeNeverEncryptedConnection();
             return false;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
@@ -40,7 +40,7 @@ import java.util.List;
 
 /**
  * TLSStreamHandler is responsible for securing plain connections by negotiating TLS. By creating
- * a new instance of this class the plain connection will be secured.
+ * a new instance of this class the plain connection will be encrypted.
  *
  * @author Hao Chen
  */
@@ -88,12 +88,12 @@ public class TLSStreamHandler {
     private static ByteBuffer hsBB = ByteBuffer.allocate(0);
 
     /**
-     * Creates a new TLSStreamHandler and secures the plain socket connection. When connecting
+     * Creates a new TLSStreamHandler and encrypt the plain socket connection. When connecting
      * to a remote server then {@code clientMode} will be <code>true</code> and
      * {@code remoteServer} is the server name of the remote server. Otherwise {@code clientMode}
      * will be <code>false</code> and  {@code remoteServer} null.
      *
-     * @param socket the plain socket connection to secure
+     * @param socket the plain socket connection to encrypt
      * @param configuration the configuration for the connection
      * @param clientMode boolean indicating if this entity is a client or a server.
      * @throws java.io.IOException if an exception occurs

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSWrapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSWrapper.java
@@ -36,7 +36,7 @@ import java.security.UnrecoverableKeyException;
 import java.util.Arrays;
 
 /**
- * Creates and initializes the SSLContext instance to use to secure the plain connection. This
+ * Creates and initializes the SSLContext instance to use to encrypt the plain connection. This
  * class is also responsible for encoding and decoding the encrypted data and place it into
  * the corresponding the {@link ByteBuffer}.
  *

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -145,7 +145,13 @@ public abstract class VirtualConnection implements Connection {
     }
 
     @Override
+    @Deprecated // Remove in Openfire 4.9 or later.
     public boolean isSecure() {
+        return isEncrypted();
+    }
+
+    @Override
+    public boolean isEncrypted() {
         // Return false since TLS is not used for virtual connections
         return false;
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NIOConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NIOConnection.java
@@ -49,6 +49,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -198,6 +199,18 @@ public class NIOConnection implements Connection {
     }
 
     @Override
+    public Optional<String> getTLSProtocolName() {
+        return Optional.ofNullable((SSLSession) ioSession.getAttribute(SslFilter.SSL_SECURED))
+            .map(SSLSession::getProtocol);
+    }
+
+    @Override
+    public Optional<String> getCipherSuiteName() {
+        return Optional.ofNullable((SSLSession) ioSession.getAttribute(SslFilter.SSL_SECURED))
+            .map(SSLSession::getCipherSuite);
+    }
+
+    @Override
     public void setUsingSelfSignedCertificate(boolean isSelfSigned) {
         this.usingSelfSignedCertificate = isSelfSigned;
     }
@@ -304,7 +317,13 @@ public class NIOConnection implements Connection {
     }
 
     @Override
+    @Deprecated // Remove in Openfire 4.9 or later.
     public boolean isSecure() {
+        return isEncrypted();
+    }
+
+    @Override
+    public boolean isEncrypted() {
         return ioSession.getFilterChain().contains(TLS_FILTER_NAME);
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -483,7 +483,7 @@ public class ServerDialback {
 
         log.debug( "Validating domain...");
         if (connection.getTlsPolicy() == Connection.TLSPolicy.required &&
-                !connection.isSecure()) {
+                !connection.isEncrypted()) {
             connection.deliverRawText(new StreamError(StreamError.Condition.policy_violation).toXML());
             // Close the underlying connection
             connection.close();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -264,7 +264,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
         final ConnectionConfiguration connectionConfiguration = connection.getConfiguration();
 
         // Indicate the TLS policy to use for this connection
-        if (!connection.isSecure()) {
+        if (!connection.isEncrypted()) {
             boolean hasCertificates = false;
             try {
                 hasCertificates = connectionConfiguration.getIdentityStore().getAllCertificates().size() > 0;
@@ -803,8 +803,8 @@ public class LocalClientSession extends LocalSession implements ClientSession {
     @Override
     public String getAvailableStreamFeatures() {
         // Offer authenticate and registration only if TLS was not required or if required
-        // then the connection is already secured
-        if (conn.getTlsPolicy() == Connection.TLSPolicy.required && !conn.isSecure()) {
+        // then the connection is already encrypted
+        if (conn.getTlsPolicy() == Connection.TLSPolicy.required && !conn.isEncrypted()) {
             return null;
         }
 
@@ -949,7 +949,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
             (getStatus() == STATUS_AUTHENTICATED ? " (authenticated)" : "" ) +
             (getStatus() == STATUS_CONNECTED ? " (connected)" : "" ) +
             (getStatus() == STATUS_CLOSED ? " (closed)" : "" ) +
-            ", isSecure=" + isSecure() +
+            ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
             ", serverName='" + getServerName() + '\'' +
             ", isInitialized=" + isInitialized() +

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
@@ -438,7 +438,7 @@ public class LocalComponentSession extends LocalSession implements ComponentSess
             (getStatus() == STATUS_AUTHENTICATED ? " (authenticated)" : "" ) +
             (getStatus() == STATUS_CONNECTED ? " (connected)" : "" ) +
             (getStatus() == STATUS_CLOSED ? " (closed)" : "" ) +
-            ", isSecure=" + isSecure() +
+            ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
             ", serverName='" + getServerName() + '\'' +
             ", defaultSubdomain='" + defaultSubdomain + '\'' +

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
@@ -183,7 +183,7 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
 
     @Override
     public String getAvailableStreamFeatures() {
-        if (conn.getTlsPolicy() == Connection.TLSPolicy.required && !conn.isSecure()) {
+        if (conn.getTlsPolicy() == Connection.TLSPolicy.required && !conn.isEncrypted()) {
             return null;
         }
 
@@ -322,7 +322,7 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
             (getStatus() == STATUS_AUTHENTICATED ? " (authenticated)" : "" ) +
             (getStatus() == STATUS_CONNECTED ? " (connected)" : "" ) +
             (getStatus() == STATUS_CLOSED ? " (closed)" : "" ) +
-            ", isSecure=" + isSecure() +
+            ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
             ", serverName='" + getServerName() + '\'' +
             '}';

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -397,7 +397,7 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
             (getStatus() == STATUS_AUTHENTICATED ? " (authenticated)" : "" ) +
             (getStatus() == STATUS_CONNECTED ? " (connected)" : "" ) +
             (getStatus() == STATUS_CLOSED ? " (closed)" : "" ) +
-            ", isSecure=" + isSecure() +
+            ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
             ", isUsingServerDialback=" + isUsingServerDialback() +
             ", localDomain=" + getLocalDomain() +

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalServerSession.java
@@ -90,7 +90,7 @@ public class LocalServerSession extends LocalSession implements ServerSession {
             (getStatus() == STATUS_AUTHENTICATED ? " (authenticated)" : "" ) +
             (getStatus() == STATUS_CONNECTED ? " (connected)" : "" ) +
             (getStatus() == STATUS_CLOSED ? " (closed)" : "" ) +
-            ", isSecure=" + isSecure() +
+            ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
             ", isUsingServerDialback=" + isUsingServerDialback() +
             '}';

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
@@ -114,6 +114,11 @@ public abstract class RemoteSession implements Session {
         return clusterTaskResult == null ? -1 : (Long) clusterTaskResult;
     }
 
+    public String getTLSProtocolName() {
+        ClusterTask<Object> task = getRemoteSessionTask(RemoteSessionTask.Operation.getTLSProtocolName);
+        return (String) doSynchronousClusterTask(task);
+    }
+
     public String getCipherSuiteName() {
         ClusterTask<Object> task = getRemoteSessionTask(RemoteSessionTask.Operation.getCipherSuiteName);
         return (String) doSynchronousClusterTask(task);
@@ -143,8 +148,13 @@ public abstract class RemoteSession implements Session {
         return clusterTaskResult == null ? false : (Boolean) clusterTaskResult;
     }
 
+    @Deprecated // Remove in Openfire 4.9 or later.
     public boolean isSecure() {
-        ClusterTask<Object> task = getRemoteSessionTask(RemoteSessionTask.Operation.isSecure);
+        return isEncrypted();
+    }
+
+    public boolean isEncrypted() {
+        ClusterTask<Object> task = getRemoteSessionTask(RemoteSessionTask.Operation.isEncrypted);
         final Object clusterTaskResult = doSynchronousClusterTask(task);
         return clusterTaskResult == null ? false : (Boolean) clusterTaskResult;
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
@@ -72,6 +72,9 @@ public abstract class RemoteSessionTask implements ClusterTask<Object> {
         else if (operation == Operation.getNumServerPackets) {
             result = getSession().getNumServerPackets();
         }
+        else if (operation == Operation.getTLSProtocolName) {
+            result = getSession().getTLSProtocolName();
+        }
         else if (operation == Operation.getCipherSuiteName) {
             result = getSession().getCipherSuiteName();
         }
@@ -110,8 +113,8 @@ public abstract class RemoteSessionTask implements ClusterTask<Object> {
         else if (operation == Operation.isClosed) {
             result = getSession().isClosed();
         }
-        else if (operation == Operation.isSecure) {
-            result = getSession().isSecure();
+        else if (operation == Operation.isEncrypted) {
+            result = getSession().isEncrypted();
         }
         else if (operation == Operation.getHostAddress) {
             try {
@@ -155,12 +158,14 @@ public abstract class RemoteSessionTask implements ClusterTask<Object> {
         getLastActiveDate,
         getNumClientPackets,
         getNumServerPackets,
+        getTLSProtocolName,
         getCipherSuiteName,
         getPeerCertificates,
         getSoftwareVersion,
         close,
         isClosed,
-        isSecure,
+        @Deprecated isSecure, // Replaced with 'isEncrypted', replace in Openfire 4.9 or later.
+        isEncrypted,
         getHostAddress,
         getHostName,
         validate,

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
@@ -21,6 +21,8 @@ import org.jivesoftware.openfire.StreamID;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Packet;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.UnknownHostException;
 import java.security.cert.Certificate;
 import java.util.Date;
@@ -131,8 +133,19 @@ public interface Session extends RoutableChannelHandler {
      * Returns true if this connection is secure.
      *
      * @return true if the connection is secure (e.g. SSL/TLS)
+     * @deprecated Renamed. Use {@link #isEncrypted()} instead.
      */
+    @Deprecated // Remove in Openfire 4.9 or later.
     boolean isSecure();
+
+    /**
+     * Returns true if this session uses encrypted connections.
+     *
+     * @return true if the session is encrypted (e.g. SSL/TLS)
+     */
+    default boolean isEncrypted() {
+        return isSecure();
+    }
 
     /**
      * Returns the peer certificates associated with this session, if any.
@@ -202,12 +215,25 @@ public interface Session extends RoutableChannelHandler {
      * @return true if the socket remains valid, false otherwise.
      */
     boolean validate();
-    
+
     /**
-     * Returns the TLS cipher suite name, if any.
+     * Returns the TLS protocol name used by the connection of the session, if any.
+     *
      * Always returns a valid string, though the string may be "NONE"
+     *
+     * @return a TLS protocol (version) name.
+     */
+    @Nonnull
+    String getTLSProtocolName();
+
+    /**
+     * Returns the TLS cipher suite name used by the connection of the session, if any.
+     *
+     * Always returns a valid string, though the string may be "NONE"
+     *
      * @return cipher suite name.
      */
+    @Nonnull
     String getCipherSuiteName();
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionConfiguration.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionConfiguration.java
@@ -146,9 +146,9 @@ public class ConnectionConfiguration
 
     /**
      * A boolean that indicates if the current validity of certificates (based on their 'notBefore' and 'notAfter'
-     * property values) is used when they are used to establish an encrypted connection..
+     * property values) is used when they are used to establish an encrypted connection.
      *
-     * @return true when certificates are required to be valid to establish a secured connection, otherwise false.
+     * @return true when certificates are required to be valid to establish an encrypted connection, otherwise false.
      */
     public boolean isVerifyCertificateValidity()
     {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -760,9 +760,9 @@ public class ConnectionListener
 
     /**
      * A boolean that indicates if the current validity of certificates (based on their 'notBefore' and 'notAfter'
-     * property values) is used when they are used to establish an encrypted connection..
+     * property values) is used when they are used to establish an encrypted connection.
      *
-     * @return true when certificates are required to be valid to establish a secured connection, otherwise false.
+     * @return true when certificates are required to be valid to establish a encrypted connection, otherwise false.
      */
     public boolean verifyCertificateValidity()
     {
@@ -782,9 +782,9 @@ public class ConnectionListener
 
     /**
      * Configures if the current validity of certificates (based on their 'notBefore' and 'notAfter' property values) is
-     * used when they are used to establish an encrypted connection..
+     * used when they are used to establish an encrypted connection.
      *
-     * @param verify true when certificates are required to be valid to establish a secured connection, otherwise false.
+     * @param verify true when certificates are required to be valid to establish a encrypted connection, otherwise false.
      */
     public void setVerifyCertificateValidity( boolean verify )
     {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
@@ -32,6 +32,7 @@ import org.xmpp.packet.StreamError;
 
 import javax.annotation.Nullable;
 import java.net.InetSocketAddress;
+import java.util.Optional;
 
 /**
  * Following the conventions of the BOSH implementation, this class extends {@link VirtualConnection}
@@ -116,8 +117,14 @@ public class WebSocketConnection extends VirtualConnection
     }
 
     @Override
+    @Deprecated // Remove in Openfire 4.9 or later.
     public boolean isSecure() {
-        return socket.isWebSocketSecure();
+        return isEncrypted();
+    }
+
+    @Override
+    public boolean isEncrypted() {
+        return socket.isWebSocketEncrypted();
     }
 
     @Override
@@ -138,6 +145,16 @@ public class WebSocketConnection extends VirtualConnection
     @Override
     public boolean isCompressed() {
         return XmppWebSocket.isCompressionEnabled();
+    }
+
+    @Override
+    public Optional<String> getTLSProtocolName() {
+        return Optional.ofNullable(this.socket.getTLSProtocolName());
+    }
+
+    @Override
+    public Optional<String> getCipherSuiteName() {
+        return Optional.ofNullable(this.socket.getCipherSuiteName());
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
@@ -183,8 +183,21 @@ public class XmppWebSocket {
         return wsSession != null && wsSession.isOpen();
     }
 
+    @Deprecated // Remove in Openfire 4.9 or later.
     synchronized boolean isWebSocketSecure() {
+        return isWebSocketEncrypted();
+    }
+
+    synchronized boolean isWebSocketEncrypted() {
         return wsSession != null && wsSession.isSecure();
+    }
+
+    synchronized String getTLSProtocolName() {
+        return wsSession == null ? null : wsSession.getProtocolVersion();
+    }
+
+    synchronized String getCipherSuiteName() {
+        return wsSession == null ? null : "unknown";
     }
 
     synchronized void closeWebSocket()

--- a/xmppserver/src/main/java/org/jivesoftware/util/EmailService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/EmailService.java
@@ -434,8 +434,8 @@ public class EmailService {
         mailProps.setProperty("mail.debug", String.valueOf(debugEnabled));
 
         // Methology from an article on www.javaworld.com (Java Tip 115)
-        // We will attempt to failback to an insecure connection
-        // if the secure one cannot be made
+        // We will attempt to failback to an unencrypted connection
+        // if the encrypted one cannot be made
         if (sslEnabled) {
             // Register with security provider.
             Security.setProperty("ssl.SocketFactory.provider", SSL_FACTORY);

--- a/xmppserver/src/main/webapp/component-session-details.jsp
+++ b/xmppserver/src/main/webapp/component-session-details.jsp
@@ -91,6 +91,24 @@
             <c:out value="${componentSession.address}"/>
         </td>
     </tr>
+    <% if (componentSession.isEncrypted()) { %>
+    <tr>
+        <td class="c1">
+            <fmt:message key="component.session.details.tls_version" />:
+        </td>
+        <td>
+            <%=StringUtils.escapeHTMLTags(componentSession.getTLSProtocolName())%>
+        </td>
+    </tr>
+    <tr>
+        <td class="c1">
+            <fmt:message key="component.session.details.cipher" />:
+        </td>
+        <td>
+            <%=StringUtils.escapeHTMLTags(componentSession.getCipherSuiteName())%>
+        </td>
+    </tr>
+    <% } %>
     <tr>
         <td class="c1">
             <fmt:message key="component.session.label.name" />

--- a/xmppserver/src/main/webapp/component-session-summary.jsp
+++ b/xmppserver/src/main/webapp/component-session-summary.jsp
@@ -194,11 +194,11 @@
             <a href="component-session-details.jsp?jid=<%= URLEncoder.encode(componentSession.getAddress().toString(), "UTF-8") %>" title="<fmt:message key="session.row.cliked" />"><%= componentSession.getAddress() %></a>
         </td>
         <td style="width: 1%">
-            <%  if (componentSession.isSecure()) {
+            <%  if (componentSession.isEncrypted()) {
                 if (componentSession.getPeerCertificates() != null && componentSession.getPeerCertificates().length > 0) { %>
             <img src="images/lock_both.gif" title="<fmt:message key='session.row.cliked_ssl' /> (mutual authentication)" alt="<fmt:message key='session.row.cliked_ssl' /> (mutual authentication)">
             <%      } else { %>
-            <img src="images/lock.gif" title="<fmt:message key='session.row.cliked_ssl' />" alt="<fmt:message key='session.row.cliked_ssl' />">
+            <img src="images/lock.gif" title="<fmt:message key='session.row.cliked_ssl' />: <%= componentSession.getTLSProtocolName() + " (" + componentSession.getCipherSuiteName() +")" %>" alt="<fmt:message key='session.row.cliked_ssl' />: <%= componentSession.getTLSProtocolName() + " (" + componentSession.getCipherSuiteName() +")" %>">
             <%      }
             } else { %>
             <img src="images/blank.gif" width="1" height="1" alt="">

--- a/xmppserver/src/main/webapp/server-session-details.jsp
+++ b/xmppserver/src/main/webapp/server-session-details.jsp
@@ -221,6 +221,7 @@
                                 <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.details.node"/></th>
                             </c:if>
                             <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.authentication"/></th>
+                            <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.tls_version"/></th>
                             <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.cipher"/></th>
                             <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.label.creation" /></th>
                             <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.label.last_active" /></th>
@@ -262,6 +263,7 @@
                                             <fmt:message key="server.session.details.tlsauth"/>
                                         </c:otherwise>
                                     </c:choose>
+                                <td><c:out value="${session.TLSProtocolName}"/></td>
                                 <td><c:out value="${session.cipherSuiteName}"/></td>
                                 <td nowrap><fmt:formatDate type="both" value="${session.creationDate}"/></td>
                                 <td nowrap><fmt:formatDate type="both" value="${session.lastActiveDate}"/></td>
@@ -281,6 +283,7 @@
                                 <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.details.node"/></th>
                             </c:if>
                             <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.authentication"/></th>
+                            <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.tls_version"/></th>
                             <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.cipher"/></th>
                             <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.label.creation" /></th>
                             <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.label.last_active" /></th>
@@ -322,6 +325,7 @@
                                         <fmt:message key="server.session.details.tlsauth"/>
                                     </c:otherwise>
                                     </c:choose>
+                                <td><c:out value="${session.TLSProtocolName}"/></td>
                                 <td><c:out value="${session.cipherSuiteName}"/></td>
                                 <td nowrap><fmt:formatDate type="both" value="${session.creationDate}"/></td>
                                 <td nowrap><fmt:formatDate type="both" value="${session.lastActiveDate}"/></td>

--- a/xmppserver/src/main/webapp/server-session-row.jspf
+++ b/xmppserver/src/main/webapp/server-session-row.jspf
@@ -19,23 +19,30 @@
  --%>
 
 <% // Show the secured icon only if ALL sessions are secure
-    boolean isSecured = true;
+    boolean isEncrypted = true;
+    Set<String> tlsProtocolNames = new HashSet<>();
+    Set<String> cipherSuiteNames = new HashSet<>();
     // Check if all incoming sessions are secured
     for (org.jivesoftware.openfire.session.IncomingServerSession inSession : inSessions) {
-        if (!inSession.isSecure()) {
-            isSecured = false;
+        if (!inSession.isEncrypted()) {
+            isEncrypted = false;
             break;
         }
+        tlsProtocolNames.add(inSession.getTLSProtocolName());
+        cipherSuiteNames.add(inSession.getCipherSuiteName());
     }
     // Check if outgoing session is secured (only if incoming sessions are secured)
-    if (isSecured) {
+    if (isEncrypted) {
         for (org.jivesoftware.openfire.session.OutgoingServerSession outSession : outSessions) {
-            if (!outSession.isSecure()) {
-                isSecured = false;
+            if (!outSession.isEncrypted()) {
+                isEncrypted = false;
                 break;
             }
+            tlsProtocolNames.add(outSession.getTLSProtocolName());
+            cipherSuiteNames.add(outSession.getCipherSuiteName());
         }
     }
+    String isEncryptedAltText = isEncrypted ? String.join(", ", tlsProtocolNames) + " - " + String.join(", ", cipherSuiteNames): "";
 %>
 <tr>
     <td style="width: 1%; white-space: nowrap"><%= count %></td>
@@ -47,9 +54,9 @@
             </tr>
         </table>
     </td>
-    <%  if (isSecured) { %>
+    <%  if (isEncrypted) { %>
     <td style="width: 1%">
-        <img src="images/lock.gif" alt="">
+        <img src="images/lock.gif" alt="<%=isEncryptedAltText%>">
     </td>
      <% } else { %>
     <td style="width: 1%"><img src="images/blank.gif" width="1" height="1" alt=""></td>

--- a/xmppserver/src/main/webapp/session-details.jsp
+++ b/xmppserver/src/main/webapp/session-details.jsp
@@ -294,6 +294,24 @@
             %>
         </td>
     </tr>
+    <% if (currentSess.isEncrypted()) { %>
+    <tr>
+        <td class="c1">
+            <fmt:message key="session.details.tls_version" />:
+        </td>
+        <td>
+            <%=StringUtils.escapeHTMLTags(currentSess.getTLSProtocolName())%>
+        </td>
+    </tr>
+    <tr>
+        <td class="c1">
+            <fmt:message key="session.details.cipher" />:
+        </td>
+        <td>
+            <%=StringUtils.escapeHTMLTags(currentSess.getCipherSuiteName())%>
+        </td>
+    </tr>
+    <% } %>
     <tr>
         <td class="c1">
             <fmt:message key="session.details.presence" />:

--- a/xmppserver/src/main/webapp/session-row.jspf
+++ b/xmppserver/src/main/webapp/session-row.jspf
@@ -85,11 +85,11 @@
     <td style="width: 1%">
         <%  if (isDetached) { %>
                     <img src="images/working-16x16.gif" width="1" height="1" alt="">
-        <%  } else if (sess.isSecure()) {
+        <%  } else if (sess.isEncrypted()) {
                 if (sess.getPeerCertificates() != null && sess.getPeerCertificates().length > 0) { %>
                     <img src="images/lock_both.gif" title="<fmt:message key='session.row.cliked_ssl' /> (mutual authentication)" alt="<fmt:message key='session.row.cliked_ssl' /> (mutual authentication)">
         <%      } else { %>
-                    <img src="images/lock.gif" title="<fmt:message key='session.row.cliked_ssl' />" alt="<fmt:message key='session.row.cliked_ssl' />">
+                    <img src="images/lock.gif" title="<fmt:message key='session.row.cliked_ssl' />: <%= sess.getTLSProtocolName() + " (" + sess.getCipherSuiteName() +")" %>" alt="<fmt:message key='session.row.cliked_ssl' />: <%= sess.getTLSProtocolName() + " (" + sess.getCipherSuiteName() +")" %>">
         <%      }
             } else { %>
                     <img src="images/blank.gif" width="1" height="1" alt="">


### PR DESCRIPTION
The cipher suite used for encryption is currently exposed (and shown on the admin console) only for S2S sessions, but should be exposed for all session types.

Similarly, lets expose the TLS version that is being used (to complement the cipher suite). This will be useful to diagnose the TLS configuration for each session type.

Implementation-wise, the TLS characteristics should be exposed by Connections, not by Session objects.

Confusingly, Openfire refers to ‘securing’ a connection, which could refer to authentication or encryption. Rename to ‘encrypt’ where appropriate.