### PR TITLE
Fix server-session-details NPE

### DIFF
--- a/xmppserver/src/main/webapp/server-session-details.jsp
+++ b/xmppserver/src/main/webapp/server-session-details.jsp
@@ -321,10 +321,10 @@
                                 </c:if>
                                 <td nowrap>
                                     <c:choose>
-                                        <c:when test="${session.usingServerDialback}">
+                                        <c:when test="${session.isUsingServerDialback()}">
                                             <fmt:message key="server.session.details.dialback"/>
                                         </c:when>
-                                        <c:when test="${session.usingSaslExternal}">
+                                        <c:when test="${session.isUsingSaslExternal()}">
                                             <fmt:message key="server.session.details.tlsauth"/>
                                         </c:when>
                                         <c:otherwise>


### PR DESCRIPTION
Previous fix missed two instances of the troublesome properties.

JSP resolvers are unable to resolve default properties on interfaces. NPEs were caused by the failure to resolve the new default methods on the ServerSession interface (e.g.  `ServerSession#isUsingServerDialback()`)

See this post for further details:

https://stackoverflow.com/questions/35130290/property-not-found-on-type-when-using-interface-default-methods-in-jsp-el