### PR TITLE
OF-2736: Admin console: missing header in session details

### DIFF
--- a/xmppserver/src/main/webapp/session-details.jsp
+++ b/xmppserver/src/main/webapp/session-details.jsp
@@ -503,8 +503,6 @@
 
     <div class="jive-table">
         <table style="width: 100%">
-            <% if (currentSess instanceof LocalClientSession) {
-                LocalClientSession s = (LocalClientSession)currentSess; %>
             <thead>
                 <tr>
                     <th colspan="2">
@@ -513,6 +511,8 @@
                 </tr>
             </thead>
             <tbody>
+                <% if (currentSess instanceof LocalClientSession) {
+                    LocalClientSession s = (LocalClientSession)currentSess; %>
                 <tr>
                     <td class="c1">
                         <fmt:message key="session.details.sm-status"/>:


### PR DESCRIPTION
The first bit of the data shown in the table is only available on the local cluster node. That is being excluded from the output, but by mistake, the table header was excluded too.