### PR TITLE
OF-2716: Fix Licences

### DIFF
--- a/build/ci/updater/src/main/java/com/igniterealtime/openfire/updaterunner/Main.java
+++ b/build/ci/updater/src/main/java/com/igniterealtime/openfire/updaterunner/Main.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.igniterealtime.openfire.updaterunner;
 
 import org.jivesoftware.database.*;

--- a/build/ci/updater/src/main/java/com/igniterealtime/openfire/updaterunner/PropertiesReader.java
+++ b/build/ci/updater/src/main/java/com/igniterealtime/openfire/updaterunner/PropertiesReader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.igniterealtime.openfire.updaterunner;
 
 import java.io.File;

--- a/checkCopyrightHeader
+++ b/checkCopyrightHeader
@@ -172,6 +172,19 @@ fixMissingLicenseHeader() {
     echo "=> Fixed missing license header in $FILE"
 }
 
+fixMissingC() {
+    local FILE=$1
+    sed -i -E "1,5 s/Copyright/Copyright (C)/" "$FILE"
+    echo "=> Fixed missing (C) in $FILE"
+}
+
+fixMissingAllRightsReserved() {
+    local FILE=$1
+    #/192.168.1.2/s/$/ myalias/
+    sed -i -E "/Copyright/s/$/. All rights reserved/" "$FILE"
+    echo "=> Fixed missing 'All rights reserved' in $FILE"
+}
+
 processFiles(){
     # Only git tracked files
     git ls-tree -r main --name-only | grep '\.java$\|\.jsp$' | sort -u | while read line
@@ -188,6 +201,14 @@ processFiles(){
         MISSING_LICENSE_HEADER=0
         MISSING_IGNITE_MENTION=0
         INCORRECT_IGNITE_MENTION=0
+        MISSING_C=0
+        MISSING_RIGHTS_RESERVED=0
+
+        head -5 "$line" | grep -E "Copyright [0-9]{4}" > /dev/null
+        if [ $? -eq 0 ]; then
+            MISSING_C=1
+            echo "Missing (C) in Copyright line: $line"
+        fi
 
         # Check for license
         grep "Licensed under the Apache License" "$line" > /dev/null
@@ -195,6 +216,16 @@ processFiles(){
             MISSING_LICENSE_HEADER=1
             FILE_CREATION_DATE=$(git log --diff-filter=A --follow --format=%ad --date="format:%Y-%m-%d" -1 -- "$line")
             echo "Missing license header in: $line (created $FILE_CREATION_DATE)"
+        fi
+
+
+        grep -E "Copyright.*[0-9]{4}" "$line" > /dev/null
+        if [ $? -eq 0 ]; then
+            grep -E "Copyright.*[0-9]{4}.*All rights reserved" "$line" > /dev/null
+            if [ $? -eq 1 ]; then
+                MISSING_RIGHTS_RESERVED=1
+                echo "Missing 'All rights reserved' in: $line"
+            fi
         fi
 
         # Calculate what the Jive attribution should be
@@ -234,6 +265,16 @@ processFiles(){
             continue
         fi
 
+        # Fix missing (C)
+        if [ $MISSING_C -eq 1 ]; then
+            fixMissingC "$line"
+        fi
+
+        # Fix missing 'All rights reserved'
+        if [ $MISSING_RIGHTS_RESERVED -eq 1 ]; then
+            fixMissingAllRightsReserved "$line"
+        fi
+
         # Fix missing license header
         if [ $MISSING_LICENSE_HEADER -eq 1 ]; then
             SET_OF_ATTRIBUTIONS=""
@@ -260,12 +301,9 @@ processFiles(){
                     "Ignite Realtime Foundation"
             fi
         fi
-
     done
 
     echo "Done."
-
 }
 
 processFiles
-#getDateFormattedGitLogBetweenTwoDates "starter/src/main/java/org/jivesoftware/openfire/launcher/DroppableFrame.java" "2004-10-17" "2010-01-31"

--- a/checkCopyrightHeader
+++ b/checkCopyrightHeader
@@ -51,7 +51,7 @@ EOM
 
 getDateFormattedGitLog() {
     local FILE=$1
-    git log --format="%cd" --date="format:%Y-%m-%d" --invert-grep --grep="Update to Apache 2.0" --follow "$FILE"
+    git log --format="%cd" --date="format:%Y-%m-%d" --invert-grep --grep="Update to Apache 2.0|OF-2716" --follow "$FILE"
 }
 
 getDateFormattedGitLogBetweenTwoDates() {
@@ -111,16 +111,17 @@ fixMissingCopyrightAttribution() {
         return 0
     fi
 
-    local INTENDED_MENTION=$1
+    local FILE=$1
+    local INTENDED_MENTION=$2
     COPYRIGHT_NEEDLE=". All rights reserved"
     FIXED=0
-    head -5 "$line" | grep "$COPYRIGHT_NEEDLE" > /dev/null
+    head -5 "$FILE" | grep "$COPYRIGHT_NEEDLE" > /dev/null
     if [ $? -eq 0 ]; then
-        sed -i "1,5 s/$COPYRIGHT_NEEDLE/, $INTENDED_MENTION$COPYRIGHT_NEEDLE/" "$line"
-        echo FIXED!
+        sed -i "1,5 s/$COPYRIGHT_NEEDLE/, $INTENDED_MENTION$COPYRIGHT_NEEDLE/" "$FILE"
+        echo "=> Fixed missing attribution!"
         FIXED=1
     else
-        echo "$COPYRIGHT_NEEDLE not found in $line"
+        echo "=> FAILED: $COPYRIGHT_NEEDLE not found in $FILE"
     fi
     return $FIXED
 }
@@ -131,18 +132,19 @@ fixIncorrectCopyrightLine(){
         return 0
     fi
 
-    CORRECT_ATTRIBUTION=$1
-    ATTRIBUTE_TO=$2
+    local FILE=$1
+    local CORRECT_ATTRIBUTION=$2
+    local ATTRIBUTE_TO=$3
     DATE_REGEX="[0-9]{4}(-[0-9]{4})?"
     COPYRIGHT_NEEDLE="$DATE_REGEX $ATTRIBUTE_TO"
     FIXED=0
-    head -5 "$line" | grep -E "$COPYRIGHT_NEEDLE" > /dev/null
+    head -5 "$FILE" | grep -E "$COPYRIGHT_NEEDLE" > /dev/null
     if [ $? -eq 0 ]; then
-        sed -i -E "1,5 s/$COPYRIGHT_NEEDLE/$CORRECT_ATTRIBUTION/" "$line"
-        echo FIXED!
+        sed -i -E "1,5 s/$COPYRIGHT_NEEDLE/$CORRECT_ATTRIBUTION/" "$FILE"
+        echo "=> Fixed incorrect attribution!"
         FIXED=1
     else
-        echo "$COPYRIGHT_NEEDLE not found in $line"
+        echo "=> FAILED: $COPYRIGHT_NEEDLE not found in $FILE"
     fi
     return $FIXED
 }
@@ -161,21 +163,20 @@ fixMissingLicenseHeader() {
         return 0
     fi
 
-    echo "Adding license header to $FILE"
-    echo "Intended attributions: $INTENDED_ATTRIBUTIONS"
-
     THIS_LICENSE=${THIS_LICENSE//###TOKEN###/$INTENDED_ATTRIBUTIONS}
 
     TMPFILE=$(mktemp)
     echo "$THIS_LICENSE" > "$TMPFILE"
     cat "$FILE" >> "$TMPFILE"
     mv "$TMPFILE" "$FILE"
+    echo "=> Fixed missing license header in $FILE"
 }
 
 processFiles(){
     # Only git tracked files
     git ls-tree -r main --name-only | grep '\.java$\|\.jsp$' | sort -u | while read line
     do
+        #echo Processing "$line"
         if ! [ -n "${line}" ] || ! [ -e "${line}" ] ||
             [[ ${line} == *"/package-info.java" ]] || # No functional code
             [[ ${line} == "xmppserver/src/main/java/org/dom4j/io/XMPPPacketReader.java" ]] || # Special license via DOM4J
@@ -186,6 +187,7 @@ processFiles(){
 
         MISSING_LICENSE_HEADER=0
         MISSING_IGNITE_MENTION=0
+        INCORRECT_IGNITE_MENTION=0
 
         # Check for license
         grep "Licensed under the Apache License" "$line" > /dev/null
@@ -214,18 +216,17 @@ processFiles(){
 
         # Calculate what the Ignite attribution should be
         IGNITE_ATTRIBUTION=$(getCopyrightAttributionForIgnite)
-        echo "Ignite attribution: $IGNITE_ATTRIBUTION"
 
         grep "Copyright .* Ignite Realtime Foundation" "$line" > /dev/null
         if [ $? -eq 1 ]; then
             MISSING_IGNITE_MENTION=1
             echo "Copyright header not found in: $line - needs to read: $IGNITE_ATTRIBUTION"
-        else
-            grep "Copyright .* $IGNITE_ATTRIBUTION" "$line" > /dev/null
-            if [ $? -eq 1 ]; then
-                INCORRECT_IGNITE_MENTION=1
-                echo "Copyright header incorrect in: $line - needs to read: $IGNITE_ATTRIBUTION"
-            fi
+        #else
+        #    grep "Copyright .* $IGNITE_ATTRIBUTION" "$line" > /dev/null
+        #    if [ $? -eq 1 ]; then
+        #        INCORRECT_IGNITE_MENTION=1
+        #        echo "Copyright header incorrect in: $line - needs to read: $IGNITE_ATTRIBUTION"
+        #    fi
         fi
 
         ## Fixes
@@ -247,16 +248,17 @@ processFiles(){
                 fi
             fi
             fixMissingLicenseHeader "$line" "$SET_OF_ATTRIBUTIONS"
-#        else
-#            # Fix missing Ignite attribution
-#            if [ $MISSING_IGNITE_MENTION -eq 1 ]; then
-#                fixMissingLicenseHeader "$line" "$IGNITE_ATTRIBUTION"
-#            fi
-#
-#            # Fix incorrect Ignite attribution
-#            if [ $INCORRECT_IGNITE_MENTION -eq 1 ]; then
-#                fixIncorrectIgniteAttribution "$line" "$IGNITE_ATTRIBUTION"
-#            fi
+        else
+            # Fix missing Ignite attribution
+            if [ $MISSING_IGNITE_MENTION -eq 1 ]; then
+                fixMissingCopyrightAttribution "$line" "$IGNITE_ATTRIBUTION"
+            fi
+
+            # Fix incorrect Ignite attribution
+            if [ $INCORRECT_IGNITE_MENTION -eq 1 ]; then
+                fixIncorrectCopyrightLine "$line" "$IGNITE_ATTRIBUTION" \
+                    "Ignite Realtime Foundation"
+            fi
         fi
 
     done

--- a/checkCopyrightHeader
+++ b/checkCopyrightHeader
@@ -107,10 +107,6 @@ existedInTheJiveSoftwareEra() {
 
 # Adds an attribution to the end of an existing copyright line in an existing license header
 fixMissingCopyrightAttribution() {
-    if [ "$FIXES_ENABLED" == "false" ]; then
-        return 0
-    fi
-
     local FILE=$1
     local INTENDED_MENTION=$2
     COPYRIGHT_NEEDLE=". All rights reserved"
@@ -128,10 +124,6 @@ fixMissingCopyrightAttribution() {
 
 # Fixes the years for an existing copyright attribution in an existing license header
 fixIncorrectCopyrightLine(){
-    if [ "$FIXES_ENABLED" == "false" ]; then
-        return 0
-    fi
-
     local FILE=$1
     local CORRECT_ATTRIBUTION=$2
     local ATTRIBUTE_TO=$3

--- a/checkCopyrightHeader
+++ b/checkCopyrightHeader
@@ -51,7 +51,7 @@ EOM
 
 getDateFormattedGitLog() {
     local FILE=$1
-    git log --format="%cd" --date="format:%Y-%m-%d" --invert-grep --grep="Update to Apache 2.0|OF-2716" --follow "$FILE"
+    git log --format="%cd" --date="format:%Y-%m-%d" --invert-grep --grep="Update to Apache 2.0" --grep="OF-2716" --follow "$FILE"
 }
 
 getDateFormattedGitLogBetweenTwoDates() {
@@ -221,12 +221,12 @@ processFiles(){
         if [ $? -eq 1 ]; then
             MISSING_IGNITE_MENTION=1
             echo "Copyright header not found in: $line - needs to read: $IGNITE_ATTRIBUTION"
-        #else
-        #    grep "Copyright .* $IGNITE_ATTRIBUTION" "$line" > /dev/null
-        #    if [ $? -eq 1 ]; then
-        #        INCORRECT_IGNITE_MENTION=1
-        #        echo "Copyright header incorrect in: $line - needs to read: $IGNITE_ATTRIBUTION"
-        #    fi
+        else
+            grep "Copyright .* $IGNITE_ATTRIBUTION" "$line" > /dev/null
+            if [ $? -eq 1 ]; then
+                INCORRECT_IGNITE_MENTION=1
+                echo "Copyright header incorrect in: $line - needs to read: $IGNITE_ATTRIBUTION"
+            fi
         fi
 
         ## Fixes

--- a/checkCopyrightHeader
+++ b/checkCopyrightHeader
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+# This script checks for the presence of the current year in the license header of all java files in the repo.
+# Inspired by (and somewhat copied from) https://github.com/palaniraja/whatchanged/blob/master/whatchanged.sh
+
+THIS_YEAR=$(date +%Y)
+IGNITE_FOUNDED="2016-10-21"
+JIVE_ENDED="2010-01-31"
+REPO_STARTED="2004-10-17"
+
+read -r -d '' JAVA_LICENSE << EOM
+/*
+ * Copyright (C) ###TOKEN###. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+EOM
+
+read -r -d '' JSP_LICENSE << EOM
+<%--
+  -
+  - Copyright (C) ###TOKEN###. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
+EOM
+
+getDateFormattedGitLog() {
+    local FILE=$1
+    git log --format="%cd" --date="format:%Y-%m-%d" --invert-grep --grep="Update to Apache 2.0" --follow "$FILE"
+}
+
+getDateFormattedGitLogBetweenTwoDates() {
+    local FILE=$1
+    local FROM_DATE=$2
+    local TO_DATE=$3
+
+    getDateFormattedGitLog "$FILE" | awk -v fromdate="$FROM_DATE" -v todate="$TO_DATE" '$1 >= fromdate && $1 <= todate'
+}
+
+getCopyrightAttribution() {
+    FROM_DATE=$1
+    TO_DATE=$2
+    ATTRIBUTE_TO=$3
+
+    FIRST_COMMIT_YEAR=$(getDateFormattedGitLogBetweenTwoDates "$line" "$FROM_DATE" "$TO_DATE" | tail -n 1 | awk -F'-' '{print $1}')
+    LAST_COMMIT_YEAR=$(getDateFormattedGitLogBetweenTwoDates "$line" "$FROM_DATE" "$TO_DATE" | head -n 1 | awk -F'-' '{print $1}')
+
+    if [ "$FIRST_COMMIT_YEAR" -ne "$LAST_COMMIT_YEAR" ]; then
+        COPYRIGHT_YEARS="$FIRST_COMMIT_YEAR-$LAST_COMMIT_YEAR"
+    else
+        COPYRIGHT_YEARS="$FIRST_COMMIT_YEAR"
+    fi
+
+    ATTRIBUTION="$COPYRIGHT_YEARS $ATTRIBUTE_TO"
+
+    echo $ATTRIBUTION
+}
+
+getCopyrightAttributionForIgnite(){
+    local START=$IGNITE_FOUNDED
+    local END="$THIS_YEAR-12-31"
+    local WHO="Ignite Realtime Foundation"
+    getCopyrightAttribution "$START" "$END" "$WHO"
+}
+
+getCopyrightAttributionForJive(){
+    local START=$REPO_STARTED
+    local END=$JIVE_ENDED
+    local WHO="Jive Software"
+    getCopyrightAttribution "$START" "$END" "$WHO"
+}
+
+existedInTheJiveSoftwareEra() {
+    # We can't use 'git log --before' because git history will cut off trees and return blank results - we need to follow all the way, then filter
+    LOGCOUNT=$(getDateFormattedGitLog "$line" | awk -v jiveended="$JIVE_ENDED" '$1 < jiveended' | wc -l)
+    if [ $LOGCOUNT -gt 0 ]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+fixMissingCopyrightLine() {
+    # Fixes
+        COPYRIGHT_NEEDLE=". All rights reserved"
+        FIXED="Not fixed."
+        head -5 "$line" | grep "$COPYRIGHT_NEEDLE" > /dev/null
+        if [ $? -eq 0 ]; then
+            sed -i "1,5 s/$COPYRIGHT_NEEDLE/, $INTENDED_IGNITE_MENTION$COPYRIGHT_NEEDLE/" "$line"
+            FIXED="Fixed."
+        fi
+}
+
+fixIncorrectCopyrightLine(){
+    CORRECT_ATTRIBUTION=$1
+    ATTRIBUTE_TO=$2
+    DATE_REGEX="[0-9]{4}(-[0-9]{4})?"
+    COPYRIGHT_NEEDLE="$DATE_REGEX $ATTRIBUTE_TO"
+    FIXED=0
+    head -5 "$line" | grep -E "$COPYRIGHT_NEEDLE" > /dev/null
+    if [ $? -eq 0 ]; then
+        sed -i -E "1,5 s/$COPYRIGHT_NEEDLE/$CORRECT_ATTRIBUTION/" "$line"
+        echo FIXED!
+        FIXED=1
+    else
+        echo "$COPYRIGHT_NEEDLE not found in $line"
+    fi
+    return $FIXED
+}
+
+processFiles(){
+    # Only git tracked files
+    git ls-tree -r main --name-only | grep '\.java$\|\.jsp$' | sort -u | while read line
+    do
+        if ! [ -n "${line}" ] || ! [ -e "${line}" ] ||
+            [[ ${line} == *"/package-info.java" ]] || # No functional code
+            [[ ${line} == "xmppserver/src/main/java/org/dom4j/io/XMPPPacketReader.java" ]] || # Special license via DOM4J
+            [[ ${line} == "xmppserver/src/main/java/org/jivesoftware/util/FastDateFormat.java" ]]; # Special license via Disney //TODO: https://igniterealtime.atlassian.net/browse/OF-2754
+                then
+            continue
+        fi
+
+        grep '\.java$' <<< "$line" > /dev/null
+        IS_JAVA=$?
+
+        grep '\.jsp$' <<< "$line" > /dev/null
+        IS_JSP=$?
+
+        MISSING_LICENSE_HEADER=0
+        MISSING_IGNITE_MENTION=0
+
+        # Check for license
+        grep "Licensed under the Apache License" "$line" > /dev/null
+        if [ $? -eq 1 ]; then
+            MISSING_LICENSE_HEADER=1
+            FILE_CREATION_DATE=$(git log --diff-filter=A --follow --format=%ad --date="format:%Y-%m-%d" -1 -- "$line")
+            echo "Missing license header in: $line (created $FILE_CREATION_DATE)"
+            continue
+        fi
+
+        # Calculate what the Jive attribution should be
+        existedInTheJiveSoftwareEra
+        EXISTED_IN_THE_JIVE_SOFTWARE_ERA=$?
+        if [ $EXISTED_IN_THE_JIVE_SOFTWARE_ERA -eq 1 ]; then
+            JIVE_ATTRIBUTION=$(getCopyrightAttributionForJive)
+
+            grep "Copyright .* Jive Software" "$line" > /dev/null
+            if [ $? -eq 1 ]; then
+                #MISSING_IGNITE_MENTION=1
+                echo "Copyright header not found in: $line - needs to read: $JIVE_ATTRIBUTION"
+            fi
+        fi
+
+        # Calculate what the Ignite attribution should be
+        IGNITE_ATTRIBUTION=$(getCopyrightAttributionForIgnite)
+
+        grep "Copyright .* Ignite Realtime Foundation" "$line" > /dev/null
+        if [ $? -eq 1 ]; then
+            MISSING_IGNITE_MENTION=1
+            echo "Copyright header not found in: $line - needs to read: $IGNITE_ATTRIBUTION"
+        else
+            grep "Copyright .* $IGNITE_ATTRIBUTION" "$line" > /dev/null
+            if [ $? -eq 1 ]; then
+                INCORRECT_IGNITE_MENTION=1
+                echo "Copyright header incorrect in: $line - needs to read: $IGNITE_ATTRIBUTION"
+                fixIncorrectCopyrightLine \
+                    "$IGNITE_ATTRIBUTION" \
+                    "Ignite Realtime Foundation"
+            fi
+        fi
+        continue
+
+    done
+
+    echo "Done."
+
+}
+
+processFiles
+#getDateFormattedGitLogBetweenTwoDates "starter/src/main/java/org/jivesoftware/openfire/launcher/DroppableFrame.java" "2004-10-17" "2010-01-31"

--- a/checkCopyrightHeader
+++ b/checkCopyrightHeader
@@ -8,6 +8,8 @@ IGNITE_FOUNDED="2016-10-21"
 JIVE_ENDED="2010-01-31"
 REPO_STARTED="2004-10-17"
 
+FIXES_ENABLED=true
+
 read -r -d '' JAVA_LICENSE << EOM
 /*
  * Copyright (C) ###TOKEN###. All rights reserved.
@@ -24,6 +26,7 @@ read -r -d '' JAVA_LICENSE << EOM
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 EOM
 
 read -r -d '' JSP_LICENSE << EOM
@@ -43,6 +46,7 @@ read -r -d '' JSP_LICENSE << EOM
   - See the License for the specific language governing permissions and
   - limitations under the License.
 --%>
+
 EOM
 
 getDateFormattedGitLog() {
@@ -101,18 +105,32 @@ existedInTheJiveSoftwareEra() {
     fi
 }
 
-fixMissingCopyrightLine() {
-    # Fixes
-        COPYRIGHT_NEEDLE=". All rights reserved"
-        FIXED="Not fixed."
-        head -5 "$line" | grep "$COPYRIGHT_NEEDLE" > /dev/null
-        if [ $? -eq 0 ]; then
-            sed -i "1,5 s/$COPYRIGHT_NEEDLE/, $INTENDED_IGNITE_MENTION$COPYRIGHT_NEEDLE/" "$line"
-            FIXED="Fixed."
-        fi
+# Adds an attribution to the end of an existing copyright line in an existing license header
+fixMissingCopyrightAttribution() {
+    if [ "$FIXES_ENABLED" == "false" ]; then
+        return 0
+    fi
+
+    local INTENDED_MENTION=$1
+    COPYRIGHT_NEEDLE=". All rights reserved"
+    FIXED=0
+    head -5 "$line" | grep "$COPYRIGHT_NEEDLE" > /dev/null
+    if [ $? -eq 0 ]; then
+        sed -i "1,5 s/$COPYRIGHT_NEEDLE/, $INTENDED_MENTION$COPYRIGHT_NEEDLE/" "$line"
+        echo FIXED!
+        FIXED=1
+    else
+        echo "$COPYRIGHT_NEEDLE not found in $line"
+    fi
+    return $FIXED
 }
 
+# Fixes the years for an existing copyright attribution in an existing license header
 fixIncorrectCopyrightLine(){
+    if [ "$FIXES_ENABLED" == "false" ]; then
+        return 0
+    fi
+
     CORRECT_ATTRIBUTION=$1
     ATTRIBUTE_TO=$2
     DATE_REGEX="[0-9]{4}(-[0-9]{4})?"
@@ -129,6 +147,31 @@ fixIncorrectCopyrightLine(){
     return $FIXED
 }
 
+fixMissingLicenseHeader() {
+    local FILE=$1
+    local INTENDED_ATTRIBUTIONS=$2
+    local FILE_EXTENSION=$(echo "$FILE" | awk -F'.' '{print $NF}')
+
+    if [ "$FILE_EXTENSION" == "java" ]; then
+        THIS_LICENSE=$JAVA_LICENSE
+    elif [ "$FILE_EXTENSION" == "jsp" ]; then
+        THIS_LICENSE=$JSP_LICENSE
+    else
+        echo "Unknown file extension: $FILE_EXTENSION"
+        return 0
+    fi
+
+    echo "Adding license header to $FILE"
+    echo "Intended attributions: $INTENDED_ATTRIBUTIONS"
+
+    THIS_LICENSE=${THIS_LICENSE//###TOKEN###/$INTENDED_ATTRIBUTIONS}
+
+    TMPFILE=$(mktemp)
+    echo "$THIS_LICENSE" > "$TMPFILE"
+    cat "$FILE" >> "$TMPFILE"
+    mv "$TMPFILE" "$FILE"
+}
+
 processFiles(){
     # Only git tracked files
     git ls-tree -r main --name-only | grep '\.java$\|\.jsp$' | sort -u | while read line
@@ -141,12 +184,6 @@ processFiles(){
             continue
         fi
 
-        grep '\.java$' <<< "$line" > /dev/null
-        IS_JAVA=$?
-
-        grep '\.jsp$' <<< "$line" > /dev/null
-        IS_JSP=$?
-
         MISSING_LICENSE_HEADER=0
         MISSING_IGNITE_MENTION=0
 
@@ -156,24 +193,28 @@ processFiles(){
             MISSING_LICENSE_HEADER=1
             FILE_CREATION_DATE=$(git log --diff-filter=A --follow --format=%ad --date="format:%Y-%m-%d" -1 -- "$line")
             echo "Missing license header in: $line (created $FILE_CREATION_DATE)"
-            continue
         fi
 
         # Calculate what the Jive attribution should be
         existedInTheJiveSoftwareEra
         EXISTED_IN_THE_JIVE_SOFTWARE_ERA=$?
+
         if [ $EXISTED_IN_THE_JIVE_SOFTWARE_ERA -eq 1 ]; then
             JIVE_ATTRIBUTION=$(getCopyrightAttributionForJive)
 
-            grep "Copyright .* Jive Software" "$line" > /dev/null
-            if [ $? -eq 1 ]; then
-                #MISSING_IGNITE_MENTION=1
-                echo "Copyright header not found in: $line - needs to read: $JIVE_ATTRIBUTION"
-            fi
+        # I'm not sure I'm happy fixing copyright headers for other folk.
+        # Jive already did this themselves in https://github.com/igniterealtime/Openfire/commit/ff0fa13dc3f67ca269da7bceef161e4a49663259
+        # So I'm going to leave this commented out for now.
+        #    grep "Copyright .* Jive Software" "$line" > /dev/null
+        #    if [ $? -eq 1 ]; then
+        #        MISSING_JIVE_MENTION=1
+        #        echo "Copyright header not found in: $line - needs to read: $JIVE_ATTRIBUTION"
+        #    fi
         fi
 
         # Calculate what the Ignite attribution should be
         IGNITE_ATTRIBUTION=$(getCopyrightAttributionForIgnite)
+        echo "Ignite attribution: $IGNITE_ATTRIBUTION"
 
         grep "Copyright .* Ignite Realtime Foundation" "$line" > /dev/null
         if [ $? -eq 1 ]; then
@@ -184,12 +225,39 @@ processFiles(){
             if [ $? -eq 1 ]; then
                 INCORRECT_IGNITE_MENTION=1
                 echo "Copyright header incorrect in: $line - needs to read: $IGNITE_ATTRIBUTION"
-                fixIncorrectCopyrightLine \
-                    "$IGNITE_ATTRIBUTION" \
-                    "Ignite Realtime Foundation"
             fi
         fi
-        continue
+
+        ## Fixes
+        if [ "$FIXES_ENABLED" == "false" ]; then
+            continue
+        fi
+
+        # Fix missing license header
+        if [ $MISSING_LICENSE_HEADER -eq 1 ]; then
+            SET_OF_ATTRIBUTIONS=""
+            if [ $EXISTED_IN_THE_JIVE_SOFTWARE_ERA -eq 1 ]; then
+                SET_OF_ATTRIBUTIONS="$JIVE_ATTRIBUTION"
+            fi
+            if [ $MISSING_IGNITE_MENTION -eq 1 ]; then
+                if [ -n "$SET_OF_ATTRIBUTIONS" ]; then
+                    SET_OF_ATTRIBUTIONS="$SET_OF_ATTRIBUTIONS, $IGNITE_ATTRIBUTION"
+                else
+                    SET_OF_ATTRIBUTIONS="$IGNITE_ATTRIBUTION"
+                fi
+            fi
+            fixMissingLicenseHeader "$line" "$SET_OF_ATTRIBUTIONS"
+#        else
+#            # Fix missing Ignite attribution
+#            if [ $MISSING_IGNITE_MENTION -eq 1 ]; then
+#                fixMissingLicenseHeader "$line" "$IGNITE_ATTRIBUTION"
+#            fi
+#
+#            # Fix incorrect Ignite attribution
+#            if [ $INCORRECT_IGNITE_MENTION -eq 1 ]; then
+#                fixIncorrectIgniteAttribution "$line" "$IGNITE_ATTRIBUTION"
+#            fi
+        fi
 
     done
 

--- a/starter/src/main/java/org/jivesoftware/openfire/launcher/DroppableFrame.java
+++ b/starter/src/main/java/org/jivesoftware/openfire/launcher/DroppableFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter/src/main/java/org/jivesoftware/openfire/launcher/DroppableTextPane.java
+++ b/starter/src/main/java/org/jivesoftware/openfire/launcher/DroppableTextPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter/src/main/java/org/jivesoftware/openfire/launcher/GraphicUtils.java
+++ b/starter/src/main/java/org/jivesoftware/openfire/launcher/GraphicUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter/src/main/java/org/jivesoftware/openfire/launcher/Launcher.java
+++ b/starter/src/main/java/org/jivesoftware/openfire/launcher/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter/src/main/java/org/jivesoftware/openfire/launcher/Uninstaller.java
+++ b/starter/src/main/java/org/jivesoftware/openfire/launcher/Uninstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter/src/main/java/org/jivesoftware/openfire/starter/JiveClassLoader.java
+++ b/starter/src/main/java/org/jivesoftware/openfire/starter/JiveClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter/src/main/java/org/jivesoftware/openfire/starter/ServerStarter.java
+++ b/starter/src/main/java/org/jivesoftware/openfire/starter/ServerStarter.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/dom4j/io/XMPPPacketReader.java
+++ b/xmppserver/src/main/java/org/dom4j/io/XMPPPacketReader.java
@@ -581,6 +581,4 @@ public class XMPPPacketReader {
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Copyright 2001-2004 (C) MetaStuff, Ltd. All Rights Reserved.
- *
  */

--- a/xmppserver/src/main/java/org/jivesoftware/admin/ASN1DERTag.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/ASN1DERTag.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.admin;
 
 import org.bouncycastle.asn1.*;

--- a/xmppserver/src/main/java/org/jivesoftware/admin/AdminConsole.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AdminConsole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/AdminContentSecurityPolicyFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AdminContentSecurityPolicyFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Ignite Realtime Foundation 2022-2023. All rights reserved.
+ * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/AdminContentSecurityPolicyFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AdminContentSecurityPolicyFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/AdminPageBean.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AdminPageBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/ContentSecurityPolicyFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/ContentSecurityPolicyFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Ignite Realtime Foundation 2022-2023. All rights reserved.
+ * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/ContentSecurityPolicyFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/ContentSecurityPolicyFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/FlashMessageTag.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/FlashMessageTag.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.admin;
 
 import java.io.IOException;

--- a/xmppserver/src/main/java/org/jivesoftware/admin/JSTLFunctions.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/JSTLFunctions.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.admin;
 
 import org.jivesoftware.util.ByteFormat;

--- a/xmppserver/src/main/java/org/jivesoftware/admin/LdapGroupTester.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/LdapGroupTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/LdapUserProfile.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/LdapUserProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/LdapUserTester.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/LdapUserTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/LoginLimitManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/LoginLimitManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/PluginFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/PluginFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/ServletRequestAuthenticator.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/ServletRequestAuthenticator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.admin;
 
 import javax.servlet.http.HttpServletRequest;

--- a/xmppserver/src/main/java/org/jivesoftware/admin/SessionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/SessionListener.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021-2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.admin;
 
 import org.jivesoftware.util.JiveGlobals;

--- a/xmppserver/src/main/java/org/jivesoftware/admin/SidebarTag.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/SidebarTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/SiteMinderServletRequestAuthenticator.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/SiteMinderServletRequestAuthenticator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.admin;
 
 import javax.servlet.http.HttpServletRequest;

--- a/xmppserver/src/main/java/org/jivesoftware/admin/SubSidebarTag.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/SubSidebarTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/SubnavTag.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/SubnavTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/TabsTag.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/TabsTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SecurityAuditViewerServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SecurityAuditViewerServlet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.admin.servlet;
 
 import java.io.IOException;

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SystemCacheDetailsServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SystemCacheDetailsServlet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019-2020 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.admin.servlet;
 
 import java.io.IOException;

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SystemPropertiesServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SystemPropertiesServlet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.admin.servlet;
 
 import java.io.IOException;

--- a/xmppserver/src/main/java/org/jivesoftware/database/AbstractConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/AbstractConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004 Jive Software. All rights reserved.
+ * Copyright (C) 2004 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/CachedPreparedStatement.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/CachedPreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/CallableStatementWrapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/CallableStatementWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004 Jive Software. All rights reserved.
+ * Copyright (C) 2004 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/ConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * TLicensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/DbConnectionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/DbConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProviderBeanInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProviderBeanInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/JNDIDataSourceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/JNDIDataSourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/JiveID.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/JiveID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/PreparedStatementWrapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/PreparedStatementWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004 Jive Software. All rights reserved.
+ * Copyright (C) 2004 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/ProfiledConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/ProfiledConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/ProfiledConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/ProfiledConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004 Jive Software, Ignite Realtime Foundation 2023. All rights reserved.
+ * Copyright (C) 2004 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/ProfiledConnectionEntry.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/ProfiledConnectionEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004 Jive Software. All rights reserved.
+ * Copyright (C) 2004 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/SequenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SequenceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/StatementWrapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/StatementWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004 Jive Software. All rights reserved.
+ * Copyright (C) 2004 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/bugfix/OF1515.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/bugfix/OF1515.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/database/bugfix/OF33.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/bugfix/OF33.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Channel.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Channel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ChannelHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ChannelNotFoundException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ChannelNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ConnectionCloseListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ConnectionCloseListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ConnectionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQHandlerInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQHandlerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/JMXManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/JMXManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/JMXManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/JMXManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Ignite Realtime Foundation 2022. All rights reserved.
+ * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/LocalSessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/LocalSessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/MulticastRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/MulticastRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessage.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStore.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/OfflineMessageStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PacketDeliverer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PacketDeliverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PacketException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PacketException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PacketRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PacketRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PrivateStorage.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PrivateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RemoteConnectionFailedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RemoteConnectionFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RemotePacketRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RemotePacketRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutableChannelHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutableChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionNotFoundException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionPacketRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionPacketRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionResultFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionResultFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SharedGroupException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SharedGroupException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/StreamID.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/StreamID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/StreamIDFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/StreamIDFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPContextListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPContextListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServerInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServerListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/admin/AdminManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/admin/AdminManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/admin/AdminProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/admin/AdminProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/admin/DefaultAdminProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/admin/DefaultAdminProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/admin/GroupBasedAdminProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/admin/GroupBasedAdminProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.admin;
 
 import org.jivesoftware.openfire.group.GroupManager;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/admin/JDBCAdminProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/admin/JDBCAdminProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  * Copyright 2008-2016 Robert Marcano
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/admin/JDBCAdminProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/admin/JDBCAdminProvider.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
- * Copyright 2008-2016 Robert Marcano
+ * Copyright (C) 2008-2016 Robert Marcano, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/archive/ArchiveCandidate.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/archive/ArchiveCandidate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/archive/ArchiveManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/archive/ArchiveManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/archive/Archiver.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/archive/Archiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/archive/GetArchiveWriteETATask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/archive/GetArchiveWriteETATask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/audit/AuditEvent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/audit/AuditEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/audit/AuditManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/audit/AuditManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/audit/AuditStreamIDFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/audit/AuditStreamIDFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/audit/Auditor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/audit/Auditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/audit/SessionEvent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/audit/SessionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/audit/spi/AuditManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/audit/spi/AuditManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/audit/spi/AuditorImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/audit/spi/AuditorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthProviderMapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthProviderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 IgniteRealtime.org
+ * Copyright (C) 2016 IgniteRealtime.org, 2017-2018 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthToken.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthorizationBasedAuthProviderMapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthorizationBasedAuthProviderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 IgniteRealtime.org
+ * Copyright (C) 2016 IgniteRealtime.org, 2017-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthorizationManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthorizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthorizationMapping.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthorizationMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthorizationPolicy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthorizationPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ConnectionException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ConnectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthorizationMapping.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthorizationMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthorizationPolicy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthorizationPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/InternalUnauthenticatedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/InternalUnauthenticatedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/MappedAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/MappedAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 IgniteRealtime.org
+ * Copyright (C) 2016 IgniteRealtime.org, 2016-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/NativeAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/NativeAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/POP3AuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/POP3AuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/PropertyBasedAuthProviderMapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/PropertyBasedAuthProviderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Ignite Realtime Foundation
+ * Copyright (C) 2018-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/PropertyBasedAuthProviderMapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/PropertyBasedAuthProviderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ignite Realtime Foundation
+ * Copyright 2018-2019 Ignite Realtime Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ScramUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ScramUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Surevine Ltd
+ * Copyright (C) 2015 Surevine Ltd, 2016-2018 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/UnauthenticatedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/UnauthenticatedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/UnauthorizedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/UnauthorizedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/carbons/Received.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/carbons/Received.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2020 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.carbons;
 
 import org.jivesoftware.openfire.forward.Forwarded;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/carbons/Sent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/carbons/Sent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.carbons;
 
 import org.jivesoftware.openfire.forward.Forwarded;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/BroadcastMessage.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/BroadcastMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2009 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2009 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterMonitor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterMonitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.cluster;
 
 import java.util.Map;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterNodeInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterNodeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterPacketRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterPacketRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2009 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusteredCacheEntryListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusteredCacheEntryListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/GetBasicStatistics.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/GetBasicStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/GetClusteredVersions.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/GetClusteredVersions.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.cluster;
 
 import java.io.IOException;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/NodeID.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/NodeID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/RemotePacketExecution.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/RemotePacketExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2009 Jive Software, 2023 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 1999-2009 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/RemotePacketExecution.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/RemotePacketExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2009 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 1999-2009 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommand.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/AdHocCommandManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/SessionData.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/SessionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetAdminConsoleInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetAdminConsoleInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetListActiveUsers.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetListActiveUsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetNumberActiveUsers.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetNumberActiveUsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetNumberOnlineUsers.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetNumberOnlineUsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetNumberUserSessions.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetNumberUserSessions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetServerStats.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetServerStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetUsersPresence.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetUsersPresence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/HttpBindStatus.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/HttpBindStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/PacketsNotification.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/PacketsNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/AddGroup.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/AddGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/AddGroupUsers.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/AddGroupUsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/DeleteGroup.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/DeleteGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/DeleteGroupUsers.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/DeleteGroupUsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/GetListGroupUsers.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/GetListGroupUsers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/GetListGroups.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/GetListGroups.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/UpdateGroup.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/group/UpdateGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/muc/CreateMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/muc/CreateMUCRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/AddUser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/AddUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/AuthenticateUser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/AuthenticateUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/ChangeUserPassword.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/ChangeUserPassword.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/DeleteUser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/DeleteUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/UserProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/UserProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupAdminAdded.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupAdminAdded.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupAdminRemoved.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupAdminRemoved.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupCreated.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupCreated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupDeleting.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupDeleting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberAdded.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberAdded.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberRemoved.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberRemoved.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupModified.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupModified.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/UserCreated.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/UserCreated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/UserDeleting.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/UserDeleting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/UserModified.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/UserModified.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/VCardCreated.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/VCardCreated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/VCardDeleting.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/VCardDeleting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/VCardModified.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/VCardModified.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/generic/Ping.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/generic/Ping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2020-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/ComponentEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/ComponentEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/ExternalComponentConfiguration.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/ExternalComponentConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/ExternalComponentManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/ExternalComponentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/ExternalComponentManagerListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/ExternalComponentManagerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/InternalComponentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/NotifyComponentInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/NotifyComponentInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/NotifyComponentRegistered.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/NotifyComponentRegistered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/NotifyComponentUnregistered.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/NotifyComponentUnregistered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/RequestComponentInfoNotification.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/RequestComponentInfoNotification.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.component;
 
 import org.jivesoftware.openfire.cluster.NodeID;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/BasicModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/BasicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/CacheInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/CacheInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/GetAdminConsoleInfoTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/GetAdminConsoleInfoTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/IsPluginInstalledTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/IsPluginInstalledTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/Module.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/Plugin.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/Plugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginCacheConfigurator.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginCacheConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginCacheRegistry.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginCacheRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginClassLoader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginIconServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginIconServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManagerListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManagerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadata.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadataHelper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMetadataHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 IgniteRealtime.org
+ * Copyright (C) 2016 IgniteRealtime.org, 2017-2021 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMonitor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMonitor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServletContext.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServletContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Ignite Realtime Foundation.
+ * Copyright (C) 2016-2023 Ignite Realtime Foundation.. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServletContext.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServletContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 IgniteRealtime.org
+ * Copyright 2016-2023 Ignite Realtime Foundation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdAdminProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdAdminProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2016-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdGroupProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdUserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdVCardProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/jaxb/AuthenticatePost.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/jaxb/AuthenticatePost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/jaxb/Group.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/jaxb/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/jaxb/Groups.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/jaxb/Groups.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/jaxb/User.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/jaxb/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/jaxb/Users.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/jaxb/Users.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoItem.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoItemsProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoItemsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoServerItem.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoServerItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ServerFeaturesProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ServerFeaturesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ServerIdentitiesProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ServerIdentitiesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ServerItemsProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ServerItemsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/UserFeaturesProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/UserFeaturesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/UserIdentitiesProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/UserIdentitiesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/UserItemsProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/UserItemsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/entitycaps/EntityCapabilities.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/entitycaps/EntityCapabilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/entitycaps/EntityCapabilitiesManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/entitycaps/EntityCapabilitiesManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/event/GroupEventAdapter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/event/GroupEventAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.event;
 
 import java.util.Map;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/event/GroupEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/event/GroupEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/event/GroupEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/event/GroupEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/event/ServerSessionEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/event/ServerSessionEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/event/ServerSessionEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/event/ServerSessionEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/event/SessionEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/event/SessionEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/event/SessionEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/event/SessionEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/event/UserEventAdapter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/event/UserEventAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/event/UserEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/event/UserEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/event/UserEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/event/UserEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/DefaultFileTransferManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/DefaultFileTransferManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransfer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferEventListener.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.filetransfer;
 
 /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferProgress.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferRejectedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferRejectedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/DefaultProxyTransfer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/DefaultProxyTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/ProxyConnectionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/ProxyConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/ProxyOutputStream.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/ProxyOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/ProxyTransfer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/ProxyTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/forward/Forwarded.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/forward/Forwarded.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/AbstractGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/AbstractGroupProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/ConcurrentGroupList.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/ConcurrentGroupList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/ConcurrentGroupMap.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/ConcurrentGroupMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupPropertyMap.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupPropertyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/Group.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupAlreadyExistsException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupAlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupAwareList.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupAwareList.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.group;
 
 import java.util.List;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupAwareMap.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupAwareMap.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.group;
 
 import java.util.Map;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupCollection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupJID.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupJID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software. 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupNameInvalidException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupNameInvalidException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupNotFoundException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/JDBCGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/JDBCGroupProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/SharedGroupVisibility.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/SharedGroupVisibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/DirectedPresence.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/DirectedPresence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBlockingHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBlockingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQEntityTimeHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQEntityTimeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2014 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2014 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQLastActivityHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQLastActivityHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQMessageCarbonsHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQMessageCarbonsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPingHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivacyHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivacyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivacyHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivacyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, Ignite Realtime Foundation 2023. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQPrivateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRegisterHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRegisterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRegisterInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRegisterInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRosterHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRosterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQSessionEstablishmentHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQSessionEstablishmentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQSharedGroupHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQSharedGroupHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQVersionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQVersionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQvCardHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQvCardHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/BoshBindingError.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/BoshBindingError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindBody.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindContentSecurityPolicyFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindContentSecurityPolicyFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindContentSecurityPolicyFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindContentSecurityPolicyFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Ignite Realtime Foundation 2022-2023. All rights reserved.
+ * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, Ignite Realtime Foundation 2022-2023. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpConnectionClosedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpConnectionClosedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/ResourceServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/ResourceServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/SessionEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/SessionEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/SessionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/SessionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/TempFileToucherTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/TempFileToucherTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/interceptor/InterceptorManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/interceptor/InterceptorManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/interceptor/PacketCopier.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/interceptor/PacketCopier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/interceptor/PacketInterceptor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/interceptor/PacketInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/interceptor/PacketRejectedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/interceptor/PacketRejectedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStore.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2020 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.keystore;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreConfigException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreConfigException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.keystore;
 
 /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreConfiguration.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreWatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreWatcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.keystore;
 
 import org.jivesoftware.util.NamedThreadFactory;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.keystore;
 
 import org.slf4j.Logger;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/IdentityStore.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/IdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.keystore;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/TrustStore.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/TrustStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.keystore;
 
 import org.jivesoftware.util.CertificateManager;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapAuthorizationMapping.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapAuthorizationMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapAuthorizationPolicy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapAuthorizationPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/DefaultLockOutProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/DefaultLockOutProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutFlag.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mbean/ThreadPoolExecutorDelegate.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mbean/ThreadPoolExecutorDelegate.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.mbean;
 
 import javax.annotation.Nonnull;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mbean/ThreadPoolExecutorDelegateMBean.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mbean/ThreadPoolExecutorDelegateMBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.mbean;
 
 /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/Channel.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/Channel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/DatagramListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/DatagramListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/DynamicAddressChannel.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/DynamicAddressChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/Echo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/Echo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxySession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxySession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/ProxyCandidate.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/ProxyCandidate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/RelaySession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/RelaySession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/SessionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/SessionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/CannotBeInvitedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/CannotBeInvitedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/ConflictException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/ConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/FMUCException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/FMUCException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/ForbiddenException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/ForbiddenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryRequest.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCEventDelegate.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCEventDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRole.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2021-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2021-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/NotAcceptableException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/NotAcceptableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/NotAllowedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/NotAllowedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/RegistrationRequiredException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/RegistrationRequiredException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/RoomLockedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/RoomLockedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/ServiceUnavailableException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/ServiceUnavailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/MUCServicePropertyClusterEventTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/MUCServicePropertyClusterEventTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software. All rights reserved.
+ * Copyright (C) 2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/NewClusterMemberJoinedTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/NewClusterMemberJoinedTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/OccupantAddedTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/OccupantAddedTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/OccupantKickedForNicknameTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/OccupantKickedForNicknameTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/OccupantRemovedTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/OccupantRemovedTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/OccupantUpdatedTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/OccupantUpdatedTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 2021-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceAddedEvent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceAddedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceRemovedEvent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceRemovedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceUpdatedEvent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/ServiceUpdatedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/SyncLocalOccupantsAndSendJoinPresenceTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/SyncLocalOccupantsAndSendJoinPresenceTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/ConversationLogEntry.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/ConversationLogEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQAdminHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQAdminHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCRegisterHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCRegisterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCSearchHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCSearchHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCvCardHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCvCardHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2020-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMuclumbusSearchHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMuclumbusSearchHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCRoomSearchInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCRoomSearchInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.muc.spi;
 
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCServiceProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCServiceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCServicePropertyEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCServicePropertyEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCServicePropertyEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCServicePropertyEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/OccupantManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/OccupantManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 2021-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ConnectionMultiplexerManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ConnectionMultiplexerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/MultiplexerPacketDeliverer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/MultiplexerPacketDeliverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/MultiplexerPacketHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/MultiplexerPacketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/Route.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/Route.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/UnknownStanzaException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/UnknownStanzaException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/BlockingReadingMode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/BlockingReadingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientStanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientTrustManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientTrustManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/DNSUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/DNSUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/MXParser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/MXParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/MulticastDNSService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/MulticastDNSService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/MultiplexerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/MultiplexerStanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/OCSPChecker.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/OCSPChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerTrafficCounter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerTrafficCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerTrustManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerTrustManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketPacketWriteHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketPacketWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketPacketWriteHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketPacketWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReadingMode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReadingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.net;
 
 import org.jivesoftware.openfire.server.RemoteServerManager;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStatus.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software and Artur Hefczyc. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software and Artur Hefczyc, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamWriter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSWrapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software and Artur Hefczyc, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software and Artur Hefczyc, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/XMLSocketWriter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/XMLSocketWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/XMPPCallbackHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/XMPPCallbackHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/InboundBufferSizeException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/InboundBufferSizeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyComponentConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyComponentConnectionHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2007-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.nio;
 
 import io.netty.channel.ChannelHandlerContext;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyMultiplexerConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyMultiplexerConnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyServerConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyServerConnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/OfflinePacketDeliverer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/OfflinePacketDeliverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2015 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2015 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLNotWellFormedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLNotWellFormedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPOwnerHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPOwnerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPServiceInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPServiceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPServiceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyItem.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyList.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyListEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyListEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyListManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyListManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyListProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyListProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CachingPubsubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CachingPubsubPersistenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2020-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultPubSubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultPubSubPersistenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/InMemoryPubSubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/InMemoryPubSubPersistenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2020-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/LeafNode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/LeafNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NotAcceptableException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NotAcceptableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PendingSubscriptionsCommand.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PendingSubscriptionsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2020-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProviderManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProviderManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubServiceInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubServiceInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.pubsub;
 
 import org.jivesoftware.openfire.XMPPServer;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PublishedItem.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PublishedItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/AffiliationTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/AffiliationTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/CancelSubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/CancelSubscriptionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/FlushTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/FlushTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/ModifySubscriptionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NewSubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NewSubscriptionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/NodeTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RefreshNodeTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RemoveNodeTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/RemoveNodeTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/SubscriptionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/cluster/SubscriptionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/AccessModel.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/AccessModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/AuthorizeAccess.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/AuthorizeAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/OnlyPublishers.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/OnlyPublishers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/OnlySubscribers.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/OnlySubscribers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/OpenAccess.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/OpenAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/OpenPublisher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/OpenPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/PresenceAccess.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/PresenceAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/PublisherModel.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/PublisherModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/RosterAccess.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/RosterAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/WhitelistAccess.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/WhitelistAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/Roster.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/Roster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItem.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItemProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItemProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2005-2009 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.roster;
 
 import java.util.Iterator;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/AnonymousSaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/AnonymousSaslServer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.sasl;
 
 import org.jivesoftware.openfire.Connection;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ExternalClientSaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ExternalClientSaslServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ExternalServerSaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ExternalServerSaslServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/Failure.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/Failure.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.sasl;
 
 /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/JiveSharedSecretSaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/JiveSharedSecretSaslServer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.sasl;
 
 import org.jivesoftware.util.JiveGlobals;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/SaslFailureException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/SaslFailureException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.sasl;
 
 import javax.security.sasl.SaslException;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/SaslProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/SaslProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/SaslServerFactoryImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/SaslServerFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/SaslServerPlainImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/SaslServerPlainImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Surevine Ltd
+ * Copyright (C) 2015 Surevine Ltd, 2016-2020 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/VerifyPasswordCallback.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/VerifyPasswordCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/security/AuditWriteOnlyException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/security/AuditWriteOnlyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/security/DefaultSecurityAuditProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/security/DefaultSecurityAuditProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/security/EventNotFoundException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/security/EventNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/security/SecurityAuditEvent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/security/SecurityAuditEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/security/SecurityAuditManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/security/SecurityAuditManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/security/SecurityAuditProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/security/SecurityAuditProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingServerSocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingServerSocketReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2015-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/RemoteServerConfiguration.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/RemoteServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/RemoteServerManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/RemoteServerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ComponentSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ComponentSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ComponentSessionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionMultiplexerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionMultiplexerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionMultiplexerSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionMultiplexerSessionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/DeliverRawTextTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/DeliverRawTextTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/DomainPair.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/DomainPair.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.session;
 
 /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/GetSessionsCountTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/GetSessionsCountTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/IncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/IncomingServerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalServerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/OutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/OutgoingServerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ProcessPacketTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ProcessPacketTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteClientSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteComponentSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteConnectionMultiplexerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteConnectionMultiplexerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteOutgoingServerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, Ignite Realtime Foundation 2023. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionLocator.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionLocatorImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionLocatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ServerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, Ignite Realtime Foundation 2023. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/SoftwareServerVersionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/SoftwareServerVersionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/SoftwareVersionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/SoftwareVersionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2019-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/BasicStreamIDFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/BasicStreamIDFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ClientRoute.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ClientRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionAcceptor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionAcceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.spi;
 
 /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionConfiguration.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.spi;
 
 import org.jivesoftware.openfire.Connection;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionType.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2020 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.spi;
 
 /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/LocalRoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/LocalRoutingTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyServerInitializer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyServerInitializer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.spi;
 
 import io.netty.channel.ChannelInitializer;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PacketDelivererImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PacketDelivererImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PacketRouterImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PacketRouterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PacketTransporterImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PacketTransporterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/XMPPServerInfoImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/XMPPServerInfoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/stanzaid/StanzaIDUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/stanzaid/StanzaIDUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/stats/Statistic.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/stats/Statistic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/stats/StatisticsManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/stats/StatisticsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/stats/i18nStatistic.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/stats/i18nStatistic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/transport/TransportHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/transport/TransportHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/AvailablePlugin.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/AvailablePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/DownloadStatus.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/DownloadStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/PluginDownloadManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/PluginDownloadManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/Update.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/Update.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/AuthorizationBasedUserProviderMapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/AuthorizationBasedUserProviderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 IgniteRealtime.org
+ * Copyright (C) 2016 IgniteRealtime.org, 2017-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/HybridUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/HybridUserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 IgniteRealtime.org
+ * Copyright (C) 2016 IgniteRealtime.org, 2018-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/JDBCUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/JDBCUserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/MappedUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/MappedUserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 IgniteRealtime.org
+ * Copyright (C) 2016 IgniteRealtime.org, 2018-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/NativeUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/NativeUserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/POP3UserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/POP3UserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/PresenceEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/PresenceEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/PresenceEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/PresenceEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/PropertyBasedUserProviderMapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/PropertyBasedUserProviderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Ignite Realtime Foundation
+ * Copyright (C) 2018-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/PropertyBasedUserProviderMapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/PropertyBasedUserProviderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ignite Realtime Foundation
+ * Copyright 2018-2019 Ignite Realtime Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/User.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserAlreadyExistsException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserAlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserCollection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserMultiProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserMultiProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 IgniteRealtime.org
+ * Copyright (C) 2016 IgniteRealtime.org, 2018 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserNameManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserNameManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserNameProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserNameProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserNotFoundException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserProviderMapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserProviderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 IgniteRealtime.org
+ * Copyright (C) 2016 IgniteRealtime.org, 2017-2018 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/DefaultUserPropertyProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/DefaultUserPropertyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IgniteRealtime.org
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/HybridUserPropertyProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/HybridUserPropertyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IgniteRealtime.org
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/JDBCUserPropertyProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/JDBCUserPropertyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IgniteRealtime.org
+ * Copyright (C) 2017-2020 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/MappedUserPropertyProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/MappedUserPropertyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IgniteRealtime.org
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/UserPropertyProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/UserPropertyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IgniteRealtime.org
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/UserPropertyProviderMapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/property/UserPropertyProviderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IgniteRealtime.org
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/DefaultVCardProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/PhotoResizer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/PhotoResizer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.vcard;
 
 import org.dom4j.Element;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/VCardEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/VCardEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/VCardListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/VCardListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/VCardManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/VCardManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/VCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/VCardProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/StreamManagementPacketRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/StreamManagementPacketRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientStanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XMPPPPacketReaderFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/XMPPPPacketReaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/AesEncryptor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/AesEncryptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import java.nio.charset.StandardCharsets;

--- a/xmppserver/src/main/java/org/jivesoftware/util/AlreadyExistsException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/AlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/AutoCloseableReentrantLock.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/AutoCloseableReentrantLock.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2020 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import java.util.Collections;

--- a/xmppserver/src/main/java/org/jivesoftware/util/Base64.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Base64.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2006-2007 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 /**

--- a/xmppserver/src/main/java/org/jivesoftware/util/BeanUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/BeanUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/Blowfish.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Blowfish.java
@@ -1,11 +1,21 @@
 /*
+ * Copyright (c) 1997-2002 Markus Hahn <markus_hahn@gmx.net>, 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
  * Adapted from Markus Hahn's Blowfish package so that all functionality is
  * in a single source file. Please visit the following URL for his excellent
  * package: http://www.hotpixel.net/software.html
  *
- * Copyright (c) 1997-2002 Markus Hahn <markus_hahn@gmx.net>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Released under the Apache 2.0 license.
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.jivesoftware.util;

--- a/xmppserver/src/main/java/org/jivesoftware/util/ByteFormat.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ByteFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/CacheableOptional.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/CacheableOptional.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2020 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import org.jivesoftware.util.cache.CacheSizes;

--- a/xmppserver/src/main/java/org/jivesoftware/util/CertificateEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/CertificateEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/CertificateManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/CertificateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/ClassUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ClassUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/CookieUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/CookieUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/ElementUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ElementUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/EmailService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/EmailService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2003-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/Encryptor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Encryptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 public interface Encryptor {

--- a/xmppserver/src/main/java/org/jivesoftware/util/FastDateFormat.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/FastDateFormat.java
@@ -50,6 +50,8 @@
  * For more information about Tea, please see http://opensource.go.com/.
  */
 
+//TODO: https://igniterealtime.atlassian.net/browse/OF-2754
+
 package org.jivesoftware.util;
 
 import java.util.Date;

--- a/xmppserver/src/main/java/org/jivesoftware/util/FaviconServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/FaviconServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/HTTPConnectionException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/HTTPConnectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/ImmediateFuture.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ImmediateFuture.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import java.util.concurrent.Future;

--- a/xmppserver/src/main/java/org/jivesoftware/util/InitializationException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/InitializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/JavaSpecVersion.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JavaSpecVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveBeanInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveBeanInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveConstants.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveInitialLdapContext.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveInitialLdapContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/LinkedList.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/LinkedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/LinkedListNode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/LinkedListNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/ListPager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ListPager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import java.io.UnsupportedEncodingException;

--- a/xmppserver/src/main/java/org/jivesoftware/util/LocaleFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/LocaleFilter.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/LocaleUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/LocaleUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/Log.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/ModificationNotAllowedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ModificationNotAllowedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/NamedThreadFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/NamedThreadFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import java.util.concurrent.ThreadFactory;

--- a/xmppserver/src/main/java/org/jivesoftware/util/NotFoundException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/NotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/ParamUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ParamUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/PersistableMap.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/PersistableMap.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import java.util.HashMap;

--- a/xmppserver/src/main/java/org/jivesoftware/util/PropertyClusterEventTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/PropertyClusterEventTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/PropertyEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/PropertyEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/PropertyEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/PropertyEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SAXReaderUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/SetCharacterEncodingFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SetCharacterEncodingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/SimpleSSLSocketFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SimpleSSLSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/SmsService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SmsService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2020 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import org.apache.commons.pool2.BasePooledObjectFactory;

--- a/xmppserver/src/main/java/org/jivesoftware/util/StringUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import java.time.Duration;

--- a/xmppserver/src/main/java/org/jivesoftware/util/TaskEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/TaskEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/Version.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/WebBean.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/WebBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/WebManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/WebManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/WebXmlUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/WebXmlUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016-2021 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import org.dom4j.Document;

--- a/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/XMLWriter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/XMLWriter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2005-2006 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import org.dom4j.*;

--- a/xmppserver/src/main/java/org/jivesoftware/util/XMPPDateTimeFormat.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/XMPPDateTimeFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Florian Schmaus
+ * Copyright (C) 2013 Florian Schmaus, 2017-2019 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/Cache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/Cache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactoryStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactoryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheSizes.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheSizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheWrapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/Cacheable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/Cacheable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CannotCalculateSizeException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CannotCalculateSizeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ClusterTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ClusterTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ComponentCacheWrapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ComponentCacheWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyMonitor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 IgniteRealtime Foundation
+ * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultCache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultExternalizableUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultExternalizableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultLocalCacheStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultLocalCacheStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ExternalizableUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ExternalizableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ExternalizableUtilStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ExternalizableUtilStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cert/CNCertificateIdentityMapping.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cert/CNCertificateIdentityMapping.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util.cert;
 
 import java.security.cert.X509Certificate;

--- a/xmppserver/src/main/java/org/jivesoftware/util/cert/CertificateIdentityMapping.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cert/CertificateIdentityMapping.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util.cert;
 
 import java.security.cert.X509Certificate;

--- a/xmppserver/src/main/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util.cert;
 
 import org.bouncycastle.asn1.*;

--- a/xmppserver/src/main/webapp/audit-policy.jsp
+++ b/xmppserver/src/main/webapp/audit-policy.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
+  - Copyright (C) 2016-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/available-plugins.jsp
+++ b/xmppserver/src/main/webapp/available-plugins.jsp
@@ -1,5 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
+  - Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
   - You may obtain a copy of the License at

--- a/xmppserver/src/main/webapp/component-session-details.jsp
+++ b/xmppserver/src/main/webapp/component-session-details.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/component-session-summary.jsp
+++ b/xmppserver/src/main/webapp/component-session-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/compression-settings.jsp
+++ b/xmppserver/src/main/webapp/compression-settings.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, Ignite Realtime Foundation 2023. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/connection-managers-settings.jsp
+++ b/xmppserver/src/main/webapp/connection-managers-settings.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/connection-settings-advanced.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-advanced.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>

--- a/xmppserver/src/main/webapp/connection-settings-external-components.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-external-components.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.component.ExternalComponentConfiguration" %>

--- a/xmppserver/src/main/webapp/connection-settings-socket-c2s.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-socket-c2s.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.time.Duration" %>
 <%@ page import="java.util.HashMap" %>

--- a/xmppserver/src/main/webapp/connection-settings-socket-s2s.jsp
+++ b/xmppserver/src/main/webapp/connection-settings-socket-s2s.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2016-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionConfiguration" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>

--- a/xmppserver/src/main/webapp/decorators/main.jsp
+++ b/xmppserver/src/main/webapp/decorators/main.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/decorators/setup.jsp
+++ b/xmppserver/src/main/webapp/decorators/setup.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/dns-check.jsp
+++ b/xmppserver/src/main/webapp/dns-check.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2016-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
 

--- a/xmppserver/src/main/webapp/error-serverdown.jsp
+++ b/xmppserver/src/main/webapp/error-serverdown.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2007 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
  <%--
 --%>

--- a/xmppserver/src/main/webapp/error.jsp
+++ b/xmppserver/src/main/webapp/error.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.io.*,
                  org.jivesoftware.util.ParamUtils,

--- a/xmppserver/src/main/webapp/file-transfer-proxy.jsp
+++ b/xmppserver/src/main/webapp/file-transfer-proxy.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/group-create.jsp
+++ b/xmppserver/src/main/webapp/group-create.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/group-delete.jsp
+++ b/xmppserver/src/main/webapp/group-delete.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/group-edit.jsp
+++ b/xmppserver/src/main/webapp/group-edit.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/group-summary.jsp
+++ b/xmppserver/src/main/webapp/group-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/http-bind.jsp
+++ b/xmppserver/src/main/webapp/http-bind.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/import-keystore-certificate.jsp
+++ b/xmppserver/src/main/webapp/import-keystore-certificate.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2007-2008 Jive Software, 2018-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>

--- a/xmppserver/src/main/webapp/import-truststore-certificate.jsp
+++ b/xmppserver/src/main/webapp/import-truststore-certificate.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2018-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
 <%@ page import="org.jivesoftware.openfire.keystore.TrustStore"%>

--- a/xmppserver/src/main/webapp/index.jsp
+++ b/xmppserver/src/main/webapp/index.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/ldap-group.jsp
+++ b/xmppserver/src/main/webapp/ldap-group.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.HashMap" %>

--- a/xmppserver/src/main/webapp/ldap-server.jsp
+++ b/xmppserver/src/main/webapp/ldap-server.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%
     String serverType = null;

--- a/xmppserver/src/main/webapp/ldap-user.jsp
+++ b/xmppserver/src/main/webapp/ldap-user.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.HashMap" %>

--- a/xmppserver/src/main/webapp/log.jsp
+++ b/xmppserver/src/main/webapp/log.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/login.jsp
+++ b/xmppserver/src/main/webapp/login.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2010 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.admin.AdminConsole,
                 org.jivesoftware.openfire.admin.AdminManager"

--- a/xmppserver/src/main/webapp/loginToken.jsp
+++ b/xmppserver/src/main/webapp/loginToken.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.admin.AdminConsole,
                  org.jivesoftware.admin.LoginLimitManager"

--- a/xmppserver/src/main/webapp/logviewer.jsp
+++ b/xmppserver/src/main/webapp/logviewer.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/manage-updates.jsp
+++ b/xmppserver/src/main/webapp/manage-updates.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/media-proxy.jsp
+++ b/xmppserver/src/main/webapp/media-proxy.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-create-permission.jsp
+++ b/xmppserver/src/main/webapp/muc-create-permission.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-default-settings.jsp
+++ b/xmppserver/src/main/webapp/muc-default-settings.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2010 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2010 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-history-settings.jsp
+++ b/xmppserver/src/main/webapp/muc-history-settings.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-room-affiliations.jsp
+++ b/xmppserver/src/main/webapp/muc-room-affiliations.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-room-cache.jsp
+++ b/xmppserver/src/main/webapp/muc-room-cache.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2021-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-room-create.jsp
+++ b/xmppserver/src/main/webapp/muc-room-create.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-room-delete.jsp
+++ b/xmppserver/src/main/webapp/muc-room-delete.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-room-federation.jsp
+++ b/xmppserver/src/main/webapp/muc-room-federation.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2020-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-room-occupants.jsp
+++ b/xmppserver/src/main/webapp/muc-room-occupants.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-room-summary.jsp
+++ b/xmppserver/src/main/webapp/muc-room-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-service-create.jsp
+++ b/xmppserver/src/main/webapp/muc-service-create.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-service-delete.jsp
+++ b/xmppserver/src/main/webapp/muc-service-delete.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-service-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-service-edit-form.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-service-summary.jsp
+++ b/xmppserver/src/main/webapp/muc-service-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-sysadmins.jsp
+++ b/xmppserver/src/main/webapp/muc-sysadmins.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/muc-tasks.jsp
+++ b/xmppserver/src/main/webapp/muc-tasks.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/offline-messages.jsp
+++ b/xmppserver/src/main/webapp/offline-messages.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/plugin-admin.jsp
+++ b/xmppserver/src/main/webapp/plugin-admin.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/plugin-showfile.jsp
+++ b/xmppserver/src/main/webapp/plugin-showfile.jsp
@@ -1,10 +1,5 @@
-<%@ page contentType="text/html; charset=UTF-8" %>
-<%@ page import="org.jivesoftware.util.ParamUtils" %>
-<%@ page import="org.jivesoftware.openfire.container.Plugin" %>
-<%@ page import="org.jivesoftware.openfire.container.PluginManager" %>
-<%@ page import="java.nio.file.Path" %>
-<%@ page import="java.io.*" %><%--
-  - Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+<%--
+  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -18,6 +13,14 @@
   - See the License for the specific language governing permissions and
   - limitations under the License.
 --%>
+
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ page import="org.jivesoftware.util.ParamUtils" %>
+<%@ page import="org.jivesoftware.openfire.container.Plugin" %>
+<%@ page import="org.jivesoftware.openfire.container.PluginManager" %>
+<%@ page import="java.nio.file.Path" %>
+<%@ page import="java.io.*" %>
+
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager"  />
 <%
     webManager.init(request, response, session, application, out );

--- a/xmppserver/src/main/webapp/private-data-settings.jsp
+++ b/xmppserver/src/main/webapp/private-data-settings.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/profile-settings.jsp
+++ b/xmppserver/src/main/webapp/profile-settings.jsp
@@ -1,12 +1,5 @@
-<%@ page contentType="text/html; charset=UTF-8" %>
-<%@ page import="org.jivesoftware.util.JiveGlobals" %>
-<%@ page import="org.jivesoftware.openfire.ldap.LdapManager" %>
-<%@ page import="org.jivesoftware.openfire.auth.AuthFactory" %>
-<%@ page import="org.jivesoftware.openfire.ldap.LdapAuthProvider" %>
-<%@ page import="javax.naming.ldap.LdapName" %>
 <%--
-  -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -20,6 +13,13 @@
   - See the License for the specific language governing permissions and
   - limitations under the License.
 --%>
+
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ page import="org.jivesoftware.util.JiveGlobals" %>
+<%@ page import="org.jivesoftware.openfire.ldap.LdapManager" %>
+<%@ page import="org.jivesoftware.openfire.auth.AuthFactory" %>
+<%@ page import="org.jivesoftware.openfire.ldap.LdapAuthProvider" %>
+<%@ page import="javax.naming.ldap.LdapName" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>

--- a/xmppserver/src/main/webapp/pubsub-form-table.jsp
+++ b/xmppserver/src/main/webapp/pubsub-form-table.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>

--- a/xmppserver/src/main/webapp/pubsub-node-affiliates-delete.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-affiliates-delete.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
                 org.jivesoftware.openfire.pubsub.NodeAffiliate,

--- a/xmppserver/src/main/webapp/pubsub-node-affiliates-edit.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-affiliates-edit.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="org.jivesoftware.openfire.XMPPServer,
                 org.jivesoftware.openfire.pep.PEPServiceInfo,

--- a/xmppserver/src/main/webapp/pubsub-node-affiliates.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-affiliates.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.openfire.pep.PEPServiceInfo,

--- a/xmppserver/src/main/webapp/pubsub-node-configuration.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-configuration.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2020-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
                  org.jivesoftware.openfire.pubsub.Node,

--- a/xmppserver/src/main/webapp/pubsub-node-delete.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-delete.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
                  org.jivesoftware.openfire.pubsub.Node,

--- a/xmppserver/src/main/webapp/pubsub-node-edit.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-edit.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.pubsub.Node,
                  org.jivesoftware.openfire.pubsub.PubSubServiceInfo,

--- a/xmppserver/src/main/webapp/pubsub-node-items.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-items.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.openfire.pep.PEPServiceInfo,

--- a/xmppserver/src/main/webapp/pubsub-node-subscribers.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-subscribers.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.pep.PEPServiceInfo,
                  org.jivesoftware.openfire.pubsub.Node,

--- a/xmppserver/src/main/webapp/pubsub-node-summary.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-summary.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer,
                  org.jivesoftware.openfire.pep.PEPServiceInfo,

--- a/xmppserver/src/main/webapp/pubsub-service-summary.jsp
+++ b/xmppserver/src/main/webapp/pubsub-service-summary.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.pubsub.PubSubServiceInfo,
                  org.jivesoftware.openfire.pubsub.PubSubServiceInfo.listType,

--- a/xmppserver/src/main/webapp/reg-settings.jsp
+++ b/xmppserver/src/main/webapp/reg-settings.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/security-audit-viewer-jsp.jsp
+++ b/xmppserver/src/main/webapp/security-audit-viewer-jsp.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="admin" uri="admin" %>

--- a/xmppserver/src/main/webapp/security-certificate-details.jsp
+++ b/xmppserver/src/main/webapp/security-certificate-details.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2016-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
 

--- a/xmppserver/src/main/webapp/security-certificate-store-backup.jsp
+++ b/xmppserver/src/main/webapp/security-certificate-store-backup.jsp
@@ -1,3 +1,19 @@
+<%--
+  ~ Copyright (C) 2018-2022 Ignite Realtime Foundation. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
@@ -15,22 +31,6 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
-
-<%--
-  ~ Copyright (C) 2018 Ignite Realtime Foundation. All rights reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  --%>
 
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
 <jsp:useBean id="now" class="java.util.Date"/>

--- a/xmppserver/src/main/webapp/security-certificate-store-management.jsp
+++ b/xmppserver/src/main/webapp/security-certificate-store-management.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>

--- a/xmppserver/src/main/webapp/security-keystore-signing-request.jsp
+++ b/xmppserver/src/main/webapp/security-keystore-signing-request.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006-2008 Jive Software, 2018-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="java.util.Enumeration"%>
 <%@page import="org.jivesoftware.openfire.XMPPServer"%>

--- a/xmppserver/src/main/webapp/security-keystore.jsp
+++ b/xmppserver/src/main/webapp/security-keystore.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2018-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@page import="org.jivesoftware.util.StringUtils"%>
 <%@page import="org.jivesoftware.util.CertificateManager"%>

--- a/xmppserver/src/main/webapp/security-truststore.jsp
+++ b/xmppserver/src/main/webapp/security-truststore.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2018-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
 <%@ page import="org.jivesoftware.openfire.keystore.TrustStore"%>

--- a/xmppserver/src/main/webapp/server-connectiontest.jsp
+++ b/xmppserver/src/main/webapp/server-connectiontest.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
-  ~ Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+  ~ Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/server-db-stats.jsp
+++ b/xmppserver/src/main/webapp/server-db-stats.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/server-db.jsp
+++ b/xmppserver/src/main/webapp/server-db.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/server-locale.jsp
+++ b/xmppserver/src/main/webapp/server-locale.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/server-props.jsp
+++ b/xmppserver/src/main/webapp/server-props.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/server-restart.jsp
+++ b/xmppserver/src/main/webapp/server-restart.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>

--- a/xmppserver/src/main/webapp/server-session-details.jsp
+++ b/xmppserver/src/main/webapp/server-session-details.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/server-session-summary.jsp
+++ b/xmppserver/src/main/webapp/server-session-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/session-conflict.jsp
+++ b/xmppserver/src/main/webapp/session-conflict.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/session-details.jsp
+++ b/xmppserver/src/main/webapp/session-details.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/session-summary.jsp
+++ b/xmppserver/src/main/webapp/session-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/setup/index.jsp
+++ b/xmppserver/src/main/webapp/setup/index.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2010 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="java.io.File,

--- a/xmppserver/src/main/webapp/setup/setup-admin-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-admin-settings.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>

--- a/xmppserver/src/main/webapp/setup/setup-admin-settings_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-admin-settings_test.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.LocaleUtils" %>
 <%@ page import="org.jivesoftware.util.ParamUtils, org.jivesoftware.openfire.ldap.LdapManager, org.jivesoftware.openfire.user.UserNotFoundException, org.xmpp.packet.JID" %>

--- a/xmppserver/src/main/webapp/setup/setup-completed.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-completed.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2007 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>

--- a/xmppserver/src/main/webapp/setup/setup-datasource-jndi.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-datasource-jndi.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.database.DbConnectionManager,
                  org.jivesoftware.database.JNDIDataSourceProvider,

--- a/xmppserver/src/main/webapp/setup/setup-datasource-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-datasource-settings.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.database.ConnectionProvider,
                  org.jivesoftware.database.DbConnectionManager,

--- a/xmppserver/src/main/webapp/setup/setup-datasource-standard.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-datasource-standard.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.database.DbConnectionManager,
                  org.jivesoftware.database.DefaultConnectionProvider,

--- a/xmppserver/src/main/webapp/setup/setup-finished.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-finished.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>

--- a/xmppserver/src/main/webapp/setup/setup-host-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-host-settings.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2007 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.net.InetAddress" %>
 <%@ page import="java.net.UnknownHostException" %>

--- a/xmppserver/src/main/webapp/setup/setup-ldap-group.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-group.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006-2007 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer"%>
 

--- a/xmppserver/src/main/webapp/setup/setup-ldap-group_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-group_test.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006-2007 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.admin.LdapGroupTester" %>
 <%@ page import="org.jivesoftware.util.LocaleUtils" %>

--- a/xmppserver/src/main/webapp/setup/setup-ldap-server.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-server.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006-2007 Jive Software, 2018-2019 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%

--- a/xmppserver/src/main/webapp/setup/setup-ldap-server_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-server_test.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006-2007 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.LocaleUtils" %>
 <%@ page import="org.jivesoftware.openfire.ldap.LdapManager, javax.naming.*, javax.naming.ldap.LdapContext, java.net.UnknownHostException" %>

--- a/xmppserver/src/main/webapp/setup/setup-ldap-user.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-user.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006-2007 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 

--- a/xmppserver/src/main/webapp/setup/setup-ldap-user_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-ldap-user_test.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006-2007 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.admin.LdapUserProfile" %>
 <%@ page import="org.jivesoftware.admin.LdapUserTester" %>

--- a/xmppserver/src/main/webapp/setup/setup-profile-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-profile-settings.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2006-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer"%>
 <%@ page import="org.jivesoftware.util.JiveGlobals"%>

--- a/xmppserver/src/main/webapp/system-admin-console-access.jsp
+++ b/xmppserver/src/main/webapp/system-admin-console-access.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp" %>
 <%@ page import="org.jivesoftware.openfire.container.AdminConsolePlugin " %>

--- a/xmppserver/src/main/webapp/system-cache-details.jsp
+++ b/xmppserver/src/main/webapp/system-cache-details.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <jsp:useBean scope="request" id="errorMessage" class="java.lang.String"/>

--- a/xmppserver/src/main/webapp/system-cache.jsp
+++ b/xmppserver/src/main/webapp/system-cache.jsp
@@ -1,17 +1,6 @@
-<%@ page contentType="text/html; charset=UTF-8" %>
-<%@ page import="java.text.DecimalFormat"%>
-<%@ page import="java.text.NumberFormat"%>
-<%@ page import="java.time.Duration"%>
-<%@ page import="org.jivesoftware.util.CookieUtils"%>
-<%@ page import="org.jivesoftware.util.JiveGlobals"%>
-<%@ page import="org.jivesoftware.util.ParamUtils"%>
-<%@ page import="org.jivesoftware.util.StringUtils"%>
-<%@ page import="org.jivesoftware.util.cache.Cache" %>
-<%@ page import="org.jivesoftware.util.cache.CacheWrapper" %>
-<%@ page import="org.jivesoftware.util.cache.DefaultCache" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -25,6 +14,18 @@
   - See the License for the specific language governing permissions and
   - limitations under the License.
 --%>
+
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ page import="java.text.DecimalFormat"%>
+<%@ page import="java.text.NumberFormat"%>
+<%@ page import="java.time.Duration"%>
+<%@ page import="org.jivesoftware.util.CookieUtils"%>
+<%@ page import="org.jivesoftware.util.JiveGlobals"%>
+<%@ page import="org.jivesoftware.util.ParamUtils"%>
+<%@ page import="org.jivesoftware.util.StringUtils"%>
+<%@ page import="org.jivesoftware.util.cache.Cache" %>
+<%@ page import="org.jivesoftware.util.cache.CacheWrapper" %>
+<%@ page import="org.jivesoftware.util.cache.DefaultCache" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>

--- a/xmppserver/src/main/webapp/system-clustering-data-consistency-check.jsp
+++ b/xmppserver/src/main/webapp/system-clustering-data-consistency-check.jsp
@@ -2,7 +2,7 @@
 
 <%--
   -
-  - Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2021-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/system-clustering.jsp
+++ b/xmppserver/src/main/webapp/system-clustering.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/system-email.jsp
+++ b/xmppserver/src/main/webapp/system-email.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/system-emailtest.jsp
+++ b/xmppserver/src/main/webapp/system-emailtest.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/system-properties.jsp
+++ b/xmppserver/src/main/webapp/system-properties.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ page contentType="text/html; charset=UTF-8" %>

--- a/xmppserver/src/main/webapp/system-sms.jsp
+++ b/xmppserver/src/main/webapp/system-sms.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.*,
                  org.jivesoftware.util.*"

--- a/xmppserver/src/main/webapp/system-smstest.jsp
+++ b/xmppserver/src/main/webapp/system-smstest.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-create.jsp
+++ b/xmppserver/src/main/webapp/user-create.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-delete.jsp
+++ b/xmppserver/src/main/webapp/user-delete.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-edit-form.jsp
+++ b/xmppserver/src/main/webapp/user-edit-form.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-groups.jsp
+++ b/xmppserver/src/main/webapp/user-groups.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-lockout.jsp
+++ b/xmppserver/src/main/webapp/user-lockout.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-message.jsp
+++ b/xmppserver/src/main/webapp/user-message.jsp
@@ -2,7 +2,7 @@
 
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-password.jsp
+++ b/xmppserver/src/main/webapp/user-password.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-privacylists.jsp
+++ b/xmppserver/src/main/webapp/user-privacylists.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2020-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-properties.jsp
+++ b/xmppserver/src/main/webapp/user-properties.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-roster-add.jsp
+++ b/xmppserver/src/main/webapp/user-roster-add.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-roster-delete.jsp
+++ b/xmppserver/src/main/webapp/user-roster-delete.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-roster-edit.jsp
+++ b/xmppserver/src/main/webapp/user-roster-edit.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-roster-view.jsp
+++ b/xmppserver/src/main/webapp/user-roster-view.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-roster.jsp
+++ b/xmppserver/src/main/webapp/user-roster.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-search.jsp
+++ b/xmppserver/src/main/webapp/user-search.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
 --%>

--- a/xmppserver/src/main/webapp/user-summary.jsp
+++ b/xmppserver/src/main/webapp/user-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/user-tabs.jsp
+++ b/xmppserver/src/main/webapp/user-tabs.jsp
@@ -1,3 +1,19 @@
+<%--
+  -
+  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%--

--- a/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
+++ b/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/admin/AuthCheckFilterTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/admin/AuthCheckFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/admin/LoginLimitManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/admin/LoginLimitManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/admin/SiteMinderServletRequestAuthenticatorTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/admin/SiteMinderServletRequestAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/OfflineMessageStoreTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/OfflineMessageStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/admin/GroupBasedAdminProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/admin/GroupBasedAdminProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/archive/ArchiverTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/archive/ArchiverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/auth/JDBCAuthProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/auth/JDBCAuthProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/carbons/MessageCarbonsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/carbons/MessageCarbonsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/cluster/ClusterMonitorTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/cluster/ClusterMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupJIDTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupJIDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/handler/IQEntityTimeHandlerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/handler/IQEntityTimeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/http/HttpSessionDeliverableTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/http/HttpSessionDeliverableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CertificateUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CertificateUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CheckChainTrustedTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CheckChainTrustedTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.keystore;
 
 import org.junit.*;

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/KeystoreTestUtils.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/KeystoreTestUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.keystore;
 
 import org.bouncycastle.asn1.x500.X500Name;

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/OpenfireX509TrustManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/ldap/LdapManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/ldap/LdapManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/muc/spi/MucPrivilegesTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/muc/spi/MucPrivilegesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/muc/spi/OccupantManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/muc/spi/OccupantManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Ignite Realtime Community. All rights reserved.
+ * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/net/DNSUtilTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/net/DNSUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/nio/XmlNumericCharacterReferenceTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/nio/XmlNumericCharacterReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ExternalServerSaslServerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ExternalServerSaslServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteInitiatingServerDummy.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteInitiatingServerDummy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.session;
 
 import org.dom4j.*;

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/SessionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/SessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactoryTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/spi/EncryptionArtifactFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/stanzaid/StanzaIDUtilTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/stanzaid/StanzaIDUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/streammanagement/StreamManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/streammanagement/StreamManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/user/UserManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/user/UserManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/AdminConsoleTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/AdminConsoleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software. 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/AesEncryptorTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/AesEncryptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/AutoCloseableReentrantLockTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/AutoCloseableReentrantLockTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018-2019 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.util;
 
 import static org.awaitility.Awaitility.await;

--- a/xmppserver/src/test/java/org/jivesoftware/util/BlowfishEncryptorTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/BlowfishEncryptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/CacheableOptionalTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/CacheableOptionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/CertificateManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/CertificateManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/CertificateTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/CertificateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/EntityCapabilitiesManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/EntityCapabilitiesManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/JIDTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/JIDTest.java
@@ -1,8 +1,17 @@
 /*
  * Copyright (C) 2004-2007 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
- * This software is published under the terms of the GNU Public License (GPL),
- * a copy of which is included in this distribution.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.jivesoftware.util;

--- a/xmppserver/src/test/java/org/jivesoftware/util/JIDTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/JIDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2007 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2007 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/JavaSpecVersionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/JavaSpecVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/LDAPTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/LDAPTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Daniel Henninger, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2008 Daniel Henninger, 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/ListPagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/ListPagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/LocaleUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/LocaleUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/StringUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/StringUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/VersionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/VersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/WebXmlUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/WebXmlUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2016-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/XMLPropertiesTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/XMLPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/XMPPDateTimeFormatTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/XMPPDateTimeFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/cache/CacheFactoryConfigTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/cache/CacheFactoryConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/java/org/jivesoftware/util/cache/ReverseLookupComputingCacheEntryListenerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/cache/ReverseLookupComputingCacheEntryListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2023 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/throttletest/src/org/jivesoftware/openfire/test/throttle/ThrottleTestReader.java
+++ b/xmppserver/src/test/throttletest/src/org/jivesoftware/openfire/test/throttle/ThrottleTestReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/test/throttletest/src/org/jivesoftware/openfire/test/throttle/ThrottleTestWriter.java
+++ b/xmppserver/src/test/throttletest/src/org/jivesoftware/openfire/test/throttle/ThrottleTestWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR should be rebased in, not squashed.

Updates copyright headers on files.

* Adds headers to files that were missing them
* If they had headers, adds Ignite Realtime Foundation where missing
* If Ignite was there, updates the years
* Fixes some typos
* Fixes one file that had the wrong license header altogether