### PR TITLE
OF-2690: Server Dialback namespace usage

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialbackErrorException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialbackErrorException.java
@@ -15,9 +15,7 @@
  */
 package org.jivesoftware.openfire.server;
 
-import org.dom4j.Document;
-import org.dom4j.DocumentHelper;
-import org.dom4j.Element;
+import org.dom4j.*;
 import org.xmpp.packet.PacketError;
 
 /**
@@ -64,10 +62,11 @@ public class ServerDialbackErrorException extends Exception
 
     public Element toXML()
     {
+        final Namespace ns = Namespace.get("db", "urn:xmpp:features:dialback");
         final Document outbound = DocumentHelper.createDocument();
         final Element root = outbound.addElement("root");
-        root.addNamespace("db", "urn:xmpp:features:dialback");
-        final Element result = root.addElement("db:result");
+        root.add(ns);
+        final Element result = root.addElement(QName.get("result", ns));
         result.addAttribute("from", from);
         result.addAttribute("to", to);
         result.addAttribute("type", "error");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialbackErrorException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialbackErrorException.java
@@ -62,7 +62,7 @@ public class ServerDialbackErrorException extends Exception
 
     public Element toXML()
     {
-        final Namespace ns = Namespace.get("db", "urn:xmpp:features:dialback");
+        final Namespace ns = Namespace.get("db", "jabber:server:dialback");
         final Document outbound = DocumentHelper.createDocument();
         final Element root = outbound.addElement("root");
         root.add(ns);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialbackKeyInvalidException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialbackKeyInvalidException.java
@@ -15,9 +15,7 @@
  */
 package org.jivesoftware.openfire.server;
 
-import org.dom4j.Document;
-import org.dom4j.DocumentHelper;
-import org.dom4j.Element;
+import org.dom4j.*;
 
 /**
  * Representation of an invalid-key result of the Server Dialback authentication mechanism.
@@ -47,10 +45,11 @@ public class ServerDialbackKeyInvalidException extends Exception
     }
 
     public Element toXML() {
+        final Namespace ns = Namespace.get("db", "urn:xmpp:features:dialback");
         final Document outbound = DocumentHelper.createDocument();
         final Element root = outbound.addElement("root");
-        root.addNamespace("db", "urn:xmpp:features:dialback");
-        final Element result = root.addElement("db:result");
+        root.add(ns);
+        final Element result = root.addElement(QName.get("result", ns));
         result.addAttribute("from", from);
         result.addAttribute("to", to);
         result.addAttribute("type", "invalid");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialbackKeyInvalidException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialbackKeyInvalidException.java
@@ -45,7 +45,7 @@ public class ServerDialbackKeyInvalidException extends Exception
     }
 
     public Element toXML() {
-        final Namespace ns = Namespace.get("db", "urn:xmpp:features:dialback");
+        final Namespace ns = Namespace.get("db", "jabber:server:dialback");
         final Document outbound = DocumentHelper.createDocument();
         final Element root = outbound.addElement("root");
         root.add(ns);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -271,7 +271,7 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
             addValidatedDomain(remoteDomain);
 
             // Report success to the peer.
-            final Namespace ns = Namespace.get("db", "urn:xmpp:features:dialback");
+            final Namespace ns = Namespace.get("db", "jabber:server:dialback");
             final Document outbound = DocumentHelper.createDocument();
             final Element root = outbound.addElement("root");
             root.add(ns);
@@ -297,14 +297,14 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
             Log.debug("Unable to validate domain '{}'", fromDomain, e);
 
             // The namespace was already defined in a parent element that was sent earlier. Strip it from the XML.
-            final Namespace ns = Namespace.get("db", "urn:xmpp:features:dialback");
+            final Namespace ns = Namespace.get("db", "jabber:server:dialback");
             final String send = e.toXML().asXML().replaceAll(ns.asXML(), "").replace("  "," ");
             getConnection().deliverRawText(send);
         } catch (ServerDialbackKeyInvalidException e) {
             Log.debug( "Dialback key is invalid. Sending verification result to remote domain." );
 
             // The namespace was already defined in a parent element that was sent earlier. Strip it from the XML.
-            final Namespace ns = Namespace.get("db", "urn:xmpp:features:dialback");
+            final Namespace ns = Namespace.get("db", "jabber:server:dialback");
             final String send = e.toXML().asXML().replaceAll(ns.asXML(), "").replace("  "," ");
             getConnection().deliverRawText(send);
             Log.debug( "Close the underlying connection as key verification failed." );

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteInitiatingServerDummy.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteInitiatingServerDummy.java
@@ -598,12 +598,12 @@ public class RemoteInitiatingServerDummy extends AbstractRemoteServerDummy
             final String key = "UNITTESTDIALBACKKEY";
 
             final Document outbound = DocumentHelper.createDocument();
-            final Element root = outbound.addElement(QName.get("result", "db", "urn:xmpp:features:dialback"));
+            final Element root = outbound.addElement(QName.get("result", "db", "jabber:server:dialback"));
             root.addAttribute("from", XMPP_DOMAIN);
             root.addAttribute("to", connectTo);
             root.setText(key);
 
-            send(root.asXML().replace(" xmlns:db=\"urn:xmpp:features:dialback\"",""));
+            send(root.asXML().replace(" xmlns:db=\"jabber:server:dialback\"",""));
         }
 
         private void processDialbackResult(final Element result) throws IOException {

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteReceivingServerDummy.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteReceivingServerDummy.java
@@ -457,7 +457,7 @@ public class RemoteReceivingServerDummy extends AbstractRemoteServerDummy implem
 
             if (encryptionPolicy == Connection.TLSPolicy.required && !(socket instanceof SSLSocket)) {
                 final Document outbound = DocumentHelper.createDocument();
-                final Element result = outbound.addElement(QName.get("result", "db", "urn:xmpp:features:dialback"));
+                final Element result = outbound.addElement(QName.get("result", "db", "jabber:server:dialback"));
                 result.addAttribute("from", XMPP_DOMAIN);
                 result.addAttribute("to", inbound.attributeValue("from", null));
                 result.addAttribute("type", "error");
@@ -475,7 +475,7 @@ public class RemoteReceivingServerDummy extends AbstractRemoteServerDummy implem
 
             // Skip the check with an Authoritative Server (which is what Dialback _should_ do). Simply report a faked validation result.
             final Document outbound = DocumentHelper.createDocument();
-            final Element result = outbound.addElement(QName.get("result", "db", "urn:xmpp:features:dialback"));
+            final Element result = outbound.addElement(QName.get("result", "db", "jabber:server:dialback"));
             result.addAttribute("from", XMPP_DOMAIN);
             result.addAttribute("to", inbound.attributeValue("from", null));
             result.addAttribute("type", "valid");


### PR DESCRIPTION
Two commits, one that fixes the namespace that's used when doing Server Dialback, and another that prevents the namespace declaration to be sent on both the parent 'stream' element, as well as its child elements.