### PR TITLE
fix: OF-2650 - improve strictCertificateValidation failure logging

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
@@ -383,4 +383,8 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
     public void setAttemptedAllAuthenticationMethods() {
         this.attemptedAllAuthenticationMethods.complete(null);
     }
+
+    public String getRemoteDomain() {
+        return domainPair.getRemote();
+    }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyOutboundConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyOutboundConnectionHandler.java
@@ -139,8 +139,9 @@ public class NettyOutboundConnectionHandler extends NettyConnectionHandler {
 
                 if (isCertificateException(event)){
                     if (configRequiresStrictCertificateValidation()) {
-                        Log.warn("Aborting attempt to create outgoing session as TLS handshake failed, and strictCertificateValidation is enabled.");
-                        throw new RuntimeException(event.cause());
+                        Log.warn("Aborting attempt to create outgoing session to {} as TLS handshake failed, and strictCertificateValidation is enabled.", stanzaHandler.getRemoteDomain());
+                        Log.debug("Error due to strictCertificateValidation", event.cause());
+                        abandonSession(stanzaHandler);
                     } else {
                         Log.warn("TLS handshake failed due to a certificate validation error");
                     }


### PR DESCRIPTION
Exception no longer thrown, logs now appropriate level for message and stack trace, and mention remote domain.