### PR TITLE
OF-2781 & OF-2782: Bugfixes for SerializingCache

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -514,18 +514,18 @@ public class CacheFactory {
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2239">Issue OF-2239: Make it easier to cache plugin class instances</a>
      */
     @SuppressWarnings("unchecked")
-    public static synchronized SerializingCache createSerializingCache(String name, Class keyClass, Class valueClass) {
-        SerializingCache cache = (SerializingCache) caches.get(name);
+    public static synchronized <T extends Cache> T createSerializingCache(String name, Class keyClass, Class valueClass) {
+        T cache = (T) caches.get(name);
         if (cache != null) {
             return cache;
         }
 
         final Cache<String, String> delegate = (Cache<String, String>) cacheFactoryStrategy.createCache(name);
-        cache = new SerializingCache(delegate, keyClass, valueClass);
+        final T sCache = (T) new SerializingCache(delegate, keyClass, valueClass);
 
         log.info("Created serializing cache [" + cacheFactoryStrategy.getClass().getName() + "] for " + name);
 
-        return wrapCache(cache, name);
+        return wrapCache(sCache, name);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -943,7 +943,11 @@ public class CacheFactory {
             .filter(CacheFactory::isClusterableCache)
             .forEach(cache -> {
                 final CacheWrapper cacheWrapper = ((CacheWrapper) cache);
-                final Cache clusteredCache = cacheFactoryStrategy.createCache(cacheWrapper.getName());
+                Cache clusteredCache = cacheFactoryStrategy.createCache(cacheWrapper.getName());
+                if (cacheWrapper.getWrappedCache() instanceof SerializingCache) {
+                    final SerializingCache serializingCache = (SerializingCache) cacheWrapper.getWrappedCache();
+                    clusteredCache = new SerializingCache(clusteredCache, serializingCache.getKeyClass(), serializingCache.getValueClass());
+                }
                 cacheWrapper.setWrappedCache(clusteredCache);
             });
         clusteringStarting = false;
@@ -964,7 +968,11 @@ public class CacheFactory {
             .filter(CacheFactory::isClusterableCache)
             .forEach(cache -> {
                 final CacheWrapper cacheWrapper = ((CacheWrapper) cache);
-                final Cache standaloneCache = cacheFactoryStrategy.createCache(cacheWrapper.getName());
+                Cache standaloneCache = cacheFactoryStrategy.createCache(cacheWrapper.getName());
+                if (cacheWrapper.getWrappedCache() instanceof SerializingCache) {
+                    final SerializingCache serializingCache = (SerializingCache) cacheWrapper.getWrappedCache();
+                    standaloneCache = new SerializingCache(standaloneCache, serializingCache.getKeyClass(), serializingCache.getValueClass());
+                }
                 cacheWrapper.setWrappedCache(standaloneCache);
             });
         log.info("Clustering stopped; cache migration complete");

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/SerializingCache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/SerializingCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,8 @@ public class SerializingCache<K extends Serializable, V extends Serializable> im
     private final Cache<String, String> delegate;
     private final Marshaller marshaller;
     private final Unmarshaller unmarshaller;
+    private final Class<K> keyClass;
+    private final Class<V> valueClass;
 
     /**
      * Creates a new serializing cache backed by the provided delegate.
@@ -78,6 +80,8 @@ public class SerializingCache<K extends Serializable, V extends Serializable> im
             final JAXBContext jaxbContext = JAXBContext.newInstance(keyClass, valueClass);
             marshaller = jaxbContext.createMarshaller();
             unmarshaller = jaxbContext.createUnmarshaller();
+            this.keyClass = keyClass;
+            this.valueClass = valueClass;
         } catch (JAXBException e) {
             throw new IllegalArgumentException("Unable to create a cache using classes " + keyClass + " and " + valueClass, e);
         }
@@ -111,6 +115,18 @@ public class SerializingCache<K extends Serializable, V extends Serializable> im
                 throw new IllegalArgumentException("XML value could not be unmarshalled into an object: " + object);
             }
         }
+    }
+
+    @Nonnull
+    public Class<K> getKeyClass()
+    {
+        return keyClass;
+    }
+
+    @Nonnull
+    public Class<V> getValueClass()
+    {
+        return valueClass;
     }
 
     @Override

--- a/xmppserver/src/test/java/org/jivesoftware/util/cache/CacheFactoryTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/cache/CacheFactoryTest.java
@@ -146,4 +146,24 @@ public class CacheFactoryTest
         assertSame(resultA, resultB);
         assertInstanceOf(SerializingCache.class, ((CacheWrapper) resultB).getWrappedCache());
     }
+
+    /**
+     * Verifies that after the JVM left the cluster (at which point the cache implementations are swapped) a Serializing
+     * Cache remains a Serializing Cache.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2782">OF-2782</a>
+     */
+    @Test
+    public void testSerializingCacheRetainsTypeAfterLeftCluster() throws Exception
+    {
+        // Setup test fixture.
+        final String name = "unittest-serializingcache-leftcluster";
+        final CacheWrapper cache = CacheFactory.createSerializingCache(name, String.class, String.class);
+
+        // Execute system under test.
+        CacheFactory.leftCluster();
+
+        // Verify results.
+        assertInstanceOf(SerializingCache.class, cache.getWrappedCache());
+    }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/util/cache/CacheFactoryTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/cache/CacheFactoryTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.util.cache;
+
+import org.jivesoftware.util.InitializationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests that verify the implemention of {@link CacheFactory}
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class CacheFactoryTest
+{
+    @BeforeEach
+    public void initCacheFactory() throws InitializationException
+    {
+        CacheFactory.initialize();
+        clearCacheFactory();
+    }
+
+    @AfterEach
+    public void clearCacheFactory() {
+        Cache[] caches = CacheFactory.getAllCaches();
+        for (Cache cache: caches) {
+            CacheFactory.destroyCache(cache.getName());
+        }
+    }
+
+    /**
+     * Asserts that a cache can be created.
+     */
+    @Test
+    public void testCacheCreation() throws Exception
+    {
+        // Setup test fixture.
+
+        // Execute system under test.
+        final Cache result = CacheFactory.createCache("unittest-cache-creation");
+
+        // Verify results.
+        assertNotNull(result);
+    }
+
+    /**
+     * Asserts that a previously created cache is returned on subsequent invocations of the creation method.
+     */
+    @Test
+    public void testCacheRecreation() throws Exception
+    {
+        // Setup test fixture.
+        final String name = "unittest-cache-recreation";
+
+        // Execute system under test.
+        final Cache resultA = CacheFactory.createCache(name);
+        final Cache resultB = CacheFactory.createCache(name);
+
+        // Verify results.
+        assertNotNull(resultB);
+        assertSame(resultA, resultB);
+    }
+
+    /**
+     * Asserts that a local cache can be created.
+     */
+    @Test
+    public void testLocalCacheCreation() throws Exception
+    {
+        // Setup test fixture.
+
+        // Execute system under test.
+        final Cache result = CacheFactory.createLocalCache("unittest-localcache-creation");
+
+        // Verify results.
+        assertNotNull(result);
+    }
+
+    /**
+     * Asserts that a previously created local cache is returned on subsequent invocations of the creation method.
+     */
+    @Test
+    public void testLocalCacheRecreation() throws Exception
+    {
+        // Setup test fixture.
+        final String name = "unittest-localcache-recreation";
+
+        // Execute system under test.
+        final Cache resultA = CacheFactory.createLocalCache(name);
+        final Cache resultB = CacheFactory.createLocalCache(name);
+
+        // Verify results.
+        assertNotNull(resultB);
+        assertSame(resultA, resultB);
+    }
+
+    /**
+     * Asserts that a serializing cache can be created.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2781">OF-2781</a>
+     */
+    @Test
+    public void testSerializingCacheCreation() throws Exception
+    {
+        // Setup test fixture.
+
+        // Execute system under test.
+        final Cache result = CacheFactory.createSerializingCache("unittest-serializingcache-creation", String.class, String.class);
+
+        // Verify results.
+        assertNotNull(result);
+        assertInstanceOf(SerializingCache.class, ((CacheWrapper) result).getWrappedCache());
+    }
+
+    /**
+     * Asserts that a previously created serializing cache is returned on subsequent invocations of the creation method.
+     */
+    @Test
+    public void testSerializingCacheRecreation() throws Exception
+    {
+        // Setup test fixture.
+        final String name = "unittest-serializingcache-recreation";
+
+        // Execute system under test.
+        final Cache resultA = CacheFactory.createSerializingCache(name, String.class, String.class);
+        final Cache resultB = CacheFactory.createSerializingCache(name, String.class, String.class);
+
+        // Verify results.
+        assertNotNull(resultB);
+        assertSame(resultA, resultB);
+        assertInstanceOf(SerializingCache.class, ((CacheWrapper) resultB).getWrappedCache());
+    }
+}


### PR DESCRIPTION
The newly created cache gets wrapped (so that its implementation can be changed on the fly, when clustering starts or stops). The previous implementation caused a ClassCastException that is herein prevented.