### PR TITLE
OF-2633: When S2S TLS is required, announce that

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -186,7 +186,9 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
                     && !connection.getConfiguration().getIdentityStore().getAllCertificates().isEmpty()
                 ) {
                     sb.append("<starttls xmlns=\"urn:ietf:params:xml:ns:xmpp-tls\">");
-                    if (!ServerDialback.isEnabled()) {
+                    if (connection.getConfiguration().getTlsPolicy() == Connection.TLSPolicy.required) {
+                        sb.append("<required/>");
+                    } else if (!ServerDialback.isEnabled()) {
                         Log.debug("Server dialback is disabled so TLS is required");
                         sb.append("<required/>");
                     }


### PR DESCRIPTION
When Openfire is configured to require TLS for S2S, the StartTLS feature that’s advertised should be marked as being “required”. It currently is only when Dialback is not available (making TLS needed for authentication purposes).