### PR TITLE
OF-2738: Include SNI when setting up outbound server-to-server connec…

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyOutboundConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyOutboundConnectionHandler.java
@@ -212,6 +212,16 @@ public class NettyOutboundConnectionHandler extends NettyConnectionHandler {
         return this.configuration.getTlsPolicy() != Connection.TLSPolicy.required;
     }
 
+    public DomainPair getDomainPair()
+    {
+        return domainPair;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
     @Override
     public String toString()
     {


### PR DESCRIPTION
…tion

When setting up an outbound server-to-server connection, Openfire should send along an indication to what domain name it is attempting to connect. This will help the recipient server to process the connection for the correct vhost when that server is hosting multipe XMPP domains on the same server (ejabberd allows for this, for example).