### PR TITLE
OF-2608: Do not wait for Dialback response if connection is closed

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingServerSocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingServerSocketReader.java
@@ -138,6 +138,10 @@ public class OutgoingServerSocketReader {
         thread.start();
     }
 
+    public boolean isOpen() {
+        return open;
+    }
+
     private void closeSession() {
         open = false;
         if (session != null) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -325,7 +325,7 @@ public class ServerDialback {
 
             // Process the answer from the Receiving Server
             try {
-                while (true) {
+                while (socketReader.isOpen()) {
                     Element doc = socketReader.getElement(RemoteServerManager.getSocketTimeout(), TimeUnit.MILLISECONDS);
                     if (doc == null) {
                         log.debug( "Failed to authenticate domain: Time out waiting for validation response." );
@@ -349,6 +349,7 @@ public class ServerDialback {
                 log.debug( "Failed to authenticate domain: An interrupt was received while waiting for validation response (is Openfire shutting down?)" );
                 return false;
             }
+            return false;
         }
     }
 


### PR DESCRIPTION
While waiting for a response to a Dialback request, Openfire should terminate when the underlying connection is closed.