### PR TITLE
Implement identity mapping CN with prefix and suffix

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/cert/CustomizedCNCertificateIdentityMapping.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cert/CustomizedCNCertificateIdentityMapping.java
@@ -1,0 +1,43 @@
+package org.jivesoftware.util.cert;
+
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.cert.CNCertificateIdentityMapping;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Certificate identity mapping that uses the CommonName as the
+ * identity credentials and provides possibility to add optional prefix and suffix
+ *
+ */
+public class CustomizedCNCertificateIdentityMapping extends CNCertificateIdentityMapping {
+
+    private final String prefix;
+    private final String suffix;
+
+    public CustomizedCNCertificateIdentityMapping(){
+        prefix = JiveGlobals.getProperty("provider.clientCertIdentityMap.customized.prefix", "");
+        suffix = JiveGlobals.getProperty("provider.clientCertIdentityMap.customized.suffix", "");
+    }
+
+    /**
+     * Maps certificate CommonName as identity credentials with optional prefix and/or suffix.
+     * Prefix and suffix are specified by properties. Default value is an empty string.
+     * @param certificate the certificates to map
+     * @return A List of customized names.
+     */
+    @Override
+    public List<String> mapIdentity(X509Certificate certificate) {
+        return super.mapIdentity(certificate)
+            .stream()
+            .map(name -> prefix + name + suffix)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public String name() {
+        return "Customized Common Name Mapping";
+    }
+}


### PR DESCRIPTION
Implement a class to map identities from client certificate CN with customizable and optional prefix and suffix. Format of Identity returned is `<prefix><CN><suffix>`.

The mapper can be configured by existing property:
`provider.serverCertIdentityMap.classList`

Prefix and suffix can be optionally specified using the properties:
```
provider.clientCertIdentityMap.customized.prefix
provider.clientCertIdentityMap.customized.suffix
```
Default value is an empty string in both cases.
