### PR TITLE
OF-2622: Do not accept inbound Server Dialback when disabled

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerSocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerSocketReader.java
@@ -22,6 +22,7 @@ import org.jivesoftware.openfire.RoutingTable;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.event.ServerSessionEventDispatcher;
 import org.jivesoftware.openfire.interceptor.PacketRejectedException;
+import org.jivesoftware.openfire.server.ServerDialback;
 import org.jivesoftware.openfire.session.LocalIncomingServerSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -195,7 +196,10 @@ public class ServerSocketReader extends SocketReader {
 
     @Override
     public String getExtraNamespaces() {
-        return "xmlns:db=\"jabber:server:dialback\"";
+        if (ServerDialback.isEnabled() || ServerDialback.isEnabledForSelfSigned()) {
+            return "xmlns:db=\"jabber:server:dialback\"";
+        }
+        return super.getExtraNamespaces();
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -129,7 +129,9 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
             // Send the stream header
             StringBuilder openingStream = new StringBuilder();
             openingStream.append("<stream:stream");
-            openingStream.append(" xmlns:db=\"jabber:server:dialback\"");
+            if (ServerDialback.isEnabled() || ServerDialback.isEnabledForSelfSigned()) {
+                openingStream.append(" xmlns:db=\"jabber:server:dialback\"");
+            }
             openingStream.append(" xmlns:stream=\"http://etherx.jabber.org/streams\"");
             openingStream.append(" xmlns=\"jabber:server\"");
             openingStream.append(" from=\"").append(toDomain).append("\"");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -294,7 +294,9 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
             log.debug( "Send the stream header and wait for response..." );
             StringBuilder openingStream = new StringBuilder();
             openingStream.append("<stream:stream");
-            openingStream.append(" xmlns:db=\"jabber:server:dialback\"");
+            if (ServerDialback.isEnabled() || ServerDialback.isEnabledForSelfSigned()) {
+                openingStream.append(" xmlns:db=\"jabber:server:dialback\"");
+            }
             openingStream.append(" xmlns:stream=\"http://etherx.jabber.org/streams\"");
             openingStream.append(" xmlns=\"jabber:server\"");
             openingStream.append(" from=\"").append(domainPair.getLocal()).append("\""); // OF-673


### PR DESCRIPTION
If the Server Dialback feature is disabled, Openfire should not allow peers to authenticate with that authentication mechanism.

Additionally, Openfire should not define the corresponding XML namespace when the feature is disabled, as other servers might use that to determine support.