### PR TITLE
OF-2765: Use mvnw everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,16 @@ all: build-openfire
 # Can not use 'build' as target name, because there is a
 # directory called build
 build-openfire:
-	mvn package
+	./mvnw package
 
 clean:
-	mvn clean
+	./mvnw clean
 
 dist:
-	mvn package
+	./mvnw package
 
 plugins:
-	mvn package
+	./mvnw package
 
 eclipse: .settings .classpath .project
 

--- a/build/docker/buildWithDocker.sh
+++ b/build/docker/buildWithDocker.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 OFROOT=$(realpath "$SCRIPTPATH/../../")
 DOMAPMAVEN=true
@@ -51,8 +52,8 @@ if [ -n "$MAVENMAP" ]; then
 fi
 DOCKERCMD+=(
     -w /usr/src/openfire
-    maven:3.6.3-jdk-11 \
-    mvn clean package
+    eclipse-temurin:11-jdk \
+    ./mvnw clean package
 )
 if [ $SKIPTESTS == true ]; then
     DOCKERCMD+=(

--- a/documentation/ide-vscode-setup.html
+++ b/documentation/ide-vscode-setup.html
@@ -159,7 +159,7 @@
             <pre>./mvnw clean verify</pre>
 
             <p>
-                <span style="color: red; ">Important!</span> -- clean part in mvn command will delete current Openfire configuration.
+                <span style="color: red; ">Important!</span> -- clean part in maven command will delete current Openfire configuration.
             </p>
 
             <p>

--- a/documentation/plugin-dev-guide.html
+++ b/documentation/plugin-dev-guide.html
@@ -547,7 +547,7 @@ public class ExamplePlugin implements Plugin {
             To build the plugin, build the maven 'package' goal. Typically, this is done as such:
         </p>
 
-        <pre>mvn clean package</pre>
+        <pre>./mvnw clean package</pre>
 
         <p>
             When the build succeeds, the <code>target/</code> folder in your project will have serveral files. One file

--- a/documentation/source-build.html
+++ b/documentation/source-build.html
@@ -133,7 +133,7 @@
                 Navigate into the root directory of this distribution named via the command-line. In that directory,
                 invoke the build tool to compile the Openfire source code:
             </p>
-            <pre>mvn compile</pre>
+            <pre>./mvnw compile</pre>
             <p>
                 If the build tool is invoked correctly and Openfire compiles, you've correctly
                 configured Maven and your copy of the Openfire source distribution.
@@ -152,7 +152,7 @@
             Apache Maven documentation. For more complete help on several commands, read the documentation below.
         </p>
         <p>
-            To execute a build phase, type <code>mvn "phase"</code> where "phase" is one of the keywords listed below:
+            To execute a build phase, type <code>./mvnw "phase"</code> where "phase" is one of the keywords listed below:
         </p>
         <ul>
             <li><a href="#clean">clean</a>
@@ -161,7 +161,7 @@
             <li><a href="#package">package</a>
         </ul>
         <p>
-            Note that you can combine several phases, for example: <code>mvn clean package</code>.
+            Note that you can combine several phases, for example: <code>./mvnw clean package</code>.
             When a phase is given, Maven will execute every phase in the sequence up to and
             including the one defined. For example, when the 'package' phase is executed, the
             'compile' and 'test' phases are also executed (but the 'clean' phase is not, unless
@@ -176,7 +176,7 @@
 
             <fieldset>
                 <legend>Syntax</legend>
-                <pre><code>mvn clean</code></pre>
+                <pre><code>./mvnw clean</code></pre>
             </fieldset>
 
         </section>

--- a/documentation/working-with-openfire.html
+++ b/documentation/working-with-openfire.html
@@ -168,9 +168,9 @@ docker build . -t openfire:mything</code></pre>
         <section id="tooling-dependencies">
             <h3>Dependencies</h3>
             <p>Testing for out-of-date dependencies is important, especially as a release approaches. You can test for ones with known CVEs using dependency-check from within the project using what's built into the POM:</p>
-            <pre>mvn verify -P deps</pre>
+            <pre>./mvnw verify -P deps</pre>
             <p>Or to see all dependencies with potential updates:</p>
-            <pre>mvn versions:display-dependency-updates</pre>
+            <pre>./mvnw versions:display-dependency-updates</pre>
         </section>
 
         <section id="tooling-dockerstacks">

--- a/runAioxmppIntegrationTests
+++ b/runAioxmppIntegrationTests
@@ -117,7 +117,7 @@ function launchOpenfire {
 	declare -r OPENFIRE_SHELL_SCRIPT="${BASEDIR}/distribution/target/distribution-base/bin/openfire.sh"
 
 	if [[ ! -f "${OPENFIRE_SHELL_SCRIPT}" ]]; then
-		mvn verify -P ci
+		./mvnw verify -P ci
 	fi
 
 	rm -f distribution/target/distribution-base/conf/openfire.xml

--- a/runIntegrationTests
+++ b/runIntegrationTests
@@ -134,7 +134,7 @@ function launchOpenfire {
 	declare -r OPENFIRE_SHELL_SCRIPT="${BASEDIR}/distribution/target/distribution-base/bin/openfire.sh"
 
 	if [[ ! -f "${OPENFIRE_SHELL_SCRIPT}" ]]; then
-		mvn verify -P ci
+		./mvnw verify -P ci
 	fi
 
 	rm -f distribution/target/distribution-base/conf/openfire.xml


### PR DESCRIPTION
* Fixes docs
* Fixes makefile
* Fixes integration test scripts
* Fixes dockerised build script (this one's a tiny bit more extensive - it swaps the maven image for a temurin one)