### PR TITLE
Fix for Netty connection cleanup bug

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -217,7 +217,7 @@ public class NettyConnection implements Connection {
     public void close(@Nullable final StreamError error) {
         if (state.compareAndSet(State.OPEN, State.CLOSED)) {
 
-            // Ensure that the state of this connection, its session and the MINA context are eventually closed.
+            // Ensure that the state of this connection, its session and the Netty Channel are eventually closed.
 
             if (session != null) {
                 session.setStatus(Session.Status.CLOSED);
@@ -237,7 +237,7 @@ public class NettyConnection implements Connection {
 
             try {
                 // TODO don't block, handle errors async with custom ChannelFutureListener
-                this.channelHandlerContext.close().addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE).sync();
+                this.channelHandlerContext.channel().close().addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE).sync();
             } catch (Exception e) {
                 Log.error("Exception while closing Netty session", e);
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -410,13 +410,21 @@ public class NettyConnection implements Connection {
     @Override
     public void addCompression() {
         // Inbound traffic only
-        channelHandlerContext.channel().pipeline().addFirst(new JZlibDecoder());
+        if (isEncrypted()) {
+            channelHandlerContext.channel().pipeline().addAfter(SSL_HANDLER_NAME, "compressionHandler", new JZlibDecoder());
+        }  else {
+            channelHandlerContext.channel().pipeline().addFirst(new JZlibDecoder());
+        }
     }
 
     @Override
     public void startCompression() {
         // Outbound traffic only
-        channelHandlerContext.channel().pipeline().addFirst(new JZlibEncoder(Z_BEST_COMPRESSION));
+        if (isEncrypted()) {
+            channelHandlerContext.channel().pipeline().addAfter(SSL_HANDLER_NAME, "compressionHandler", new JZlibEncoder(Z_BEST_COMPRESSION));
+        }  else {
+            channelHandlerContext.channel().pipeline().addFirst(new JZlibEncoder(Z_BEST_COMPRESSION));
+        }
         // Z_BEST_COMPRESSION is the same level as COMPRESSION_MAX in MINA
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -411,7 +411,7 @@ public class NettyConnection implements Connection {
     public void addCompression() {
         // Inbound traffic only
         if (isEncrypted()) {
-            channelHandlerContext.channel().pipeline().addAfter(SSL_HANDLER_NAME, "compressionHandler", new JZlibDecoder());
+            channelHandlerContext.channel().pipeline().addAfter(SSL_HANDLER_NAME, "inboundCompressionHandler", new JZlibDecoder());
         }  else {
             channelHandlerContext.channel().pipeline().addFirst(new JZlibDecoder());
         }
@@ -421,7 +421,7 @@ public class NettyConnection implements Connection {
     public void startCompression() {
         // Outbound traffic only
         if (isEncrypted()) {
-            channelHandlerContext.channel().pipeline().addAfter(SSL_HANDLER_NAME, "compressionHandler", new JZlibEncoder(Z_BEST_COMPRESSION));
+            channelHandlerContext.channel().pipeline().addAfter(SSL_HANDLER_NAME, "outboundCompressionHandler", new JZlibEncoder(Z_BEST_COMPRESSION));
         }  else {
             channelHandlerContext.channel().pipeline().addFirst(new JZlibEncoder(Z_BEST_COMPRESSION));
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnectionHandler.java
@@ -151,12 +151,15 @@ public abstract class NettyConnectionHandler extends SimpleChannelInboundHandler
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         // Close the connection when an exception is raised.
         Log.error(cause.getMessage(), cause);
-        ctx.close();
+        ctx.channel().close();
     }
 
     @Override
     public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
-        ctx.channel().attr(CONNECTION).get().close();
+        Connection connection = ctx.channel().attr(CONNECTION).get();
+        if (connection != null) {
+            connection.close(); // clean up resources (connection and session) when channel is unregistered.
+        }
         super.channelUnregistered(ctx);
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnectionHandler.java
@@ -155,6 +155,12 @@ public abstract class NettyConnectionHandler extends SimpleChannelInboundHandler
     }
 
     @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        ctx.channel().attr(CONNECTION).get().close();
+        super.channelUnregistered(ctx);
+    }
+
+    @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (!sslInitDone && evt instanceof SslHandshakeCompletionEvent) {
             SslHandshakeCompletionEvent e = (SslHandshakeCompletionEvent) evt;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyIdleStateKeepAliveHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyIdleStateKeepAliveHandler.java
@@ -81,7 +81,7 @@ public class NettyIdleStateKeepAliveHandler extends ChannelDuplexHandler {
             IdleStateEvent e = (IdleStateEvent) evt;
             final boolean doPing = ConnectionSettings.Client.KEEP_ALIVE_PING_PROPERTY.getValue() && clientConnection;
             if (e.state() == IdleState.READER_IDLE) {
-                ctx.close();
+                ctx.channel().attr(CONNECTION).get().close();
             } else if (doPing && e.state() == IdleState.WRITER_IDLE) {
                 sendPingPacket(ctx);
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyOutboundConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyOutboundConnectionHandler.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.security.cert.CertificateException;
+import java.time.Duration;
 
 /**
  * Outbound (S2S) specific ConnectionHandler that knows which subclass of {@link StanzaHandler} should be created
@@ -74,7 +75,11 @@ public class NettyOutboundConnectionHandler extends NettyConnectionHandler {
 
     @Override
     public int getMaxIdleTime() {
-        return JiveGlobals.getIntProperty(ConnectionSettings.Server.IDLE_TIMEOUT_PROPERTY, 360);
+        return Math.toIntExact(
+            Duration.ofMillis(
+                JiveGlobals.getIntProperty(ConnectionSettings.Server.IDLE_TIMEOUT_PROPERTY,360000))
+                .toSeconds()
+        );
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactory.java
@@ -403,13 +403,16 @@ public class EncryptionArtifactFactory
         Set<String> protocols = new HashSet<>(configuration.getEncryptionProtocols());
         protocols.remove("SSLv2Hello");
 
+        // createClientModeSslContext is only used when the Openfire server is acting as a client when
+        // making outbound S2S connections so the first stanza we send should be encrypted hence startTls(false)
+
         return SslContextBuilder
             .forClient()
             .protocols(protocols)
             .ciphers(configuration.getEncryptionCipherSuites())
             .keyManager(getKeyManagerFactory())
             .trustManager(getTrustManagers()[0]) // The existing implementation never returns more than one trust manager.
-            .startTls(false)
+            .startTls(false) // Acting as client making outbound S2S connection so encrypt next stanza
             .build();
     }
 

--- a/xmppserver/src/main/webapp/server-session-details.jsp
+++ b/xmppserver/src/main/webapp/server-session-details.jsp
@@ -256,10 +256,10 @@
                                 </c:if>
                                 <td nowrap>
                                     <c:choose>
-                                        <c:when test="${session.usingServerDialback}">
+                                        <c:when test="${session.isUsingServerDialback()}">
                                             <fmt:message key="server.session.details.dialback"/>
                                         </c:when>
-                                        <c:when test="${session.usingSaslExternal}">
+                                        <c:when test="${session.isUsingSaslExternal()}">
                                             <fmt:message key="server.session.details.tlsauth"/>
                                         </c:when>
                                         <c:otherwise>


### PR DESCRIPTION
Fixes session cleanup on idle

Adds idle state handling for outbound connections so that they are automatically closed when idle, as is already the case for inbound connections. Closes the connection on idle, not just the channel, to ensure that connections and sessions are cleaned up properly.

Also fixes:

- NPE on server session details page in admin console
- Errors when compression is enabled with TLS