### PR TITLE
Modify server-to-server connection timeouts

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -118,7 +118,7 @@ public final class ConnectionSettings {
          */
         public static final SystemProperty<Duration> IDLE_TIMEOUT_PROPERTY = SystemProperty.Builder.ofType(Duration.class)
             .setKey("xmpp.server.idle")
-            .setDefaultValue(Duration.ofMinutes(6))
+            .setDefaultValue(Duration.ofMinutes(30))
             .setMinValue(Duration.ofMillis(-1))
             .setChronoUnit(ChronoUnit.MILLIS)
             .setDynamic(Boolean.TRUE)

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -72,13 +72,12 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
 
     private static final Interner<JID> remoteAuthMutex = Interners.newWeakInterner();
 
-    public static final String XMPP_SERVER_SESSION_INITIALISE_TIMEOUT_KEY = "xmpp.server.session.initialise-timeout";
     /**
      * Controls the S2S outgoing session initialise timeout time in seconds
      */
     public static final SystemProperty<Duration> INITIALISE_TIMEOUT_SECONDS = SystemProperty.Builder.ofType(Duration.class)
-        .setKey(XMPP_SERVER_SESSION_INITIALISE_TIMEOUT_KEY)
-        .setDefaultValue(Duration.ofSeconds(5))
+        .setKey("xmpp.server.session.initialise-timeout")
+        .setDefaultValue(Duration.ofSeconds(10))
         .setChronoUnit(ChronoUnit.SECONDS)
         .setDynamic(true)
         .build();


### PR DESCRIPTION
This changes the default value for the server-to-server initialization timeout from 5 to 10 seconds, and the idle timeout from 6 to 30 minutes. This is more in line with behavior experienced on Ignite's own XMPP domain.