### PR TITLE
Remove unnecessary caching in Github Actions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -228,13 +228,6 @@ jobs:
           curl https://raw.githubusercontent.com/igniterealtime/Openfire/v3.9.3/src/database/openfire_sqlserver.sql > $GITHUB_WORKSPACE/olddb/openfire_sqlserver.sql
       - name: Start database server and install database
         run: docker-compose -f ./build/ci/compose/mssql.yml up --detach
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Build & run update tester
         run: |
           pushd ./build/ci/updater
@@ -271,13 +264,6 @@ jobs:
           curl https://raw.githubusercontent.com/igniterealtime/Openfire/v3.9.3/src/database/openfire_postgresql.sql > $GITHUB_WORKSPACE/olddb/openfire_postgresql.sql
       - name: Start database server and install database
         run: docker-compose -f ./build/ci/compose/postgresql.yml up --detach
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Build & run update tester
         run: |
           pushd ./build/ci/updater
@@ -314,13 +300,6 @@ jobs:
           curl https://raw.githubusercontent.com/igniterealtime/Openfire/v3.9.3/src/database/openfire_mysql.sql > $GITHUB_WORKSPACE/olddb/openfire_mysql.sql
       - name: Start database server and install database
         run: docker-compose -f ./build/ci/compose/mysql.yml up --detach
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Build & run update tester
         run: |
           pushd ./build/ci/updater


### PR DESCRIPTION
setup-java now includes caches, so the separate cache steps are redundant