### PR TITLE
OF-2559: Do not assume that all connections have established TLS

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -183,12 +183,18 @@ public class NettyConnection implements Connection {
     @Override
     public Optional<String> getTLSProtocolName() {
         SslHandler sslhandler = (SslHandler) channelHandlerContext.channel().pipeline().get(SSL_HANDLER_NAME);
+        if (sslhandler == null) {
+            return Optional.empty();
+        }
         return Optional.ofNullable(sslhandler.engine().getSession().getProtocol());
     }
 
     @Override
     public Optional<String> getCipherSuiteName() {
         SslHandler sslhandler = (SslHandler) channelHandlerContext.channel().pipeline().get(SSL_HANDLER_NAME);
+        if (sslhandler == null) {
+            return Optional.empty();
+        }
         return Optional.ofNullable(sslhandler.engine().getSession().getCipherSuite());
     }
 


### PR DESCRIPTION
This intends to guard against null pointer exceptions.

With the new Netty code, I'm seeing null pointer exceptions on the admin console (see screenshot).

Although this PR might prevent the NPE, there migth be a deeper issue that is not addressed by this PR. At the time that this screenshot was taken, Openfire did not have any active server-to-server sessions (as verified by the `netstat` command).

![image](https://github.com/igniterealtime/Openfire/assets/4253898/4c4ccfe4-a510-4b6d-aa61-653fe88b73b8)
