### PR TITLE
OF-1382: Admin console should not autocomplete username/password in all forms

### DIFF
--- a/xmppserver/src/main/webapp/group-edit.jsp
+++ b/xmppserver/src/main/webapp/group-edit.jsp
@@ -575,7 +575,7 @@
                         <fmt:message key="group.edit.add_user" />
                     </td>
                     <td class="c1" style="text-align: left; white-space: nowrap">
-                         <input type="text" size="45" name="username"/>
+                         <input type="text" size="45" name="username" autocomplete="off"/>
                         &nbsp;<input type="submit" name="addbutton" value="<fmt:message key="global.add" />">
                     </td>
                     <c:if test="${not empty errors['addMember']}">

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -501,7 +501,7 @@
         </c:otherwise>
     </c:choose>
 
-    <form action="muc-room-edit-form.jsp">
+    <form action="muc-room-edit-form.jsp" autocomplete="off">
         <c:if test="${not create}">
             <input type="hidden" name="roomJID" value="${fn:escapeXml(roomJIDBare)}">
         </c:if>

--- a/xmppserver/src/main/webapp/user-create.jsp
+++ b/xmppserver/src/main/webapp/user-create.jsp
@@ -221,7 +221,7 @@
     </c:when>
 </c:choose>
 
-<form name="f" action="user-create.jsp" method="get">
+<form name="f" action="user-create.jsp" method="get" autocomplete="off">
     <input type="hidden" name="csrf" value="${csrf}">
 
     <div class="jive-contentBoxHeader">

--- a/xmppserver/src/main/webapp/user-password.jsp
+++ b/xmppserver/src/main/webapp/user-password.jsp
@@ -121,7 +121,7 @@
 <fmt:message key="user.password.info" />
 </p>
 
-<form action="user-password.jsp" name="passform" method="post">
+<form action="user-password.jsp" name="passform" method="post" autocomplete="off">
 <input type="hidden" name="username" value="<%=StringUtils.escapeForXML(username) %>">
     <input type="hidden" name="csrf" value="${csrf}">
 
@@ -143,7 +143,7 @@
                 <label for="password"><fmt:message key="user.password.new_pwd" />:</label>
             </td>
             <td class="c2">
-                <input type="password" id="password" name="password" value="" size="20" maxlength="50">
+                <input type="password" id="password" name="password" value="" size="20" maxlength="50" autocomplete="new-password">
             </td>
         </tr>
         <tr>
@@ -151,7 +151,7 @@
                 <label for="passwordConfirm"><fmt:message key="user.password.confirm_new_pwd" />:</label>
             </td>
             <td class="c2">
-                <input type="password" id="passwordConfirm" name="passwordConfirm" value="" size="20" maxlength="50">
+                <input type="password" id="passwordConfirm" name="passwordConfirm" value="" size="20" maxlength="50" autocomplete="new-password">
             </td>
         </tr>
     </tbody>

--- a/xmppserver/src/main/webapp/user-search.jsp
+++ b/xmppserver/src/main/webapp/user-search.jsp
@@ -56,7 +56,7 @@
 <%    if (errors.size() > 0) { %>
 <p class="jive-error-text"><fmt:message key="user.search.not_found" /></p>
 <%    } %>
-<form name="f" action="user-search.jsp">
+<form name="f" action="user-search.jsp" autocomplete="off">
   <input type="hidden" name="search" value="true"/>
   <fieldset>
     <legend><fmt:message key="user.search.search_user" /></legend>


### PR DESCRIPTION
Auto-complete is helpful when logging into the admin console, but it is not helpful when creating new users or other forms where usernames and/or passwords are to be provided to create something new (like a MUC room).