### PR TITLE
Implement use of TLSv1.3 for S2S automated tests

### DIFF
--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalIncomingServerSessionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalIncomingServerSessionTest.java
@@ -310,6 +310,7 @@ public class LocalIncomingServerSessionTest
                     assertTrue(result.isEncrypted());
                     assertTrue(result.isAuthenticated());
                     assertEquals(ServerSession.AuthenticationMethod.DIALBACK, result.getAuthenticationMethod());
+                    assertEquals( "TLSv1.3", result.getConnection().getTLSProtocolName().get());
 
                     // Assertions that are specific to OF-1913:
                     assertEquals(2, remoteInitiatingServerDummy.getReceivedStreamIDs().size());
@@ -323,6 +324,7 @@ public class LocalIncomingServerSessionTest
                     assertTrue(result.isEncrypted());
                     assertTrue(result.isAuthenticated());
                     assertEquals(ServerSession.AuthenticationMethod.SASL_EXTERNAL, result.getAuthenticationMethod());
+                    assertEquals("TLSv1.3", result.getConnection().getTLSProtocolName().get());
 
                     // Assertions that are specific to OF-1913:
                     assertEquals(2, remoteInitiatingServerDummy.getReceivedStreamIDs().size());

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteInitiatingServerDummy.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteInitiatingServerDummy.java
@@ -531,7 +531,7 @@ public class RemoteInitiatingServerDummy extends AbstractRemoteServerDummy
             if (doLog) System.out.println("Received StartTLS proceed.");
             if (doLog) System.out.println("Replace the socket with one that will do TLS on the next inbound and outbound data");
 
-            final SSLContext sc = SSLContext.getInstance("TLSv1.2");
+            final SSLContext sc = SSLContext.getInstance("TLSv1.3");
 
             TrustManager[] tm = createTrustManagerThatTrustsAll();
             SecureRandom random = new SecureRandom();

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteReceivingServerDummy.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteReceivingServerDummy.java
@@ -365,7 +365,7 @@ public class RemoteReceivingServerDummy extends AbstractRemoteServerDummy implem
 
             if (doLog) System.out.println("Replace the socket with one that will do TLS on the next inbound and outbound data");
 
-            final SSLContext sc = SSLContext.getInstance("TLSv1.2");
+            final SSLContext sc = SSLContext.getInstance("TLSv1.3");
 
             sc.init(createKeyManager(generatedPKIX == null ? null : generatedPKIX.getKeyPair(), generatedPKIX == null ? null : generatedPKIX.getCertificateChain()), createTrustManagerThatTrustsAll(), new java.security.SecureRandom());
             SSLContext.setDefault(sc);


### PR DESCRIPTION
As the automated S2S tests now use Netty we can confidently run these tests using TLSv1.3

This PR also removes the modification of expected outcome logic for LocalOutgoingServerSessionTest as it appears to no longer be needed. 