### PR TITLE
OF-2725: Update dependency-check, and deal with the results

### DIFF
--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -68,4 +68,10 @@
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-servlet\-api@4\.0\..*$</packageUrl>
         <cpe>cpe:/a:jetty:jetty</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Ignore CVE about Netty defaults for hostname validation, since Openfire implements its own configurable hostname validation.
+   ]]></notes>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
 </suppressions>

--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -102,4 +102,11 @@
         <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
         <cve>CVE-2022-34305</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Openfire doesn't use the ROOT webapp. Additional testing on 2023-11-13 against 7a53b23e565cdf06a541af82560a6c49d6c9d2ae.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <cve>CVE-2023-41080</cve>
+    </suppress>
 </suppressions>

--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -47,4 +47,11 @@
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-servlets@.*$</packageUrl>
         <vulnerabilityName>CVE-2023-36479</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Ignore a withdrawn CVE (see https://github.com/joker-xiaoyan/XXE-SAXReader/issues/1 and https://github.com/dom4j/dom4j/issues/171#issuecomment-1781547256)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.dom4j/dom4j@.*$</packageUrl>
+        <cve>CVE-2023-45960</cve>
+    </suppress>
 </suppressions>

--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -74,4 +74,11 @@
    ]]></notes>
         <cve>CVE-2023-4586</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Ignore a CVE regarding Tomcat clustering, which isn't used in Openfire.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <cve>CVE-2022-29885</cve>
+    </suppress>
 </suppressions>

--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -81,4 +81,11 @@
         <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
         <cve>CVE-2022-29885</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Rapid Reset was fixed in Jetty 10.0.18, which brings in this dependency.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <cve>CVE-2023-44487</cve>
+    </suppress>
 </suppressions>

--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -40,4 +40,11 @@
         <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
         <vulnerabilityName>CVE-2020-8908</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Ignore a CVE related only to Jetty's CGI servlet, which isn't used in Openfire.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-servlets@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-36479</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -88,4 +88,11 @@
         <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
         <cve>CVE-2023-44487</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Openfire doesn't persist sessions via Tomcat FileStore (or anything else, beyond preferences)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <cve>CVE-2022-23181</cve>
+    </suppress>
 </suppressions>

--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -95,4 +95,11 @@
         <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
         <cve>CVE-2022-23181</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Openfire doesn't make use of the example webapp in Tomcat
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <cve>CVE-2022-34305</cve>
+    </suppress>
 </suppressions>

--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -54,4 +54,18 @@
         <packageUrl regex="true">^pkg:maven/org\.dom4j/dom4j@.*$</packageUrl>
         <cve>CVE-2023-45960</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppress eclipse:jetty issues for jetty-servlet-api@4.0.x since it's incorrectly pulling in all Jetty issues after Jetty v4, whereas jetty-servlet-api v4 is included in Jetty v10.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-servlet\-api@4\.0\..*$</packageUrl>
+        <cpe>cpe:/a:eclipse:jetty</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppress jetty:jetty issues for jetty-servlet-api@4.0.x since it's incorrectly pulling in all Jetty issues after Jetty v4, whereas jetty-servlet-api v4 is included in Jetty v10.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-servlet\-api@4\.0\..*$</packageUrl>
+        <cpe>cpe:/a:jetty:jetty</cpe>
+    </suppress>
 </suppressions>

--- a/build/ci/updater/pom.xml
+++ b/build/ci/updater/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
-      <version>8.0.32</version>
+      <version>8.2.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>8.1.2</version>
+                        <version>8.4.2</version>
                         <configuration>
                             <suppressionFiles>
                                 <suppressionFile>.dependency-check-suppressions.xml</suppressionFile>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -235,7 +235,7 @@
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.3</version>
+            <version>2.1.4</version>
         </dependency>
 
         <dependency>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -466,7 +466,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>8.0.32</version>
+            <version>8.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
OF-2725 updates `dependency-check-maven` to 8.4.2, then adds suppressions for known false positives

OF-2726 updates `dom4j` to 2.1.4

OF-2727 updates `mysql-connector-j` to 8.2.0

Notes:
* Remaining CVEs are all against `org.mortbay.jasper/apache-jsp@9.0.52` which is a dependency of Jetty 10. I've suppressed the obvious/easy ones, but suspect we're vulnerable to zero.
* There might be other out of date dependencies that weren't flagged. I've not looked.
