### PR TITLE
OF-2774: Fix reset of 'idle' state of Netty connections

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettySessionInitializer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettySessionInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,10 +126,10 @@ public class NettySessionInitializer {
                     NettyConnectionHandler businessLogicHandler = new NettyOutboundConnectionHandler(listener.generateConnectionConfiguration(), domainPair, port);
                     Duration maxIdleTimeBeforeClosing = businessLogicHandler.getMaxIdleTime().isNegative() ? Duration.ZERO : businessLogicHandler.getMaxIdleTime();
 
-                    ch.pipeline().addLast(new NettyXMPPDecoder());
-                    ch.pipeline().addLast(new StringEncoder(StandardCharsets.UTF_8));
                     ch.pipeline().addLast("idleStateHandler", new IdleStateHandler(maxIdleTimeBeforeClosing.dividedBy(2).toMillis(), 0, 0, TimeUnit.MILLISECONDS));
                     ch.pipeline().addLast("keepAliveHandler", new NettyIdleStateKeepAliveHandler(false));
+                    ch.pipeline().addLast(new NettyXMPPDecoder());
+                    ch.pipeline().addLast(new StringEncoder(StandardCharsets.UTF_8));
                     ch.pipeline().addLast(businessLogicHandler);
 
                     final ConnectionAcceptor connectionAcceptor = listener.getConnectionAcceptor();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyServerInitializer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyServerInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,11 +75,11 @@ public class NettyServerInitializer extends ChannelInitializer<SocketChannel> {
 
         ch.pipeline()
             .addLast(TRAFFIC_HANDLER_NAME, new ChannelTrafficShapingHandler(0))
+            .addLast("idleStateHandler", new IdleStateHandler(maxIdleTimeBeforeClosing.dividedBy(2).toMillis(), 0, 0, TimeUnit.MILLISECONDS))
+            .addLast("keepAliveHandler", new NettyIdleStateKeepAliveHandler(isClientConnection))
             .addLast(new NettyXMPPDecoder())
             .addLast(new StringEncoder(StandardCharsets.UTF_8))
             .addLast("stalledSessionHandler", new WriteTimeoutHandler(Math.toIntExact(WRITE_TIMEOUT_SECONDS.getValue().getSeconds())))
-            .addLast("idleStateHandler", new IdleStateHandler(maxIdleTimeBeforeClosing.dividedBy(2).toMillis(), 0, 0, TimeUnit.MILLISECONDS))
-            .addLast("keepAliveHandler", new NettyIdleStateKeepAliveHandler(isClientConnection))
             .addLast(businessLogicHandler);
 
         // Add ChannelHandler providers implemented by plugins, if any.


### PR DESCRIPTION
Whenever data is received, the 'idle' state of a Netty connection is to be reset. Prior to this commit, this occured conditionally on a particular handler being set (which was set only for s2s connections). With this change, the idle flag is always reset upon inbound data.