### PR TITLE
OF-2788 & OF-2651: Netty threadpool usage

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -349,8 +349,6 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 Log.error( "An exception occurred while stopping listener " + listener, ex );
             }
         }
-
-        NettyConnectionAcceptor.shutdownEventLoopGroups();
 
         // Stop the HTTP client listener.
         try

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
@@ -43,12 +43,6 @@ import java.util.Set;
 
 public class ConnectionManagerImpl extends BasicModule implements ConnectionManager, CertificateEventListener, PropertyEventListener
 {
-    public static final String EXECUTOR_FILTER_NAME = "threadModel";
-    public static final String TLS_FILTER_NAME = "tls";
-    public static final String STARTTLS_FILTER_NAME = "startTls";
-    public static final String COMPRESSION_FILTER_NAME = "compression";
-    public static final String XMPP_CODEC_FILTER_NAME = "xmpp";
-    public static final String CAPACITY_FILTER_NAME = "outCap";
 
     private static final Logger Log = LoggerFactory.getLogger(ConnectionManagerImpl.class);
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyConnectionAcceptor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyConnectionAcceptor.java
@@ -29,12 +29,14 @@ import io.netty.util.concurrent.GlobalEventExecutor;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.nio.NettyChannelHandlerFactory;
 import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import static org.jivesoftware.openfire.nio.NettyConnection.SSL_HANDLER_NAME;
@@ -96,7 +98,8 @@ public class NettyConnectionAcceptor extends ConnectionAcceptor {
 
         String name = configuration.getType().toString().toLowerCase() + (isDirectTLSConfigured() ? "_ssl" : "");
 
-        childGroup = new NioEventLoopGroup(configuration.getMaxThreadPoolSize());
+        final ThreadFactory threadFactory = new NamedThreadFactory( name + "-thread-", null, true, null );
+        childGroup = new NioEventLoopGroup(configuration.getMaxThreadPoolSize(), threadFactory);
 
         Log = LoggerFactory.getLogger( NettyConnectionAcceptor.class.getName() + "[" + name + "]" );
     }


### PR DESCRIPTION
Fixes for two related issues. As with MINA, Netty _should_ use a distinct thread pool for processing data of a particular connection type (OF-2788). The threads that are used should be aptly named (OF-2651)