### PR TITLE
fix: escape asterisk in remote debug command args

### DIFF
--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -121,7 +121,7 @@ case $arguments in
     ;;
     -remotedebug)
     echo "Starting remote debug mode"
-    JAVACMD="$JAVACMD -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
+    JAVACMD="$JAVACMD -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=\*:5005"
     ;;
     -demoboot)
     echo "Starting demoboot"


### PR DESCRIPTION
When debugging on an Amazon Linux EC2 instance we've found that the remote debug command failed as the asterisk character needed to be escaped.

@Fishbowler I see from your original commit message that you were working in Docker, I assume it already worked there so I'm not sure if this change breaks it for your Docker scenario.