### PR TITLE
OF-2573 Add Name to Version in Session Summary

### DIFF
--- a/xmppserver/src/main/webapp/session-row.jspf
+++ b/xmppserver/src/main/webapp/session-row.jspf
@@ -43,10 +43,21 @@
     </td>
     <td style="width: 15%; white-space: nowrap">
         <% if (sess.getSoftwareVersion() != null) {
-            String version = sess.getSoftwareVersion().get("version");
-            if (version != null) { %>
-        <%= StringUtils.escapeHTMLTags(version) %>
-        <% } } %>
+            final String softwareName = sess.getSoftwareVersion().get("name");
+            final String softwareVersion = sess.getSoftwareVersion().get("version");
+
+            String softwareString = "";
+            if(softwareName != null && !softwareName.isBlank()){
+                softwareString += softwareName + " - ";
+            }
+            if(softwareVersion != null && !softwareVersion.isBlank()) {
+                softwareString += softwareVersion;
+            };
+
+            if (!softwareString.isBlank()) { %>
+                <%= StringUtils.escapeHTMLTags(softwareString) %>
+            <% }
+        } %>
     </td>
     <% if (ClusterManager.isClusteringStarted() || ClusterManager.isClusteringStarting()) { %>
     <td nowrap>

--- a/xmppserver/src/main/webapp/session-row.jspf
+++ b/xmppserver/src/main/webapp/session-row.jspf
@@ -48,9 +48,12 @@
 
             String softwareString = "";
             if(softwareName != null && !softwareName.isBlank()){
-                softwareString += softwareName + " - ";
+                softwareString += softwareName;
             }
             if(softwareVersion != null && !softwareVersion.isBlank()) {
+                if (!softwareString.isBlank()) {
+                    softwareString += " - ";
+                }
                 softwareString += softwareVersion;
             };
 

--- a/xmppserver/src/main/webapp/session-summary.jsp
+++ b/xmppserver/src/main/webapp/session-summary.jsp
@@ -125,9 +125,12 @@
                 final String softwareVersion = clientSession.getSoftwareVersion().get("version");
                 String softwareString = "";
                 if(softwareName != null && !softwareName.isBlank()){
-                    softwareString += softwareName + " - ";
+                    softwareString += softwareName;
                 }
                 if(softwareVersion != null && !softwareVersion.isBlank()) {
+                    if (!softwareString.isBlank()) {
+                        softwareString += " - ";
+                    }
                     softwareString += softwareVersion;
                 };
                 return StringUtils.containsIgnoringCase(softwareString, searchCriteria);

--- a/xmppserver/src/main/webapp/session-summary.jsp
+++ b/xmppserver/src/main/webapp/session-summary.jsp
@@ -120,7 +120,18 @@
     final String searchVersion = ParamUtils.getStringParameter(request, "searchVersion", "");
         if(!searchVersion.trim().isEmpty()) {
             final String searchCriteria = searchVersion.trim();
-            filter = filter.and(clientSession -> StringUtils.containsIgnoringCase(clientSession.getSoftwareVersion().get("version"), searchCriteria));
+            filter = filter.and(clientSession -> {
+                final String softwareName = clientSession.getSoftwareVersion().get("name");
+                final String softwareVersion = clientSession.getSoftwareVersion().get("version");
+                String softwareString = "";
+                if(softwareName != null && !softwareName.isBlank()){
+                    softwareString += softwareName + " - ";
+                }
+                if(softwareVersion != null && !softwareVersion.isBlank()) {
+                    softwareString += softwareVersion;
+                };
+                return StringUtils.containsIgnoringCase(softwareString, searchCriteria);
+            });
         }
     final String searchNode = ParamUtils.getStringParameter(request, "searchNode", "");
     if(searchNode.equals("local")) {


### PR DESCRIPTION
Tidies up the implementation from OF-2192, adding the name of the software being used, as well as the version.

Openfire appears to allow for other properties in the map created from the pairs received in the IQ, but Name and Version are the only props required by XEP-0092.