### PR TITLE
OF-2778: Fix for Carbons in context of MUC

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/forward/Forwarded.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/forward/Forwarded.java
@@ -123,6 +123,11 @@ public class Forwarded extends PacketExtension {
             }
         }
 
+        // A <message/> of type "groupchat" SHOULD NOT be carbon-copied.
+        if (stanza.getType() == Message.Type.groupchat) {
+            return false;
+        }
+
         // A <message/> is eligible for carbons delivery if it does not contain a <private/> child element...
         if (containsChildElement(stanza, Set.of("private", "received"), "urn:xmpp:carbons"))
         {
@@ -151,11 +156,6 @@ public class Forwarded extends PacketExtension {
 
         // ... it is of type "error" and it was sent in response to a <message/> that was eligible for carbons delivery.
         // TODO implement me (OF-2779)
-
-        // A <message/> of type "groupchat" SHOULD NOT be carbon-copied.
-        if (stanza.getType() == Message.Type.groupchat) {
-            return false;
-        }
 
         return false;
     }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/forward/ForwardedTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/forward/ForwardedTest.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.forward;
 
+import org.dom4j.DocumentHelper;
 import org.jivesoftware.Fixtures;
 import org.jivesoftware.openfire.XMPPServer;
 import org.junit.jupiter.api.BeforeEach;
@@ -156,6 +157,44 @@ public class ForwardedTest
         // Setup test fixture.
         final Message input = new Message();
         input.setType(Message.Type.groupchat);
+
+        // Execute system under test.
+        final boolean result = Forwarded.isEligibleForCarbonsDelivery(input);
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    /**
+     * Asserts that a message of type 'groupchat' is not eligible for Carbons delivery.
+     *
+     * The stanza that's the input of the text is taken from a real-world stanza. This intends to make test coverage
+     * more conform real-world scenario's than the basic test in {@link #testMucGroupChat()}
+     */
+    @Test
+    public void testMucGroupChatRawData() throws Exception
+    {
+        // Setup test fixture.
+        final String raw = "<message xmlns=\"jabber:client\" to=\"john@example.org/barfoo\" type=\"groupchat\" id=\"7cb29947-fda2-4a44-b349-ec83fbbf062f\" from=\"room1@muc.example.org/Johnny\">\n" +
+            "        <active xmlns=\"http://jabber.org/protocol/chatstates\" />\n" +
+            "        <markable xmlns=\"urn:xmpp:chat-markers:0\" />\n" +
+            "        <origin-id xmlns=\"urn:xmpp:sid:0\" id=\"7cb29947-fda2-4a44-b349-ec83fbbf062f\" />\n" +
+            "        <encrypted xmlns=\"eu.siacs.conversations.axolotl\">\n" +
+            "          <header sid=\"12121212\">\n" +
+            "            <key rid=\"2334343434\">MOCK-TESTDATA</key>\n" +
+            "            <iv>TESTTEST</iv>\n" +
+            "</header>\n" +
+            "          <payload>TEST</payload>\n" +
+            "</encrypted>\n" +
+            "        <encryption xmlns=\"urn:xmpp:eme:0\" name=\"OMEMO\" namespace=\"eu.siacs.conversations.axolotl\" />\n" +
+            "        <body>You received a message encrypted with OMEMO but your client doesn't support OMEMO.</body>\n" +
+            "        <store xmlns=\"urn:xmpp:hints\" />\n" +
+            "        <stanza-id xmlns=\"urn:xmpp:sid:0\" id=\"d9c123d0-8738-40be-a1a3-497435e0761d\" by=\"room1@muc.example.org\" />\n" +
+            "        <addresses xmlns=\"http://jabber.org/protocol/address\">\n" +
+            "          <address type=\"ofrom\" jid=\"john@example.org\" />\n" +
+            "</addresses>\n" +
+            "</message>\n";
+        final Message input = new Message(DocumentHelper.parseText(raw).getRootElement());
 
         // Execute system under test.
         final boolean result = Forwarded.isEligibleForCarbonsDelivery(input);


### PR DESCRIPTION
Code should first evaluate disqualifiers, before qualifiers. Added a unit test based on a real-world example that exposes the problem with the original code.