### PR TITLE
CI: Use TCP connections only

### DIFF
--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -190,6 +190,7 @@ function runTestsInGradle {
 			-Dsinttest.replyTimeout=60000 \
 			-Dsinttest.adminAccountUsername="${ADMINUSER}" \
 			-Dsinttest.adminAccountPassword="${ADMINPASS}" \
+			-Dsinttest.enabledConnections=tcp \
 			-Dsinttest.dnsResolver=javax \
 			${SINTTEST_DISABLED_TESTS_ARGUMENT}
 }


### PR DESCRIPTION
The Modular connection type is experimental in 4.4.6, so likely to flake some tests.

TODO: When Smack 4.5.0 is released, this should be updated to use Websocket connections too.