### PR TITLE
OF-2752: Refactor solution

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -1251,11 +1251,6 @@ public class HttpSession extends LocalClientSession {
         }
 
         @Override
-        public void onVirtualUnexpectedDisconnect() {
-            ((HttpSession) session).closeSession(null, false);
-        }
-
-        @Override
         public void closeVirtualConnection(@Nullable final StreamError error) {
             ((HttpSession) session).closeSession(error, true);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
@@ -214,9 +214,4 @@ public class ClientSessionConnection extends VirtualConnection {
             }
         }
     }
-
-    @Override
-    public void onVirtualUnexpectedDisconnect() {
-        throw new IllegalStateException("Unable to process disconnect event.");
-    }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -118,48 +118,6 @@ public abstract class VirtualConnection extends AbstractConnection
         return session != null && !isClosed();
     }
 
-    @Override
-    public void onUnexpectedDisconnect()
-    {
-        if (state.compareAndSet(State.OPEN, State.CLOSED)) {
-            Log.trace("Remote peer unexpectedly disconnected: {}, cleaning up connection.", this);
-
-            if (session != null) {
-                // Ensure that the state of this connection, its session and the Netty Channel are eventually closed.
-                session.setStatus(Session.Status.CLOSED);
-            }
-
-            // See OF-1596
-            // The notification will trigger some shutdown procedures that, amongst other things,
-            // check what type of session (eg: anonymous) is being closed. This check depends on the
-            // session still being available.
-            //
-            // For that reason, it's important to first notify the listeners, and then close the
-            // session - not the other way around.
-            //
-            // This fixes a very visible bug where MUC users would remain in the MUC room long after
-            // their session was closed. Effectively, the bug prevents the MUC room from getting a
-            // presence update to notify it that the user logged off.
-            notifyCloseListeners();
-            closeListeners.clear();
-
-            try {
-                onVirtualUnexpectedDisconnect();
-            } catch (Exception e) {
-                Log.error(LocaleUtils.getLocalizedString("admin.error.close") + "\n" + toString(), e);
-            }
-        }
-    }
-
-    /**
-     * Closes the session, the virtual connection and notifies listeners that the connection
-     * has been closed.
-     */
-    @Override
-    public void close() {
-        close(null);
-    }
-
     /**
      * Closes the session, the virtual connection and notifies listeners that the connection
      * has been closed.
@@ -167,13 +125,14 @@ public abstract class VirtualConnection extends AbstractConnection
      * @param error If non-null, the end-stream tag will be preceded with this error.
      */
     @Override
-    public void close(@Nullable final StreamError error) {
+    public void close(@Nullable final StreamError error, final boolean networkInterruption) {
         if (state.compareAndSet(State.OPEN, State.CLOSED)) {
             
             if (session != null) {
-                // A 'clean' closure should never be resumed (see #onRemoteDisconnect for handling of unclean disconnects). OF-2752
-                session.getStreamManager().formalClose();
-
+                if (!networkInterruption) {
+                    // A 'clean' closure should never be resumed (see #onRemoteDisconnect for handling of unclean disconnects). OF-2752
+                    session.getStreamManager().formalClose();
+                }
                 session.setStatus(Session.Status.CLOSED);
             }
 
@@ -206,12 +165,4 @@ public abstract class VirtualConnection extends AbstractConnection
      * @param error If non-null, this error will be sent to the peer before the connection is disconnected.
      */
     public abstract void closeVirtualConnection(@Nullable final StreamError error);
-
-    /**
-     * Processes an event where the network connection between Openfire and the remote peer has been disconnected.
-     * At this point the session has a CLOSED state.
-     *
-     * Implementations should free up resources without attempting to send data to the peer.
-     */
-    public abstract void onVirtualUnexpectedDisconnect();
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -186,47 +186,18 @@ public class NettyConnection extends AbstractConnection
     }
 
     @Override
-    public void onUnexpectedDisconnect()
-    {
-        if (state.compareAndSet(State.OPEN, State.CLOSED)) {
-            Log.trace("Remote peer unexpectedly disconnected: {}, cleaning up connection.", this);
-
-            if (session != null) {
-                // Ensure that the state of this connection, its session and the Netty Channel are eventually closed.
-                session.setStatus(Session.Status.CLOSED);
-            }
-
-            try {
-                final ChannelFuture f = channelHandlerContext.newSucceededFuture();
-                f.addListener(ChannelFutureListener.CLOSE)
-                    .addListener(e -> {
-                        Log.trace("Notifying close listeners.");
-                        notifyCloseListeners();
-                        closeListeners.clear();
-                    })
-                    .addListener(e -> Log.trace("Finished closing connection."))
-                    .sync();
-            } catch (Exception e) {
-                Log.error("Problem during connection close or cleanup", e);
-            }
-        }
-    }
-
-    @Override
-    public void close() {
-        close(null);
-    }
-
-    @Override
-    public void close(@Nullable final StreamError error) {
+    public void close(@Nullable final StreamError error, final boolean networkInterruption) {
         if (state.compareAndSet(State.OPEN, State.CLOSED)) {
             Log.trace("Closing {} with optional error: {}", this, error);
 
             ChannelFuture f;
 
             if (session != null) {
-                // A 'clean' closure should never be resumed (see #onRemoteDisconnect for handling of unclean disconnects). OF-2752
-                session.getStreamManager().formalClose();
+
+                if (!networkInterruption) {
+                    // A 'clean' closure should never be resumed (OF-2752).
+                    session.getStreamManager().formalClose();
+                }
 
                 // Ensure that the state of this connection, its session and the Netty Channel are eventually closed.
                 session.setStatus(Session.Status.CLOSED);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyIdleStateKeepAliveHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyIdleStateKeepAliveHandler.java
@@ -90,7 +90,7 @@ public class NettyIdleStateKeepAliveHandler extends ChannelDuplexHandler {
                 // Idle flag already present. Connection has been idle for a while. Close it.
                 final NettyConnection connection = channel.attr(CONNECTION).get();
                 Log.debug("Closing connection because of inactivity: {}", connection);
-                connection.close(new StreamError(StreamError.Condition.connection_timeout, doPing ? "Connection has been idle and did not respond to a keep-alive check." : "Connection has been idle."));
+                connection.close(new StreamError(StreamError.Condition.connection_timeout, doPing ? "Connection has been idle and did not respond to a keep-alive check." : "Connection has been idle."), doPing);
             }
         }
         super.userEventTriggered(ctx, evt);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
@@ -67,13 +67,8 @@ public class NettyXMPPDecoder extends ByteToMessageDecoder {
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        NettyConnection connection = ctx.channel().attr(CONNECTION).get();
-        if (cause instanceof IOException) {
-            Log.warn("IOException caught by XMPP decoder. Marking connection as 'closed' (but potentially resumable): {}", connection, cause);
-            connection.onUnexpectedDisconnect();
-        } else {
-            Log.warn("Error occurred while decoding XMPP stanza, closing connection: {}", connection, cause);
-            connection.close(new StreamError(StreamError.Condition.internal_server_error, "An error occurred in XMPP Decoder"));
-        }
+        final NettyConnection connection = ctx.channel().attr(CONNECTION).get();
+        Log.warn("Error occurred while decoding XMPP stanza, closing connection: {}", connection, cause);
+        connection.close(new StreamError(StreamError.Condition.internal_server_error, "An error occurred in XMPP Decoder"), cause instanceof IOException);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
@@ -169,10 +169,10 @@ public class WebSocketClientConnectionHandler
             try {
                 if (isWebSocketOpen()) {
                     Log.warn("Attempting to close connection on which an error occurred: {}", wsConnection, error);
-                    wsConnection.close(new StreamError(StreamError.Condition.internal_server_error));
+                    wsConnection.close(new StreamError(StreamError.Condition.internal_server_error), !isWebSocketOpen());
                 } else {
                     Log.debug("Error detected on websocket that isn't open (any more):", error);
-                    wsConnection.onVirtualUnexpectedDisconnect();
+                    wsConnection.close(null, !isWebSocketOpen());
                 }
             } catch (Exception e) {
                 Log.error("Error disconnecting websocket", e);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
@@ -58,12 +58,6 @@ public class WebSocketConnection extends VirtualConnection
     }
 
     @Override
-    public void onVirtualUnexpectedDisconnect()
-    {
-        socket.getWsSession().close();
-    }
-
-    @Override
     public void closeVirtualConnection(@Nullable final StreamError error)
     {
         try {


### PR DESCRIPTION
In the previous commit for this issue, it was assumed that the state of a connection was always known 'good' or 'terminated'. In reality, there are lenghty periods in which Openfire cannot be sure of a connection is terminated, or simply unresponsive.

To avoid clients being disconnected by Openfire without their knowledge, Openfire should always try to send an end-of-stream indication. Without this, clients might assume for indefinite amounts of time that they're connected, while they are not.