### PR TITLE
OF-2592: autosetup: Do not force default DB when authprovider is default

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -490,9 +490,6 @@ public class XMPPServer {
 
         // steps from setup-profile-settings.jsp
         if ("default".equals(JiveGlobals.getXMLProperty("autosetup.authprovider.mode", "default"))) {
-            JiveGlobals.setXMLProperty("connectionProvider.className",
-                "org.jivesoftware.database.DefaultConnectionProvider");
-
             JiveGlobals.setProperty(AuthFactory.AUTH_PROVIDER.getKey(), JiveGlobals.getXMLProperty(AuthFactory.AUTH_PROVIDER.getKey(),
                 AuthFactory.AUTH_PROVIDER.getDefaultValue().getName()));
             JiveGlobals.setProperty(UserManager.USER_PROVIDER.getKey(), JiveGlobals.getXMLProperty(UserManager.USER_PROVIDER.getKey(),


### PR DESCRIPTION
When autosetup is running, existing code forced the database connection provider to be the default, when the authprovider was the default.

I'm not seeing why this is needed.

The result of this is that after running auto-setup (with a default auth provider config), all starts of Openfire except for the first one are likely to fail, when the original setup used something else than the default database provider (eg: the embedded provider).