### PR TITLE
OF-1389: Admin Console - PubSub Node ID should be clickable

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -3093,7 +3093,6 @@ pubsub.node.summary.creator=Creator
 pubsub.node.summary.items=Items
 pubsub.node.summary.affiliates=Affiliates
 pubsub.node.summary.subscribers=Subscribers
-pubsub.node.summary.configuration=Config
 pubsub.node.summary.table.info=Node summary is show in the following table:
 pubsub.node.summary.table.no_nodes=No leaf nodes in the PubSub service.
 pubsub.node.summary.table.no_nodes_matching=No leaf nodes matches the search criteria.

--- a/i18n/src/main/resources/openfire_i18n_fr.properties
+++ b/i18n/src/main/resources/openfire_i18n_fr.properties
@@ -1771,7 +1771,6 @@ pubsub.node.summary.creator=Créateur
 pubsub.node.summary.items=Éléments
 pubsub.node.summary.affiliates=Affiliés
 pubsub.node.summary.subscribers=Abonnés
-pubsub.node.summary.configuration=Config
 pubsub.node.summary.table.info=Le résumé des nœuds est présenté dans le tableau suivant :
 pubsub.node.summary.table.no_nodes=Pas de nœud leaf dans le service PubSub.
 pubsub.node.summary.table.no_nodes_matching=Naucun nœud leaf ne correspond aux critères de recherche.

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -2852,7 +2852,6 @@ pubsub.node.summary.creator=Constructeur
 pubsub.node.summary.items=Items
 pubsub.node.summary.affiliates=Geassocieerden
 pubsub.node.summary.subscribers=Abonnees
-pubsub.node.summary.configuration=Config
 pubsub.node.summary.table.info=Samenvatting van nodes wordt in de volgende tabel getoond:
 pubsub.node.summary.table.no_nodes=Geen leaf nodes in de PubSub service.
 pubsub.node.summary.table.no_nodes_matching=Er zijn geen leaf nodes die voldoen aan de zoekcriteria.

--- a/i18n/src/main/resources/openfire_i18n_uk_UA.properties
+++ b/i18n/src/main/resources/openfire_i18n_uk_UA.properties
@@ -2820,7 +2820,6 @@ pubsub.node.summary.creator=Творець
 pubsub.node.summary.items=Елементи
 pubsub.node.summary.affiliates=Філії
 pubsub.node.summary.subscribers=Підписники
-pubsub.node.summary.configuration=Конфігурація
 pubsub.node.summary.table.info=Підсумок вузла показано в наступній таблиці:
 pubsub.node.summary.table.no_nodes=Немає кінцевих вузлів у службі PubSub.
 pubsub.node.summary.table.no_nodes_matching=Жоден листковий вузол не відповідає критеріям пошуку.

--- a/xmppserver/src/main/webapp/pubsub-node-summary.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-summary.jsp
@@ -191,7 +191,6 @@
         <c:if test="${not PEPMode}" >
             <th nowrap><fmt:message key="global.edit" /></th>
         </c:if>
-        <th nowrap><fmt:message key="pubsub.node.summary.configuration" /></th>
         <th nowrap><fmt:message key="global.delete" /></th>
     </tr>
     <tr>
@@ -224,7 +223,6 @@
             <td></td>
         </c:if>
         <td></td>
-        <td></td>
     </tr>
 </thead>
 <tbody>
@@ -248,7 +246,13 @@
             <c:out value="${listPager.firstItemNumberOnPage + loop.index}"/>
         </td>
         <td style="width: 1%; vertical-align: middle">
-            <c:out value="${node.nodeID}"/>
+            <c:url value="pubsub-node-configuration.jsp" var="url">
+                <c:param name="nodeID" value="${node.nodeID}" />
+                <c:param name="owner" value="${owner}" />
+            </c:url>
+            <a href="${url}" title="<fmt:message key="pubsub.node.summary.click_config" />">
+                <c:out value="${node.nodeID}"/>
+            </a>
         </td>
         <td style="width: 1%; white-space: nowrap" valign="middle">
             <c:out value="${node.name}"/>
@@ -293,15 +297,6 @@
                 </a>
             </td>
         </c:if>
-        <td style="width: 1%; text-align: center">
-            <c:url value="pubsub-node-configuration.jsp" var="url">
-                <c:param name="nodeID" value="${node.nodeID}" />
-                <c:param name="owner" value="${owner}" />
-            </c:url>
-            <a href="${url}" title="<fmt:message key="pubsub.node.summary.click_config" />">
-                <img src="images/info-16x16.gif" alt="">
-            </a>
-        </td>
         <td style="width: 1%; text-align: center; border-right:1px #ccc solid;">
             <c:url value="pubsub-node-delete.jsp" var="url">
                 <c:param name="nodeID" value="${node.nodeID}" />


### PR DESCRIPTION
To be consistent with other admin console summary pages, the identifier of nodes on the PEP and Pubsub Node summary pages should be clickable.

This commit replaces the 'config' column with a link on the pre-existing node ID.