### PR TITLE
OF-2625 - accept self-signed certificates for both encryption and authentication

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientStanzaHandler.java
@@ -53,7 +53,7 @@ public class ClientStanzaHandler extends StanzaHandler {
      * @return always false.
      */
     @Override
-    protected boolean processUnknowPacket(Element doc) {
+    protected boolean processUnknownPacket(Element doc) {
         return false;
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
@@ -51,7 +51,7 @@ public class ComponentStanzaHandler extends StanzaHandler {
     }
 
     @Override
-    boolean processUnknowPacket(Element doc) throws UnauthorizedException {
+    boolean processUnknownPacket(Element doc) throws UnauthorizedException {
         String tag = doc.getName();
         if ("handshake".equals(tag)) {
             // External component is trying to authenticate

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/MultiplexerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/MultiplexerStanzaHandler.java
@@ -102,7 +102,7 @@ public class MultiplexerStanzaHandler extends StanzaHandler {
     }
 
     @Override
-    boolean processUnknowPacket(Element doc) {
+    boolean processUnknownPacket(Element doc) {
         String tag = doc.getName();
         if ("route".equals(tag)) {
             // Process stanza wrapped by the route packet

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
@@ -127,7 +127,7 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
     }
 
     @Override
-    boolean processUnknowPacket(Element doc) {
+    boolean processUnknownPacket(Element doc) {
         String rootTagName = doc.getName();
 
         // Handle features
@@ -225,16 +225,6 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
         if ("success".equals(rootTagName)) {
             LOG.debug("EXTERNAL SASL was successful.");
 
-            // SASL was successful so initiate a new stream
-            StringBuilder sb = new StringBuilder();
-            sb.append("<stream:stream");
-            sb.append(" xmlns:stream=\"http://etherx.jabber.org/streams\"");
-            sb.append(" xmlns=\"jabber:server\"");
-            sb.append(" from=\"").append(domainPair.getLocal()).append("\""); // OF-673
-            sb.append(" to=\"").append(domainPair.getRemote()).append("\"");
-            sb.append(" version=\"1.0\">");
-            connection.deliverRawText(sb.toString());
-
             connection.init(session);
             // Set the remote domain name as the address of the session.
             session.setAddress(new JID(null, domainPair.getRemote(), null));
@@ -245,6 +235,17 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
                 return false;
             }
             isSessionAuthenticated = true;
+
+            // SASL was successful so initiate a new stream
+            StringBuilder sb = new StringBuilder();
+            sb.append("<stream:stream");
+            sb.append(" xmlns:stream=\"http://etherx.jabber.org/streams\"");
+            sb.append(" xmlns=\"jabber:server\"");
+            sb.append(" from=\"").append(domainPair.getLocal()).append("\""); // OF-673
+            sb.append(" to=\"").append(domainPair.getRemote()).append("\"");
+            sb.append(" version=\"1.0\">");
+            connection.deliverRawText(sb.toString());
+
             return true;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
@@ -70,7 +70,7 @@ public class ServerStanzaHandler extends StanzaHandler {
     }
 
     @Override
-    boolean processUnknowPacket(Element doc) throws UnauthorizedException {
+    boolean processUnknownPacket(Element doc) throws UnauthorizedException {
         // Handle subsequent db:result packets
         if ("db".equals(doc.getNamespacePrefix()) && "result".equals(doc.getName())) {
             if (!((LocalIncomingServerSession) session).validateSubsequentDomain(doc)) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -336,7 +336,7 @@ public abstract class StanzaHandler {
             processIQ(packet);
         }
         else {
-            if (!processUnknowPacket(doc)) {
+            if (!processUnknownPacket(doc)) {
                 Log.warn(LocaleUtils.getLocalizedString("admin.error.packet.tag") + doc.asXML() + ". Closing session: " + session);
                 session.close();
             }
@@ -446,7 +446,7 @@ public abstract class StanzaHandler {
      * @return true if a received packet has been processed.
      * @throws UnauthorizedException if stanza failed to be processed. Connection will be closed.
      */
-    abstract boolean processUnknowPacket(Element doc) throws UnauthorizedException;
+    abstract boolean processUnknownPacket(Element doc) throws UnauthorizedException;
 
     /**
      * Tries to encrypt the connection using TLS. If the connection is encrypted then reset

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -88,7 +88,7 @@ public final class ConnectionSettings {
         public static final String DIALBACK_ENABLED = "xmpp.server.dialback.enabled";
         public static final String TLS_POLICY = "xmpp.server.tls.policy";
 
-        public static final String TLS_ACCEPT_SELFSIGNED_CERTS = "xmpp.server.certificate.accept-selfsigned";
+        public static final String TLS_ACCEPT_SELFSIGNED_CERTS = "xmpp.socket.ssl.certificate.accept-selfsigned";
         public static final String TLS_CERTIFICATE_VERIFY = "xmpp.server.certificate.verify";
         public static final String TLS_CERTIFICATE_VERIFY_VALIDITY = "xmpp.server.certificate.verify.validity";
         public static final String TLS_CERTIFICATE_ROOT_VERIFY = "xmpp.server.certificate.verify.root";


### PR DESCRIPTION
Accept self-signed now implicitly accepts any certificate for authentication.

Encryption requires that the certificate is valid (not expired), and we only authenticate using a self-signed cert after encryption. This does rely on the handshake verifying the cert for us.