### PR TITLE
OF-2795 / OF-2166: Remove MUC affiliation of a user that is being deleted.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ import com.google.common.collect.Multimap;
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.database.SequenceManager;
 import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.openfire.cluster.ClusterEventListener;
-import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.container.BasicModule;
 import org.jivesoftware.openfire.event.UserEventDispatcher;
 import org.jivesoftware.openfire.event.UserEventListener;
@@ -48,11 +46,7 @@ import org.xmpp.packet.JID;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -957,10 +951,11 @@ public class MultiUserChatManager extends BasicModule implements MUCServicePrope
 
     @Override
     public void userDeleting(User user, Map<String, Object> params) {
-        // Delete any affiliation of the user to any room of any MUC service
+        // When a user is being deleted, all its affiliations need to be removed from chat rooms (OF-2166). Note that
+        // every room is an event listener for the same event, which should update rooms that are loaded into memory
+        // from the database. This event handler intends to update rooms that are not in memory, but only in the database.
         MUCPersistenceManager
                 .removeAffiliationFromDB(XMPPServer.getInstance().createJID(user.getUsername(), null, true));
-        // TODO Delete any user information from the rooms loaded into memory (OF-2166)
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2016-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.cluster.ClusteredCacheEntryListener;
 import org.jivesoftware.openfire.cluster.NodeID;
 import org.jivesoftware.openfire.event.GroupEventDispatcher;
+import org.jivesoftware.openfire.event.UserEventDispatcher;
 import org.jivesoftware.openfire.muc.MUCRole;
 import org.jivesoftware.openfire.muc.MUCRoom;
 import org.jivesoftware.openfire.muc.MultiUserChatService;
@@ -36,14 +37,7 @@ import org.xmpp.packet.Presence;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.Duration;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 
@@ -160,6 +154,7 @@ public class LocalMUCRoomManager
         }
 
         GroupEventDispatcher.addListener(room); // TODO this event listener is added only in the node where the room is created. Does this mean that events are not propagated in a cluster?
+        UserEventDispatcher.addListener(room);
     }
 
     /**
@@ -234,6 +229,7 @@ public class LocalMUCRoomManager
             if (room != null) {
                 room.getRoomHistory().purge();
                 GroupEventDispatcher.removeListener(room);
+                UserEventDispatcher.removeListener(room);
                 updateNonPersistentRoomStat(room, null);
             }
             localRooms.remove(roomName);


### PR DESCRIPTION
This prevents a new user by the same name to claim the affiliation.

I've not yet found the time to test these changes. I'd appreciate someone stepping up to help out with that.

I am somewhat worried about the performance of this solution in a big cluster full of chat rooms. Suggestions to improve on this are welcome.