### PR TITLE
OF-1112: Switch to MINA for inbound S2S

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1660,6 +1660,7 @@ system_property.xmpp.auth.ssl.context_protocol=The TLS protocol to use for encry
 system_property.xmpp.socket.ssl.active=Set to true to enable legacy encrypted connections for clients, otherwise false
 system_property.xmpp.component.ssl.active=Set to true to enable legacy encrypted connections for external components, otherwise false
 system_property.xmpp.server.startup.retry.delay=Set to a positive value to allow a retry of a failed startup after the specified duration.
+system_property.xmpp.server.enable-old-io=When true, switches Openfire back to using the legacy network IO implementation for server-to-server communication.
 system_property.sasl.realm=The realm used for SASL authentication, which can be used when realms that are passed through SASL are different from the XMPP domain name.
 system_property.sasl.approvedRealms=A collection of realm names that can be used for SASL authentication. This can be used when realms that are passed through SASL are different from the XMPP domain name.
 system_property.sasl.proxyAuth=Controls if Openfire's default authorization policy allows authentication identities (identity whose password will be used) that are different from authorization identities (identity to act as).

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/BlockingReadingMode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/BlockingReadingMode.java
@@ -25,7 +25,6 @@ import java.net.SocketException;
 import java.nio.channels.AsynchronousCloseException;
 
 import org.dom4j.Element;
-import org.dom4j.QName;
 import org.jivesoftware.util.LocaleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +41,9 @@ import org.xmpp.packet.StreamError;
  * sequentially.
  *
  * @author Gaston Dombiak
+ * @deprecated Old, pre NIO / MINA code. Should not be used as NIO offers better performance
  */
+@Deprecated
 class BlockingReadingMode extends SocketReadingMode {
 
     private static final Logger Log = LoggerFactory.getLogger(BlockingReadingMode.class);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerSocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerSocketReader.java
@@ -46,7 +46,9 @@ import java.util.concurrent.ThreadPoolExecutor;
  * by changing the property <b>xmpp.server.processing.max.threads</b>.
  *
  * @author Gaston Dombiak
+ * @deprecated Old, pre NIO / MINA code. Should not be used as NIO offers better performance. Currently only in use for s2s.
  */
+@Deprecated
 public class ServerSocketReader extends SocketReader {
 
     private static final Logger Log = LoggerFactory.getLogger(ServerSocketReader.class);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
@@ -41,8 +41,6 @@ import org.xmpp.packet.*;
  * The connection used for receiving packets will use a ServerStanzaHandler since the other
  * connection will not receive packets.<p>
  *
- * TODO Finish migration of s2s to use NIO instead of blocking threads. Migrate from ServerSocketReader.
- *
  * @author Gaston Dombiak
  */
 public class ServerStanzaHandler extends StanzaHandler {
@@ -64,6 +62,7 @@ public class ServerStanzaHandler extends StanzaHandler {
 
     @Override
     boolean processUnknowPacket(Element doc) throws UnauthorizedException {
+        Log.trace("Processing 'unknown' packet");
         // Handle subsequent db:result packets
         if ("db".equals(doc.getNamespacePrefix()) && "result".equals(doc.getName())) {
             if (!((LocalIncomingServerSession) session).validateSubsequentDomain(doc)) {
@@ -98,12 +97,11 @@ public class ServerStanzaHandler extends StanzaHandler {
     @Override
     boolean createSession(String namespace, String serverName, XmlPullParser xpp, Connection connection)
             throws XmlPullParserException {
-        // TODO Finish implementation
-        /*if ("jabber:server".equals(namespace)) {
+        if ("jabber:server".equals(namespace)) {
             // The connected client is a server so create an IncomingServerSession
-            session = LocalIncomingServerSession.createSession(serverName, reader, connection);
+            session = LocalIncomingServerSession.createSession(serverName, xpp, connection);
             return true;
-        }*/
+        }
         return false;
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
@@ -44,7 +44,9 @@ import org.xmpp.packet.*;
  * stream element and will then keep reading and routing the received packets.
  *
  * @author Gaston Dombiak
+ * @deprecated Old, pre NIO / MINA code. Should not be used as NIO offers better performance
  */
+@Deprecated
 public abstract class SocketReader implements Runnable {
 
     private static final Logger Log = LoggerFactory.getLogger(SocketReader.class);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReadingMode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReadingMode.java
@@ -33,7 +33,9 @@ import java.net.Socket;
  * Abstract class for {@link BlockingReadingMode}.
  *
  * @author Gaston Dombiak
+ * @deprecated Old, pre NIO / MINA code. Should not be used as NIO offers better performance
  */
+@Deprecated
 abstract class SocketReadingMode {
 
     private static final Logger Log = LoggerFactory.getLogger(SocketReadingMode.class);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -68,6 +68,12 @@ public final class ConnectionSettings {
 
     public static final class Server {
 
+        public static final SystemProperty<Boolean> USE_OLD_IO = SystemProperty.Builder.ofType(Boolean.class)
+            .setKey("xmpp.server.enable-old-io")
+            .setDefaultValue(false)
+            .setDynamic(false)
+            .build();
+
         public static final String SOCKET_ACTIVE = "xmpp.server.socket.active";
         public static final String PORT = "xmpp.server.socket.port";
         public static final String OLD_SSLPORT = "xmpp.server.socket.ssl.port";

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -19,7 +19,7 @@ import org.apache.mina.transport.socket.nio.NioSocketAcceptor;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.keystore.CertificateStoreConfiguration;
-import org.jivesoftware.openfire.net.SocketConnection;
+import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -226,7 +226,7 @@ public class ConnectionListener
         }
 
         Log.debug( "Starting..." );
-        if ( getType() == ConnectionType.SOCKET_S2S )
+        if (ConnectionSettings.Server.USE_OLD_IO.getValue() && getType() == ConnectionType.SOCKET_S2S )
         {
             connectionAcceptor = new LegacyConnectionAcceptor( generateConnectionConfiguration() );
         }
@@ -551,7 +551,7 @@ public class ConnectionListener
      *
      * @param policy an encryption policy (not null).
      */
-    public void setTLSPolicy( SocketConnection.TLSPolicy policy )
+    public void setTLSPolicy( Connection.TLSPolicy policy )
     {
         final Connection.TLSPolicy oldPolicy = getTLSPolicy();
         if ( oldPolicy.equals( policy ) )


### PR DESCRIPTION
This is a provisional change that switches inbound s2s traffic from the old net-io implementation to the newer nio (based on MINA).

In my limited tests, this seemed to work while setting up s2s connections, both with Dialback as with SASL External.

More work is probably desired. I particularly want to identify all code that can now be removed (as it's replaced by this change), while unmarking code as being 'deprecated' that is not (some classes that have already been marked as being deprecated in anticipation of this change remain in use, for example to initiate outbound traffic).

It is probably best to not remove the old implementation until after the new implementation has been released, and has proven itself. I'd like to give users an opportunity to reconfigure Openfire to use the old implementation. A similar configuration option existed when moving from the old IO to NIO for client-to-server traffic.

MINA's 2.2 branch seems to have a change in its TLS handling that almost guarantees a deadlock when working with Stream Management. This isn't related to the change in this PR, but might be reason to move away from MINA.