### PR TITLE
OF-2648: Restore restoration of stream namespaces

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -178,10 +178,13 @@ public abstract class StanzaHandler {
             // establishing those prefixes is achieved by wrapping the data-to-be-parsed in a dummy root element on which
             // the prefixes are defined. After the data has been parsed, the dummy root element is discarded. See OF-2556.
             Log.trace("Connection defined namespace prefixes on its original 'stream' element.");
+            if (namespaces.stream().noneMatch(namespace -> namespace.getPrefix().equals("stream"))) {
+                namespaces.add(Namespace.get("stream", "http://etherx.jabber.org/streams"));
+            }
             final StringBuilder sb = new StringBuilder();
-            sb.append("<stream ");
+            sb.append("<stream:stream");
             namespaces.forEach(namespace -> sb.append(" ").append(namespace.asXML()));
-            sb.append(">").append(stanza).append("</stream>");
+            sb.append(">").append(stanza).append("</stream:stream>");
 
             doc = reader.read(new StringReader(sb.toString())).getRootElement().elementIterator().next();
             doc.detach();


### PR DESCRIPTION
In OF-2556, a workaround was provided to 'restore' namespace declarations on a stream element that had been parsed during the setup of the session.

This workaround injected a prefix-less 'stream' element. Unless the original stream defined a default namespace, this will not properly be parsed by an XML parser.

In this commit, the prefix 'stream' is used for the injected element (which is a de-facto standard in XMPP), and, for good measure, the namespace for that prefix is added, if it wasn't already recorded before.