### PR TITLE
OF-2675: Make SNI configurable (defaults to off)

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1660,6 +1660,7 @@ system_property.hybridAuthProvider.secondaryProvider.className=The second class 
 system_property.hybridAuthProvider.tertiaryProvider.className=The third class the HybridAuthProvider should to use to authenticate users
 system_property.admin.authorizedJIDs=The bare JID of every admin user for the DefaultAdminProvider
 system_property.xmpp.auth.ssl.context_protocol=The TLS protocol to use for encryption context initialization, overriding the Java default.
+system_property.xmpp.auth.ssl.enforce_sni=Controls if the server enforces the use of SNI (Server Name Indication) when clients connect using TLS.
 system_property.xmpp.socket.ssl.active=Set to true to enable Direct TLS encrypted connections for clients, otherwise false
 system_property.xmpp.socket.write-timeout-seconds=The write timeout time in seconds to handle stalled sessions and prevent DoS
 system_property.xmpp.component.ssl.active=Set to true to enable Direct TLS encrypted connections for external components, otherwise false

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
@@ -217,7 +217,9 @@ public class AdminConsolePlugin implements Plugin {
                     httpsConfig.setSendServerVersion( false );
                     httpsConfig.setSecureScheme( "https" );
                     httpsConfig.setSecurePort( adminSecurePort );
-                    httpsConfig.addCustomizer( new SecureRequestCustomizer() );
+                    SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
+                    secureRequestCustomizer.setSniHostCheck(sslContextFactory.isSniRequired());
+                    httpsConfig.addCustomizer( secureRequestCustomizer );
                     configureProxiedConnector(httpsConfig);
 
                     final HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory( httpsConfig );

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -484,8 +484,10 @@ public final class HttpBindManager implements CertificateEventListener {
                 final HttpConfiguration httpsConfig = new HttpConfiguration();
                 httpsConfig.setSecureScheme("https");
                 httpsConfig.setSecurePort(securePort);
+                SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
+                secureRequestCustomizer.setSniHostCheck(sslContextFactory.isSniRequired());
+                httpsConfig.addCustomizer( secureRequestCustomizer );
                 configureProxiedConnector(httpsConfig);
-                httpsConfig.addCustomizer(new SecureRequestCustomizer());
                 httpsConfig.setSendServerVersion( false );
 
                 final ServerConnector sslConnector = new ServerConnector(httpBindServer, new SslConnectionFactory(sslContextFactory, "http/1.1"), new HttpConnectionFactory(httpsConfig));

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactory.java
@@ -56,6 +56,13 @@ public class EncryptionArtifactFactory
         .setDynamic( false )
         .build();
 
+    public static final SystemProperty<Boolean> SNI_ENABLED = SystemProperty.Builder.ofType( Boolean.class )
+        .setKey( "xmpp.auth.ssl.enforce_sni" )
+        .setDefaultValue( false ) // Default to false, as SNI breaks https://localhost:9091
+        .setDynamic( false )
+        .build();
+
+
     private final ConnectionConfiguration configuration;
 
     // lazy loaded factory objects. These re-usable objects should be lazy loaded, preventing initialization in situations where they're never going to be used.
@@ -349,6 +356,9 @@ public class EncryptionArtifactFactory
                     sslContextFactory.setNeedClientAuth( true );
                     break;
             }
+
+            sslContextFactory.setSniRequired(SNI_ENABLED.getValue());
+
             return sslContextFactory;
         }
         catch ( RuntimeException ex )


### PR DESCRIPTION
SNI checks hostnames. Admin is usually addressed via tunnels and via localhost, which fails the SNI check.

This makes SNI configurable (for TLS and for hostname verification via the same setting) and defaults it to false.

This puts the same configuration to Admin and to HTTPBind - we might want to extend this later to separate it.

![image](https://github.com/igniterealtime/Openfire/assets/2117083/96dbfa7d-4f90-4f28-a7c9-9424efb07095)
