### PR TITLE
Github actions update (node12 -> node16)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -38,7 +38,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: 11
         distribution: zulu

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -16,9 +16,9 @@ jobs:
         distribution: [ zulu ] # We could add more here: temurin, adopt, liberica, microsoft, corretto
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }} ${{ matrix.distribution }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ matrix.distribution }}
@@ -27,13 +27,13 @@ jobs:
         run: ./mvnw -B package -Pcoverage --file pom.xml
       - name: Upload distribution
         if: ${{ matrix.distribution == 'zulu' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: distribution-java${{ matrix.java }}
           path: distribution/target/distribution-base
       - name: Upload test files
         if: ${{ matrix.distribution == 'zulu' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-files
           path: |
@@ -43,7 +43,7 @@ jobs:
             test.gradle
       - name: Upload coverage report for 'xmppserver' module
         if: ${{ matrix.distribution == 'zulu' && matrix.java == 11 }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Coverage Report for 'xmppserver' module
           path: xmppserver/target/site/jacoco/
@@ -58,12 +58,12 @@ jobs:
       - name: Set JAVA_HOME to use Java 11
         run: echo "JAVA_HOME=$(echo $JAVA_HOME_11_X64)" >> $GITHUB_ENV
       - name: Download distribution artifact from build job.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: distribution-java11
           path: distribution/target/distribution-base
       - name: Download test files from build job.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-files
       - name: Fix file permissions
@@ -81,14 +81,14 @@ jobs:
             
       - name: Expose test output
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: aioxmpp test output
           path: aioxmpp/output
 
       - name: Expose openfire output
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: openfire logs
           path: distribution/target/distribution-base/logs/*
@@ -117,16 +117,16 @@ jobs:
       - name: Set JAVA_HOME to use Java 11
         run: echo "JAVA_HOME=$(echo $JAVA_HOME_11_X64)" >> $GITHUB_ENV
       - name: Download distribution artifact from build job.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: distribution-java11
           path: distribution/target/distribution-base
       - name: Download test files from build job.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-files
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
@@ -147,16 +147,16 @@ jobs:
       - name: Set JAVA_HOME to use Java 11
         run: echo "JAVA_HOME=$(echo $JAVA_HOME_11_X64)" >> $GITHUB_ENV
       - name: Download distribution artifact from build job.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: distribution-java11
           path: distribution/target/distribution-base
       - name: Download test files from build job.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-files
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
@@ -175,13 +175,13 @@ jobs:
     if: ${{github.repository == 'igniterealtime/Openfire' && github.event_name == 'push' && needs.check_branch.outputs.is_publishable_branch == 'true'}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Defend against another commit quickly following the first
           # We want the one that's been tested, rather than the head of main
           ref: ${{ github.event.push.after }}
       - name: Set up Java for publishing
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
@@ -235,14 +235,14 @@ jobs:
         if: ${{ contains(github.ref, 'refs/tags/') }}
         run: echo "SOURCE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Defend against another commit quickly following the first
           # We want the one that's been tested, rather than the head of main
           ref: ${{ github.event.push.after }}
 
       - name: Download distribution artifact from build job.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: distribution-java11
           path: distribution/target/distribution-base
@@ -257,7 +257,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Cache Docker layers # TODO: Validate that caches are faster than no caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/database-upgrades.yml
+++ b/.github/workflows/database-upgrades.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Openfire
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set environment variables
       run: |
         echo "CONNECTION_STRING=jdbc:sqlserver://localhost:1433;databaseName=openfire;applicationName=Openfire" >> $GITHUB_ENV
@@ -44,7 +44,7 @@ jobs:
     - name: Start database server and install database
       run: docker-compose -f ./build/ci/compose/mssql.yml up --detach
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Openfire
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set environment variables
         run: |
           echo "CONNECTION_STRING=jdbc:postgresql://localhost:5432/openfire" >> $GITHUB_ENV
@@ -81,7 +81,7 @@ jobs:
       - name: Start database server and install database
         run: docker-compose -f ./build/ci/compose/postgresql.yml up --detach
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Openfire
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set environment variables
         run: |
           echo "CONNECTION_STRING=jdbc:mysql://localhost:3306/openfire?rewriteBatchedStatements=true&characterEncoding=UTF-8&characterSetResults=UTF-8&serverTimezone=UTC" >> $GITHUB_ENV
@@ -118,7 +118,7 @@ jobs:
       - name: Start database server and install database
         run: docker-compose -f ./build/ci/compose/mysql.yml up --detach
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/macos-release-artifact.yml
+++ b/.github/workflows/macos-release-artifact.yml
@@ -14,9 +14,9 @@ jobs:
         java: [ 11 ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: zulu
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get release
         id: get_release
-        uses: bruceadams/get-release@v1.2.3
+        uses: bruceadams/get-release@v1.3.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
This updates all Github actions for which the following deprecation warning is logged:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-java@v1, bruceadams/get-release@v1.2.3, actions/upload-release-asset@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

There is one exception: the 'upload-release-asset' used by macos-release-artifact does not have an update.