### PR TITLE
OF-2752: Sessions should be resumable only if closed due to 'unclean' disconnect

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
@@ -214,4 +214,9 @@ public class ClientSessionConnection extends VirtualConnection {
             }
         }
     }
+
+    @Override
+    public void onVirtualUnexpectedDisconnect() {
+        throw new IllegalStateException("Unable to process disconnect event.");
+    }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
@@ -119,7 +119,7 @@ public class WebSocketClientConnectionHandler
     @OnWebSocketClose
     public void onClose(int statusCode, String reason)
     {
-        wsConnection.close();
+        wsConnection.close(); // or: wsConnection.onVirtualUnexpectedDisconnect(); ??
     }
 
     @OnWebSocketMessage
@@ -172,6 +172,7 @@ public class WebSocketClientConnectionHandler
                     wsConnection.close(new StreamError(StreamError.Condition.internal_server_error));
                 } else {
                     Log.debug("Error detected on websocket that isn't open (any more):", error);
+                    wsConnection.onVirtualUnexpectedDisconnect();
                 }
             } catch (Exception e) {
                 Log.error("Error disconnecting websocket", e);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
@@ -58,6 +58,12 @@ public class WebSocketConnection extends VirtualConnection
     }
 
     @Override
+    public void onVirtualUnexpectedDisconnect()
+    {
+        socket.getWsSession().close();
+    }
+
+    @Override
     public void closeVirtualConnection(@Nullable final StreamError error)
     {
         try {


### PR DESCRIPTION
Prior to this commit, a session was (stream management) resumable whenever it got closed.

When a session is closed 'cleanly' (eg, with an exchange of `</stream>`), then a session should never be resumed.

This commit attempts to reverse the strategy. It is implied that a session is never resumable, unless it is closed unexpectedly (for example, as caused by a network disconnect).