### PR TITLE
OF-2642: Remove incorrect code to prevent XEP-0084

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -443,15 +443,6 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
         if (publishElement != null) {
             final String nodeID = publishElement.attributeValue("node");
 
-            // Do not allow User Avatar nodes to be created.
-            // TODO: Implement XEP-0084
-            if (nodeID.startsWith("http://www.xmpp.org/extensions/xep-0084.html")) {
-                IQ reply = IQ.createResultIQ(packet);
-                reply.setChildElement(packet.getChildElement().createCopy());
-                reply.setError(PacketError.Condition.feature_not_implemented);
-                return reply;
-            }
-
             if (pepService.getNode(nodeID) == null) {
                 // Create the node
                 final JID creator = bareJidFrom;


### PR DESCRIPTION
This code aims to prevent PEP from being used to store avatars. The existing code will not prevent this, and should be removed.

Potentially, it is to be replaced with something that integrates the avatar upload with the VCardManager, to facilitate conversions between the various avatar-based XEPs. See OF-2034