### PR TITLE
OF-2740: Fix fallback JAVA_HOME on macOS

### DIFF
--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -13,7 +13,7 @@ case "`uname`" in
   CYGWIN*) cygwin=true ;;
   Darwin*) darwin=true
            if [ -z "$JAVA_HOME" ] ; then
-             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Home
+             JAVA_HOME=/usr/libexec/java_home
            fi
            ;;
   Linux*) linux=true


### PR DESCRIPTION
Old default no longer exists.
Modern macOS has a utility for this.