### PR TITLE
Stabilize LocalOutgoingServerSessionTest outcome

### DIFF
--- a/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
+++ b/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
@@ -171,6 +171,10 @@ public final class Fixtures {
         return connectionListener;
     }
 
+    public static RoutingTable mockRoutingTable() {
+        return  mock(RoutingTable.class, withSettings().lenient());
+    }
+
     public static class StubUserProvider implements UserProvider {
         final Map<String, User> users = new HashMap<>();
 

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalOutgoingServerSessionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalOutgoingServerSessionTest.java
@@ -18,6 +18,7 @@ package org.jivesoftware.openfire.session;
 import org.jivesoftware.Fixtures;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.ConnectionManager;
+import org.jivesoftware.openfire.RoutingTable;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.keystore.*;
 import org.jivesoftware.openfire.net.DNSUtil;
@@ -140,10 +141,13 @@ public class LocalOutgoingServerSessionTest
 
         final ConnectionManager connectionManager = Fixtures.mockConnectionManager();
         final ConnectionListener connectionListener = Fixtures.mockConnectionListener();
+        final RoutingTable routingTable = Fixtures.mockRoutingTable();
         doAnswer(new ConnectionConfigurationAnswer(identityStoreConfig, trustStoreConfig)).when(connectionListener).generateConnectionConfiguration();
         doReturn(Set.of(connectionListener)).when(connectionManager).getListeners(any(ConnectionType.class));
         doReturn(connectionListener).when(connectionManager).getListener(any(ConnectionType.class), anyBoolean());
         doReturn(connectionManager).when(xmppServer).getConnectionManager();
+        doReturn(routingTable).when(xmppServer).getRoutingTable();
+
         setUp();
     }
 


### PR DESCRIPTION
A race condition can cause LocalOutgoingServerSessionTest to occasionally fail. This seems to affect the Github based runners more than my local machine.

The issue is caused by a NullPointerException that is thrown immediately after a S2S connection has been set up. This causes the connection to close at the same time that the connection state is evaluated.

This commit prevents the NPE by adding a mock for the routing table to the test fixture.