### PR TITLE
CI should generate javadoc

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: ${{ matrix.distribution }}
           cache: maven
       - name: Build with Maven
-        run: ./mvnw -B package -Pcoverage --file pom.xml
+        run: ./mvnw -B package -Pcoverage,ci --file pom.xml
       - name: Upload distribution
         if: ${{ matrix.distribution == 'zulu' }}
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Adding the 'ci' Maven profile to be used by the continuous integration build / Github flow.

This intends to generate javadoc (and maybe source) artifacts that are uploaded to the Maven repo.