### PR TITLE
OF-2559: Use Netty for LocalIncomingServerSessionTest

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
@@ -189,12 +189,14 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
                 LOG.debug("Dialback was successful.");
 
                 connection.init(session);
-                isSessionAuthenticated = true;
                 // Set the remote domain name as the address of the session.
                 session.setAddress(new JID(null, domainPair.getRemote(), null));
                 if (session instanceof LocalOutgoingServerSession) {
                     ((LocalOutgoingServerSession) session).setAuthenticationMethod(ServerSession.AuthenticationMethod.DIALBACK);
                 }
+
+                // Make sure to set 'authenticated' only after the internal state of 'session' itself is updated, to avoid race conditions.
+                isSessionAuthenticated = true;
 
                 return true;
             } else {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
@@ -246,6 +246,8 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
                 LOG.debug("Expected session to be a LocalOutgoingServerSession but it isn't, unable to setAuthenticationMethod().");
                 return false;
             }
+
+            // Make sure to set 'authenticated' only after the internal state of 'session' itself is updated, to avoid race conditions.
             isSessionAuthenticated = true;
             return true;
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -902,16 +902,16 @@ public class LocalClientSession extends LocalSession implements ClientSession {
             }
         }
         return this.getClass().getSimpleName() +"{" +
-            "address=" + getAddress() +
-            ", streamID=" + getStreamID() +
-            ", status=" + getStatus() +
+            "address=" + address +
+            ", streamID=" + streamID +
+            ", status=" + status +
             ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
-            ", serverName='" + getServerName() + '\'' +
-            ", isInitialized=" + isInitialized() +
-            ", hasAuthToken=" + (getAuthToken() != null) +
+            ", serverName='" + serverName + '\'' +
+            ", isInitialized=" + initialized +
+            ", hasAuthToken=" + (authToken != null) +
             ", peer address='" + peerAddress +'\'' +
-            ", presence='" + getPresence().toString() + '\'' +
+            ", presence='" + presence.toString() + '\'' +
             '}';
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
@@ -432,12 +432,12 @@ public class LocalComponentSession extends LocalSession implements ComponentSess
     public String toString()
     {
         return this.getClass().getSimpleName() +"{" +
-            "address=" + getAddress() +
-            ", streamID=" + getStreamID() +
-            ", status=" + getStatus() +
+            "address=" + address +
+            ", streamID=" + streamID +
+            ", status=" + status +
             ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
-            ", serverName='" + getServerName() + '\'' +
+            ", serverName='" + serverName + '\'' +
             ", defaultSubdomain='" + defaultSubdomain + '\'' +
             '}';
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
@@ -306,12 +306,12 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
     public String toString()
     {
         return this.getClass().getSimpleName() +"{" +
-            "address=" + getAddress() +
-            ", streamID=" + getStreamID() +
-            ", status=" + getStatus() +
+            "address=" + address +
+            ", streamID=" + streamID +
+            ", status=" + status +
             ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
-            ", serverName='" + getServerName() + '\'' +
+            ", serverName='" + serverName + '\'' +
             '}';
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -431,14 +431,14 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
     public String toString()
     {
         return this.getClass().getSimpleName() +"{" +
-            "address=" + getAddress() +
-            ", streamID=" + getStreamID() +
-            ", status=" + getStatus() +
+            "address=" + address +
+            ", streamID=" + streamID +
+            ", status=" + status +
             ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
-            ", authenticationMethod=" + getAuthenticationMethod() +
-            ", localDomain=" + getLocalDomain() +
-            ", defaultIdentity=" + getDefaultIdentity() +
+            ", authenticationMethod=" + authenticationMethod +
+            ", localDomain=" + localDomain +
+            ", defaultIdentity=" + fromDomain +
             ", validatedDomains=" + validatedDomains.stream().collect( Collectors.joining( ", ", "{", "}")) +
             '}';
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -408,12 +408,12 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
     public String toString()
     {
         return this.getClass().getSimpleName() +"{" +
-            "address=" + getAddress() +
-            ", streamID=" + getStreamID() +
-            ", status=" + getStatus() +
+            "address=" + address +
+            ", streamID=" + streamID +
+            ", status=" + status +
             ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
-            ", authenticationMethod=" + getAuthenticationMethod() +
+            ", authenticationMethod=" + authenticationMethod +
             ", outgoingDomainPairs=" + getOutgoingDomainPairs().stream().map( DomainPair::toString ).collect(Collectors.joining(", ", "{", "}")) +
             '}';
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalServerSession.java
@@ -34,7 +34,7 @@ public class LocalServerSession extends LocalSession implements ServerSession {
     /**
      * The method that was used to authenticate this session. Null when the session is not authenticated.
      */
-    private AuthenticationMethod authenticationMethod = null;
+    protected AuthenticationMethod authenticationMethod = null;
 
     public LocalServerSession(String serverName, Connection connection,
             StreamID streamID) {
@@ -127,12 +127,12 @@ public class LocalServerSession extends LocalSession implements ServerSession {
     public String toString()
     {
         return this.getClass().getSimpleName() +"{" +
-            "address=" + getAddress() +
-            ", streamID=" + getStreamID() +
-            ", status=" + getStatus() +
+            "address=" + address +
+            ", streamID=" + streamID +
+            ", status=" + status +
             ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
-            ", isUsingServerDialback=" + isUsingServerDialback() +
+            ", authenticationMethod=" + authenticationMethod +
             '}';
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -60,11 +60,12 @@ public abstract class LocalSession implements Session {
     /**
      * The Address this session is authenticated as.
      */
-    private JID address;
+    protected JID address;
+
     /**
      * The stream id for this session (random and unique).
      */
-    private StreamID streamID;
+    protected final StreamID streamID;
 
     /**
      * The current session status.
@@ -78,9 +79,9 @@ public abstract class LocalSession implements Session {
 
     protected SessionManager sessionManager;
 
-    private String serverName;
+    protected final String serverName;
 
-    private long startDate = System.currentTimeMillis();
+    protected final long startDate = System.currentTimeMillis();
 
     private long lastActiveDate;
 
@@ -533,13 +534,13 @@ public abstract class LocalSession implements Session {
     @Override
     public String toString()
     {
-        return this.getClass().getSimpleName() +"{" +
-            "address=" + getAddress() +
-            ", streamID=" + getStreamID() +
-            ", status=" + getStatus() +
+        return this.getClass().getSimpleName() + "{" +
+            "address=" + address +
+            ", streamID=" + streamID +
+            ", status=" + status +
             ", isEncrypted=" + isEncrypted() +
             ", isDetached=" + isDetached() +
-            ", serverName='" + getServerName() + '\'' +
+            ", serverName='" + serverName + '\'' +
             '}';
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -289,7 +289,7 @@ public class ConnectionListener
      *
      * In order to stop this listener (and persist this as the desired state for this connection, use #enable(false).
      */
-    protected synchronized void stop()
+    public synchronized void stop()
     {
         if ( connectionAcceptor == null )
         {

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalOutgoingServerSessionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalOutgoingServerSessionTest.java
@@ -26,6 +26,7 @@ import org.jivesoftware.openfire.spi.ConnectionListener;
 import org.jivesoftware.openfire.spi.ConnectionType;
 import org.jivesoftware.util.JiveGlobals;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -36,6 +37,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 
 import java.io.File;
+import java.security.Key;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.*;
 
@@ -60,11 +63,48 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class LocalOutgoingServerSessionTest
 {
+    private static Key FIXTURE_VALID_KEY;
+    private static Certificate[] FIXTURE_VALID_CERTIFICATE_CHAIN;
     private RemoteReceivingServerDummy remoteReceivingServerDummy;
     private File tmpIdentityStoreFile;
     private IdentityStore identityStore;
     private File tmpTrustStoreFile;
     private TrustStore trustStore;
+
+    /**
+     * Generates (one time) content for a 'valid' identity store: a private key and associated (self-signed) certificate
+     * chain.
+     *
+     * This generated artifacts are stored in static fields, intended to be re-used by different tests. This prevents
+     * each test from having to generate them, which saves around 66% of the CPU time that's consumed by the tests.
+     */
+    @BeforeAll
+    public static void generateValidKeyAndCert() throws Exception {
+        Fixtures.reconfigureOpenfireHome();
+        JiveGlobals.setProperty("xmpp.domain", Fixtures.XMPP_DOMAIN);
+        final XMPPServer xmppServer = Fixtures.mockXMPPServer();
+        XMPPServer.setInstance(xmppServer);
+
+        final File tmpDir = new File(System.getProperty("java.io.tmpdir"));
+        final File tmpValidIdentityStoreFile = new File(tmpDir, "unittest-identitystorevalid-" + System.currentTimeMillis() + ".jks");
+        tmpValidIdentityStoreFile.deleteOnExit();
+        try {
+            final CertificateStoreConfiguration identityStoreConfig = new CertificateStoreConfiguration("jks", tmpValidIdentityStoreFile, "secret".toCharArray(), tmpDir);
+            final IdentityStore validStore = new IdentityStore(identityStoreConfig, true);
+            validStore.ensureDomainCertificate();
+            final Enumeration<String> aliases = validStore.getStore().aliases();
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+                if (validStore.getStore().isKeyEntry(alias)) {
+                    FIXTURE_VALID_KEY = validStore.getStore().getKey(alias, "secret".toCharArray());
+                    FIXTURE_VALID_CERTIFICATE_CHAIN = validStore.getStore().getCertificateChain(alias);
+                    return;
+                }
+            }
+        } finally {
+            tmpValidIdentityStoreFile.delete();
+        }
+    }
 
     /**
      * Prepares the local server for operation. This mostly involves preparing the test fixture by mocking parts of the
@@ -235,8 +275,8 @@ public class LocalOutgoingServerSessionTest
                     identityStore.installCertificate(Fixtures.expiredX509Certificate, Fixtures.privateKeyForExpiredCert, "");
                     break;
                 case VALID:
-                    // Generate a valid certificate and insert into identity store
-                    identityStore.ensureDomainCertificate();
+                    // Adds a valid certificate into identity store
+                    identityStore.getStore().setKeyEntry( "selfsignedkey", FIXTURE_VALID_KEY, "secret".toCharArray(), FIXTURE_VALID_CERTIFICATE_CHAIN);
                     break;
             }
 

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalOutgoingServerSessionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalOutgoingServerSessionTest.java
@@ -228,6 +228,7 @@ public class LocalOutgoingServerSessionTest
         if (RemoteReceivingServerDummy.doLog) System.out.println("Executing test:\n - Local Server (Openfire, System under test) Settings: " + localServerSettings + "\n - Remote Server (dummy/mock server) Settings: " + remoteServerSettings + "\nExpected outcome: " + expected.getConnectionState());
 
         JiveGlobals.setProperty("xmpp.domain", Fixtures.XMPP_DOMAIN);
+        JiveGlobals.setProperty("xmpp.server.session.initialise-timeout", Long.toString(1));
         final TrustStore trustStore = XMPPServer.getInstance().getCertificateStoreManager().getTrustStore(ConnectionType.SOCKET_S2S);
         final IdentityStore identityStore = XMPPServer.getInstance().getCertificateStoreManager().getIdentityStore(ConnectionType.SOCKET_S2S);
 


### PR DESCRIPTION
Prior to this commit, the unit test for LocalIncomingServerSession used the old, pre-Netty code. With this commit, the Netty code is being used instead.

Insteead of the old blocking code, the test now uses a (Netty-backed) ConnectionListener directly. To identify the LocalIncomingServderSession instance that is to be created, a streamID value is used, which is collected by the dummy server peer implementation for that purpose.