### PR TITLE
OF-2665: Ensure correct cache config for SessionManager caches

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -78,7 +78,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
     public static final String COMPONENT_SESSION_CACHE_NAME = "Components Sessions";
     public static final String CM_CACHE_NAME = "Connection Managers Sessions";
     public static final String ISS_CACHE_NAME = "Incoming Server Session Info Cache";
-    public static final String DOMAIN_SESSIONS_CACHE_NAME = "Sessions by Domain";
+    public static final String DOMAIN_SESSIONS_CACHE_NAME = "Sessions by Hostname"; // although it's "by domain" rather than "by hostname", changing the name would require changes in the Hazelcast plugin!
     public static final String C2S_INFO_CACHE_NAME = "Client Session Info Cache";
 
     public static final int NEVER_KICK = -1;

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.util.cache;
 
+import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.XMPPServerListener;
 import org.jivesoftware.openfire.cluster.ClusterEventListener;
@@ -129,10 +130,11 @@ public class CacheFactory {
         cacheNames.put("Routing User Sessions", "routeUserSessions");
         cacheNames.put("Routing Result Listeners", "routeResultListeners");
         cacheNames.put("Components", "components");
-        cacheNames.put("Components Sessions", "componentsSessions");
-        cacheNames.put("Connection Managers Sessions", "connManagerSessions");
-        cacheNames.put("Incoming Server Sessions", "incServerSessions");
-        cacheNames.put("Sessions by Hostname", "sessionsHostname");
+        cacheNames.put(SessionManager.COMPONENT_SESSION_CACHE_NAME, "componentsSessions");
+        cacheNames.put(SessionManager.CM_CACHE_NAME, "connManagerSessions");
+        cacheNames.put(SessionManager.C2S_INFO_CACHE_NAME, "c2sInfoSessions");
+        cacheNames.put(SessionManager.DOMAIN_SESSIONS_CACHE_NAME, "sessionsHostname");
+        cacheNames.put(SessionManager.ISS_CACHE_NAME, "incServerSessions");
         cacheNames.put("Secret Keys Cache", "secretKeys");
         cacheNames.put("Validated Domains", "validatedDomains");
         cacheNames.put("Directed Presences", "directedPresences");
@@ -206,6 +208,8 @@ public class CacheFactory {
         cacheProps.put(PROPERTY_PREFIX_CACHE + "componentsSessions" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "connManagerSessions" + PROPERTY_SUFFIX_SIZE, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "connManagerSessions" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
+        cacheProps.put(PROPERTY_PREFIX_CACHE + "c2sInfoSessions" + PROPERTY_SUFFIX_SIZE, -1L);
+        cacheProps.put(PROPERTY_PREFIX_CACHE + "c2sInfoSessions" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "incServerSessions" + PROPERTY_SUFFIX_SIZE, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "incServerSessions" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "sessionsHostname" + PROPERTY_SUFFIX_SIZE, -1L);


### PR DESCRIPTION
Various caches used by SessionManager are expected to be configured as unlimited, never expire. However, they had no explicit configuration, therefor had the default size limitation and expiry. This leads to cache inconsistency issues as documented in OF-2665

For two out of three caches, it appears that the names of the caches have at some point been modified, without that same change having been applied to the cache configuration. The third cache is new, and never had cache configuration added.

This commit fixes that, be updating/adding cache configurion.

Special care needs to be taken with regards to a second set of cache configuration, that lives in the Hazelcast plugin. The names used in Openfire and there should be equal!