### PR TITLE
OF-2568: Improve Stream Management roll-over detection

### DIFF
--- a/xmppserver/src/test/java/org/jivesoftware/openfire/streammanagement/StreamManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/streammanagement/StreamManagerTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (C) 2015-2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.streammanagement;
+
+import org.junit.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests that verify the implementation of {@link StreamManager}.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class StreamManagerTest
+{
+    @Test
+    public void testValidateClientAcknowledgement() throws Exception
+    {
+        // Setup test fixture.
+        final long h = 0;
+        final long oldH = 0;
+        final Long lastUnackedX = null;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_clientAcksSentStanza() throws Exception
+    {
+        // Setup test fixture.
+        final long h = 1;
+        final long oldH = 0;
+        final Long lastUnackedX = 1L;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_clientAcksSentStanzaWithMoreInflight() throws Exception
+    {
+        // Setup test fixture.
+        final long h = 10;
+        final long oldH = 4;
+        final Long lastUnackedX = 12L;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_clientAcksUnsentStanza() throws Exception
+    {
+        // Setup test fixture.
+        final long h = 1;
+        final long oldH = 0;
+        final Long lastUnackedX = null;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_clientAcksUnsentStanzaA() throws Exception
+    {
+        // Setup test fixture.
+        final long h = 3;
+        final long oldH = 1;
+        final Long lastUnackedX = 2L;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = MAX - 1;
+        final long oldH = MAX - 1;
+        final Long lastUnackedX = null;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase_unsent() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = MAX;
+        final long oldH = MAX - 1;
+        final Long lastUnackedX = null;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase_sent() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = MAX;
+        final long oldH = MAX - 1;
+        final Long lastUnackedX = MAX;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase1() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = MAX;
+        final long oldH = MAX;
+        final Long lastUnackedX = null;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase2() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = MAX;
+        final long oldH = MAX-2;
+        final Long lastUnackedX = MAX;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase3() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = 0;
+        final long oldH = MAX-2;
+        final Long lastUnackedX = 0L;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase3a() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = 0;
+        final long oldH = MAX-2;
+        final Long lastUnackedX = 4L;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase3_unsent() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = 0;
+        final long oldH = MAX - 2;
+        final Long lastUnackedX = null;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase4() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = 0;
+        final long oldH = MAX;
+        final Long lastUnackedX = 0L;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase4a() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = 0;
+        final long oldH = MAX;
+        final Long lastUnackedX = 3L;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase4_unsent() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = 0;
+        final long oldH = MAX;
+        final Long lastUnackedX = null;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase5() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = 3;
+        final long oldH = MAX - 2;
+        final Long lastUnackedX = 4L;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase5a() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = 4;
+        final long oldH = MAX - 2;
+        final Long lastUnackedX = 4L;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    @Test
+    public void testValidateClientAcknowledgement_rollover_edgecase5_unsent() throws Exception
+    {
+        // Setup test fixture.
+        final long MAX = new BigInteger( "2" ).pow( 32 ).longValue() - 1;
+        final long h = 5;
+        final long oldH = MAX - 2;
+        final Long lastUnackedX = 4L;
+
+        // Execute system under test.
+        final boolean result = StreamManager.validateClientAcknowledgement(h, oldH, lastUnackedX);
+
+        // Verify results.
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
When a client Ack's with a value _lower_ than the previous Ack'ed value, this should be interpreted as it Acking a stanza count that rolls over (2^32)-1. This very likely should cause the stream to be closed.