### PR TITLE
OF-2677: Use UTF-8 character sets when Netty decodes strings

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettySessionInitializer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettySessionInitializer.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.SSLException;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
@@ -117,7 +118,7 @@ public class NettySessionInitializer {
                     int maxIdleTimeBeforePinging = maxIdleTimeBeforeClosing / 2;
 
                     ch.pipeline().addLast(new NettyXMPPDecoder());
-                    ch.pipeline().addLast(new StringEncoder());
+                    ch.pipeline().addLast(new StringEncoder(StandardCharsets.UTF_8));
                     ch.pipeline().addLast("idleStateHandler", new IdleStateHandler(maxIdleTimeBeforeClosing, maxIdleTimeBeforePinging, 0));
                     ch.pipeline().addLast("keepAliveHandler", new NettyIdleStateKeepAliveHandler(false));
                     ch.pipeline().addLast(businessLogicHandler);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyServerInitializer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyServerInitializer.java
@@ -14,6 +14,7 @@ import org.jivesoftware.util.SystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
@@ -60,7 +61,7 @@ public class NettyServerInitializer extends ChannelInitializer<SocketChannel> {
         ch.pipeline()
             .addLast(TRAFFIC_HANDLER_NAME, new ChannelTrafficShapingHandler(0))
             .addLast(new NettyXMPPDecoder())
-            .addLast(new StringEncoder())
+            .addLast(new StringEncoder(StandardCharsets.UTF_8))
             .addLast("stalledSessionHandler", new WriteTimeoutHandler(Math.toIntExact(WRITE_TIMEOUT_SECONDS.getValue().getSeconds())))
             .addLast("idleStateHandler", new IdleStateHandler(maxIdleTimeBeforeClosing, maxIdleTimeBeforePinging, 0))
             .addLast("keepAliveHandler", new NettyIdleStateKeepAliveHandler(isClientConnection))


### PR DESCRIPTION
XMPP mandates that UTF-8 must be supported. Netty's default StringDecoder uses the character set that's the default of the server. Force UTF-8 instead.