### PR TITLE
OF-2631: Enforce pubsub node access model

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -850,6 +850,8 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
                             item.getSubStatus() == RosterItem.SUB_TO)) {
                         PEPService pepService = pepServiceManager.getPEPService(item.getJid().asBareJID());
                         if (pepService != null) {
+                            pepService.getRootCollectionNode().getSubscriptions(availableSessionJID)
+                            pepService.getRootCollectionNode().getAccessModel().canAccessItems(pepService.getRootCollectionNode(), availableSessionJID, availableSessionJID);
                             pepService.sendLastPublishedItems(availableSessionJID);
                         }
                     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -850,7 +850,7 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
                             item.getSubStatus() == RosterItem.SUB_TO)) {
                         PEPService pepService = pepServiceManager.getPEPService(item.getJid().asBareJID());
                         if (pepService != null) {
-                            pepService.getRootCollectionNode().getSubscriptions(availableSessionJID)
+                            pepService.getRootCollectionNode().getSubscriptions(availableSessionJID);
                             pepService.getRootCollectionNode().getAccessModel().canAccessItems(pepService.getRootCollectionNode(), availableSessionJID, availableSessionJID);
                             pepService.sendLastPublishedItems(availableSessionJID);
                         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
@@ -41,7 +41,7 @@ import static org.jivesoftware.openfire.muc.spi.IQOwnerHandler.parseFirstValueAs
  * A subscription to a node. Entities may subscribe to a node to be notified when new events
  * are published to the node. Published events may contain a {@link PublishedItem}. Only
  * nodes that are configured to not deliver payloads with event notifications and to not
- * persist items will let publishers to publish events without items thus not including
+ * persist items will let publishers publish events without items thus not including
  * items in the notifications sent to subscribers.<p>
  *
  * Node subscriptions may need to be configured by the subscriber or approved by a node owner
@@ -648,6 +648,9 @@ public class NodeSubscription {
                 return false;
             }
         }
+        if (!leafNode.getAccessModel().canAccessItems(leafNode, this.owner, this.getJID())) {
+            return false;
+        }
 
         Log.trace("Can send publication node event.");
         return true;
@@ -685,6 +688,10 @@ public class NodeSubscription {
         // Check if added/deleted node is a descendant child of the subscribed node
         if (getDepth() == 0 && !node.isDescendantNode(originatingNode)) {
             Log.trace("Cannot send child node event: node is not a descendant child of the subscribed node.");
+            return false;
+        }
+
+        if (!originatingNode.getAccessModel().canAccessItems(originatingNode, this.owner, this.getJID())) {
             return false;
         }
 


### PR DESCRIPTION
When items on a pubsub leaf node are processed, ensure that the access model of the node itself (and not just its collection) are taken into account.