### PR TITLE
OF-2681: Add Server Dialback namespace even on authenticated connections

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
@@ -147,7 +147,7 @@ public class ServerStanzaHandler extends StanzaHandler {
         final Document document = DocumentHelper.createDocument(stream);
         document.setXMLEncoding(StandardCharsets.UTF_8.toString());
         stream.add(getNamespace());
-        if (ServerDialback.isEnabled() && (this.session != null && !this.session.isAuthenticated())) {
+        if (ServerDialback.isEnabled() && this.session != null) {
             stream.add(Namespace.get("db", "jabber:server:dialback"));
         }
         stream.addAttribute("from", domainPair.getLocal());


### PR DESCRIPTION
The connection to the authoritative server can be authenticated (I'm assuming that it uses laxer SASL EXTERNAL rules). Over that connection, dialback-namespaced data is sent. So, we'll need the namespace prefix to be defined on its stream.