### PR TITLE
OF-2732: Updated bundled 'search' plugin to 1.7.4

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.igniterealtime.openfire.plugins</groupId>
             <artifactId>search</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4</version>
             <classifier>openfire-plugin-assembly</classifier>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
The Openfire distribution contains one plugin: the search plugin.

It currently ships with version 1.7.3, while the latest release is 1.7.4.

Openfire should ship with the latest release.