### PR TITLE
Revert "Limit aioxmpp's python to 3.11.2 "

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -75,7 +75,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
-     
+          check-latest: true # attempt to prevent to use 3.11.3 by enticing the runner to update (to something later)
+
       - name: Run aioxmpp tests
         run: ./runAioxmppIntegrationTests -d -l -h example.org -i 127.0.0.1 || ./runAioxmppIntegrationTests -d -l -h example.org -i 127.0.0.1 || ./runAioxmppIntegrationTests -d -l -h example.org -i 127.0.0.1 # Try tests a few times, in case of flakiness
             

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11.2
+          python-version: 3.11
      
       - name: Run aioxmpp tests
         run: ./runAioxmppIntegrationTests -d -l -h example.org -i 127.0.0.1 || ./runAioxmppIntegrationTests -d -l -h example.org -i 127.0.0.1 || ./runAioxmppIntegrationTests -d -l -h example.org -i 127.0.0.1 # Try tests a few times, in case of flakiness


### PR DESCRIPTION
This reverts commit 63e2e12d32c34ba11d855e73411fc74fce0f54f3.

https://github.com/horazont/aioxmpp/issues/391 suggests that with the new Python 3.11.4, the problem that occured in 3.11.3 has been resolved. If that's the case, we no longer have to pin to 3.11.2.