### PR TITLE
OF-2652 - Fix max buffer size error

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
@@ -35,12 +35,10 @@ public class NettyXMPPDecoder extends ByteToMessageDecoder {
         // Get the XML parser from the channel
         XMLLightweightParser parser = ctx.channel().attr(NettyConnectionHandler.XML_PARSER).get();
 
-        // Check that the buffer is not bigger than 1 Megabyte. For security reasons
+        // Check that the stanza constructed by the parser is not bigger than 1 Megabyte. For security reasons
         // we will abort parsing when 1 Mega of queued chars was found.
         if (parser.isMaxBufferSizeExceeded()) {
-            if (in.refCnt() > 0) { // prevent IllegalReferenceCountException if the ByteBuf has already been deallocated.
-                in.release();
-            }
+            in.release();
             return;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
@@ -38,7 +38,9 @@ public class NettyXMPPDecoder extends ByteToMessageDecoder {
         // Check that the buffer is not bigger than 1 Megabyte. For security reasons
         // we will abort parsing when 1 Mega of queued chars was found.
         if (parser.isMaxBufferSizeExceeded()) {
-            in.release();
+            if (in.refCnt() > 0) { // prevent IllegalReferenceCountException if the ByteBuf has already been deallocated.
+                in.release();
+            }
             return;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
@@ -20,15 +20,20 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.util.CharsetUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static org.jivesoftware.openfire.nio.NettyConnectionHandler.CONNECTION;
 
 /**
  * Decoder that parses ByteBuffers and generates XML stanzas. Generated
  * stanzas are then passed to the next filters.
  */
 public class NettyXMPPDecoder extends ByteToMessageDecoder {
+    private static final Logger Log = LoggerFactory.getLogger(NettyXMPPDecoder.class);
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
@@ -50,5 +55,12 @@ public class NettyXMPPDecoder extends ByteToMessageDecoder {
         if (parser.areThereMsgs()) {
             out.addAll(Arrays.asList(parser.getMsgs()));
         }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        NettyConnection connection = ctx.channel().attr(CONNECTION).get();
+        Log.warn("Error occurred while decoding XMPP stanza, closing connection: " + connection, cause);
+        connection.close();
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
@@ -155,7 +155,7 @@ class XMLLightweightParser {
     }
 
     public boolean isMaxBufferSizeExceeded() {
-        return maxBufferSizeExceeded || buffer.length() > maxBufferSize;
+        return maxBufferSizeExceeded;
     }
 
     public void read(char[] buf) throws Exception {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
@@ -155,7 +155,7 @@ class XMLLightweightParser {
     }
 
     public boolean isMaxBufferSizeExceeded() {
-        return maxBufferSizeExceeded;
+        return maxBufferSizeExceeded || buffer.length() > maxBufferSize;
     }
 
     public void read(char[] buf) throws Exception {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
@@ -19,6 +19,8 @@ package org.jivesoftware.openfire.nio;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.PropertyEventDispatcher;
 import org.jivesoftware.util.PropertyEventListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +38,9 @@ import java.util.Map;
  * @author Gaston Dombiak
  */
 class XMLLightweightParser {
+
+    private static final Logger Log = LoggerFactory.getLogger(XMLLightweightParser.class);
+
     private static final String MAX_PROPERTY_NAME = "xmpp.parser.buffer.size";
     private static int maxBufferSize;
     // Chars that represent CDATA section start
@@ -163,6 +168,7 @@ class XMLLightweightParser {
         // Check that the buffer is not bigger than 1 Megabyte. For security reasons
         // we will abort parsing when 1 Mega of queued chars was found.
         if (buffer.length() > maxBufferSize) {
+            Log.debug("Stanza that has filled the XML parser buffer:\n" + buffer);
             // set flag to inform higher level network decoders to stop reading more data
             maxBufferSizeExceeded = true;
             // purge the local buffer / free memory


### PR DESCRIPTION
The current code does not set the 'maxBufferSizeExceeded' flag to true until the parser.read function is called. This PR changes the boolean logic such that the NettyXMPPDecoder will release the byte buffer and return if the max buffer size is exceeded, preventing the error from being thrown