### PR TITLE
OF-2540: Update slf4j and log4j2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <netty.version>4.1.94.Final</netty.version>
         <bouncycastle.version>1.70</bouncycastle.version>
-        <slf4j.version>1.7.36</slf4j.version>
-        <log4j.version>2.17.1</log4j.version>
+        <slf4j.version>2.0.9</slf4j.version>
+        <log4j.version>2.20.0</log4j.version>
     </properties>
 
     <profiles>
@@ -377,7 +377,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>install4j</groupId>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -320,7 +320,7 @@
         <!-- Logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
This updates the slf4j logging dependency from 1.7.36 to 2.0.9.

As no compatible log4j2 binding is available for the version of log4j2 that was used (2.17.1), this dependency has also been updated to 2.20.0.