### PR TITLE
Improve SO_TIMEOUT for more stable S2S unit test execution

### DIFF
--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/AbstractRemoteServerDummy.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/AbstractRemoteServerDummy.java
@@ -45,7 +45,7 @@ public class AbstractRemoteServerDummy
     private final static KeystoreTestUtils.ResultHolder VALID_CERTIFICATE_CHAIN;
     private final static KeystoreTestUtils.ResultHolder EXPIRED_CERTIFICATE_CHAIN;
 
-    public static final Duration SO_TIMEOUT = Duration.ofMillis(50);
+    public static final Duration SO_TIMEOUT = Duration.ofMillis(100);
     protected boolean useExpiredEndEntityCertificate;
     protected boolean useSelfSignedCertificate;
     protected boolean disableDialback;

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteInitiatingServerDummy.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteInitiatingServerDummy.java
@@ -548,9 +548,9 @@ public class RemoteInitiatingServerDummy extends AbstractRemoteServerDummy
             SSLContext.setDefault(sc);
 
             final SSLSocket sslSocket = (SSLSocket) ((SSLSocketFactory) SSLSocketFactory.getDefault()).createSocket(socket, null, socket.getPort(), true);
-            sslSocket.setSoTimeout((int) SO_TIMEOUT.toMillis());
+            sslSocket.setSoTimeout((int) SO_TIMEOUT.multipliedBy(10).toMillis()); // TLS handshaking is resource intensive. Relax the SO_TIMEOUT value a bit, to prevent test failures in constraint environments.
             sslSocket.addHandshakeCompletedListener(event -> { if (doLog) System.out.println("SSL handshake completed: " + event); });
-            sslSocket.startHandshake();
+                sslSocket.startHandshake();
 
             // Just indicate that we would like to authenticate the client but if client
             // certificates are self-signed or have no certificate chain then we are still


### PR DESCRIPTION
TLS handshaking is resource intensive. Relax the SO_TIMEOUT value a bit, to prevent test failures in constraint environments.