### PR TITLE
fix: View plugin pages or resource reports http status code 403

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServlet.java
@@ -520,7 +520,7 @@ public class PluginServlet extends HttpServlet {
         String contextPath = "";
         int index = pathInfo.indexOf(parts[1]);
         if (index != -1) {
-            contextPath = pathInfo.substring(index + parts[1].length());
+            contextPath = pathInfo.substring(index + parts[1].length() + 1);
         }
 
         Path pluginDirectory = JiveGlobals.getHomePath().resolve("plugins");


### PR DESCRIPTION
Refer OF-2647, since code changed from:
```
File file = new File(pluginDirectory, parts[1] + File.separator + "web" + contextPath);
```
 to:
```
Path file = pluginDirectory.resolve(parts[1]).resolve("web").resolve(contextPath);
``` 
If `contextPath` start with `/`, the variable `file` will change to `contextPath` after `.resolve(contextPath)`, that is not correct. If system property "plugins.servlet.allowLocalFileReading" not setting, will get http status code 403, restAPI document page cannot open `/plugins/restapi/docs/index.html`, and monitoring resource `/plugins/monitoring/images/*.gif` cannot download.