### PR TITLE
OF-2565: Should drop stream when client sends stanzas prior to resource binding

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -104,6 +104,10 @@ public class IQRouter extends BasicModule {
                         "jabber:iq:register".equals(childElement.getNamespaceURI()) ||
                         "urn:ietf:params:xml:ns:xmpp-bind".equals(childElement.getNamespaceURI())))) {
                 handle(packet);
+            } else if (SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(packet, session)) {
+                Log.debug("Closing session that attempts to send stanza to an entity other than the server itself or the client's account, before completing resource binding. Session closed: {}", session);
+                session.deliverRawText(new StreamError(StreamError.Condition.not_authorized).toXML());
+                return;
             } else {
                 Log.debug("Rejecting stanza from client that has not (yet?) established an authenticated session: {}", packet.toXML());
                 if (packet.getType() == IQ.Type.get || packet.getType() == IQ.Type.set) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
@@ -28,10 +28,7 @@ import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xmpp.packet.JID;
-import org.xmpp.packet.Message;
-import org.xmpp.packet.Packet;
-import org.xmpp.packet.PacketError;
+import org.xmpp.packet.*;
 
 import java.util.List;
 import java.util.StringTokenizer;
@@ -160,6 +157,11 @@ public class MessageRouter extends BasicModule {
                         }
                     }
                 }
+            }
+            else if (SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(packet, session)) {
+                log.debug("Closing session that attempts to send stanza to an entity other than the server itself or the client's account, before completing resource binding. Session closed: {}", session);
+                session.deliverRawText(new StreamError(StreamError.Condition.not_authorized).toXML());
+                return;
             }
             else {
                 packet.setTo(session.getAddress());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceRouter.java
@@ -78,6 +78,11 @@ public class PresenceRouter extends BasicModule {
             if (session == null || session.getStatus() != Session.Status.CONNECTED) {
                 handle(packet);
             }
+            else if (SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(packet, session)) {
+                Log.debug("Closing session that attempts to send stanza to an entity other than the server itself or the client's account, before completing resource binding. Session closed: {}", session);
+                session.deliverRawText(new StreamError(StreamError.Condition.not_authorized).toXML());
+                return;
+            }
             else {
                 packet.setTo(session.getAddress());
                 packet.setFrom((JID)null);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionPacketRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionPacketRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@ package org.jivesoftware.openfire;
 import org.dom4j.Element;
 import org.jivesoftware.openfire.multiplex.UnknownStanzaException;
 import org.jivesoftware.openfire.net.SASLAuthentication;
+import org.jivesoftware.openfire.session.ClientSession;
 import org.jivesoftware.openfire.session.LocalClientSession;
+import org.jivesoftware.openfire.session.Session;
 import org.xmpp.packet.*;
 
 /**
@@ -117,5 +119,47 @@ public class SessionPacketRouter implements PacketRouter {
         packet.setFrom(session.getAddress());
         router.route(packet);
         session.incrementClientPacketCount();
+    }
+
+    /**
+     * Determines if a peer that is sending a stanza in violation of RFC 6120, section 7.1:
+     *
+     * <blockquote>If, before completing the resource binding step, the client attempts to send an XML
+     * stanza to an entity other than the server itself or the client's account, the server MUST NOT process the
+     * stanza and MUST close the stream with a &lt;not-authorized/&gt; stream error.</blockquote>
+     *
+     * When this method returns 'true', the stream should be closed. This method does not close the stream.
+     *
+     * @param session The session over which the stanza is sent to Openfire.
+     * @param stanza The stanza that is sent to Openfire.
+     * @return true if the peer is in violation (and the stream should be closed), otherwise false.
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc6120#section-7.1">RFC 6120, section 7.1</a>
+     * @see <a href="https://igniterealtime.atlassian.net/jira/software/c/projects/OF/issues/OF-2565">issue OF-2565</a>
+     */
+    public static boolean isInvalidStanzaSentPriorToResourceBinding(final Packet stanza, final ClientSession session)
+    {
+        // Openfire sets 'authenticated' only after resource binding.
+        if (session.getStatus() == Session.STATUS_AUTHENTICATED) {
+            return false;
+        }
+
+        // Beware, the 'to' address in the stanza will have been overwritten by the
+        final JID intendedRecipient = stanza.getTo();
+        final JID serverDomain = new JID(XMPPServer.getInstance().getServerInfo().getXMPPDomain());
+
+        // If there's no 'to' address, then the stanza is implicitly addressed at the user itself.
+        if (intendedRecipient == null) {
+            return false;
+        }
+
+        // TODO: after authentication (but prior to resource binding), it should be possible to verify that the
+        // intended recipient's bare JID corresponds with the authorized user. Openfire currently does not have an API
+        // that can be used to obtain the authorized username, prior to resource binding.
+
+        if (intendedRecipient.equals(serverDomain)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XmppWebSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -278,13 +278,13 @@ public class XmppWebSocket {
             if (STREAM_FOOTER.equals(tag)) {
                 xmppSession.getStreamManager().formalClose();
                 closeStream(null);
-            } else if ("auth".equals(tag)) {
+            } else if ("auth".equals(tag)) { // TODO this if-statement can probably be removed, as SessionPacketRouter does almost the same (Except for incrementing client packet count maybe).
                 // User is trying to authenticate using SASL
                 startedSASL = true;
                 // Process authentication stanza
                 xmppSession.incrementClientPacketCount();
                 saslStatus = SASLAuthentication.handle(xmppSession, stanza);
-            } else if (startedSASL && "response".equals(tag) || "abort".equals(tag)) {
+            } else if (startedSASL && "response".equals(tag) || "abort".equals(tag)) { // TODO this if-statement can probably be removed, as SessionPacketRouter does almost the same (Except for the abort, and incrementing client packet count maybe).
                 // User is responding to SASL challenge. Process response
                 xmppSession.incrementClientPacketCount();
                 saslStatus = SASLAuthentication.handle(xmppSession, stanza);
@@ -292,7 +292,7 @@ public class XmppWebSocket {
                 // restart the stream
                 openStream(stanza.attributeValue(QName.get("lang", XMLConstants.XML_NS_URI), "en"), stanza.attributeValue("from"));
                 configureStream();
-            } else if (Status.authenticated.equals(saslStatus)) {
+            } else {
                 if (router == null) {
                     if (StreamManager.isStreamManagementActive()) {
                         router = new StreamManagementPacketRouter(xmppSession);
@@ -309,10 +309,6 @@ public class XmppWebSocket {
                         sendPacketError(stanza, PacketError.Condition.bad_request);
                     }
                 });
-            } else {
-                // require authentication
-                Log.warn("Not authorized: " + stanza.asXML());
-                sendPacketError(stanza, PacketError.Condition.not_authorized);
             }
         } catch (Exception ex) {
             Log.error("Failed to process incoming stanza: " + stanza.asXML(), ex);

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/SessionPacketRouterTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/SessionPacketRouterTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.container.PluginManager;
+import org.jivesoftware.openfire.session.ClientSession;
+import org.jivesoftware.openfire.session.LocalClientSession;
+import org.jivesoftware.openfire.session.Session;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.quality.Strictness;
+import org.xmpp.packet.*;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests that verify the implementation of {@link SessionPacketRouter}
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SessionPacketRouterTest
+{
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Fixtures.reconfigureOpenfireHome();
+    }
+
+    @Before
+    public void setUp() {
+        Fixtures.clearExistingProperties();
+
+        //noinspection deprecation
+        XMPPServer.setInstance(Fixtures.mockXMPPServer());
+    }
+
+    /**
+     * Tests the implementation of {@link SessionPacketRouter#isInvalidStanzaSentPriorToResourceBinding(Packet, ClientSession)}
+     * by sending a stanza without a 'to' address (instructing the server to handle it directly on behalf of the entity
+     * that sent it) on a session that has completed resource binding.
+     *
+     * As the session has a resource bound, any stanza should be accepted by the method under test.
+     */
+    @Test
+    public void testIsInvalid_noToAddress_authenticated() throws Exception
+    {
+        // Setup test fixture.
+        final Packet stanza = new Message();
+        final LocalClientSession session = mock(LocalClientSession.class, withSettings().strictness(Strictness.LENIENT));
+        when(session.getStatus()).thenReturn(Session.Status.AUTHENTICATED); // Openfire sets 'AUTHENTICATED' only after resource binding has been done.
+
+        // Execute system under test.
+        final boolean result = SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(stanza, session);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    /**
+     * Tests the implementation of {@link SessionPacketRouter#isInvalidStanzaSentPriorToResourceBinding(Packet, ClientSession)}
+     * by sending a stanza that is addressed to the domain of the server on a session that has completed resource
+     * binding.
+     *
+     * As the session has a resource bound, any stanza should be accepted by the method under test.
+     */
+    @Test
+    public void testIsInvalid_addressedAtDomain_authenticated() throws Exception
+    {
+        // Setup test fixture.
+        final Packet stanza = new Message();
+        stanza.setTo(XMPPServer.getInstance().getServerInfo().getXMPPDomain());
+        final LocalClientSession session = mock(LocalClientSession.class, withSettings().strictness(Strictness.LENIENT));
+        when(session.getStatus()).thenReturn(Session.Status.AUTHENTICATED); // Openfire sets 'AUTHENTICATED' only after resource binding has been done.
+
+        // Execute system under test.
+        final boolean result = SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(stanza, session);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    /**
+     * Tests the implementation of {@link SessionPacketRouter#isInvalidStanzaSentPriorToResourceBinding(Packet, ClientSession)}
+     * by sending a stanza that is addressed to a third party user on a session that has completed resource binding.
+     *
+     * As the session has a resource bound, any stanza should be accepted by the method under test.
+     */
+    @Test
+    public void testIsInvalid_addressedAtThirdPartyUser_authenticated() throws Exception
+    {
+        // Setup test fixture.
+        final Packet stanza = new Message();
+        stanza.setTo(new JID("foobar123", XMPPServer.getInstance().getServerInfo().getXMPPDomain(), "test123"));
+        final LocalClientSession session = mock(LocalClientSession.class, withSettings().strictness(Strictness.LENIENT));
+        when(session.getStatus()).thenReturn(Session.Status.AUTHENTICATED); // Openfire sets 'AUTHENTICATED' only after resource binding has been done.
+
+        // Execute system under test.
+        final boolean result = SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(stanza, session);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    /**
+     * Tests the implementation of {@link SessionPacketRouter#isInvalidStanzaSentPriorToResourceBinding(Packet, ClientSession)}
+     * by sending a stanza that is addressed to a third party server on a session that has completed resource binding.
+     *
+     * As the session has a resource bound, any stanza should be accepted by the method under test.
+     */
+    @Test
+    public void testIsInvalid_addressedAtThirdPartyServer_authenticated() throws Exception
+    {
+        // Setup test fixture.
+        final Packet stanza = new Message();
+        stanza.setTo(new JID(null, "makedifferent" + XMPPServer.getInstance().getServerInfo().getXMPPDomain(), null));
+        final LocalClientSession session = mock(LocalClientSession.class, withSettings().strictness(Strictness.LENIENT));
+        when(session.getStatus()).thenReturn(Session.Status.AUTHENTICATED); // Openfire sets 'AUTHENTICATED' only after resource binding has been done.
+
+        // Execute system under test.
+        final boolean result = SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(stanza, session);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    /**
+     * Tests the implementation of {@link SessionPacketRouter#isInvalidStanzaSentPriorToResourceBinding(Packet, ClientSession)}
+     * by sending a stanza without a 'to' address (instructing the server to handle it directly on behalf of the entity
+     * that sent it) on a session that has not completed resource binding.
+     *
+     * The server must handle a stanza without a 'to' address on behalf of the entity that sent it (per RFC 6120,
+     * section 10.3), therefor the method under test should accept the stanza.
+     */
+    @Test
+    public void testIsInvalid_noToAddress_unauthenticated() throws Exception
+    {
+        // Setup test fixture.
+        final Packet stanza = new Message();
+        final LocalClientSession session = mock(LocalClientSession.class, withSettings().strictness(Strictness.LENIENT));
+        when(session.getStatus()).thenReturn(Session.Status.CONNECTED); // Openfire sets 'AUTHENTICATED' only after resource binding has been done.
+
+        // Execute system under test.
+        final boolean result = SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(stanza, session);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    /**
+     * Tests the implementation of {@link SessionPacketRouter#isInvalidStanzaSentPriorToResourceBinding(Packet, ClientSession)}
+     * by sending a stanza that is addressed to the domain of the server on a session that has not completed resource
+     * binding.
+     *
+     * Stanzas addressed to the server itself are acceptable (per RFC 6120, section 7.1). The method under test should
+     * accept the stanza.
+     */
+    @Test
+    public void testIsInvalid_addressedAtDomain_unauthenticated() throws Exception
+    {
+        // Setup test fixture.
+        final Packet stanza = new Message();
+        stanza.setTo(XMPPServer.getInstance().getServerInfo().getXMPPDomain());
+        final LocalClientSession session = mock(LocalClientSession.class, withSettings().strictness(Strictness.LENIENT));
+        when(session.getStatus()).thenReturn(Session.Status.CONNECTED); // Openfire sets 'AUTHENTICATED' only after resource binding has been done.
+
+        // Execute system under test.
+        final boolean result = SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(stanza, session);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    /**
+     * Tests the implementation of {@link SessionPacketRouter#isInvalidStanzaSentPriorToResourceBinding(Packet, ClientSession)}
+     * by sending a stanza that is addressed to a third party user on a session that has not completed resource binding.
+     *
+     * Stanzas addressed to other clients or servers are invalid (per RFC 6120, section 7.1). The method under test
+     * should not accept the stanza.
+     */
+    @Test
+    public void testIsInvalid_addressedAtThirdPartyUser_unauthenticated() throws Exception
+    {
+        // Setup test fixture.
+        final Packet stanza = new Message();
+        stanza.setTo(new JID("foobar123", XMPPServer.getInstance().getServerInfo().getXMPPDomain(), "test123"));
+        final LocalClientSession session = mock(LocalClientSession.class, withSettings().strictness(Strictness.LENIENT));
+        when(session.getStatus()).thenReturn(Session.Status.CONNECTED); // Openfire sets 'AUTHENTICATED' only after resource binding has been done.
+
+        // Execute system under test.
+        final boolean result = SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(stanza, session);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    /**
+     * Tests the implementation of {@link SessionPacketRouter#isInvalidStanzaSentPriorToResourceBinding(Packet, ClientSession)}
+     * by sending a stanza that is addressed to a third party server on a session that has not completed resource
+     * binding.
+     *
+     * Stanzas addressed to other clients or servers are invalid (per RFC 6120, section 7.1). The method under test
+     * should not accept the stanza.
+     */
+    @Test
+    public void testIsInvalid_addressedAtThirdPartyServer_unauthenticated() throws Exception
+    {
+        // Setup test fixture.
+        final Packet stanza = new Message();
+        stanza.setTo(new JID(null, "makedifferent" + XMPPServer.getInstance().getServerInfo().getXMPPDomain(), null));
+        final LocalClientSession session = mock(LocalClientSession.class, withSettings().strictness(Strictness.LENIENT));
+        when(session.getStatus()).thenReturn(Session.Status.CONNECTED); // Openfire sets 'AUTHENTICATED' only after resource binding has been done.
+
+        // Execute system under test.
+        final boolean result = SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(stanza, session);
+
+        // Verify results.
+        assertTrue(result);
+    }
+}


### PR DESCRIPTION
RFC 6120, section 7.1 dictates:
> If, before completing the resource binding step, the client attempts to send an XML
> stanza to an entity other than the server itself or the client's account, the server MUST NOT process the
> stanza and MUST close the stream with a `<not-authorized>` stream error.

Openfire, prior to this commit, would reply to pretty much all stanzas that are sent prior to resource binding with a stanza (not stream) error, and would not terminate the stream when the stanza is addressed to an entity other than the server itself or the client's account.

With this commit, stanzas that match the RFC definition will now cause the stream to be closed with a stream error. The prior behavior will remain in place for all other stanzas.

Arguably, there is room for further optimization:
- There appears to be duplication of processing in IQ-, Message- and PresenceRouter. However, they are invoked by other instances than those of SessionPacketRouter (which may in itself be something that's desirable to change)
- XmppWebSocket appears to duplicate part of the processing of data that is exchanged during session setup. Comments have been added for future improvement.
- The Openfire API makes it hard to distinghuish between 'client authenticated & completed resource binding' and 'client authenticated, but did not complete resource binding yet'. There are no explicit handling for the latter scenario, which again could be improved upon in the future.