### PR TITLE
OF-2647: Restore JiveGlobals.getHomeDirectory(String)

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
@@ -64,7 +64,7 @@ public class EmbeddedConnectionProvider implements ConnectionProvider {
 
     @Override
     public void start() {
-        final Path databaseDir = JiveGlobals.getHomeDirectory().resolve("embedded-db");
+        final Path databaseDir = JiveGlobals.getHomePath().resolve("embedded-db");
         try {
             // If the database doesn't exist, create it.
             if (!Files.exists(databaseDir)) {

--- a/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
@@ -86,7 +86,7 @@ public class SchemaManager {
                     new ResourceLoader() {
                         @Override
                         public InputStream loadResource(String resourceName) {
-                            File file = new File(JiveGlobals.getHomeDirectory() + File.separator +
+                            File file = new File(JiveGlobals.getHomePath() + File.separator +
                                     "resources" + File.separator + "database", resourceName);
                             try {
                                 return new FileInputStream(file);
@@ -300,7 +300,7 @@ public class SchemaManager {
         InputStream resource = null;
         if ("openfire".equals(schemaKey)) {
             // Resource will be like "/database/upgrade/6/openfire_hsqldb.sql"
-            String path = JiveGlobals.getHomeDirectory() + File.separator + "resources" +
+            String path = JiveGlobals.getHomePath() + File.separator + "resources" +
                     File.separator + "database" + File.separator + "upgrade" + File.separator +
                     upgradeVersion;
             String filename = schemaKey + "_" + DbConnectionManager.getDatabaseType() + ".sql";

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -1131,7 +1131,7 @@ public class XMPPServer {
         }
         else {
             // Set the home directory for the config file
-            JiveGlobals.setHomeDirectory(openfireHome);
+            JiveGlobals.setHomePath(openfireHome);
             // Set the name of the config file
             JiveGlobals.setConfigName(configName);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/audit/spi/AuditManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/audit/spi/AuditManagerImpl.java
@@ -271,7 +271,7 @@ public class AuditManagerImpl extends BasicModule implements AuditManager, Prope
         maxFileSize = JiveGlobals.getIntProperty("xmpp.audit.filesize", MAX_FILE_SIZE);
         retention = Duration.ofDays(JiveGlobals.getIntProperty("xmpp.audit.days", (int)MAX_DAYS.toDays()));
         logTimeout = Duration.ofMillis(JiveGlobals.getIntProperty("xmpp.audit.logtimeout", (int)DEFAULT_LOG_TIMEOUT.toMillis()));
-        logDir = JiveGlobals.getProperty("xmpp.audit.logdir", JiveGlobals.getHomeDirectory() +
+        logDir = JiveGlobals.getProperty("xmpp.audit.logdir", JiveGlobals.getHomePath() +
                 File.separator + "logs");
         processIgnoreString(JiveGlobals.getProperty("xmpp.audit.ignore", ""));
 
@@ -368,7 +368,7 @@ public class AuditManagerImpl extends BasicModule implements AuditManager, Prope
                     d = new File(value);
                 }
                 logDir = (d == null || !d.exists() || !d.canRead() || !d.canWrite() || !d
-                        .isDirectory()) ? JiveGlobals.getHomeDirectory()
+                        .isDirectory()) ? JiveGlobals.getHomePath()
                         + File.separator + "logs" : value;
                 auditor.setLogDir(logDir);
                 break;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
@@ -424,7 +424,7 @@ public class InternalComponentManager extends BasicModule implements ClusterEven
     }
 
     public Path getHomeDirectory() {
-        return JiveGlobals.getHomeDirectory();
+        return JiveGlobals.getHomePath();
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServlet.java
@@ -523,13 +523,13 @@ public class PluginServlet extends HttpServlet {
             contextPath = pathInfo.substring(index + parts[1].length());
         }
 
-        Path pluginDirectory = JiveGlobals.getHomeDirectory().resolve("plugins");
+        Path pluginDirectory = JiveGlobals.getHomePath().resolve("plugins");
         Path file = pluginDirectory.resolve(parts[1]).resolve("web").resolve(contextPath);
 
         if ( !ALLOW_LOCAL_FILE_READING.getValue() ) {
             // Ensure that the file that's being served is a file that is part of Openfire. This guards against
             // accessing files from the operating system, or other files that shouldn't be accessible via the web (OF-1886).
-            final Path absoluteHome = JiveGlobals.getHomeDirectory().normalize().toAbsolutePath();
+            final Path absoluteHome = JiveGlobals.getHomePath().normalize().toAbsolutePath();
             final Path absoluteLookup = file.normalize().toAbsolutePath();
             if ( !absoluteLookup.startsWith( absoluteHome ) )
             {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdProperties.java
@@ -46,7 +46,7 @@ public class CrowdProperties {
     public CrowdProperties() throws IOException {
         props = new Properties();
         
-        File file = new File(JiveGlobals.getHomeDirectory() + File.separator + "conf" + File.separator + "crowd.properties");
+        File file = new File(JiveGlobals.getHomePath() + File.separator + "conf" + File.separator + "crowd.properties");
         if (!file.exists()) {
             throw new IOException("The file crowd.properties is missing from Openfire conf folder");
         } else {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -712,7 +712,7 @@ public final class HttpBindManager implements CertificateEventListener {
      */
     protected Handler createStaticContentHandler()
     {
-        final File spankDirectory = new File( JiveGlobals.getHomeDirectory() + File.separator + "resources" + File.separator + "spank" );
+        final File spankDirectory = new File( JiveGlobals.getHomePath() + File.separator + "resources" + File.separator + "spank" );
         if ( spankDirectory.exists() )
         {
             if ( spankDirectory.canRead() )

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/ResourceServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/ResourceServlet.java
@@ -180,7 +180,7 @@ public class ResourceServlet extends HttpServlet {
     }
 
     private static InputStream getResourceAsStream(String resourceName) {
-        File file = new File(JiveGlobals.getHomeDirectory() + File.separator +
+        File file = new File(JiveGlobals.getHomePath() + File.separator +
                 "resources" + File.separator + "spank" + File.separator + "scripts", resourceName);
         try {
             return new FileInputStream(file);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreManager.java
@@ -568,7 +568,7 @@ public class CertificateStoreManager extends BasicModule
     {
         File file = new File( path );
         if (!file.isAbsolute()) {
-            file = new File( JiveGlobals.getHomeDirectory() + File.separator + path );
+            file = new File( JiveGlobals.getHomePath() + File.separator + path );
         }
 
         return file;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
@@ -691,7 +691,7 @@ public class UpdateManager extends BasicModule {
         // Write data out to conf/server-update.xml file.
         try {
             // Create the conf folder if required
-            final Path confDir = JiveGlobals.getHomeDirectory().resolve("conf");
+            final Path confDir = JiveGlobals.getHomePath().resolve("conf");
             if (!Files.exists(confDir)) {
                 Files.createDirectory(confDir);
             }
@@ -744,7 +744,7 @@ public class UpdateManager extends BasicModule {
         // Write data out to conf/available-plugins.xml file.
         try {
             // Create the conf folder if required
-            final Path confDir = JiveGlobals.getHomeDirectory().resolve("conf");
+            final Path confDir = JiveGlobals.getHomePath().resolve("conf");
             if (!Files.exists(confDir)) {
                 Files.createDirectory(confDir);
             }
@@ -786,7 +786,7 @@ public class UpdateManager extends BasicModule {
 
     private void loadLatestServerInfo() {
         Document xmlResponse;
-        File file = new File(JiveGlobals.getHomeDirectory() + File.separator + "conf",
+        File file = new File(JiveGlobals.getHomePath() + File.separator + "conf",
                 "server-update.xml");
         if (!file.exists()) {
             return;
@@ -839,7 +839,7 @@ public class UpdateManager extends BasicModule {
 
     private void loadAvailablePluginsInfo() {
         Document xmlResponse;
-        File file = new File(JiveGlobals.getHomeDirectory() + File.separator + "conf",
+        File file = new File(JiveGlobals.getHomePath() + File.separator + "conf",
                 "available-plugins.xml");
         if (!file.exists()) {
             return;

--- a/xmppserver/src/main/java/org/jivesoftware/util/FaviconServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/FaviconServlet.java
@@ -97,7 +97,7 @@ public class FaviconServlet extends HttpServlet {
             .build();
         // Load the default favicon to use when no favicon was found of a remote host
         try {
-            defaultBytes = Files.readAllBytes(JiveGlobals.getHomeDirectory().resolve("plugins").resolve("admin").resolve("webapp").resolve("images").resolve("server_16x16.gif"));
+            defaultBytes = Files.readAllBytes(JiveGlobals.getHomePath().resolve("plugins").resolve("admin").resolve("webapp").resolve("images").resolve("server_16x16.gif"));
         }
         catch (final IOException e) {
             LOGGER.warn("Unable to retrieve default favicon", e);

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -40,7 +40,7 @@ import java.util.Map.Entry;
  * When starting up the application this class needs to be configured so that the initial
  * configuration of the application may be loaded from the configuration file. The configuration
  * file holds properties stored in XML format, database configuration and user authentication
- * configuration. Use {@link #setHomeDirectory(Path)} and {@link #setConfigName(String)} for
+ * configuration. Use {@link #setHomePath(Path)} and {@link #setConfigName(String)} for
  * setting the home directory and path to the configuration file.<p>
  *
  * XML property names must be in the form <code>prop.name</code> - parts of the name must
@@ -257,8 +257,19 @@ public class JiveGlobals {
      * Returns the location of the <code>home</code> directory.
      *
      * @return the location of the home dir.
+     * @deprecated Replaced by {@link #getHomePath()}
      */
-    public static Path getHomeDirectory() {
+    @Deprecated(since = "4.8.0") // Remove in or after Openfire 4.9.0.
+    public static String getHomeDirectory() {
+        return getHomePath().toString();
+    }
+
+    /**
+     * Returns the location of the <code>home</code> directory.
+     *
+     * @return the location of the home dir.
+     */
+    public static Path getHomePath() {
         if (openfireProperties == null) {
             loadOpenfireProperties();
         }
@@ -271,8 +282,21 @@ public class JiveGlobals {
      * directory.
      *
      * @param homeDir the location of the home dir.
+     * @deprecated Replaced by {@link #setHomePath(Path)}
      */
-    public static void setHomeDirectory(Path homeDir) {
+    @Deprecated(since = "4.8.0") // Remove in or after Openfire 4.9.0.
+    public static void setHomeDirectory(String homeDir) {
+        setHomePath(new File(homeDir).toPath());
+    }
+
+    /**
+     * Sets the location of the <code>home</code> directory. The directory must exist and the
+     * user running the application must have read and write permissions over the specified
+     * directory.
+     *
+     * @param homeDir the location of the home dir.
+     */
+    public static void setHomePath(Path homeDir) {
         // Do a permission check on the new home directory
         if (!Files.exists(homeDir) || !Files.isDirectory(homeDir)) {
             Log.error("Error - the specified home directory does not exist or is not a directory (" + homeDir + ")");

--- a/xmppserver/src/main/java/org/jivesoftware/util/Log.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Log.java
@@ -129,7 +129,7 @@ public final class Log {
     public static String getLogDirectory() {
         // SLF4J doesn't provide a hook into the logging implementation. We'll have to do this 'direct', bypassing slf4j.
         final StringBuilder sb = new StringBuilder();
-        sb.append(JiveGlobals.getHomeDirectory());
+        sb.append(JiveGlobals.getHomePath());
         if (!sb.substring(sb.length()-1).startsWith(File.separator)) {
             sb.append(File.separator);
         }

--- a/xmppserver/src/main/webapp/index.jsp
+++ b/xmppserver/src/main/webapp/index.jsp
@@ -231,7 +231,7 @@
             <tr>
                 <td class="c1"><fmt:message key="index.home" /></td>
                 <td class="c2">
-                    <%= JiveGlobals.getHomeDirectory() %>
+                    <%= JiveGlobals.getHomePath() %>
                 </td>
             </tr>
             <tr>

--- a/xmppserver/src/main/webapp/logviewer.jsp
+++ b/xmppserver/src/main/webapp/logviewer.jsp
@@ -401,7 +401,7 @@ IFRAME {
 <br>
 
 <span class="jive-description" style="color:#666;">
-<fmt:message key="logviewer.log_dir" />: <%= JiveGlobals.getHomeDirectory() %><%= File.separator %>logs
+<fmt:message key="logviewer.log_dir" />: <%= JiveGlobals.getHomePath() %><%= File.separator %>logs
 </span>
 
 <br><br>

--- a/xmppserver/src/main/webapp/setup/setup-datasource-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-datasource-settings.jsp
@@ -80,7 +80,7 @@
     // Defaults
     if (mode == null) {
         // If the "embedded-database" directory exists, select to the embedded db as the default.
-        if (Files.exists(JiveGlobals.getHomeDirectory().resolve("embedded-db"))) {
+        if (Files.exists(JiveGlobals.getHomePath().resolve("embedded-db"))) {
             mode = EMBEDDED;
         }
         // Otherwise default to standard.

--- a/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
+++ b/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
@@ -81,7 +81,7 @@ public final class Fixtures {
             throw new IllegalStateException("Unable to read openfire.xml file; does conf/openfire.xml exist in the test classpath, i.e. test/resources?");
         }
         final Path openfireHome = Paths.get(configFile.toURI()).getParent().getParent();
-        JiveGlobals.setHomeDirectory(openfireHome);
+        JiveGlobals.setHomePath(openfireHome);
     }
 
     /**


### PR DESCRIPTION
A previous commit for OF-2647 replaced the argument to the getter and setter of `JiveGlobals.setHomeDirectory()` from a String to a Path.

This leads to compatibility issues in various plugins:
- https://github.com/igniterealtime/openfire-bookmarks-plugin/issues/20
- https://github.com/igniterealtime/openfire-certificateManager-plugin/issues/19
- https://github.com/igniterealtime/openfire-monitoring-plugin/issues/362

In hindsight, the signature change was to much of a change. This commit 'undoes' that change, by:
- introducing `get/setHomePath(Path)` (instead of replacing `getHomeDirectory`)
- restoring `get/setHomeDirectory(String)` and marking it as being deprecated

This should restore backwards compatilibity, and give plugin implementors time to migrate from the old to the new API.