### PR TITLE
Session details page fixes

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -128,6 +128,8 @@ public abstract class LocalSession implements Session {
         this.sessionManager = SessionManager.getInstance();
         this.streamManager = new StreamManager(this);
         this.language = language;
+        this.lastActiveDate = startDate;
+
     }
 
     /**

--- a/xmppserver/src/main/webapp/server-session-details.jsp
+++ b/xmppserver/src/main/webapp/server-session-details.jsp
@@ -216,17 +216,17 @@
                 <c:if test="${not empty inSessions}">
                     <table style="width: 100%">
                         <tr>
-                            <th style="width: 35%; white-space: nowrap" colspan="2"><fmt:message key="server.session.details.incoming_session" /> <fmt:message key="server.session.details.streamid" /></th>
+                            <th style="width: 20%;" colspan="2"><fmt:message key="server.session.details.incoming_session" /> <fmt:message key="server.session.details.streamid" /></th>
                             <c:if test="${clusteringEnabled}">
-                                <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.details.node"/></th>
+                                <th style="width: 1%; "><fmt:message key="server.session.details.node"/></th>
                             </c:if>
-                            <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.authentication"/></th>
-                            <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.tls_version"/></th>
-                            <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.cipher"/></th>
-                            <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.label.creation" /></th>
-                            <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.label.last_active" /></th>
-                            <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.details.incoming_statistics" /></th>
-                            <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.details.outgoing_statistics" /></th>
+                            <th style="width: 10%;"><fmt:message key="server.session.details.authentication"/></th>
+                            <th style="width: 10%;"><fmt:message key="server.session.details.tls_version"/></th>
+                            <th style="width: 10%;"><fmt:message key="server.session.details.cipher"/></th>
+                            <th style="width: 10%;"><fmt:message key="server.session.label.creation" /></th>
+                            <th style="width: 10%;"><fmt:message key="server.session.label.last_active" /></th>
+                            <th style="width: 1%;"><fmt:message key="server.session.details.incoming_statistics" /></th>
+                            <th style="width: 1%;"><fmt:message key="server.session.details.outgoing_statistics" /></th>
                         </tr>
 
                         <c:forEach items="${inSessions}" var="session">
@@ -243,7 +243,7 @@
                                 </td>
                                 <td><c:out value="${session.streamID}"/></td>
                                 <c:if test="${clusteringEnabled}">
-                                    <td nowrap>
+                                    <td >
                                         <c:choose>
                                             <c:when test="${session['class'].simpleName eq 'LocalIncomingServerSession'}">
                                                 <fmt:message key="server.session.details.local"/>
@@ -254,7 +254,7 @@
                                         </c:choose>
                                     </td>
                                 </c:if>
-                                <td nowrap>
+                                <td >
                                     <c:choose>
                                         <c:when test="${session.isUsingServerDialback()}">
                                             <fmt:message key="server.session.details.dialback"/>
@@ -268,10 +268,10 @@
                                     </c:choose>
                                 <td><c:out value="${session.TLSProtocolName}"/></td>
                                 <td><c:out value="${session.cipherSuiteName}"/></td>
-                                <td nowrap><fmt:formatDate type="both" value="${session.creationDate}"/></td>
-                                <td nowrap><fmt:formatDate type="both" value="${session.lastActiveDate}"/></td>
-                                <td style="text-align: center" nowrap><fmt:formatNumber type="number" value="${session.numClientPackets}"/></td>
-                                <td style="text-align: center" nowrap><fmt:formatNumber type="number" value="${session.numServerPackets}"/></td>
+                                <td ><fmt:formatDate type="both" value="${session.creationDate}"/></td>
+                                <td ><fmt:formatDate type="both" value="${session.lastActiveDate}"/></td>
+                                <td style="text-align: center" ><fmt:formatNumber type="number" value="${session.numClientPackets}"/></td>
+                                <td style="text-align: center" ><fmt:formatNumber type="number" value="${session.numServerPackets}"/></td>
                             </tr>
                         </c:forEach>
                     </table>
@@ -281,17 +281,17 @@
                 <c:if test="${not empty outSessions}">
                     <table style="width: 100%">
                         <tr>
-                            <th style="width: 35%; white-space: nowrap" colspan="2"><fmt:message key="server.session.details.outgoing_session" /> <fmt:message key="server.session.details.streamid" /></th>
+                            <th style="width: 20%;" colspan="2"><fmt:message key="server.session.details.outgoing_session" /> <fmt:message key="server.session.details.streamid" /></th>
                             <c:if test="${clusteringEnabled}">
-                                <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.details.node"/></th>
+                                <th style="width: 1%; "><fmt:message key="server.session.details.node"/></th>
                             </c:if>
-                            <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.authentication"/></th>
-                            <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.tls_version"/></th>
-                            <th style="width: 10%; white-space: nowrap"><fmt:message key="server.session.details.cipher"/></th>
-                            <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.label.creation" /></th>
-                            <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.label.last_active" /></th>
-                            <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.details.incoming_statistics" /></th>
-                            <th style="width: 1%; white-space: nowrap"><fmt:message key="server.session.details.outgoing_statistics" /></th>
+                            <th style="width: 10%; "><fmt:message key="server.session.details.authentication"/></th>
+                            <th style="width: 10%; "><fmt:message key="server.session.details.tls_version"/></th>
+                            <th style="width: 10%; "><fmt:message key="server.session.details.cipher"/></th>
+                            <th style="width: 10%; "><fmt:message key="server.session.label.creation" /></th>
+                            <th style="width: 10%; "><fmt:message key="server.session.label.last_active" /></th>
+                            <th style="width: 1%; "><fmt:message key="server.session.details.incoming_statistics" /></th>
+                            <th style="width: 1%; "><fmt:message key="server.session.details.outgoing_statistics" /></th>
                         </tr>
 
                         <c:forEach items="${outSessions}" var="session">
@@ -308,7 +308,7 @@
                                 </td>
                                 <td><c:out value="${session.streamID}"/></td>
                                 <c:if test="${clusteringEnabled}">
-                                    <td nowrap>
+                                    <td >
                                         <c:choose>
                                             <c:when test="${session['class'].simpleName eq 'LocalOutgoingServerSession'}">
                                                 <fmt:message key="server.session.details.local"/>
@@ -319,7 +319,7 @@
                                         </c:choose>
                                     </td>
                                 </c:if>
-                                <td nowrap>
+                                <td >
                                     <c:choose>
                                         <c:when test="${session.isUsingServerDialback()}">
                                             <fmt:message key="server.session.details.dialback"/>
@@ -333,10 +333,10 @@
                                     </c:choose>
                                 <td><c:out value="${session.TLSProtocolName}"/></td>
                                 <td><c:out value="${session.cipherSuiteName}"/></td>
-                                <td nowrap><fmt:formatDate type="both" value="${session.creationDate}"/></td>
-                                <td nowrap><fmt:formatDate type="both" value="${session.lastActiveDate}"/></td>
-                                <td style="text-align: center" nowrap><fmt:formatNumber type="number" value="${session.numClientPackets}"/></td>
-                                <td style="text-align: center" nowrap><fmt:formatNumber type="number" value="${session.numServerPackets}"/></td>
+                                <td ><fmt:formatDate type="both" value="${session.creationDate}"/></td>
+                                <td ><fmt:formatDate type="both" value="${session.lastActiveDate}"/></td>
+                                <td style="text-align: center" ><fmt:formatNumber type="number" value="${session.numClientPackets}"/></td>
+                                <td style="text-align: center" ><fmt:formatNumber type="number" value="${session.numServerPackets}"/></td>
                             </tr>
                         </c:forEach>
                      </table>


### PR DESCRIPTION
- last activity will no longer show 1970  if no activity is detected - will instead show creation time.
- session details tables now flex - no more overflow off the page