### PR TITLE
OF-2581: Add invite to Transifex to admin console

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1117,6 +1117,7 @@ locale.system.set=Set Locale
 locale.current=Current Settings
 language.choose=Choose Language
 timezone.choose=Choose Time Zone
+locale.translator-invitation=Is the language of your preference not listed, or is the translation of that language not complete? You can easily help to improve the translations available in Openfire! Please have a look at our <a target="_blank" href="https://explore.transifex.com/igniterealtime/">Transifex project page</a> to get started!
 
 # Log Page
 
@@ -2556,6 +2557,7 @@ setup.index.not_permission=Setup was able to find your conf directory but does n
         on it. Please alter the directory permissions.
 setup.index.not_write_permission=Setup was able to find your conf directory but does not have write \
         permission on it. Please alter the directory permissions.
+setup.index.translator-invitation=Is the language of your preference not listed, or is the translation of that language not complete? You can easily help to improve the translations available in Openfire! Please have a look at our <a target="_blank" href="https://explore.transifex.com/igniterealtime/">Transifex project page</a> to get started!
 
 # Setup pause Page
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1096,6 +1096,7 @@ locale.system.set=Systeemregio kiezen
 locale.current=Huidige systeemregio
 language.choose=Choose Language
 timezone.choose=Choose Time Zone
+locale.translator-invitation=Staat de taal van uw voorkeur niet in deze lijst, of is de vertaling incompleet? Door gebruik te maken van de <a target="_blank" href="https://explore.transifex.com/igniterealtime/">Transifex project page</a> kunnen verbeteringen eenvoudig worden aangedragen!
 
 # Log Page
 
@@ -2375,6 +2376,7 @@ setup.index.valid_conf=Geldige conf map.
 setup.index.unable_locate_dir=Kan geen geldige conf map vinden. Lees de installatiehandleiding om te leren hoe de conf map moet worden bepaald.
 setup.index.not_permission=De conf map bestaat maar het installatieprogramma heeft geen leestoegang. Wijzig de toegangsrechten op de map.
 setup.index.not_write_permission=De conf map bestaat maar het installatieprogramma heeft geen schrijftoegang. Wijzig de toegangsrechten op de map.
+setup.index.translator-invitation=Staat de taal van uw voorkeur niet in deze lijst, of is de vertaling incompleet? Door gebruik te maken van de <a target="_blank" href="https://explore.transifex.com/igniterealtime/">Transifex project page</a> kunnen verbeteringen eenvoudig worden aangedragen!
 
 # Setup pause Page
 

--- a/xmppserver/src/main/webapp/server-locale.jsp
+++ b/xmppserver/src/main/webapp/server-locale.jsp
@@ -27,6 +27,7 @@
 <%@ page import="org.slf4j.Logger" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
 
+<%@ taglib uri="admin" prefix="admin" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -102,9 +103,13 @@
         <div class="error"><c:out value="${err.value}"/></div>
     </c:forEach>
 
+    <admin:infobox type="info">
+        <fmt:message key="locale.translator-invitation" />
+    </admin:infobox>
+
     <p>
-<fmt:message key="locale.title.info" />
-</p>
+        <fmt:message key="locale.title.info" />
+    </p>
 
 
 <!-- BEGIN locale settings -->

--- a/xmppserver/src/main/webapp/setup/index.jsp
+++ b/xmppserver/src/main/webapp/setup/index.jsp
@@ -327,6 +327,10 @@
                 </form>
 
             </div>
+
+            <p class="info">
+                <fmt:message key="setup.index.translator-invitation"/>
+            </p>
             <!-- END jive-contentBox -->
 
         </c:otherwise>

--- a/xmppserver/src/main/webapp/style/setup.css
+++ b/xmppserver/src/main/webapp/style/setup.css
@@ -316,6 +316,22 @@ html>body .jive-vcardTable {
     background-position : 5px 5px;
     -moz-border-radius: 3px;
 }
+
+.info {
+    color : #333;
+    font-weight : bold;
+    background-color : #EEE;
+    padding : 5px;
+    border: 1px solid #CCC;
+    margin-top : 10px;
+    margin-bottom: 20px;
+    padding-left : 28px;
+    background-image : url(/images/info-16x16.gif);
+    background-repeat : no-repeat;
+    background-position : 5px 5px;
+    -moz-border-radius: 3px;
+}
+
 .jive_setup_launchAdmin a,
 .jive_setup_launchAdmin a:visited {
     position: relative;


### PR DESCRIPTION
Admin console pages in which translations are selected now have a text that invites people to supply translations via Transifex.

![openfire-setup-transifex](https://user-images.githubusercontent.com/4253898/222435957-e025557e-d31c-47b2-aad7-f16bf0c1706c.png)
![openfire-admin-console-language](https://user-images.githubusercontent.com/4253898/222435971-63f173ee-9d3d-481e-af43-2b972306a09e.png)
