### PR TITLE
OF-2682: concurrent modification exception connection namespaces

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.net.UnknownHostException;
 import java.security.cert.Certificate;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -38,15 +37,7 @@ import java.util.Set;
  * @author Iain Shigeoka
  */
 public interface Connection extends Closeable {
-/**
-     * When a connection is used to transmit an XML data, the root element of that data can define XML namespaces other
-     * than the ones that are default (eg: 'jabber:client', 'jabber:server', etc). For an XML parser to be able to parse
-     * stanzas or other elements that are defined in that namespace (eg: are prefixed), these namespaces are recorded
-     * here.
-     *
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2556">Issue OF-2556</a>
-     */
-    Set<Namespace> additionalNamespaces = new HashSet<>();
+
     /**
      * Verifies that the connection is still live. Typically this is done by
      * sending a whitespace character between packets.
@@ -385,10 +376,7 @@ public interface Connection extends Closeable {
      *
      * @return A collection that contains all non-default namespaces that the peer defined when last opening a new stream.
      */
-    @Nonnull
-    default Set<Namespace> getAdditionalNamespaces() {
-        return additionalNamespaces;
-    }
+    Set<Namespace> getAdditionalNamespaces();
 
     /**
      * When a connection is used to transmit an XML data, the root element of that data can define XML namespaces other
@@ -399,10 +387,7 @@ public interface Connection extends Closeable {
      * @param additionalNamespaces A collection that contains all non-default namespaces that the peer defined when last
      *                            opening a new stream.
      */
-    default void setAdditionalNamespaces(@Nonnull final Set<Namespace> additionalNamespaces) {
-        this.additionalNamespaces.clear();
-        this.additionalNamespaces.addAll(additionalNamespaces);
-    }
+    void setAdditionalNamespaces(@Nonnull final Set<Namespace> additionalNamespaces);
 
     /**
      * Enumeration of possible compression policies required to interact with the server.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
@@ -39,7 +39,7 @@ import java.util.Set;
 public interface Connection extends Closeable {
 
     /**
-     * Verifies that the connection is still live. Typically this is done by
+     * Verifies that the connection is still live. Typically, this is done by
      * sending a whitespace character between packets.
      *
      * @return true if the socket remains valid, false otherwise.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/AbstractConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/AbstractConnection.java
@@ -70,15 +70,37 @@ public abstract class AbstractConnection implements Connection
      */
     final protected Map<ConnectionCloseListener, Object> closeListeners = new HashMap<>();
 
+    /**
+     * The session that owns this connection.
+     */
+    protected LocalSession session;
+
     @Override
-    public void reinit(final LocalSession session)
+    public void init(LocalSession owner) {
+        session = owner;
+    }
+
+    @Override
+    public void reinit(final LocalSession owner)
     {
+        this.session = owner;
+
         // ConnectionCloseListeners are registered with their session instance as a callback object. When re-initializing,
         // this object needs to be replaced with the new session instance (or otherwise, the old session will be used
         // during the callback. OF-2014
         closeListeners.entrySet().stream()
             .filter(entry -> entry.getValue() instanceof LocalSession)
-            .forEach(entry -> entry.setValue(session));
+            .forEach(entry -> entry.setValue(owner));
+    }
+
+    /**
+     * Returns the session that owns this connection, if the connection has been initialized.
+     *
+     * @return session that owns this connection.
+     */
+    public LocalSession getSession() {
+        // TODO is it needed to expose this publicly? This smells.
+        return session;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/AbstractConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/AbstractConnection.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.net;
+
+import org.dom4j.Namespace;
+import org.jivesoftware.openfire.Connection;
+
+import javax.annotation.Nonnull;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A partial implementation of the {@link org.jivesoftware.openfire.Connection} interface, implementing functionality
+ * that's commonly shared by Connection implementations.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public abstract class AbstractConnection implements Connection
+{
+    /**
+     * When a connection is used to transmit an XML data, the root element of that data can define XML namespaces other
+     * than the ones that are default (eg: 'jabber:client', 'jabber:server', etc). For an XML parser to be able to parse
+     * stanzas or other elements that are defined in that namespace (eg: are prefixed), these namespaces are recorded
+     * here.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2556">Issue OF-2556</a>
+     */
+    private final Set<Namespace> additionalNamespaces = new HashSet<>();
+
+    @Override
+    @Nonnull
+    public Set<Namespace> getAdditionalNamespaces() {
+        return additionalNamespaces;
+    }
+
+    @Override
+    public void setAdditionalNamespaces(@Nonnull final Set<Namespace> additionalNamespaces) {
+        this.additionalNamespaces.clear();
+        this.additionalNamespaces.addAll(additionalNamespaces);
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/AbstractConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/AbstractConnection.java
@@ -31,6 +31,20 @@ import java.util.Set;
 public abstract class AbstractConnection implements Connection
 {
     /**
+     * The major version of XMPP being used by this connection (major_version.minor_version). In most cases, the version
+     * should be "1.0". However, older clients using the "Jabber" protocol do not set a version. In that case, the
+     * version is "0.0".
+     */
+    private int majorVersion = 1;
+
+    /**
+     * The minor version of XMPP being used by this connection (major_version.minor_version). In most cases, the version
+     * should be "1.0". However, older clients using the "Jabber" protocol do not set a version. In that case, the
+     * version is "0.0".
+     */
+    private int minorVersion = 0;
+
+    /**
      * When a connection is used to transmit an XML data, the root element of that data can define XML namespaces other
      * than the ones that are default (eg: 'jabber:client', 'jabber:server', etc). For an XML parser to be able to parse
      * stanzas or other elements that are defined in that namespace (eg: are prefixed), these namespaces are recorded
@@ -39,6 +53,22 @@ public abstract class AbstractConnection implements Connection
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2556">Issue OF-2556</a>
      */
     private final Set<Namespace> additionalNamespaces = new HashSet<>();
+
+    @Override
+    public int getMajorXMPPVersion() {
+        return majorVersion;
+    }
+
+    @Override
+    public int getMinorXMPPVersion() {
+        return minorVersion;
+    }
+
+    @Override
+    public void setXMPPVersion(int majorVersion, int minorVersion) {
+        this.majorVersion = majorVersion;
+        this.minorVersion = minorVersion;
+    }
 
     @Override
     @Nonnull

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -95,8 +95,6 @@ public class SocketConnection extends AbstractConnection {
     private boolean isEncrypted;
     private boolean compressed;
     private org.jivesoftware.util.XMLWriter xmlSerializer;
-    private int majorVersion = 1;
-    private int minorVersion = 0;
     private String language = null;
     private TLSStreamHandler tlsStreamHandler;
 
@@ -379,30 +377,6 @@ public class SocketConnection extends AbstractConnection {
      */
     public void setIdleTimeout(long timeout) {
         this.idleTimeout = timeout;
-    }
-
-    @Override
-    public int getMajorXMPPVersion() {
-        return majorVersion;
-    }
-
-    @Override
-    public int getMinorXMPPVersion() {
-        return minorVersion;
-    }
-
-    /**
-     * Sets the XMPP version information. In most cases, the version should be "1.0".
-     * However, older clients using the "Jabber" protocol do not set a version. In that
-     * case, the version is "0.0".
-     *
-     * @param majorVersion the major version.
-     * @param minorVersion the minor version.
-     */
-    @Override
-    public void setXMPPVersion(int majorVersion, int minorVersion) {
-        this.majorVersion = majorVersion;
-        this.minorVersion = minorVersion;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -51,13 +51,13 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * An object to track the state of a XMPP client-server session.
- * Currently this class contains the socket channel connecting the
+ * Currently, this class contains the socket channel connecting the
  * client and server.
  *
  * @author Iain Shigeoka
  * @deprecated Old, pre NIO / MINA code. Should not be used as Netty offers better performance. Currently only in use for server dialback.
  */
-public class SocketConnection implements Connection {
+public class SocketConnection extends AbstractConnection {
 
     private static final Logger Log = LoggerFactory.getLogger(SocketConnection.class);
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -21,7 +21,6 @@ import com.jcraft.jzlib.ZOutputStream;
 import org.jivesoftware.openfire.*;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.session.IncomingServerSession;
-import org.jivesoftware.openfire.session.LocalSession;
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
 import org.jivesoftware.openfire.spi.ConnectionType;
@@ -88,7 +87,6 @@ public class SocketConnection extends AbstractConnection {
      */
     private PacketDeliverer backupDeliverer;
 
-    private LocalSession session;
     private boolean isEncrypted;
     private boolean compressed;
     private org.jivesoftware.util.XMLWriter xmlSerializer;
@@ -238,17 +236,6 @@ public class SocketConnection extends AbstractConnection {
             }
         }
         return !isClosed();
-    }
-
-    @Override
-    public void init(LocalSession owner) {
-        session = owner;
-    }
-
-    @Override
-    public void reinit(LocalSession owner) {
-        super.reinit(owner);
-        session = owner;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -60,8 +60,7 @@ public class SocketConnection extends AbstractConnection {
 
     private static final Logger Log = LoggerFactory.getLogger(SocketConnection.class);
 
-    private static Map<SocketConnection, String> instances =
-            new ConcurrentHashMap<>();
+    private static final Map<SocketConnection, String> instances = new ConcurrentHashMap<>();
 
     /**
      * Milliseconds a connection has to be idle to be closed. Timeout is disabled by default. It's
@@ -74,23 +73,22 @@ public class SocketConnection extends AbstractConnection {
      */
     private long idleTimeout = -1;
 
-    private Socket socket;
+    private final Socket socket;
     private SocketReader socketReader;
 
     private Writer writer;
-    private AtomicBoolean writing = new AtomicBoolean(false);
-    private AtomicReference<State> state = new AtomicReference<State>(State.OPEN);
+    private final AtomicBoolean writing = new AtomicBoolean(false);
+    private final AtomicReference<State> state = new AtomicReference<State>(State.OPEN);
 
     /**
      * Deliverer to use when the connection is closed or was closed when delivering
      * a packet.
      */
-    private PacketDeliverer backupDeliverer;
+    private final PacketDeliverer backupDeliverer;
 
     private boolean isEncrypted;
     private boolean compressed;
     private org.jivesoftware.util.XMLWriter xmlSerializer;
-    private String language = null;
     private TLSStreamHandler tlsStreamHandler;
 
     private long writeStarted = -1;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -16,7 +16,6 @@
 
 package org.jivesoftware.openfire.net;
 
-import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.ConnectionCloseListener;
 import org.jivesoftware.openfire.PacketDeliverer;
 import org.jivesoftware.openfire.session.LocalSession;
@@ -42,8 +41,8 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @author Gaston Dombiak
  */
-public abstract class VirtualConnection implements Connection  {
-
+public abstract class VirtualConnection extends AbstractConnection
+{
     private static final Logger Log = LoggerFactory.getLogger(VirtualConnection.class);
 
     protected LocalSession session;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -53,18 +53,6 @@ public abstract class VirtualConnection extends AbstractConnection
    private AtomicReference<State> state = new AtomicReference<State>(State.OPEN);
 
     @Override
-    public int getMajorXMPPVersion() {
-        // Information not available. Return any value. This is not actually used.
-        return 0;
-    }
-
-    @Override
-    public int getMinorXMPPVersion() {
-        // Information not available. Return any value. This is not actually used.
-        return 0;
-    }
-
-    @Override
     public Certificate[] getLocalCertificates() {
         // Ignore
         return new Certificate[0];
@@ -94,11 +82,6 @@ public abstract class VirtualConnection extends AbstractConnection
     public boolean isCompressed() {
         // Return false since compression is not used for virtual connections
         return false;
-    }
-
-    @Override
-    public void setXMPPVersion(int majorVersion, int minorVersion) {
-        //Ignore
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -41,7 +41,7 @@ public abstract class VirtualConnection extends AbstractConnection
 {
     private static final Logger Log = LoggerFactory.getLogger(VirtualConnection.class);
 
-    private AtomicReference<State> state = new AtomicReference<State>(State.OPEN);
+    private final AtomicReference<State> state = new AtomicReference<State>(State.OPEN);
 
     @Override
     public Certificate[] getLocalCertificates() {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -17,7 +17,6 @@
 package org.jivesoftware.openfire.net;
 
 import org.jivesoftware.openfire.PacketDeliverer;
-import org.jivesoftware.openfire.session.LocalSession;
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.util.LocaleUtils;
 import org.slf4j.Logger;
@@ -41,8 +40,6 @@ import java.util.concurrent.atomic.AtomicReference;
 public abstract class VirtualConnection extends AbstractConnection
 {
     private static final Logger Log = LoggerFactory.getLogger(VirtualConnection.class);
-
-    protected LocalSession session;
 
     private AtomicReference<State> state = new AtomicReference<State>(State.OPEN);
 
@@ -114,17 +111,6 @@ public abstract class VirtualConnection extends AbstractConnection
     public boolean validate() {
         // Return true since the virtual connection is valid until it no longer exists
         return true;
-    }
-
-    @Override
-    public void init(LocalSession session) {
-        this.session = session;
-    }
-
-    @Override
-    public void reinit(LocalSession owner) {
-        super.reinit(owner);
-        this.session = owner;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -70,7 +70,6 @@ public class NettyConnection extends AbstractConnection
      */
     public static final String CHARSET = "UTF-8";
 
-    public LocalSession session;
     private final ChannelHandlerContext channelHandlerContext;
 
     /**
@@ -236,17 +235,9 @@ public class NettyConnection extends AbstractConnection
         close(new StreamError(StreamError.Condition.system_shutdown));
     }
 
-
-
-    @Override
-    public void init(LocalSession owner) {
-        session = owner;
-    }
-
     @Override
     public void reinit(LocalSession owner) {
         super.reinit(owner);
-        session = owner;
         StanzaHandler stanzaHandler = this.channelHandlerContext.channel().attr(NettyConnectionHandler.HANDLER).get();
         stanzaHandler.setSession(owner);
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -64,12 +64,6 @@ public class NettyConnection extends AbstractConnection
     private static final Logger Log = LoggerFactory.getLogger(NettyConnection.class);
     public static final String SSL_HANDLER_NAME = "ssl";
     private final ConnectionConfiguration configuration;
-
-    /**
-     * The utf-8 charset for decoding and encoding XMPP packet streams.
-     */
-    public static final String CHARSET = "UTF-8";
-
     private final ChannelHandlerContext channelHandlerContext;
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -83,8 +83,6 @@ public class NettyConnection extends AbstractConnection
      * a packet.
      */
     private final PacketDeliverer backupDeliverer;
-    private int majorVersion = 1;
-    private int minorVersion = 0;
 
     private boolean usingSelfSignedCertificate;
 
@@ -441,22 +439,6 @@ public class NettyConnection extends AbstractConnection
     public ConnectionConfiguration getConfiguration()
     {
         return configuration;
-    }
-
-    @Override
-    public int getMajorXMPPVersion() {
-        return majorVersion;
-    }
-
-    @Override
-    public int getMinorXMPPVersion() {
-        return minorVersion;
-    }
-
-    @Override
-    public void setXMPPVersion(int majorVersion, int minorVersion) {
-        this.majorVersion = majorVersion;
-        this.minorVersion = minorVersion;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -16,7 +16,6 @@
 
 package org.jivesoftware.openfire.nio;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -29,6 +28,7 @@ import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.ConnectionCloseListener;
 import org.jivesoftware.openfire.PacketDeliverer;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
+import org.jivesoftware.openfire.net.AbstractConnection;
 import org.jivesoftware.openfire.net.ServerTrafficCounter;
 import org.jivesoftware.openfire.net.StanzaHandler;
 import org.jivesoftware.openfire.session.LocalSession;
@@ -62,8 +62,8 @@ import static org.jivesoftware.openfire.spi.NettyServerInitializer.TRAFFIC_HANDL
  * @author Matthew Vivian
  * @author Alex Gidman
  */
-public class NettyConnection implements Connection {
-
+public class NettyConnection extends AbstractConnection
+{
     private static final Logger Log = LoggerFactory.getLogger(NettyConnection.class);
     public static final String SSL_HANDLER_NAME = "ssl";
     private final ConnectionConfiguration configuration;
@@ -468,5 +468,4 @@ public class NettyConnection implements Connection {
     public String toString() {
         return this.getClass().getSimpleName() + "{state: " + state + ", session: " + session + ", Netty channel handler context name: " + channelHandlerContext.name() + "}";
     }
-
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyIdleStateKeepAliveHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyIdleStateKeepAliveHandler.java
@@ -97,7 +97,7 @@ public class NettyIdleStateKeepAliveHandler extends ChannelDuplexHandler {
      */
     private void sendPingPacket(ChannelHandlerContext ctx) throws UnauthorizedException {
         NettyConnection connection = ctx.channel().attr(CONNECTION).get();
-        JID entity = connection.session == null ? null : connection.session.getAddress();
+        JID entity = connection.getSession() == null ? null : connection.getSession().getAddress();
         if (entity != null) {
             // Ping the connection to see if it is alive.
             final IQ pingRequest = new IQ(IQ.Type.get);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
@@ -209,11 +209,6 @@ public class WebSocketConnection extends VirtualConnection
     }
 
     @Override
-    public void init(LocalSession session) {
-        super.init(session);
-    }
-
-    @Override
     public void reinit(LocalSession session) {
         super.reinit(session);
         stanzaHandler.setSession(session);


### PR DESCRIPTION
The first commit fixes issue OF-2682, by replacing a static field with a non-static field in a new abstract class.

As we now have an abstract base class, the subsequent commits are used to replace some duplicate code in implementations, by moving it to that new base class. The migration of duplicated code is far from complete, but I didn't want to pile on to much for this commit.

Please refer to individual commit messages for a bit more detail on each change.