### PR TITLE
OF-2624: Try to answer data forms in users' preferred language

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1103,6 +1103,8 @@ index.local=Locale / Timezone:
 index.process_owner=OS Process Owner:
 index.memory=Java Memory
 index.memory_usage_description={0} MB of {1} MB ({2}%) used
+index.available_users=Available Users
+index.available_users_sessions=Available Users Sessions
 index.update.alert=Update information
 index.update.info=Server version {0} is now available. Click {1}here{2} to download or read the \
         {3}change log{4} for more information.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PrivateStorage.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PrivateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ public class PrivateStorage extends BasicModule {
         Node node = pepService.getNode( data.getNamespaceURI() );
         if ( node == null )
         {
-            PubSubEngine.CreateNodeResponse response = PubSubEngine.createNodeHelper( pepService, owner, pepService.getDefaultNodeConfiguration( true ).getConfigurationForm().getElement(), data.getNamespaceURI(), PRIVATE_DATA_PUBLISHING_OPTIONS );
+            PubSubEngine.CreateNodeResponse response = PubSubEngine.createNodeHelper( pepService, owner, pepService.getDefaultNodeConfiguration( true ).getConfigurationForm(null).getElement(), data.getNamespaceURI(), PRIVATE_DATA_PUBLISHING_OPTIONS );
             node = response.newNode;
 
             if ( node == null )

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1271,6 +1271,20 @@ public class SessionManager extends BasicModule implements ClusterEventListener
     public void setConflictKickLimit(int limit) {
         conflictLimit = limit;
         CONFLICT_LIMIT.setValue(limit);
+    }
+
+    public Locale getLocaleForSession(JID address)
+    {
+        if (address == null || !XMPPServer.getInstance().isLocal(address)) {
+            return null;
+        }
+
+        final ClientSession session = getSession(address);
+        if (session == null) {
+            return null;
+        }
+
+        return session.getLanguage();
     }
 
     private class ClientSessionListener implements ConnectionCloseListener {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetServerStats.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetServerStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,8 @@ public class GetServerStats extends AdHocCommand {
 
     @Override
     public void execute(SessionData data, Element command) {
+        final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(data.getOwner());
+
         DataForm form = new DataForm(DataForm.Type.result);
 
         FormField field = form.addField();
@@ -59,25 +61,25 @@ public class GetServerStats extends AdHocCommand {
 
         field = form.addField();
         field.setType(FormField.Type.text_single);
-        field.setLabel(LocaleUtils.getLocalizedString("index.server_name"));
+        field.setLabel(LocaleUtils.getLocalizedString("index.server_name", preferredLocale));
         field.setVariable("name");
         field.addValue(AdminConsole.getAppName());
 
         field = form.addField();
         field.setType(FormField.Type.text_single);
-        field.setLabel(LocaleUtils.getLocalizedString("index.version"));
+        field.setLabel(LocaleUtils.getLocalizedString("index.version", preferredLocale));
         field.setVariable("version");
         field.addValue(AdminConsole.getVersionString());
 
         field = form.addField();
         field.setType(FormField.Type.text_single);
-        field.setLabel(LocaleUtils.getLocalizedString("index.domain_name"));
+        field.setLabel(LocaleUtils.getLocalizedString("index.domain_name", preferredLocale));
         field.setVariable("domain");
         field.addValue(XMPPServer.getInstance().getServerInfo().getXMPPDomain());
 
         field = form.addField();
         field.setType(FormField.Type.text_single);
-        field.setLabel(LocaleUtils.getLocalizedString("index.jvm"));
+        field.setLabel(LocaleUtils.getLocalizedString("index.jvm", preferredLocale));
         field.setVariable("os");
         String vmName = System.getProperty("java.vm.name");
         if (vmName == null) {
@@ -90,7 +92,7 @@ public class GetServerStats extends AdHocCommand {
 
         field = form.addField();
         field.setType(FormField.Type.text_single);
-        field.setLabel(LocaleUtils.getLocalizedString("index.uptime"));
+        field.setLabel(LocaleUtils.getLocalizedString("index.uptime", preferredLocale));
         field.setVariable("uptime");
         field.addValue(XMPPDateTimeFormat.format(XMPPServer.getInstance().getServerInfo().getLastStarted()));
 
@@ -105,7 +107,7 @@ public class GetServerStats extends AdHocCommand {
         double percentUsed = 100 - percentFree;
         field = form.addField();
         field.setType(FormField.Type.text_single);
-        field.setLabel(LocaleUtils.getLocalizedString("index.memory"));
+        field.setLabel(LocaleUtils.getLocalizedString("index.memory", preferredLocale));
         field.setVariable("memory");
         field.addValue(mbFormat.format(usedMemory) + " MB of " + mbFormat.format(maxMemory) + " MB (" +
                 percentFormat.format(percentUsed) + "%) used");
@@ -122,13 +124,13 @@ public class GetServerStats extends AdHocCommand {
         }
         field = form.addField();
         field.setType(FormField.Type.text_single);
-        field.setLabel("Available Users");
+        field.setLabel(LocaleUtils.getLocalizedString("index.available_users", preferredLocale));
         field.setVariable("activeusersnum");
         field.addValue(users.size());
 
         field = form.addField();
         field.setType(FormField.Type.text_single);
-        field.setLabel("Available Users Sessions");
+        field.setLabel(LocaleUtils.getLocalizedString("index.available_users_sessions", preferredLocale));
         field.setVariable("sessionsnum");
         field.addValue(availableSessions);
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2021-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,7 @@ package org.jivesoftware.openfire.muc.spi;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.QName;
-import org.jivesoftware.openfire.PacketException;
-import org.jivesoftware.openfire.RoutingTable;
-import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.openfire.XMPPServerListener;
+import org.jivesoftware.openfire.*;
 import org.jivesoftware.openfire.archive.Archiver;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.cluster.ClusterEventListener;
@@ -2969,6 +2966,9 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
             // Answer the extended info of a given room
             final MUCRoom room = getChatRoom(name);
             if (room != null) {
+
+                final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(senderJID);
+
                 final DataForm dataForm = new DataForm(Type.result);
 
                 final FormField fieldType = dataForm.addField();
@@ -2979,19 +2979,19 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                 final FormField fieldDescr = dataForm.addField();
                 fieldDescr.setVariable("muc#roominfo_description");
                 fieldDescr.setType(FormField.Type.text_single);
-                fieldDescr.setLabel(LocaleUtils.getLocalizedString("muc.extended.info.desc"));
+                fieldDescr.setLabel(LocaleUtils.getLocalizedString("muc.extended.info.desc", preferredLocale));
                 fieldDescr.addValue(room.getDescription());
 
                 final FormField fieldSubj = dataForm.addField();
                 fieldSubj.setVariable("muc#roominfo_subject");
                 fieldSubj.setType(FormField.Type.text_single);
-                fieldSubj.setLabel(LocaleUtils.getLocalizedString("muc.extended.info.subject"));
+                fieldSubj.setLabel(LocaleUtils.getLocalizedString("muc.extended.info.subject", preferredLocale));
                 fieldSubj.addValue(room.getSubject());
 
                 final FormField fieldOcc = dataForm.addField();
                 fieldOcc.setVariable("muc#roominfo_occupants");
                 fieldOcc.setType(FormField.Type.text_single);
-                fieldOcc.setLabel(LocaleUtils.getLocalizedString("muc.extended.info.occupants"));
+                fieldOcc.setLabel(LocaleUtils.getLocalizedString("muc.extended.info.occupants", preferredLocale));
                 fieldOcc.addValue(Integer.toString(room.getOccupantsCount()));
 
                 /*field = new XFormFieldImpl("muc#roominfo_lang");
@@ -3003,7 +3003,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                 final FormField fieldDate = dataForm.addField();
                 fieldDate.setVariable("x-muc#roominfo_creationdate");
                 fieldDate.setType(FormField.Type.text_single);
-                fieldDate.setLabel(LocaleUtils.getLocalizedString("muc.extended.info.creationdate"));
+                fieldDate.setLabel(LocaleUtils.getLocalizedString("muc.extended.info.creationdate", preferredLocale));
                 fieldDate.addValue(XMPPDateTimeFormat.format(room.getCreationDate()));
                 final Set<DataForm> dataForms = new HashSet<>();
                 dataForms.add(dataForm);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.dom4j.Element;
 import org.dom4j.QName;
 import org.jivesoftware.openfire.IQHandlerInfo;
 import org.jivesoftware.openfire.JMXManager;
+import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.disco.*;
 import org.jivesoftware.openfire.event.UserEventDispatcher;
@@ -810,11 +811,12 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
         JID recipientJID = XMPPServer.getInstance().createJID(name, null, true).asBareJID();
         PEPService pepService = pepServiceManager.getPEPService(recipientJID);
         if (node != null) {
+            final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(senderJID);
             // Answer the extended info of a given node
             Node pubNode = pepService.getNode(node);
             // Get the metadata data form
             final Set<DataForm> dataForms = new HashSet<>();
-            dataForms.add(pubNode.getMetadataForm());
+            dataForms.add(pubNode.getMetadataForm(preferredLocale));
             return dataForms;
         }
         return new HashSet<>();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,6 @@
 
 package org.jivesoftware.openfire.pubsub;
 
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.dom4j.Element;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.pep.PEPService;
@@ -40,6 +30,12 @@ import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A type of node that contains nodes and/or other collections but no published
@@ -156,8 +152,8 @@ public class CollectionNode extends Node {
     }
 
     @Override
-    protected void addFormFields(DataForm form, boolean isEditing) {
-        super.addFormFields(form, isEditing);
+    protected void addFormFields(DataForm form, Locale preferredLocale, boolean isEditing) {
+        super.addFormFields(form, preferredLocale, isEditing);
 
         FormField typeField = form.getField("pubsub#node_type");
         typeField.addValue("collection");
@@ -167,10 +163,10 @@ public class CollectionNode extends Node {
         formField.setVariable("pubsub#leaf_node_association_policy");
         if (isEditing) {
             formField.setType(FormField.Type.list_single);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy"));
-            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.all"), LeafNodeAssociationPolicy.all.name());
-            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.owners"), LeafNodeAssociationPolicy.owners.name());
-            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.whitelist"), LeafNodeAssociationPolicy.whitelist.name());
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy", preferredLocale));
+            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.all", preferredLocale), LeafNodeAssociationPolicy.all.name());
+            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.owners", preferredLocale), LeafNodeAssociationPolicy.owners.name());
+            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.whitelist", preferredLocale), LeafNodeAssociationPolicy.whitelist.name());
         }
         formField.addValue(associationPolicy.name());
 
@@ -178,10 +174,10 @@ public class CollectionNode extends Node {
         formField.setVariable("pubsub#children_association_policy");
         if (isEditing) {
             formField.setType(FormField.Type.list_single);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy"));
-            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.all"), LeafNodeAssociationPolicy.all.name());
-            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.owners"), LeafNodeAssociationPolicy.owners.name());
-            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.whitelist"), LeafNodeAssociationPolicy.whitelist.name());
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy", preferredLocale));
+            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.all", preferredLocale), LeafNodeAssociationPolicy.all.name());
+            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.owners", preferredLocale), LeafNodeAssociationPolicy.owners.name());
+            formField.addOption(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_policy.whitelist", preferredLocale), LeafNodeAssociationPolicy.whitelist.name());
         }
         formField.addValue(associationPolicy.name());
 
@@ -190,7 +186,7 @@ public class CollectionNode extends Node {
         formField.setVariable("pubsub#leaf_node_association_whitelist");
         if (isEditing) {
             formField.setType(FormField.Type.jid_multi);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_whitelist"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_whitelist", preferredLocale));
         }
         for (JID contact : associationTrusted) {
             formField.addValue(contact.toString());
@@ -200,7 +196,7 @@ public class CollectionNode extends Node {
         formField.setVariable("pubsub#children_association_whitelist");
         if (isEditing) {
             formField.setType(FormField.Type.jid_multi);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_whitelist"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_association_whitelist", preferredLocale));
         }
         for (JID contact : associationTrusted) {
             formField.addValue(contact.toString());
@@ -210,7 +206,7 @@ public class CollectionNode extends Node {
         formField.setVariable("pubsub#leaf_nodes_max");
         if (isEditing) {
             formField.setType(FormField.Type.text_single);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_max"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_max", preferredLocale));
         }
         formField.addValue(maxLeafNodes);
 
@@ -218,7 +214,7 @@ public class CollectionNode extends Node {
         formField.setVariable("pubsub#children_max");
         if (isEditing) {
             formField.setType(FormField.Type.text_single);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_max"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children_max", preferredLocale));
         }
         formField.addValue(maxLeafNodes);
 
@@ -226,7 +222,7 @@ public class CollectionNode extends Node {
         formField.setVariable("pubsub#children");
         if (isEditing) {
             formField.setType(FormField.Type.text_multi);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.children", preferredLocale));
         }
         for (Node.UniqueIdentifier nodeId : nodes.keySet()) {
             formField.addValue(nodeId.getNodeId());
@@ -272,7 +268,7 @@ public class CollectionNode extends Node {
         Element item = items.addElement("item");
         item.addAttribute("id", child.getUniqueIdentifier().getNodeId());
         if (deliverPayloads) {
-            item.add(child.getMetadataForm().getElement());
+            item.add(child.getMetadataForm(null).getElement()); // FIXME: figure out a way to have proper localization.
         }
         // Broadcast event notification to subscribers
         broadcastCollectionNodeEvent(child, message);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
@@ -16,14 +16,16 @@
 
 package org.jivesoftware.openfire.pubsub;
 
-import org.jivesoftware.util.LocaleUtils;
 import org.jivesoftware.openfire.pubsub.models.AccessModel;
 import org.jivesoftware.openfire.pubsub.models.PublisherModel;
+import org.jivesoftware.util.LocaleUtils;
 import org.jivesoftware.util.cache.CacheSizes;
 import org.jivesoftware.util.cache.Cacheable;
 import org.jivesoftware.util.cache.CannotCalculateSizeException;
 import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
+
+import java.util.Locale;
 
 /**
  * A DefaultNodeConfiguration keeps the default configuration values for leaf or collection
@@ -433,10 +435,10 @@ public class DefaultNodeConfiguration implements Cacheable {
     }
 
 
-    public DataForm getConfigurationForm() {
+    public DataForm getConfigurationForm(Locale preferredLocale) {
         DataForm form = new DataForm(DataForm.Type.form);
-        form.setTitle(LocaleUtils.getLocalizedString("pubsub.form.default.title"));
-        form.addInstruction(LocaleUtils.getLocalizedString("pubsub.form.default.instruction"));
+        form.setTitle(LocaleUtils.getLocalizedString("pubsub.form.default.title", preferredLocale));
+        form.addInstruction(LocaleUtils.getLocalizedString("pubsub.form.default.instruction", preferredLocale));
         // Add the form fields and configure them for edition
 
         FormField formField = form.addField();
@@ -447,37 +449,37 @@ public class DefaultNodeConfiguration implements Cacheable {
         formField = form.addField();
         formField.setVariable("pubsub#subscribe");
         formField.setType(FormField.Type.boolean_type);
-        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.subscribe"));
+        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.subscribe", preferredLocale));
         formField.addValue(subscriptionEnabled);
 
         formField = form.addField();
         formField.setVariable("pubsub#deliver_payloads");
         formField.setType(FormField.Type.boolean_type);
-        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.deliver_payloads"));
+        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.deliver_payloads", preferredLocale));
         formField.addValue(deliverPayloads);
 
         formField = form.addField();
         formField.setVariable("pubsub#notify_config");
         formField.setType(FormField.Type.boolean_type);
-        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.notify_config"));
+        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.notify_config", preferredLocale));
         formField.addValue(notifyConfigChanges);
 
         formField = form.addField();
         formField.setVariable("pubsub#notify_delete");
         formField.setType(FormField.Type.boolean_type);
-        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.notify_delete"));
+        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.notify_delete", preferredLocale));
         formField.addValue(notifyDelete);
 
         formField = form.addField();
         formField.setVariable("pubsub#notify_retract");
         formField.setType(FormField.Type.boolean_type);
-        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.notify_retract"));
+        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.notify_retract", preferredLocale));
         formField.addValue(notifyRetract);
 
         formField = form.addField();
         formField.setVariable("pubsub#presence_based_delivery");
         formField.setType(FormField.Type.boolean_type);
-        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.presence_based"));
+        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.presence_based", preferredLocale));
         formField.addValue(presenceBasedDelivery);
 
         if (leaf) {
@@ -485,32 +487,32 @@ public class DefaultNodeConfiguration implements Cacheable {
             formField.setVariable("pubsub#send_item_subscribe");
             formField.setType(FormField.Type.boolean_type);
             formField.setLabel(
-                    LocaleUtils.getLocalizedString("pubsub.form.conf.send_item_subscribe"));
+                    LocaleUtils.getLocalizedString("pubsub.form.conf.send_item_subscribe", preferredLocale));
             formField.addValue(sendItemSubscribe);
 
             formField = form.addField();
             formField.setVariable("pubsub#persist_items");
             formField.setType(FormField.Type.boolean_type);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.persist_items"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.persist_items", preferredLocale));
             formField.addValue(persistPublishedItems);
 
             formField = form.addField();
             formField.setVariable("pubsub#max_items");
             formField.setType(FormField.Type.text_single);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.max_items"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.max_items", preferredLocale));
             formField.addValue(maxPublishedItems);
 
             formField = form.addField();
             formField.setVariable("pubsub#max_payload_size");
             formField.setType(FormField.Type.text_single);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.max_payload_size"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.max_payload_size", preferredLocale));
             formField.addValue(maxPayloadSize);
         }
 
         formField = form.addField();
         formField.setVariable("pubsub#access_model");
         formField.setType(FormField.Type.list_single);
-        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.access_model"));
+        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.access_model", preferredLocale));
         formField.addOption(null, AccessModel.authorize.getName());
         formField.addOption(null, AccessModel.open.getName());
         formField.addOption(null, AccessModel.presence.getName());
@@ -521,7 +523,7 @@ public class DefaultNodeConfiguration implements Cacheable {
         formField = form.addField();
         formField.setVariable("pubsub#publish_model");
         formField.setType(FormField.Type.list_single);
-        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.publish_model"));
+        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.publish_model", preferredLocale));
         formField.addOption(null, PublisherModel.publishers.getName());
         formField.addOption(null, PublisherModel.subscribers.getName());
         formField.addOption(null, PublisherModel.open.getName());
@@ -530,13 +532,13 @@ public class DefaultNodeConfiguration implements Cacheable {
         formField = form.addField();
         formField.setVariable("pubsub#language");
         formField.setType(FormField.Type.text_single);
-        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.language"));
+        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.language", preferredLocale));
         formField.addValue(language);
 
         formField = form.addField();
         formField.setVariable("pubsub#itemreply");
         formField.setType(FormField.Type.list_single);
-        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.itemreply"));
+        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.itemreply", preferredLocale));
         if (replyPolicy != null) {
             formField.addValue(replyPolicy.name());
         }
@@ -545,7 +547,7 @@ public class DefaultNodeConfiguration implements Cacheable {
             formField = form.addField();
             formField.setVariable("pubsub#leaf_node_association_policy");
             formField.setType(FormField.Type.list_single);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.leaf_node_association"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.leaf_node_association", preferredLocale));
             formField.addOption(null, CollectionNode.LeafNodeAssociationPolicy.all.name());
             formField.addOption(null, CollectionNode.LeafNodeAssociationPolicy.owners.name());
             formField.addOption(null, CollectionNode.LeafNodeAssociationPolicy.whitelist.name());
@@ -554,7 +556,7 @@ public class DefaultNodeConfiguration implements Cacheable {
             formField = form.addField();
             formField.setVariable("pubsub#leaf_nodes_max");
             formField.setType(FormField.Type.text_single);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.leaf_nodes_max"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.leaf_nodes_max", preferredLocale));
             formField.addValue(maxLeafNodes);
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/LeafNode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/LeafNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,6 @@
  */
 
 package org.jivesoftware.openfire.pubsub;
-
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.*;
 
 import org.dom4j.Element;
 import org.jivesoftware.openfire.SessionManager;
@@ -38,6 +33,11 @@ import org.xmpp.forms.FormField;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.*;
 
 import static org.jivesoftware.openfire.muc.spi.IQOwnerHandler.parseFirstValueAsBoolean;
 
@@ -126,8 +126,8 @@ public class LeafNode extends Node {
     }
 
     @Override
-    protected void addFormFields(DataForm form, boolean isEditing) {
-        super.addFormFields(form, isEditing);
+    protected void addFormFields(DataForm form, Locale preferredLocale, boolean isEditing) {
+        super.addFormFields(form, preferredLocale, isEditing);
 
         FormField typeField = form.getField("pubsub#node_type");
         typeField.addValue("leaf");
@@ -137,7 +137,7 @@ public class LeafNode extends Node {
         if (isEditing) {
             formField.setType(FormField.Type.boolean_type);
             formField.setLabel(
-                    LocaleUtils.getLocalizedString("pubsub.form.conf.send_item_subscribe"));
+                    LocaleUtils.getLocalizedString("pubsub.form.conf.send_item_subscribe", preferredLocale));
         }
         formField.addValue(sendItemSubscribe);
 
@@ -145,7 +145,7 @@ public class LeafNode extends Node {
         formField.setVariable("pubsub#persist_items");
         if (isEditing) {
             formField.setType(FormField.Type.boolean_type);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.persist_items"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.persist_items", preferredLocale));
         }
         formField.addValue(persistPublishedItems);
 
@@ -153,7 +153,7 @@ public class LeafNode extends Node {
         formField.setVariable("pubsub#max_items");
         if (isEditing) {
             formField.setType(FormField.Type.text_single);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.max_items"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.max_items", preferredLocale));
         }
         formField.addValue(maxPublishedItems);
 
@@ -161,7 +161,7 @@ public class LeafNode extends Node {
         formField.setVariable("pubsub#max_payload_size");
         if (isEditing) {
             formField.setType(FormField.Type.text_single);
-            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.max_payload_size"));
+            formField.setLabel(LocaleUtils.getLocalizedString("pubsub.form.conf.max_payload_size", preferredLocale));
         }
         formField.addValue(maxPayloadSize);
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PendingSubscriptionsCommand.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PendingSubscriptionsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.openfire.pubsub;
 
 import org.dom4j.Element;
+import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.commands.AdHocCommand;
 import org.jivesoftware.openfire.commands.SessionData;
 import org.jivesoftware.util.LocaleUtils;
@@ -26,6 +27,7 @@ import org.xmpp.packet.JID;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Ad-hoc command that sends pending subscriptions to node owners.
@@ -42,16 +44,15 @@ public class PendingSubscriptionsCommand extends AdHocCommand {
 
     @Override
     protected void addStageInformation(SessionData data, Element command) {
+        final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(data.getOwner());
         DataForm form = new DataForm(DataForm.Type.form);
-        form.setTitle(LocaleUtils.getLocalizedString("pubsub.command.pending-subscriptions.title"));
-        form.addInstruction(
-                LocaleUtils.getLocalizedString("pubsub.command.pending-subscriptions.instruction"));
+        form.setTitle(LocaleUtils.getLocalizedString("pubsub.command.pending-subscriptions.title", preferredLocale));
+        form.addInstruction(LocaleUtils.getLocalizedString("pubsub.command.pending-subscriptions.instruction", preferredLocale));
 
         FormField formField = form.addField();
         formField.setVariable("pubsub#node");
         formField.setType(FormField.Type.list_single);
-        formField.setLabel(
-                LocaleUtils.getLocalizedString("pubsub.command.pending-subscriptions.node"));
+        formField.setLabel(LocaleUtils.getLocalizedString("pubsub.command.pending-subscriptions.node", preferredLocale));
         for (Node node : service.getNodes()) {
             if (!node.isCollectionNode() && node.isAdmin(data.getOwner())) {
                 formField.addOption(null, node.getUniqueIdentifier().getNodeId());
@@ -63,27 +64,26 @@ public class PendingSubscriptionsCommand extends AdHocCommand {
 
     @Override
     public void execute(SessionData data, Element command) {
+        final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(data.getOwner());
+
         Element note = command.addElement("note");
         List<String> nodeIDs = data.getData().get("pubsub#node");
         if (nodeIDs.isEmpty()) {
             // No nodeID was provided by the requester
             note.addAttribute("type", "error");
-            note.setText(LocaleUtils.getLocalizedString(
-                    "pubsub.command.pending-subscriptions.error.idrequired"));
+            note.setText(LocaleUtils.getLocalizedString("pubsub.command.pending-subscriptions.error.idrequired", preferredLocale));
         }
         else if (nodeIDs.size() > 1) {
             // More than one nodeID was provided by the requester
             note.addAttribute("type", "error");
-            note.setText(LocaleUtils.getLocalizedString(
-                    "pubsub.command.pending-subscriptions.error.manyIDs"));
+            note.setText(LocaleUtils.getLocalizedString("pubsub.command.pending-subscriptions.error.manyIDs", preferredLocale));
         }
         else {
             Node node = service.getNode(nodeIDs.get(0));
             if (node != null) {
                 if (node.isAdmin(data.getOwner())) {
                     note.addAttribute("type", "info");
-                    note.setText(LocaleUtils.getLocalizedString(
-                            "pubsub.command.pending-subscriptions.success"));
+                    note.setText(LocaleUtils.getLocalizedString("pubsub.command.pending-subscriptions.success", preferredLocale));
 
                     for (NodeSubscription subscription : node.getPendingSubscriptions()) {
                         subscription.sendAuthorizationRequest(data.getOwner());
@@ -92,15 +92,13 @@ public class PendingSubscriptionsCommand extends AdHocCommand {
                 else {
                     // Requester is not an admin of the specified node
                     note.addAttribute("type", "error");
-                    note.setText(LocaleUtils.getLocalizedString(
-                            "pubsub.command.pending-subscriptions.error.forbidden"));
+                    note.setText(LocaleUtils.getLocalizedString("pubsub.command.pending-subscriptions.error.forbidden", preferredLocale));
                 }
             }
             else {
                 // Node with the specified nodeID was not found
                 note.addAttribute("type", "error");
-                note.setText(LocaleUtils.getLocalizedString(
-                        "pubsub.command.pending-subscriptions.error.badid"));
+                note.setText(LocaleUtils.getLocalizedString("pubsub.command.pending-subscriptions.error.badid", preferredLocale));
             }
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -507,7 +507,7 @@ public class PubSubEngine
             return true;
         }
 
-        final DataForm conditions = node.getConfigurationForm();
+        final DataForm conditions = node.getConfigurationForm(null);
         for ( final FormField precondition : preconditions.getFields() )
         {
             if ( precondition.getVariable().equals( "FORM_TYPE" ) )
@@ -933,10 +933,11 @@ public class PubSubEngine
         }
 
         // Return data form containing subscription configuration to the subscriber
+        final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(iq.getFrom());
         IQ reply = IQ.createResultIQ(iq);
         Element replyChildElement = childElement.createCopy();
         reply.setChildElement(replyChildElement);
-        replyChildElement.element("options").add(subscription.getConfigurationForm().getElement());
+        replyChildElement.element("options").add(subscription.getConfigurationForm(preferredLocale).getElement());
         router.route(reply);
     }
 
@@ -1467,10 +1468,12 @@ public class PubSubEngine
         }
 
         // Return data form containing node configuration to the owner
+        final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(iq.getFrom());
+
         IQ reply = IQ.createResultIQ(iq);
         Element replyChildElement = childElement.createCopy();
         reply.setChildElement(replyChildElement);
-        replyChildElement.element("configure").add(node.getConfigurationForm().getElement());
+        replyChildElement.element("configure").add(node.getConfigurationForm(preferredLocale).getElement());
         router.route(reply);
     }
 
@@ -1491,10 +1494,12 @@ public class PubSubEngine
         }
 
         // Return data form containing default node configuration
+        final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(iq.getFrom());
+
         IQ reply = IQ.createResultIQ(iq);
         Element replyChildElement = childElement.createCopy();
         reply.setChildElement(replyChildElement);
-        replyChildElement.element("default").add(config.getConfigurationForm().getElement());
+        replyChildElement.element("default").add(config.getConfigurationForm(preferredLocale).getElement());
         router.route(reply);
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,7 @@ package org.jivesoftware.openfire.pubsub;
 
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
-import org.jivesoftware.openfire.PacketRouter;
-import org.jivesoftware.openfire.RoutableChannelHandler;
-import org.jivesoftware.openfire.RoutingTable;
-import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.*;
 import org.jivesoftware.openfire.commands.AdHocCommandManager;
 import org.jivesoftware.openfire.component.InternalComponentManager;
 import org.jivesoftware.openfire.container.BasicModule;
@@ -685,7 +682,8 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
             Node pubNode = getNode(node);
             Set<DataForm> dataForms = new HashSet<>();
             if (canDiscoverNode(pubNode)) {
-                dataForms.add(pubNode.getMetadataForm());
+                final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(senderJID);
+                dataForms.add(pubNode.getMetadataForm(preferredLocale));
                 // Get the metadata data form
                 return dataForms;
             }

--- a/xmppserver/src/main/webapp/pubsub-node-edit.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-edit.jsp
@@ -57,7 +57,7 @@
     // Load the node object
     Node node = pubSubServiceInfo.getNode(nodeID);
 
-    DataForm form = node.getConfigurationForm();
+    DataForm form = node.getConfigurationForm(null);
 
     //Field that will not be returned to the server, i.e. cannot be edited on this page
     ArrayList<String> nonReturnFields = new ArrayList<>();


### PR DESCRIPTION
When a user is requesting a data form, try to localize the text in the form according to the user's preferred language.

In this commit, the preferred language is being obtained from the session of a locally connected user. This will not work for federated users.

As a fallback, the default langague as configured in Openfire is used (as is already the case prior to this commit).