### PR TITLE
OF-2621: Fix the href link error on muc-service-summary.jsp

### DIFF
--- a/xmppserver/src/main/webapp/muc-service-summary.jsp
+++ b/xmppserver/src/main/webapp/muc-service-summary.jsp
@@ -195,7 +195,7 @@
             <%= StringUtils.escapeHTMLTags(service.getDescription()) %> &nbsp;
         </td>
         <td style="width: 5%">
-            <a href="muc-room-summary.jsp?mucname==<%= URLEncoder.encode(service.getServiceName(), "UTF-8") %>"><%= service.getNumberChatRooms() %></a>
+            <a href="muc-room-summary.jsp?mucname=<%= URLEncoder.encode(service.getServiceName(), "UTF-8") %>"><%= service.getNumberChatRooms() %></a>
         </td>
         <td style="width: 5%">
             <%= service.getNumberConnectedUsers() %>


### PR DESCRIPTION
The room count href link on muc-service-summary.jsp jump to muc-room-summary.jsp add parameter use '==', this will jump to the default page on muc-room-summary.jsp.