### PR TITLE
OF-2792: Admin Console Cache Summary page improvements

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheWrapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,11 @@ public class CacheWrapper<K extends Serializable, V extends Serializable> implem
     }
 
     @Override
+    public CapacityUnit getCapacityUnit() {
+        return cache.getCapacityUnit();
+    }
+
+    @Override
     public String getName() {
         return cache.getName();
     }
@@ -67,6 +72,11 @@ public class CacheWrapper<K extends Serializable, V extends Serializable> implem
     }
 
     @Override
+    public String getMaxCacheSizeRemark() {
+        return cache.getMaxCacheSizeRemark();
+    }
+
+    @Override
     public long getMaxLifetime() {
         return cache.getMaxLifetime();
     }
@@ -78,6 +88,11 @@ public class CacheWrapper<K extends Serializable, V extends Serializable> implem
 
     public long getLongCacheSize(){
         return cache.getLongCacheSize();
+    }
+
+    @Override
+    public String getCacheSizeRemark() {
+        return cache.getCacheSizeRemark();
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CaffeineCache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CaffeineCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,17 @@ public class CaffeineCache<K extends Serializable, V extends Serializable> imple
         }
         this.cache = cache;
         this.name = name;
+    }
+
+    /**
+     * Defines the unit used to calculate the capacity of the cache, which for all instances of this class is byte-size
+     * based.
+     *
+     * @return the unit to be used to calculate the capacity of this cache, which will be {@link CapacityUnit#BYTES}.
+     */
+    @Override
+    public CapacityUnit getCapacityUnit() {
+        return CapacityUnit.BYTES;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultCache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -336,6 +336,17 @@ public class DefaultCache<K extends Serializable, V extends Serializable> implem
         synchronized (this) {
             return new HashSet<>(map.keySet());
         }
+    }
+
+    /**
+     * Defines the unit used to calculate the capacity of the cache, which for all instances of this class is byte-size
+     * based.
+     *
+     * @return the unit to be used to calculate the capacity of this cache, which will be {@link CapacityUnit#BYTES}.
+     */
+    @Override
+    public CapacityUnit getCapacityUnit() {
+        return CapacityUnit.BYTES;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/SerializingCache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/SerializingCache.java
@@ -269,6 +269,11 @@ public class SerializingCache<K extends Serializable, V extends Serializable> im
     }
 
     @Override
+    public CapacityUnit getCapacityUnit() {
+        return delegate.getCapacityUnit();
+    }
+
+    @Override
     public String getName() {
         return delegate.getName();
     }
@@ -293,12 +298,23 @@ public class SerializingCache<K extends Serializable, V extends Serializable> im
     }
 
     @Override
+    public String getCacheSizeRemark() {
+        return delegate.getCacheSizeRemark();
+    }
+
+    @Override
     public long getMaxCacheSize() {
         return delegate.getMaxCacheSize();
     }
 
+    @Override
     public void setMaxCacheSize(long maxSize){
         delegate.setMaxCacheSize(maxSize);
+    }
+
+    @Override
+    public String getMaxCacheSizeRemark() {
+        return delegate.getMaxCacheSizeRemark();
     }
 
     @Override

--- a/xmppserver/src/main/webapp/system-cache.jsp
+++ b/xmppserver/src/main/webapp/system-cache.jsp
@@ -157,13 +157,13 @@
 <table>
 <thead>
     <tr>
-        <th style="width: 39%" nowrap><fmt:message key="system.cache.head.name" /></th>
-        <th style="width: 10%" nowrap><fmt:message key="system.cache.head.max" /></th>
-        <th style="width: 10%" nowrap><fmt:message key="system.cache.head.lifetime" /></th>
-        <th style="width: 10%; text-align: center;" nowrap colspan="2"><fmt:message key="system.cache.head.current" /></th>
-        <th style="width: 10%" nowrap><fmt:message key="system.cache.head.percent" /></th>
-        <th style="width: 20%; text-align: center;" colspan="2"><fmt:message key="system.cache.head.effectiveness" /></th>
-        <th style="width: 20%; text-align: center;" nowrap><fmt:message key="system.cache.head.culls" /><br/>3/6/12 <fmt:message key="global.hours" /></th>
+        <th><fmt:message key="system.cache.head.name" /></th>
+        <th nowrap><fmt:message key="system.cache.head.max" /></th>
+        <th nowrap><fmt:message key="system.cache.head.lifetime" /></th>
+        <th style="text-align: center;" nowrap colspan="2"><fmt:message key="system.cache.head.current" /></th>
+        <th nowrap><fmt:message key="system.cache.head.percent" /></th>
+        <th style="text-align: center;" colspan="2"><fmt:message key="system.cache.head.effectiveness" /></th>
+        <th style="text-align: center;" nowrap><fmt:message key="system.cache.head.culls" /><br/>3/6/12 <fmt:message key="global.hours" /></th>
         <th style="width: 1%" class="c5"><input type="checkbox" name="" value="" onclick="handleCBClick(this);"></th>
     </tr>
 </thead>
@@ -320,7 +320,7 @@
     <td class="c2">
         <%= new DecimalFormat("#0.00").format(overallTotal/(1024.0*1024.0)) %> MB
     </td>
-    <td style="text-align: right" colspan="7">
+    <td style="text-align: right" colspan="8">
         <input type="submit" name="clear" value="<fmt:message key="system.cache.clear-selected" />" disabled>
     </td>
 </tr>


### PR DESCRIPTION
When clustering the 'Cache Summary' page in the admin console should provide a correct overview of the state of the caches. With the commits in this PR, this is improved (but not _fixed_ - for that, a change in the Hazelcast plugin is needed).

Please refer to https://igniterealtime.atlassian.net/browse/OF-2792 for details on the problem.

The commit message of the second commit describes the most relevant changes.

This is a screenshot of the admin console, with the changes in this PR, but without an updated Hazelcast plugin:
![image](https://github.com/igniterealtime/Openfire/assets/4253898/cca6f583-7193-4375-bfe7-849f59604380)
