### PR TITLE
OF-2655: Fix S2S outbound hanging

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,9 +80,12 @@ import java.util.List;
 public interface RoutingTable {
 
     /**
-     * Adds a route to the routing table for the specified outgoing server session. When running
-     * inside of a cluster this message {@code must} be sent from the cluster node that is
-     * actually holding the physical connection to the remote server.
+     * Adds a route to the routing table for the specified outgoing server session, or replaces a pre-existing one.
+     *
+     * When running inside a cluster, this method <em>must</em> be invoked on the cluster node that is actually holding
+     * the physical connection to the remote server. Additionally, replacing a pre-existing server session can only
+     * occur on the same cluster node as the one that was holding the original session. A runtime exception is thrown
+     * when another cluster node attempts to replace the session.
      *
      * @param route the address associated to the route.
      * @param destination the outgoing server session.
@@ -357,13 +360,4 @@ public interface RoutingTable {
      * @param onlyLocal true if only client sessions connect to the local JVM will get the message.
      */
     void broadcastPacket(Message packet, boolean onlyLocal);
-
-
-    /**
-     * Replaces all previous sessions associated with the domain pair with a new session.
-     *
-     * @param domainPair the address associated to the route.
-     * @param session the outgoing server session
-     */
-    void replaceServerRoute(DomainPair domainPair, LocalOutgoingServerSession session);
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
@@ -357,4 +357,13 @@ public interface RoutingTable {
      * @param onlyLocal true if only client sessions connect to the local JVM will get the message.
      */
     void broadcastPacket(Message packet, boolean onlyLocal);
+
+
+    /**
+     * Replaces all previous sessions associated with the domain pair with a new session.
+     *
+     * @param domainPair the address associated to the route.
+     * @param session the outgoing server session
+     */
+    void replaceServerRoute(DomainPair domainPair, LocalOutgoingServerSession session);
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
 
         // Clear routing table cache of previous sessions for domain pair and re-add it.
         RoutingTable routingTable = XMPPServer.getInstance().getRoutingTable();
-        routingTable.replaceServerRoute(domainPair, (LocalOutgoingServerSession) session);
+        routingTable.addServerRoute(domainPair, (LocalOutgoingServerSession) session); // This _replaces_ the pre-existing session in the routing table.
         SessionManager sessionManager = SessionManager.getInstance();
         sessionManager.outgoingServerSessionCreated((LocalOutgoingServerSession) session);
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
@@ -23,6 +23,7 @@ import org.dom4j.Namespace;
 import org.dom4j.io.XMPPPacketReader;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.PacketRouter;
+import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.server.ServerDialback;
 import org.jivesoftware.openfire.session.DomainPair;
 import org.jivesoftware.openfire.session.LocalOutgoingServerSession;
@@ -101,6 +102,8 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
      */
     private void transferConnectionToNewSession(String newStreamId, ServerSession.AuthenticationMethod existingAuthMethod) {
         session = createLocalOutgoingServerSession(newStreamId, connection);
+        SessionManager sessionManager = SessionManager.getInstance();
+        sessionManager.outgoingServerSessionCreated((LocalOutgoingServerSession) session);
         connection.reinit(session);
         if (isSessionAuthenticated.isDone() && session instanceof LocalOutgoingServerSession) {
             ((LocalOutgoingServerSession) session).setAuthenticationMethod(existingAuthMethod);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
@@ -98,14 +98,11 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
      * @param existingAuthMethod authentication method used previously (possibly null)
      */
     private void transferConnectionToNewSession(String newStreamId, ServerSession.AuthenticationMethod existingAuthMethod) {
-        // Clear routing table cache of previous sessions for domain pair
-        RoutingTable routingTable = XMPPServer.getInstance().getRoutingTable();
-        routingTable.removeServerRoute(domainPair);
-
-
-        // Re-add the session and domain pair to the routing table
         session = createLocalOutgoingServerSession(newStreamId, connection);
-        routingTable.addServerRoute(domainPair, (LocalOutgoingServerSession) session);
+
+        // Clear routing table cache of previous sessions for domain pair and re-add it.
+        RoutingTable routingTable = XMPPServer.getInstance().getRoutingTable();
+        routingTable.replaceServerRoute(domainPair, (LocalOutgoingServerSession) session);
         SessionManager sessionManager = SessionManager.getInstance();
         sessionManager.outgoingServerSessionCreated((LocalOutgoingServerSession) session);
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -227,36 +227,16 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         Lock lock = serversCache.getLock(address);
         lock.lock();
         try {
-            checkOnlyOneClusterNodeConnectedToAddress(address);
+            final NodeID oldValue = serversCache.putIfAbsent(address, server.getNodeID());
+            if (oldValue != null && !oldValue.equals(XMPPServer.getInstance().getNodeID())) {
+                // Existing implementation assumes that only one node has an outgoing server connection for a domain. Fail if that's not the case. See: OF-2280
+                throw new IllegalStateException("The local cluster node attempts to established a new S2S connection to '"+address+"', but such a connection already exists on cluster node '"+oldValue+"'.");
+            }
         }
         finally {
             lock.unlock();
         }
         localRoutingTable.addRoute(address, destination);
-    }
-
-    private void checkOnlyOneClusterNodeConnectedToAddress(DomainPair address) {
-        final NodeID oldValue = serversCache.putIfAbsent(address, server.getNodeID());
-        if (oldValue != null && !oldValue.equals(XMPPServer.getInstance().getNodeID())) {
-            // Existing implementation assumes that only one node has an outgoing server connection for a domain. Fail if that's not the case. See: OF-2280
-            throw new IllegalStateException("The local cluster node attempts to established a new S2S connection to '"+ address +"', but such a connection already exists on cluster node '"+oldValue+"'.");
-        }
-    }
-
-
-    @Override
-    public void replaceServerRoute(DomainPair domainPair, LocalOutgoingServerSession session) {
-        Lock lock = serversCache.getLock(domainPair);
-        lock.lock();
-        try {
-            checkOnlyOneClusterNodeConnectedToAddress(domainPair);
-            serversCache.remove(domainPair);
-            localRoutingTable.removeRoute(domainPair);
-            localRoutingTable.addRoute(domainPair, session);
-        }
-        finally {
-            lock.unlock();
-        }
     }
 
     @Override


### PR DESCRIPTION
- Explicitly add close listener for new sessions that are created.
- Fix the new session on stream ID code for outbound S2S by verifying the streamID is new.
- Clear routing table cache of any lingering session objects via a replaceServerRoute function in the RoutingTable for atomic session replacement