### PR TITLE
CI: run on ubuntu-latest

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -51,8 +51,7 @@ jobs:
   aioxmpp:
 
     name: Execute aioxmpp-based CI tests
-    # ubuntu-latest may have issues with Epoll python events
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: build
 
     steps:
@@ -111,8 +110,7 @@ jobs:
   connectivity:
 
     name: Execute Connectivity CI tests
-    # ubuntu-latest may have issues with this workflow?
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: build
 
     steps:


### PR DESCRIPTION
We had hard coded to run on `ubuntu-18.04` due to perceived issues with python+epoll on later ubuntu releases.  Well, this runner is going away at GHA by the end of the month, so lets see what `ubuntu-latest` yields us now.