### PR TITLE
OF-2614 - Always allow plugin.xml in be the root of a plugin source tree

### DIFF
--- a/plugins/openfire-plugin-assembly-descriptor/src/main/resources/assemblies/openfire-plugin-assembly.xml
+++ b/plugins/openfire-plugin-assembly-descriptor/src/main/resources/assemblies/openfire-plugin-assembly.xml
@@ -18,8 +18,23 @@
             </includes>
         </fileSet>
 
-        <!-- filtered metadata files (html, plugin.xml) -->
-        <fileSet>
+        <!--
+            filtered metadata files (html, plugin.xml)
+            This includes 2 sections, one for the current project structure and one for legacy projects
+            This used to assume a 'src/java' directory, but that is not always the case. Default project
+            structure is now src/main/java. Some plugins have worked around this by placing the plugin.xml
+            and related collateral in the src directory. This section now supports both structures.
+        -->
+        <fileSet> <!-- Current project structure - plugin descriptors in the project root -->
+            <outputDirectory/>
+            <directory>${project.basedir}</directory>
+            <filtered>true</filtered>
+            <includes>
+                <include>*.html</include>
+                <include>plugin.xml</include>
+            </includes>
+        </fileSet>
+        <fileSet> <!-- Cope with legacy & unusual project structures - plugin descriptors 2 folders above plugin source -->
             <outputDirectory/>
             <directory>${project.build.sourceDirectory}/../..</directory>
             <filtered>true</filtered>


### PR DESCRIPTION
* When creating a plugin project using src/java for the source root, plugin.xml must be in the root.
* When creating a plugin project using the default src/main/java structure, the plugin.xml must be in the src folder.

This is because the openfire-plugin-assembly specifically looks for this file two directories above.

This makes the building more flexible, searching in the project root for the plugin.xml and html files, but keeps the old rule too to avoid breaking existing plugins.

Most of our plugins (e.g. Rest API, Monitoring, Hazelcast) use `src/java` and so have plugin.xml in the root. There are some exceptions (Push Notification, Thread Dump, MUC RTBL) which use the default structure and store the XML in the `src` directory. Real outliers include the Password Reset plugin (which uses gradle to orchestrate a correct build) and ofmeet (which is a monorepo).

By keeping the original rule, I don't think there's any plugin that would be affected. The only unintended consequence I can imagine is something like this:

```
openfire-mucrtbl-plugin
├── DONT-INCLUDE-MY-SECRETS.xml
├── LICENSE
├── pom.xml
├── README.md
└── src
    ├── changelog.html
    ├── logo_large.png
    ├── logo_small.png
    ├── main
    │   ├── java
    │   │   └── org
    │   │       └── igniterealtime
    │   │           └── openfire
    │   │               └── plugin
    │   │                   └── myplugin
    │   │                       ├── MyPlugin.java
    │   │                       └── MyPluginLib.java
    │   └── web
    │       ├── mypage.jsp
    │       └── WEB-INF
    │           └── web.xml
    ├── plugin.xml
    └── readme.html
```

Here, you'd get the plugin.xml as before, but also the DONT-INCLUDE-MY-SECRETS.xml that previously would have been missed.

Feels unlikely?