### PR TITLE
fix: OF-2655 - correct is new stream ID logic

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
@@ -158,7 +158,7 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
     }
 
     private boolean isNewStreamId(String streamHeaderId) {
-        return streamHeaderId.equals(session.getStreamID().getID());
+        return !streamHeaderId.equals(session.getStreamID().getID());
     }
 
     private static boolean isRelevantNamespace(Namespace ns) {


### PR DESCRIPTION
Original commit to explicitly check the streamId is a new ID before creating a new session (fc79a39f) had the is-new-stream logic inverted.