### PR TITLE
OF-2661: Ensure we send everything (flush) before actual channel closure

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -274,7 +274,7 @@ public class NettyConnection extends AbstractConnection
                 channelHandlerContext.writeAndFlush(packet.getElement().asXML())
                     .addListener(l ->
                         updateWrittenBytesCounter(channelHandlerContext)
-                    ).sync();
+                    );
                 // TODO - handle errors more specifically
                 // Currently errors are handled by the default exceptionCaught method (log error, close channel)
                 // We can add a new listener to the ChannelFuture f for more specific error handling.
@@ -303,13 +303,9 @@ public class NettyConnection extends AbstractConnection
     public void deliverRawText(String text) {
         if (!isClosed()) {
             Log.trace("Sending: {}", text);
-            try {
-                channelHandlerContext.writeAndFlush(text).addListener(l ->
-                    updateWrittenBytesCounter(channelHandlerContext)
-                ).sync();
-            } catch (InterruptedException e) {
-                Log.warn("An exception occurred while sending data to: {}", this);
-            }
+            channelHandlerContext.writeAndFlush(text).addListener(l ->
+                updateWrittenBytesCounter(channelHandlerContext)
+            );
             // TODO - handle errors more specifically
             // Currently errors are handled by the default exceptionCaught method (log error, close channel)
             // We can add a new listener to the ChannelFuture f for more specific error handling.


### PR DESCRIPTION
Fixes a behaviour we saw in `testDisconnectAfterConnect` in Smack's `ModularXmppClientToServerConnectionLowLevelIntegrationTest` where Openfire closed a connection before it could send a stream closure to the departing client.