### PR TITLE
OF-2615: Avoid direct usage of ConnectionManagerImpl

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ConnectionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 package org.jivesoftware.openfire;
 
+import org.jivesoftware.openfire.spi.ConnectionListener;
 import org.jivesoftware.openfire.spi.ConnectionType;
+
+import java.util.Set;
 
 /**
  * Coordinates connections (accept, read, termination) on the server.
@@ -113,4 +116,33 @@ public interface ConnectionManager {
      * @param port a port number.
      */
     void setPort(ConnectionType type, boolean startInSslMode, int port);
+
+    /**
+     * Returns all connection listeners.
+     *
+     * @return All connection listeners (never null).
+     */
+    Set<ConnectionListener> getListeners();
+
+    /**
+     * Returns al connection listeners for the provided type.
+     *
+     * @param type The connection type for which a listener is to be configured.
+     * @return The connection listener (never null).
+     */
+    Set<ConnectionListener> getListeners( ConnectionType type );
+
+    /**
+     * Returns a connection listener.
+     *
+     * The #startInSslMode parameter is used to distinguish between listeners that expect to receive SSL encrypted data
+     * immediately, as opposed to connections that initially accept plain text data (the latter are typically subject to
+     * StartTLS for in-band encryption configuration). When for a particular connection type only one of these options
+     * is implemented, the parameter value is ignored.
+     *
+     * @param type The connection type for which a listener is to be configured.
+     * @param startInSslMode true when the listener to be configured is in legacy SSL mode, otherwise false.
+     * @return The connection listener (never null).
+     */
+    ConnectionListener getListener(ConnectionType type, boolean startInSslMode);
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,13 +32,13 @@ import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.*;
+import org.jivesoftware.openfire.ConnectionManager;
 import org.jivesoftware.admin.AuthCheckFilter;
 import org.jivesoftware.openfire.JMXManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.keystore.CertificateStore;
 import org.jivesoftware.openfire.keystore.IdentityStore;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
-import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.jivesoftware.openfire.spi.ConnectionType;
 import org.jivesoftware.openfire.spi.EncryptionArtifactFactory;
 import org.jivesoftware.util.*;
@@ -209,7 +209,7 @@ public class AdminConsolePlugin implements Plugin {
                         Log.warn( "Admin console: Using certificates but they are not valid for the hosted domain" );
                     }
 
-                    final ConnectionManagerImpl connectionManager = ( (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager() );
+                    final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
                     final ConnectionConfiguration configuration = connectionManager.getListener( ConnectionType.WEBADMIN, true ).generateConnectionConfiguration();
                     final SslContextFactory sslContextFactory = new EncryptionArtifactFactory( configuration ).getSslContextFactory();
 
@@ -254,7 +254,7 @@ public class AdminConsolePlugin implements Plugin {
 
         try {
             adminServer.start(); // excludes initialised
-        
+
             if(XMPPServer.getInstance().isSetupMode()) {
                 AuthCheckFilter.loadSetupExcludes();
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, Ignite Realtime Foundation 2022. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, Ignite Realtime Foundation 2022-2023. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,12 +33,12 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.jivesoftware.openfire.Connection;
+import org.jivesoftware.openfire.ConnectionManager;
 import org.jivesoftware.openfire.JMXManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.keystore.CertificateStore;
 import org.jivesoftware.openfire.keystore.IdentityStore;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
-import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.jivesoftware.openfire.spi.ConnectionType;
 import org.jivesoftware.openfire.spi.EncryptionArtifactFactory;
 import org.jivesoftware.openfire.websocket.OpenfireWebSocketServlet;
@@ -477,7 +477,7 @@ public final class HttpBindManager implements CertificateEventListener {
                     Log.warn("HTTP binding: Using certificates but they are not valid for the hosted domain");
                 }
 
-                final ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
+                final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
                 final ConnectionConfiguration configuration = connectionManager.getListener( ConnectionType.BOSH_C2S, true ).generateConnectionConfiguration();
                 final SslContextFactory sslContextFactory = new EncryptionArtifactFactory(configuration).getSslContextFactory();
 
@@ -696,7 +696,7 @@ public final class HttpBindManager implements CertificateEventListener {
 
     // NOTE: enabled by default
     private boolean isHttpCompressionEnabled() {
-        final ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
+        final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
         final ConnectionConfiguration configuration = connectionManager.getListener( ConnectionType.BOSH_C2S, true ).generateConnectionConfiguration();
         return configuration.getCompressionPolicy() == null || configuration.getCompressionPolicy().equals( Connection.CompressionPolicy.optional );
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -22,10 +22,7 @@ import org.dom4j.Element;
 import org.dom4j.Namespace;
 import org.dom4j.QName;
 import org.dom4j.io.XMPPPacketReader;
-import org.jivesoftware.openfire.PacketDeliverer;
-import org.jivesoftware.openfire.SessionPacketRouter;
-import org.jivesoftware.openfire.StreamID;
-import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.*;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.multiplex.UnknownStanzaException;
 import org.jivesoftware.openfire.net.MXParser;
@@ -33,7 +30,6 @@ import org.jivesoftware.openfire.net.SASLAuthentication;
 import org.jivesoftware.openfire.net.VirtualConnection;
 import org.jivesoftware.openfire.session.LocalClientSession;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
-import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.jivesoftware.openfire.spi.ConnectionType;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.SystemProperty;
@@ -1312,7 +1308,7 @@ public class HttpSession extends LocalClientSession {
         @Override
         public ConnectionConfiguration getConfiguration() {
             if (configuration == null) {
-                final ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
+                final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
                 configuration = connectionManager.getListener( connectionType, true ).generateConnectionConfiguration();
             }
             return configuration;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.jivesoftware.openfire.keystore;
 
+import org.jivesoftware.openfire.ConnectionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.container.BasicModule;
 import org.jivesoftware.openfire.spi.ConnectionListener;
-import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.jivesoftware.openfire.spi.ConnectionType;
 import org.jivesoftware.util.CollectionUtils;
 import org.jivesoftware.util.JiveGlobals;
@@ -187,7 +187,7 @@ public class CertificateStoreManager extends BasicModule
             }
 
             // Update all connection listeners that were using the old configuration.
-            final ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
+            final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
             for ( ConnectionListener connectionListener : connectionManager.getListeners( type ) ) {
                 try {
                     connectionListener.setIdentityStoreConfiguration( configuration );
@@ -242,7 +242,7 @@ public class CertificateStoreManager extends BasicModule
             }
 
             // Update all connection listeners that were using the old configuration.
-            final ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
+            final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
             for ( ConnectionListener connectionListener : connectionManager.getListeners( type ) ) {
                 try {
                     connectionListener.setTrustStoreConfiguration( configuration );

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@
 package org.jivesoftware.openfire.multiplex;
 
 import org.dom4j.Element;
+import org.jivesoftware.openfire.ConnectionManager;
 import org.jivesoftware.openfire.StreamID;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.net.VirtualConnection;
 import org.jivesoftware.openfire.session.ConnectionMultiplexerSession;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
-import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.jivesoftware.openfire.spi.ConnectionType;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.Packet;
@@ -131,7 +131,7 @@ public class ClientSessionConnection extends VirtualConnection {
     {
         // Here, a client-to-server configuration is mocked. It is likely not used, as actual connection handling takes
         // place at the connection manager.
-        final ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
+        final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
         return connectionManager.getListener( ConnectionType.SOCKET_C2S, true ).generateConnectionConfiguration();
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.jivesoftware.openfire.session.IncomingServerSession;
 import org.jivesoftware.openfire.session.LocalSession;
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
-import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.jivesoftware.openfire.spi.ConnectionType;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.LocaleUtils;
@@ -227,7 +226,7 @@ public class SocketConnection implements Connection {
         // This is an ugly hack to get backwards compatibility with the pre-MINA era. As this implementation is being
         // removed (it is marked as deprecated - at the time of writing, it is only used for S2S). The ugly hack: assume
         // S2S:
-        final ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
+        final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
         return connectionManager.getListener( ConnectionType.SOCKET_S2S, false ).generateConnectionConfiguration();
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -16,26 +16,17 @@
 
 package org.jivesoftware.openfire.server;
 
-import java.io.*;
-import java.net.Socket;
-import java.net.SocketAddress;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.Element;
 import org.dom4j.io.XMPPPacketReader;
 import org.jivesoftware.openfire.*;
 import org.jivesoftware.openfire.auth.AuthFactory;
+import org.jivesoftware.openfire.event.ServerSessionEventDispatcher;
 import org.jivesoftware.openfire.net.*;
 import org.jivesoftware.openfire.session.*;
 import org.jivesoftware.openfire.spi.BasicStreamIDFactory;
-import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.jivesoftware.openfire.spi.ConnectionType;
-import org.jivesoftware.openfire.event.ServerSessionEventDispatcher;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.StringUtils;
 import org.jivesoftware.util.cache.Cache;
@@ -51,6 +42,13 @@ import org.xmpp.packet.StreamError;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
+import java.io.*;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Implementation of the Server Dialback method as defined by the RFC3920.
@@ -657,7 +655,7 @@ public class ServerDialback {
 
         VerifyResult result = VerifyResult.error;
 
-        final ConnectionManagerImpl connectionManager = ( (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager() );
+        final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
         final TLSStreamHandler tlsStreamHandler = new TLSStreamHandler( socket, connectionManager.getListener( ConnectionType.SOCKET_S2S, directTLS ).generateConnectionConfiguration(), true );
 
         if ( directTLS ) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
@@ -18,17 +18,13 @@ package org.jivesoftware.openfire.session;
 
 import org.dom4j.Element;
 import org.dom4j.io.XMPPPacketReader;
-import org.jivesoftware.openfire.Connection;
-import org.jivesoftware.openfire.SessionManager;
-import org.jivesoftware.openfire.StreamID;
-import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.*;
 import org.jivesoftware.openfire.auth.AuthFactory;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.multiplex.ConnectionMultiplexerManager;
 import org.jivesoftware.openfire.multiplex.MultiplexerPacketDeliverer;
 import org.jivesoftware.openfire.net.SASLAuthentication;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
-import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.jivesoftware.openfire.spi.ConnectionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -261,7 +257,7 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
      */
     private void sendClientOptions() {
 
-        final ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
+        final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
         final ConnectionConfiguration configuration = connectionManager.getListener( ConnectionType.SOCKET_C2S, false ).generateConnectionConfiguration();
 
         IQ options = new IQ(IQ.Type.set);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.jivesoftware.openfire.spi;
 
 import org.apache.mina.transport.socket.nio.NioSocketAcceptor;
 import org.jivesoftware.openfire.Connection;
+import org.jivesoftware.openfire.ConnectionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.keystore.CertificateStoreConfiguration;
 import org.jivesoftware.openfire.net.SocketConnection;
@@ -95,7 +96,7 @@ public class ConnectionListener
 
 
     ConnectionListener getConnectionListener( ConnectionType type ) {
-        ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
+        ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
         return connectionManager.getListener( type, getTLSPolicy().equals( Connection.TLSPolicy.legacyMode ) );
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -409,6 +409,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
      *
      * @return All connection listeners (never null).
      */
+    @Override
     public Set<ConnectionListener> getListeners() {
         final Set<ConnectionListener> listeners = new LinkedHashSet<>();
         listeners.add( clientListener );
@@ -438,6 +439,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
      * @param startInSslMode true when the listener to be configured is in legacy SSL mode, otherwise false.
      * @return The connection listener (never null).
      */
+    @Override
     public ConnectionListener getListener( ConnectionType type, boolean startInSslMode )
     {
         switch ( type )
@@ -493,6 +495,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
      * @param type The connection type for which a listener is to be configured.
      * @return The connection listener (never null).
      */
+    @Override
     public Set<ConnectionListener> getListeners( ConnectionType type )
     {
         final Set<ConnectionListener> result = new HashSet<>();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
@@ -16,13 +16,13 @@
 package org.jivesoftware.openfire.websocket;
 
 import org.dom4j.Namespace;
+import org.jivesoftware.openfire.ConnectionManager;
 import org.jivesoftware.openfire.PacketDeliverer;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.net.VirtualConnection;
 import org.jivesoftware.openfire.session.LocalSession;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
-import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.jivesoftware.openfire.spi.ConnectionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -179,7 +179,7 @@ public class WebSocketConnection extends VirtualConnection
     @Override
     public ConnectionConfiguration getConfiguration() {
         if (configuration == null) {
-            final ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
+            final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
             configuration = connectionManager.getListener( connectionType, true ).generateConnectionConfiguration();
         }
         return configuration;

--- a/xmppserver/src/main/webapp/compression-settings.jsp
+++ b/xmppserver/src/main/webapp/compression-settings.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, Ignite Realtime Foundation 2023. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -18,12 +18,12 @@
 
 <%@ page errorPage="error.jsp" %>
 <%@ page import="org.jivesoftware.openfire.Connection" %>
-<%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
 <%@ page import="org.jivesoftware.util.CookieUtils" %>
 <%@ page import="org.jivesoftware.util.StringUtils" %>
+<%@ page import="org.jivesoftware.openfire.ConnectionManager" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -43,7 +43,7 @@
     boolean clientEnabled = ParamUtils.getBooleanParameter(request, "clientEnabled");
     boolean serverEnabled = ParamUtils.getBooleanParameter(request, "serverEnabled");
 
-    final ConnectionManagerImpl connectionManager = (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager();
+    final ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
     Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
     String csrfParam = ParamUtils.getParameter(request, "csrf");
 

--- a/xmppserver/src/main/webapp/connection-settings-advanced.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-advanced.jsp
@@ -6,6 +6,7 @@
 <%@ page import="org.jivesoftware.openfire.Connection" %>
 <%@ page import="org.jivesoftware.openfire.spi.*" %>
 <%@ page import="java.util.*" %>
+<%@ page import="org.jivesoftware.openfire.ConnectionManager" %>
 <%@ page errorPage="error.jsp" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
@@ -47,7 +48,7 @@
         errors.put( "connectionMode", "Unrecognized connection mode." );
     }
 
-    final ConnectionManagerImpl manager = (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager();
+    final ConnectionManager manager = XMPPServer.getInstance().getConnectionManager();
     final boolean startInSslMode = "legacy".equalsIgnoreCase( connectionModeParam );
 
     if ( update && errors.isEmpty() )

--- a/xmppserver/src/main/webapp/connection-settings-external-components.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-external-components.jsp
@@ -4,7 +4,6 @@
 <%@ page import="org.jivesoftware.openfire.component.ExternalComponentManager" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionConfiguration" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionListener" %>
-<%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ page import="org.jivesoftware.util.ModificationNotAllowedException" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
@@ -13,6 +12,7 @@
 <%@ page import="org.xmpp.packet.JID" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="org.jivesoftware.openfire.ConnectionManager" %>
 <%@ page errorPage="error.jsp" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
@@ -23,7 +23,7 @@
 <% webManager.init(request, response, session, application, out ); %>
 <%
     final ConnectionType connectionType = ConnectionType.COMPONENT;
-    final ConnectionManagerImpl manager = (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager();
+    final ConnectionManager manager = XMPPServer.getInstance().getConnectionManager();
 
     final ConnectionConfiguration plaintextConfiguration  = manager.getListener( connectionType, false ).generateConnectionConfiguration();
     final ConnectionConfiguration legacymodeConfiguration = manager.getListener( connectionType, true  ).generateConnectionConfiguration();

--- a/xmppserver/src/main/webapp/connection-settings-socket-c2s.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-socket-c2s.jsp
@@ -6,11 +6,11 @@
 <%@ page import="org.jivesoftware.openfire.session.ConnectionSettings" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionConfiguration" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionListener" %>
-<%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ page import="org.jivesoftware.util.CookieUtils" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
 <%@ page import="org.jivesoftware.util.StringUtils" %>
+<%@ page import="org.jivesoftware.openfire.ConnectionManager" %>
 <%@ page errorPage="error.jsp" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
@@ -20,7 +20,7 @@
 <% webManager.init(request, response, session, application, out ); %>
 <%
     final ConnectionType connectionType = ConnectionType.SOCKET_C2S;
-    final ConnectionManagerImpl manager = (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager();
+    final ConnectionManager manager = XMPPServer.getInstance().getConnectionManager();
 
     final ConnectionConfiguration plaintextConfiguration  = manager.getListener( connectionType, false ).generateConnectionConfiguration();
     final ConnectionConfiguration legacymodeConfiguration = manager.getListener( connectionType, true  ).generateConnectionConfiguration();

--- a/xmppserver/src/main/webapp/connection-settings-socket-s2s.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-socket-s2s.jsp
@@ -1,6 +1,5 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionConfiguration" %>
-<%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionListener" %>
@@ -11,6 +10,7 @@
 <%@ page import="org.jivesoftware.openfire.server.RemoteServerManager" %>
 <%@ page import="org.jivesoftware.openfire.server.RemoteServerConfiguration" %>
 <%@ page import="org.jivesoftware.util.StringUtils" %>
+<%@ page import="org.jivesoftware.openfire.ConnectionManager" %>
 <%@ page errorPage="error.jsp" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
@@ -20,7 +20,7 @@
 <% webManager.init(request, response, session, application, out ); %>
 <%
     final ConnectionType connectionType = ConnectionType.SOCKET_S2S;
-    final ConnectionManagerImpl manager = (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager();
+    final ConnectionManager manager = XMPPServer.getInstance().getConnectionManager();
 
     pageContext.setAttribute("permissionPolicy", RemoteServerManager.getPermissionPolicy().toString());
 

--- a/xmppserver/src/main/webapp/dns-check.jsp
+++ b/xmppserver/src/main/webapp/dns-check.jsp
@@ -5,8 +5,8 @@
 <%@ page import="org.jivesoftware.openfire.net.DNSUtil" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionConfiguration" %>
-<%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
+<%@ page import="org.jivesoftware.openfire.ConnectionManager" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -43,7 +43,7 @@
         }
     }
 
-    final ConnectionManagerImpl manager = (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager();
+    final ConnectionManager manager = XMPPServer.getInstance().getConnectionManager();
 
     final ConnectionConfiguration plaintextClientConfiguration  = manager.getListener( ConnectionType.SOCKET_C2S, false ).generateConnectionConfiguration();
     final ConnectionConfiguration legacymodeClientConfiguration = manager.getListener( ConnectionType.SOCKET_C2S, true  ).generateConnectionConfiguration();

--- a/xmppserver/src/main/webapp/http-bind.jsp
+++ b/xmppserver/src/main/webapp/http-bind.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -16,16 +16,15 @@
 --%>
 <%@ page import="org.jivesoftware.openfire.http.HttpBindManager" %>
 <%@ page import="org.jivesoftware.util.CookieUtils" %>
-<%@ page import="org.jivesoftware.util.Log" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
 <%@ page import="org.jivesoftware.util.StringUtils" %>
 <%@ page import="org.jivesoftware.openfire.Connection" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionConfiguration" %>
-<%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
 <%@ page import="java.util.*" %>
+<%@ page import="org.jivesoftware.openfire.ConnectionManager" %>
 <%@ page contentType="text/html;charset=UTF-8" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
@@ -52,7 +51,7 @@
             final boolean isXFFEnabled = ParamUtils.getBooleanParameter( request, "XFFEnabled", HttpBindManager.HTTP_BIND_FORWARDED.getValue() );
             final String CORSDomains = ParamUtils.getParameter( request, "CORSDomains", true );
 
-            final ConnectionManagerImpl manager = (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager();
+            final ConnectionManager manager = XMPPServer.getInstance().getConnectionManager();
             final ConnectionConfiguration configuration = manager.getListener( ConnectionType.BOSH_C2S, true ).generateConnectionConfiguration();
             final String mutualAuthenticationText = ParamUtils.getParameter( request, "mutualauthentication", true );
             final Connection.ClientAuth mutualAuthentication;
@@ -142,7 +141,7 @@
 
     csrfParam = StringUtils.randomString( 15 );
     CookieUtils.setCookie( request, response, "csrf", csrfParam, -1 );
-    final ConnectionManagerImpl manager = (ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager();
+    final ConnectionManager manager = XMPPServer.getInstance().getConnectionManager();
     final ConnectionConfiguration configuration = manager.getListener( ConnectionType.BOSH_C2S, true ).generateConnectionConfiguration();
 
     pageContext.setAttribute( "csrf", csrfParam );

--- a/xmppserver/src/main/webapp/index.jsp
+++ b/xmppserver/src/main/webapp/index.jsp
@@ -1,8 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
-<%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -25,7 +24,6 @@
 <%@ page import="org.jivesoftware.openfire.keystore.IdentityStore" %>
 <%@ page import="org.jivesoftware.openfire.mediaproxy.MediaProxyService" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionListener" %>
-<%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ page import="org.jivesoftware.openfire.update.Update" %>
 <%@ page import="org.jivesoftware.openfire.update.UpdateManager" %>
@@ -50,6 +48,8 @@
 <%@ page import="com.rometools.rome.feed.synd.SyndEntry" %>
 <%@ page import="java.io.InputStreamReader" %>
 <%@ page import="org.jivesoftware.util.MemoryUsageMonitor" %>
+<%@ page import="org.jivesoftware.openfire.ConnectionManager" %>
+<%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -77,8 +77,7 @@
 <% // Get parameters //
     boolean serverOn = (webManager.getXMPPServer() != null);
 
-    ConnectionManagerImpl connectionManager = ((ConnectionManagerImpl) XMPPServer.getInstance().getConnectionManager());
-
+    ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
     FileTransferProxy fileTransferProxy = XMPPServer.getInstance().getFileTransferProxy();
     MediaProxyService mediaProxyService = XMPPServer.getInstance().getMediaProxyService();
 
@@ -579,10 +578,10 @@
     }
 
     final String interfaceName;
-    if (connectionManager.getListenAddress() == null || connectionManager.getListenAddress().isAnyLocalAddress() ) {
+    if (((ConnectionManagerImpl)connectionManager).getListenAddress() == null || ((ConnectionManagerImpl)connectionManager).getListenAddress().isAnyLocalAddress() ) {
         interfaceName = LocaleUtils.getLocalizedString("ports.all_ports");
     } else {
-        interfaceName = connectionManager.getListenAddress().getHostName();
+        interfaceName = ((ConnectionManagerImpl)connectionManager).getListenAddress().getHostName();
     }
 %>
     <%


### PR DESCRIPTION
Openfire’s `ConnectionManager` module has one implementation: `ConnectionManagerImpl`. The two are often used interchangably.

Where possible, Openfire should use the interface, rather than the implemention. This can be easily achieved by defining often-used methods in the interface definition. If these methods are that important, that should be reason enough to define them in the interface contract.

The benefit of this approach is that mocking a `ConnectionManager` becomes easier.