### PR TITLE
OF-2639: No longer require authzid for S2S SASL EXTERNAL

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1706,6 +1706,7 @@ system_property.usermanager.remote-disco-info-timeout-seconds=The maximum time t
 system_property.usermanager.future-users.enable=When enabled, allows Openfire to process data for local JIDs that potentially are future users. To be used when users are provisioned externally/on an ad-hoc basis.
 system_property.provider.userproperty.className=The class to use to provide user properties
 system_property.xmpp.auth.sasl.external.client.suppress-matching-realmname=Ignore the realm of a SASL EXTERNAL provided username if it matches the XMPP domain name.
+system_property.xmpp.auth.sasl.external.server.require-authzid=Require servers to send a non-empty authorization ID during the SASL EXTERNAL handshake, even if the stream 'from' attribute already specifies one.
 system_property.adminConsole.access.ip-blocklist=List of IP addresses that are not allowed to access the admin console.
 system_property.adminConsole.access.ip-allowlist=List of IP addresses that are allowed to access the admin console. When empty, this list is ignored.
 system_property.adminConsole.access.ignore-excludes=Controls if IP Access lists are applied to excluded URLs.

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1623,6 +1623,7 @@ system_property.usermanager.remote-disco-info-timeout-seconds=De maximale tijd (
 system_property.usermanager.future-users.enable=Indien ingeschakeld zal Openfire data verwerken voor JIDs die toebehoren aan potentieel toekomstige gebruikers. Deze instelling kan gebruikt worden als gebruikers extern/op een ad-hoc basis worden aangemaakt. 
 system_property.provider.userproperty.className=De klasse die gebruikt wordt om gebruikersgegevens te beheren.
 system_property.xmpp.auth.sasl.external.client.suppress-matching-realmname=Negeer de realm van een gebruikersnaam die via SASL EXTERNAL authenticeert, als deze gelijk is aan de XMPP domeinnaam.
+system_property.xmpp.auth.sasl.external.server.require-authzid=Verplicht servers die via SASL EXTERNAL authenticeren om een ID tijdens de SASL EXTERNAL handshake mee te sturen, zelfs als het 'from' attribute van de stream dit al definieert.
 system_property.adminConsole.access.ip-blocklist=Lijst van IP adressen die geen toestemming hebben tot de beheerconsole.
 system_property.adminConsole.access.ip-allowlist=Lijst van IP adressen die toestemming hebben tot de beheerconsole. Deze lijst wordt genegeerd als ze leeg ieeg is.
 system_property.adminConsole.access.ignore-excludes=Defineert of IP toegangslijsten worden gebruikt op uitgezonderde URLs.


### PR DESCRIPTION
In the old days, the 'from' attribute on a stream element was not present. This made providing an authorization identity during the SASL handshake a requirement (otherwise, you'd not know who you'd be talking to).

Now that the 'from' attribute can be relied on to provide the identity of the peer, it does not need to be included in the SASL EXTERNAL handshake any longer.

This commit drops this requirement, but adds a new property (`xmpp.auth.sasl.external.server.require-authzid`) that can re-introduce it.