### PR TITLE
OF-2561: Fix fallback for ConnectionListener 'verify'

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -776,7 +776,7 @@ public class ConnectionListener
         }
         else
         {
-            return JiveGlobals.getBooleanProperty( propertyName, getConnectionListener( type.getFallback() ).acceptSelfSignedCertificates() );
+            return JiveGlobals.getBooleanProperty( propertyName, getConnectionListener( type.getFallback() ).verifyCertificateValidity() );
         }
     }
 


### PR DESCRIPTION
This fixes a bug that occurs when the verifyCertificateValidity call of a ConnectionListener is delegated to a fall-back ConnectionListener.