### PR TITLE
OF-2649: Prevent incorrect CSI warning message from being logged

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiManager.java
@@ -126,6 +126,7 @@ public class CsiManager
                 break;
             case "inactive":
                 deactivate();
+                break;
             default:
                 Log.warn("Unable to process element that was expected to be a CSI nonza for {}: {}", session, nonza);
         }


### PR DESCRIPTION
There is an unintended fall-through in a switch/case that leads to a warning being logged.