### PR TITLE
Revert "OF-2665: Add trace logs for when caches are modified for incoming server sessions (#2293)"

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/LocalSessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/LocalSessionManager.java
@@ -106,12 +106,10 @@ class LocalSessionManager {
     }
 
     public void addIncomingServerSessions(StreamID streamID, LocalIncomingServerSession session) {
-        Log.trace("IncomingServerSession added to local session manager: " + streamID);
         incomingServerSessions.put(streamID, session);
     }
 
     public LocalIncomingServerSession removeIncomingServerSessions(StreamID streamID) {
-        Log.trace("IncomingServerSession removed from local session manager: " + streamID);
         return incomingServerSessions.remove(streamID);
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -561,7 +561,6 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         try {
             // Add this instance (possibly replacing an older version, if the session already existed but now has an additional validated domain).
             localSessionManager.addIncomingServerSessions(streamID, session);
-            Log.trace("IncomingServerSession added to incoming server session info cache: " + streamID);
             incomingServerSessionInfoCache.put(streamID, new IncomingServerSessionInfo(session));
         } finally {
             lock.unlock();
@@ -590,12 +589,10 @@ public class SessionManager extends BasicModule implements ClusterEventListener
             if (!remaining.isEmpty()) {
                 Log.trace("Other validated domain(s) remain ({}). Replace the cache entry with an updated entry", String.join(", ", remaining));
                 localSessionManager.addIncomingServerSessions(streamID, session);
-                Log.trace("IncomingServerSession added to incoming server session info cache: " + streamID);
                 incomingServerSessionInfoCache.put(streamID, new IncomingServerSessionInfo(session));
             } else {
                 Log.trace("This session does not have any validated domains anymore. Remove it completely.");
                 localSessionManager.removeIncomingServerSessions(streamID);
-                Log.trace("IncomingServerSession removed from incoming server session info cache: " + streamID);
                 incomingServerSessionInfoCache.remove(streamID);
             }
         } finally {
@@ -625,7 +622,6 @@ public class SessionManager extends BasicModule implements ClusterEventListener
                 domainsToRemove.addAll(local.getValidatedDomains());
             }
             final IncomingServerSessionInfo cached = incomingServerSessionInfoCache.remove(streamID);
-            Log.trace("IncomingServerSession removed from incoming server session info cache: " + streamID);
             Log.trace("Found {} cached server session info to remove for stream ID {}", local == null ? "NO" : "a", streamID);
             if (cached != null) {
                 domainsToRemove.addAll(cached.getValidatedDomains());


### PR DESCRIPTION
@AlexGidman added trace logging to diagnose OF-2665. With OF-2665 fixed, we no longer need this. As it can be quite verbose, I'd rather take it out, even if it's just logging on trace.

This reverts commit b5ed121675a9b0223954e84fc8b9485c60ac6fc3.