### PR TITLE
CI: use _all_ Smack connection types

### DIFF
--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -190,7 +190,6 @@ function runTestsInGradle {
 			-Dsinttest.replyTimeout=60000 \
 			-Dsinttest.adminAccountUsername="${ADMINUSER}" \
 			-Dsinttest.adminAccountPassword="${ADMINPASS}" \
-			-Dsinttest.enabledConnections=tcp \
 			-Dsinttest.dnsResolver=javax \
 			${SINTTEST_DISABLED_TESTS_ARGUMENT}
 }


### PR DESCRIPTION
Although the modular connections are experimental, lets experiment with enabling them.

It is particularly desirable to have Websocket support.