### PR TITLE
Prevent deadlock in Netty Outbound S2S

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
@@ -100,11 +100,11 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
     private void transferConnectionToNewSession(String newStreamId, ServerSession.AuthenticationMethod existingAuthMethod) {
         session = createLocalOutgoingServerSession(newStreamId, connection);
 
-        // Clear routing table cache of previous sessions for domain pair and re-add it.
-        RoutingTable routingTable = XMPPServer.getInstance().getRoutingTable();
-        routingTable.addServerRoute(domainPair, (LocalOutgoingServerSession) session); // This _replaces_ the pre-existing session in the routing table.
-        SessionManager sessionManager = SessionManager.getInstance();
-        sessionManager.outgoingServerSessionCreated((LocalOutgoingServerSession) session);
+//        // Clear routing table cache of previous sessions for domain pair and re-add it.
+//        RoutingTable routingTable = XMPPServer.getInstance().getRoutingTable();
+//        routingTable.addServerRoute(domainPair, (LocalOutgoingServerSession) session); // This _replaces_ the pre-existing session in the routing table.
+//        SessionManager sessionManager = SessionManager.getInstance();
+//        sessionManager.outgoingServerSessionCreated((LocalOutgoingServerSession) session);
 
         // Transfer new session to existing connection
         connection.reinit(session);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
@@ -100,15 +100,10 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
     private void transferConnectionToNewSession(String newStreamId, ServerSession.AuthenticationMethod existingAuthMethod) {
         session = createLocalOutgoingServerSession(newStreamId, connection);
 
-//        // Clear routing table cache of previous sessions for domain pair and re-add it.
-//        RoutingTable routingTable = XMPPServer.getInstance().getRoutingTable();
-//        routingTable.addServerRoute(domainPair, (LocalOutgoingServerSession) session); // This _replaces_ the pre-existing session in the routing table.
-//        SessionManager sessionManager = SessionManager.getInstance();
-//        sessionManager.outgoingServerSessionCreated((LocalOutgoingServerSession) session);
-
         // Transfer new session to existing connection
         connection.reinit(session);
         if (isSessionAuthenticated.isDone()) {
+            ((LocalOutgoingServerSession) session).addOutgoingDomainPair(domainPair);
             ((LocalOutgoingServerSession) session).setAuthenticationMethod(existingAuthMethod);
         } else {
             LOG.debug("Session not authenticated yet, unable to setAuthenticationMethod().");


### PR DESCRIPTION
This, combined with fixes in https://github.com/igniterealtime/Openfire/pull/2263, seems to help getting S2S outbound connections established.

I'm not sure why though, and if by doing this, something important is neglected.

I got the idea of doing this, as I observed that when an outgoing session was being created to another Openfire server, a thread seemed to linger for a _long_ time waiting on obtaining a lock. I suspect a deadlock-like scenario.

I feel that more investigation is needed here, but I wanted to share this finding.