### PR TITLE
OF-2705: Improve routing stanzas to matching full JID

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -343,7 +343,7 @@ public class IQRouter extends BasicModule {
                 (routingTable.hasComponentRoute(recipientJID) ||
                     (packet.getFrom() != null && routingTable.hasServerRoute(new DomainPair(packet.getFrom().getDomain(), recipientJID.getDomain()))))) {
                 // A component/service/remote server was found that can handle the Packet
-                routingTable.routePacket(recipientJID, packet, false);
+                routingTable.routePacket(recipientJID, packet);
                 return;
             }
 
@@ -428,7 +428,7 @@ public class IQRouter extends BasicModule {
                 if (isAcceptable) {
                     // JID is of the form <node@domain/resource> or belongs to a remote server
                     // or to an uninstalled component
-                    routingTable.routePacket(recipientJID, packet, false);
+                    routingTable.routePacket(recipientJID, packet);
                 }
             }
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
@@ -127,7 +127,7 @@ public class MessageRouter extends BasicModule {
                     boolean isPrivate = packet.getElement().element(QName.get("private", "urn:xmpp:carbons:2")) != null;
                     try {
                         // Deliver stanza to requested route
-                        routingTable.routePacket(recipientJID, packet, false);
+                        routingTable.routePacket(recipientJID, packet);
                     } catch (Exception e) {
                         log.error("Failed to route packet: " + packet.toXML(), e);
                         routingFailed(recipientJID, packet);
@@ -255,7 +255,7 @@ public class MessageRouter extends BasicModule {
                 if (session != null && session.isInitialized()) {
                     if (session.getPresence().getPriority() >= 0) {
                         // If message was sent to an unavailable full JID of a user then retry using the bare JID.
-                        routingTable.routePacket( recipient.asBareJID(), packet, false );
+                        routingTable.routePacket(recipient.asBareJID(), packet);
                         return;
                     }
                 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceRouter.java
@@ -132,7 +132,7 @@ public class PresenceRouter extends BasicModule {
             if (recipientJID != null && !XMPPServer.getInstance().isLocal(recipientJID) &&
                     !XMPPServer.getInstance().isLocal(senderJID)) {
                 // Route the packet
-                routingTable.routePacket(recipientJID, packet, false);
+                routingTable.routePacket(recipientJID, packet);
                 return;
             }
 
@@ -167,7 +167,7 @@ public class PresenceRouter extends BasicModule {
                         // Register the sent directed presence
                         updateHandler.directedPresenceSent(packet, jid, recipientJID.toString());
                         // Route the packet
-                        routingTable.routePacket(jid, packet, false);
+                        routingTable.routePacket(jid, packet);
                     }
                 }
 
@@ -182,7 +182,7 @@ public class PresenceRouter extends BasicModule {
             else if (Presence.Type.probe == type) {
                 // Handle a presence probe sent by a remote server
                 if (!XMPPServer.getInstance().isLocal(recipientJID)) {
-                    routingTable.routePacket(recipientJID, packet, false);
+                    routingTable.routePacket(recipientJID, packet);
                 }
                 else {
                     // Handle probe to a local user
@@ -192,7 +192,7 @@ public class PresenceRouter extends BasicModule {
             else {
                 // It's an unknown or ERROR type, just deliver it because there's nothing
                 // else to do with it
-                routingTable.routePacket(recipientJID, packet, false);
+                routingTable.routePacket(recipientJID, packet);
             }
 
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
@@ -145,12 +145,18 @@ public interface RoutingTable {
      *
      * @param jid the recipient of the packet to route.
      * @param packet the packet to route.
-     * @param fromServer true if the packet was created by the server. This packets should
-     *        always be delivered
      * @throws PacketException thrown if the packet is malformed (results in the sender's
      *      session being shutdown).
      */
-    void routePacket(JID jid, Packet packet, boolean fromServer) throws PacketException;
+    void routePacket(JID jid, Packet packet) throws PacketException;
+
+    /**
+     * @deprecated Replaced by {@link #routePacket(JID, Packet)}
+     */
+    @Deprecated // Remove in or after Openfire 4.9.0.
+    default void routePacket(JID jid, Packet packet, boolean fromServer) throws PacketException {
+        routePacket(jid, packet);
+    }
 
     /**
      * Returns true if a registered user or anonymous user with the specified full JID is

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -730,7 +730,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         // RFC 6121 4.4.2 says we always send to the originating resource.
         // Also RFC 6121 4.2.2 for updates.
         presence.setTo(originatingResource);
-        routingTable.routePacket(originatingResource, presence, false);
+        routingTable.routePacket(originatingResource, presence);
         if (!SessionManager.isOtherResourcePresenceEnabled()) {
             return;
         }
@@ -742,7 +742,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
                 // Send the presence of the session whose presence has changed to
                 // this user's other session(s)
                 presence.setTo(address);
-                routingTable.routePacket(address, presence, false);
+                routingTable.routePacket(address, presence);
             }
         }
     }
@@ -1166,7 +1166,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         // TODO broadcast to ALL sessions of the user and not only available
         for (JID address : routingTable.getRoutes(new JID(username, serverName, null), null)) {
             packet.setTo(address);
-            routingTable.routePacket(address, packet, true);
+            routingTable.routePacket(address, packet);
         }
     }
 
@@ -1459,7 +1459,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
             // Full JID: address to the session, if one exists.
             for (JID sessionAddress : routingTable.getRoutes(address, null)) {
                 packet.setTo(sessionAddress); // expected to be equal to 'address'.
-                routingTable.routePacket(sessionAddress, packet, true);
+                routingTable.routePacket(sessionAddress, packet);
             }
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/RemotePacketExecution.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/RemotePacketExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2009 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2009 Jive Software, 2023 Ignite Realtime Community. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public class RemotePacketExecution implements ClusterTask<Void> {
     public void run() {
         // Route packet to entity hosted by this node. If delivery fails then the routing table
         // will inform the proper router of the failure and the router will handle the error reply logic
-        XMPPServer.getInstance().getRoutingTable().routePacket(recipient, packet, false);
+        XMPPServer.getInstance().getRoutingTable().routePacket(recipient, packet);
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
@@ -508,7 +508,7 @@ public class InternalComponentManager extends BasicModule implements ClusterEven
                 Presence presence = new Presence();
                 presence.setFrom(prober);
                 presence.setTo(probee);
-                routingTable.routePacket(probee, presence, false);
+                routingTable.routePacket(probee, presence);
 
                 // No reason to hold onto prober reference.
                 presenceMap.remove(prober);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ public class IQOfflineMessagesHandler extends IQHandler implements ServerFeature
         Element offlineInfo = offlineMessage.addChildElement("offline", NAMESPACE);
         offlineInfo.addElement("item").addAttribute("node",
                 XMPPDateTimeFormat.format(offlineMessage.getCreationDate()));
-        routingTable.routePacket(receipient, offlineMessage, true);
+        routingTable.routePacket(receipient, offlineMessage);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -210,7 +210,7 @@ public class PresenceSubscribeHandler extends BasicModule implements ChannelHand
                             // Stamp the presence with the user's bare JID as the 'from' address,
                             // as required by section 8.2.5 of RFC 3921
                             presenteToSend.setFrom(senderJID.toBareJID());
-                            routingTable.routePacket(jid, presenteToSend, false);
+                            routingTable.routePacket(jid, presenteToSend);
                         }
                     }
                     else {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/interceptor/PacketCopier.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/interceptor/PacketCopier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -192,7 +192,7 @@ public class PacketCopier implements PacketInterceptor, ComponentEventListener {
                         childElement.addAttribute("date", XMPPDateTimeFormat.format(interceptedPacket.getCreationDate()));
                         childElement.add(interceptedPacket.getElement().createCopy());
                         // Send message notification to subscribed component
-                        routingTable.routePacket(message.getTo(), message, true);
+                        routingTable.routePacket(message.getTo(), message);
                     }
                     catch (Exception e) {
                         Log.error(LocaleUtils.getLocalizedString("admin.error"), e);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketPacketWriteHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketPacketWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Community. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,21 +53,21 @@ public class SocketPacketWriteHandler implements ChannelHandler {
             JID recipient = packet.getTo();
             // Check if the target domain belongs to a remote server or a component
             if (server.matchesComponent(recipient) || server.isRemote(recipient)) {
-                routingTable.routePacket(recipient, packet, false);
+                routingTable.routePacket(recipient, packet);
             }
             // The target domain belongs to the local server
             else if (recipient == null || (recipient.getNode() == null && recipient.getResource() == null)) {
                 // no TO was found so send back the packet to the sender
-                routingTable.routePacket(packet.getFrom(), packet, false);
+                routingTable.routePacket(packet.getFrom(), packet);
             }
             else if (recipient.getResource() != null || !(packet instanceof Presence)) {
                 // JID is of the form <user@domain/resource>
-                routingTable.routePacket(recipient, packet, false);
+                routingTable.routePacket(recipient, packet);
             }
             else {
                 // JID is of the form <user@domain>
                 for (JID route : routingTable.getRoutes(recipient, null)) {
-                    routingTable.routePacket(route, packet, false);
+                    routingTable.routePacket(route, packet);
                 }
             }
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/Roster.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/Roster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -603,7 +603,7 @@ public class Roster implements Cacheable, Externalizable {
                 final List<JID> routingTableRoutes = routingTable.getRoutes(searchNode, null);
                 for (JID jid : routingTableRoutes) {
                     try {
-                        routingTable.routePacket(jid, packet, false);
+                        routingTable.routePacket(jid, packet);
                     } catch (Exception e) {
                         // Theoretically only happens if session has been closed.
                         Log.debug(e.getMessage(), e);
@@ -630,7 +630,7 @@ public class Roster implements Cacheable, Externalizable {
             final List<JID> routingTableRoutes = routingTable.getRoutes(new JID(contact), null);
             for (JID jid : routingTableRoutes) {
                 try {
-                    routingTable.routePacket(jid, packet, false);
+                    routingTable.routePacket(jid, packet);
                 } catch (Exception e) {
                     // Theoretically only happens if session has been closed.
                     Log.debug(e.getMessage(), e);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -844,7 +844,7 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
         else {
             presence.setType(Presence.Type.unsubscribe);
         }
-        routingTable.routePacket(recipient, presence, false);
+        routingTable.routePacket(recipient, presence);
     }
 
     private Collection<Group> getVisibleGroups(Group groupToCheck) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Community. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -422,7 +422,7 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
                     presence.setType(Presence.Type.probe);
                     presence.setFrom(prober);
                     presence.setTo(probee);
-                    routingTable.routePacket(probee, presence, true);
+                    routingTable.routePacket(probee, presence);
                 }
                 else {
                     // Check if the probee may be hosted by this server


### PR DESCRIPTION
RFC 6121 section 8.5.3 defines how a server should process a stanza that is addressed to a full JID. When a matching resource is found, the specification does not distinghuis between an “available” resource and a “connected” resource. Instead, it refers to an “available resource or connected resource” (this is different for processing of stanzas to bare JIDs, in section 8.5.2).

Openfire’s implementation of routing stanzas addressed to a full JID of a resource for which a route exist should not evaluate the ‘availability’ of the route, as this contradicts the RFC, which doesn’t differentiate between ‘available’ and ‘connected’.