### PR TITLE
OF-2641 - Cannot establish S2S with conference subdomain

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
@@ -105,7 +105,8 @@ public class ServerStanzaHandler extends StanzaHandler {
 
     @Override
     boolean validateHost() {
-        return true;
+        // Hosts are not currently validated for S2S
+        return false;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnectionHandler.java
@@ -164,6 +164,12 @@ public abstract class NettyConnectionHandler extends SimpleChannelInboundHandler
     }
 
     @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        ctx.channel().attr(CONNECTION).get().close();
+        super.channelUnregistered(ctx);
+    }
+
+    @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (!sslInitDone && evt instanceof SslHandshakeCompletionEvent) {
             SslHandshakeCompletionEvent e = (SslHandshakeCompletionEvent) evt;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnectionHandler.java
@@ -164,12 +164,6 @@ public abstract class NettyConnectionHandler extends SimpleChannelInboundHandler
     }
 
     @Override
-    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
-        ctx.channel().attr(CONNECTION).get().close();
-        super.channelUnregistered(ctx);
-    }
-
-    @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (!sslInitDone && evt instanceof SslHandshakeCompletionEvent) {
             SslHandshakeCompletionEvent e = (SslHandshakeCompletionEvent) evt;


### PR DESCRIPTION
This fix restores the pre-existing behaviour of Openfire before the migration to the Netty framework for NIO (OF-2559). 