### PR TITLE
OF-2668 / OF-2723: Allow plugins to be compiled against Openfire 4.8

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -368,6 +368,13 @@
             <version>${openfire.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.igniterealtime.openfire</groupId>
+            <artifactId>xmppserver</artifactId>
+            <version>${openfire.version}</version>
+            <classifier>taglib</classifier>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -340,6 +340,7 @@
                                 <sourceVersion>11</sourceVersion>
                                 <targetVersion>11</targetVersion>
                                 <keepSources>true</keepSources>
+                                <scanManifest>false</scanManifest>
                             </configuration>
                         </execution>
                     </executions>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -128,6 +128,25 @@
                 </configuration>
             </plugin>
 
+            <!-- Expose our taglibs as a JAR file that can be consumed as a dependency by plugins -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assembly/taglib.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- Compile the JSP pages -->
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>

--- a/xmppserver/src/assembly/taglib.xml
+++ b/xmppserver/src/assembly/taglib.xml
@@ -10,7 +10,7 @@
     <fileSets>
         <fileSet>
             <outputDirectory>META-INF/tags/admin</outputDirectory>
-            <directory>${project.basedir}/../src/web/WEB-INF/tags/admin</directory>
+            <directory>${project.basedir}/src/main/webapp/WEB-INF/classes/META-INF/tags/admin</directory>
             <includes>
                 <include>**/*.tag</include>
                 <include>**/*.tagx</include>
@@ -19,7 +19,7 @@
 
         <fileSet>
             <outputDirectory>META-INF/</outputDirectory>
-            <directory>${project.basedir}/src/main/webapp/META-INF/</directory>
+            <directory>${project.basedir}/src/main/webapp/WEB-INF/classes/META-INF/</directory>
             <includes>
                 <include>*.tld</include>
             </includes>


### PR DESCRIPTION
In this commit, a second artifact is produced from the xmppserver module. Apart from the prexisting 'jar' artifact, there now is a 'taglib' artifact.

This taglib artifact is a jar file (that needs to go into our maven repository), that holds the Admin Console taglibs, in a spec-compliant directory structure.

The plugin's parent pom-file is modified to be able to make use of this new artifact.

With this, compilation of a plugin that defins the plugin parent pom as its parent succeeds (although an unhealty amount of errors is logged). The resulting admin console pages appear functional, at least in Openfire 4.8.