### PR TITLE
OF-2616: Upgrade Gauva from 30.1-jre to 32.0.1-jre

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -453,7 +453,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.github.jgonian</groupId>


### PR DESCRIPTION
This intends to replace https://github.com/igniterealtime/Openfire/pull/2203