### PR TITLE
OF-2559: When Inbound S2S session fails, return stream error

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -701,6 +701,10 @@ public abstract class StanzaHandler {
             // may offer the client to encrypt the connection. If the client decides to encrypt
             // the connection then a <starttls> stanza should be received
             createSession(serverName, xpp, connection);
+
+            if (session == null) {
+                throw new StreamErrorException(StreamError.Condition.internal_server_error, "Unable to create a session.");
+            }
         }
         catch (final StreamErrorException ex) {
             Log.warn("Failed to create a session. Closing connection: {}", connection, ex);


### PR DESCRIPTION
This might have been a problem that existed in the code for a long time, but only popped up with the migration from MINA to Netty: that's when ServerStanzaHandler started to being used in anger.

ServerStanzaHandler is invoked to create a session. The code more or less assumes that this always happens.

When a session is not created, the code should inform the peer that something went wrong. Without that, the peer is left hanging.

In this commit, any attempt to create a session that does not lead to a session being created results in a stream error to be returned to the peer, after which the connection is forcefully closed.