### PR TITLE
OF-2715: Websockets should send closing frame when disconnecting

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
@@ -62,7 +62,7 @@ public class WebSocketClientConnectionHandler
      *
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2479">OF-2479: Allow Tsung to test with websockets</a>
      */
-    private static final SystemProperty<Boolean> STREAM_SUBSTITUTION_ENABLED = SystemProperty.Builder.ofType(Boolean.class)
+    public static final SystemProperty<Boolean> STREAM_SUBSTITUTION_ENABLED = SystemProperty.Builder.ofType(Boolean.class)
         .setKey("xmpp.websocket.stream-substitution-enabled")
         .setDefaultValue(false)
         .setDynamic(true)

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientStanzaHandler.java
@@ -68,7 +68,7 @@ public class WebSocketClientStanzaHandler extends ClientStanzaHandler
     @Override
     protected void initiateSession(String stanza, XMPPPacketReader reader) throws Exception
     {
-        // Found an stream:stream tag...
+        // Found a stream:stream tag...
         if (!sessionCreated) {
             sessionCreated = true;
             MXParser parser = reader.getXPPParser();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
@@ -33,6 +33,8 @@ import javax.annotation.Nullable;
 import java.net.InetSocketAddress;
 import java.util.Optional;
 
+import static org.jivesoftware.openfire.websocket.WebSocketClientConnectionHandler.STREAM_SUBSTITUTION_ENABLED;
+
 /**
  * Following the conventions of the BOSH implementation, this class extends {@link VirtualConnection}
  * and delegates the expected XMPP connection behaviors to the corresponding {@link WebSocketClientConnectionHandler}.
@@ -62,6 +64,14 @@ public class WebSocketConnection extends VirtualConnection
             if (error != null) {
                 deliverRawText0(error.toXML());
             }
+
+            final String closeElement;
+            if (STREAM_SUBSTITUTION_ENABLED.getValue()) {
+                closeElement = "</stream:stream>";
+            } else {
+                closeElement = "<" + WebSocketClientStanzaHandler.STREAM_FOOTER + " xmlns='"+WebSocketClientStanzaHandler.FRAMING_NAMESPACE+"'/>";
+            }
+            deliverRawText0(closeElement);
         } finally {
             socket.getWsSession().close();
         }


### PR DESCRIPTION
When closing a websocket connection, a `<close xmlns='urn:ietf:params:xml:ns:xmpp-framing'/>` should be sent prior to closing the connection.