### PR TITLE
OF-2699: Define optional PacketError on PacketRejectedException

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -125,7 +125,7 @@ public class IQRouter extends BasicModule {
         }
         catch (PacketRejectedException e) {
             if (session != null) {
-                // An interceptor rejected this packet so answer a not_allowed error
+                // An interceptor rejected this packet so answer with an error
                 IQ reply = new IQ();
                 if (childElement != null) {
                     reply.setChildElement(childElement.createCopy());
@@ -133,10 +133,16 @@ public class IQRouter extends BasicModule {
                 reply.setID(packet.getID());
                 reply.setTo(session.getAddress());
                 reply.setFrom(packet.getTo());
-                reply.setError(PacketError.Condition.not_allowed);
+
+                if (e.getRejectionError() != null) {
+                    reply.setError(e.getRejectionError());
+                } else {
+                    reply.setError(PacketError.Condition.not_allowed);
+                }
                 session.process(reply);
+
                 // Check if a message notifying the rejection should be sent
-                if (e.getRejectionMessage() != null && e.getRejectionMessage().trim().length() > 0) {
+                if (e.getRejectionMessage() != null && !e.getRejectionMessage().trim().isEmpty()) {
                     // A message for the rejection will be sent to the sender of the rejected packet
                     Message notification = new Message();
                     notification.setTo(session.getAddress());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
@@ -173,7 +173,7 @@ public class MessageRouter extends BasicModule {
             InterceptorManager.getInstance().invokeInterceptors(packet, session, true, true);
         } catch (PacketRejectedException e) {
             // An interceptor rejected this packet
-            if (session != null && e.getRejectionMessage() != null && e.getRejectionMessage().trim().length() > 0) {
+            if (session != null && (e.getRejectionError() != null || (e.getRejectionMessage() != null && !e.getRejectionMessage().trim().isEmpty()))) {
                 // A message for the rejection will be sent to the sender of the rejected packet
                 Message reply = new Message();
                 reply.setID(packet.getID());
@@ -181,7 +181,12 @@ public class MessageRouter extends BasicModule {
                 reply.setFrom(packet.getTo());
                 reply.setType(packet.getType());
                 reply.setThread(packet.getThread());
-                reply.setBody(e.getRejectionMessage());
+                if (e.getRejectionMessage() != null && !e.getRejectionMessage().trim().isEmpty()) {
+                    reply.setBody(e.getRejectionMessage());
+                }
+                if (e.getRejectionError() != null) {
+                    reply.setError(e.getRejectionError());
+                }
                 session.process(reply);
             }
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceRouter.java
@@ -94,15 +94,21 @@ public class PresenceRouter extends BasicModule {
         }
         catch (PacketRejectedException e) {
             if (session != null) {
-                // An interceptor rejected this packet so answer a not_allowed error
+                // An interceptor rejected this packet so answer with an error.
                 Presence reply = new Presence();
                 reply.setID(packet.getID());
                 reply.setTo(session.getAddress());
                 reply.setFrom(packet.getTo());
-                reply.setError(PacketError.Condition.not_allowed);
+
+                if (e.getRejectionError() != null) {
+                    reply.setError(e.getRejectionError());
+                } else {
+                    reply.setError(PacketError.Condition.not_allowed);
+                }
                 session.process(reply);
+
                 // Check if a message notifying the rejection should be sent
-                if (e.getRejectionMessage() != null && e.getRejectionMessage().trim().length() > 0) {
+                if (e.getRejectionMessage() != null && !e.getRejectionMessage().trim().isEmpty()) {
                     // A message for the rejection will be sent to the sender of the rejected packet
                     Message notification = new Message();
                     notification.setTo(session.getAddress());


### PR DESCRIPTION
This change allows a PacketError to be added to the exception that is used to reject (incoming) stanzas in PacketInterceptors. This new field is used in the error that's sent back to the sender, allowing for more detailed error reporting.