### PR TITLE
OF-2628: Avoid polynomial regular expression used on uncontrolled data

### DIFF
--- a/xmppserver/src/test/java/org/jivesoftware/openfire/nio/XMLLightweightParserTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/nio/XMLLightweightParserTest.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests that verify the functionality as implemented in {@link XMLLightweightParser}
@@ -184,5 +183,33 @@ public class XMLLightweightParserTest {
         // Verify results.
         assertNotNull( result );
         assertEquals(1, result.length );
+    }
+
+    @Test
+    public void testHasIllegalCharacterReferencesFindsIllegalDecimalChars() throws Exception
+    {
+        final String input = "test &#65; test";
+        assertFalse(XMLLightweightParser.hasIllegalCharacterReferences(input));
+    }
+
+    @Test
+    public void testHasIllegalCharacterReferencesFindsLegalDecimalChars() throws Exception
+    {
+        final String input = "test &#7; test";
+        assertTrue(XMLLightweightParser.hasIllegalCharacterReferences(input));
+    }
+
+    @Test
+    public void testHasIllegalCharacterReferencesFindsIllegalHexChars() throws Exception
+    {
+        final String input = "test &#x41; test";
+        assertFalse(XMLLightweightParser.hasIllegalCharacterReferences(input));
+    }
+
+    @Test
+    public void testHasIllegalCharacterReferencesFindsLegalHexChars() throws Exception
+    {
+        final String input = "test &#x7; test";
+        assertTrue(XMLLightweightParser.hasIllegalCharacterReferences(input));
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/nio/XMLLightweightParserTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/nio/XMLLightweightParserTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Unit tests that verify the functionality as implemented in {@link XMLLightweightParser}
@@ -183,33 +184,5 @@ public class XMLLightweightParserTest {
         // Verify results.
         assertNotNull( result );
         assertEquals(1, result.length );
-    }
-
-    @Test
-    public void testHasIllegalCharacterReferencesFindsIllegalDecimalChars() throws Exception
-    {
-        final String input = "test &#65; test";
-        assertFalse(XMLLightweightParser.hasIllegalCharacterReferences(input));
-    }
-
-    @Test
-    public void testHasIllegalCharacterReferencesFindsLegalDecimalChars() throws Exception
-    {
-        final String input = "test &#7; test";
-        assertTrue(XMLLightweightParser.hasIllegalCharacterReferences(input));
-    }
-
-    @Test
-    public void testHasIllegalCharacterReferencesFindsIllegalHexChars() throws Exception
-    {
-        final String input = "test &#x41; test";
-        assertFalse(XMLLightweightParser.hasIllegalCharacterReferences(input));
-    }
-
-    @Test
-    public void testHasIllegalCharacterReferencesFindsLegalHexChars() throws Exception
-    {
-        final String input = "test &#x7; test";
-        assertTrue(XMLLightweightParser.hasIllegalCharacterReferences(input));
     }
 }


### PR DESCRIPTION
Prevent possibility of regular expression execution depending on user-provided values taking exceptionally long / many resources to complete

This commit replaces the regular expression with a solution that doesn't use regular expressions. Arguably, the complexity of this code does not change much.