### PR TITLE
OF-2799: MUC occupant management for federated users in a cluster

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ import com.google.common.collect.Multimap;
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.database.SequenceManager;
 import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.openfire.cluster.ClusterEventListener;
-import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.container.BasicModule;
 import org.jivesoftware.openfire.event.UserEventDispatcher;
 import org.jivesoftware.openfire.event.UserEventListener;
@@ -48,11 +46,7 @@ import org.xmpp.packet.JID;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -990,8 +984,9 @@ public class MultiUserChatManager extends BasicModule implements MUCServicePrope
             .map(mucService -> ConsistencyChecks.generateReportForMucRooms(
                 mucService.getLocalMUCRoomManager().getROOM_CACHE(),
                 mucService.getLocalMUCRoomManager().getLocalRooms(),
-                mucService.getOccupantManager().getOccupantsByNode(),
-                mucService.getOccupantManager().getNodesByOccupant(),
+                mucService.getOccupantManager().getLocalOccupantsByNode(),
+                mucService.getOccupantManager().getNodeByLocalOccupant(),
+                mucService.getOccupantManager().getFederatedOccupants(),
                 mucService.getServiceName()
             )).collect(Collectors.toList());
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/SyncLocalOccupantsAndSendJoinPresenceTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/cluster/SyncLocalOccupantsAndSendJoinPresenceTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import java.util.Set;
 /**
  * Task that is used by a cluster node to inform other cluster nodes of its local occupants. This is intended to be used
  * by a node that is joining a cluster (to send its local occupants to all other nodes), and by nodes in an existing
- * cluster that detect a new node joining (to send their local occupants to the joining node.
+ * cluster that detect a new node joining (to send their local occupants to the joining node).
  *
  * @author Guus der Kinderen
  */

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
@@ -550,12 +550,8 @@ public class ConsistencyChecks {
         result.put("info", String.format("RoutingTable's getClientsRoutes response is used to track 'local' data to be restored after a cache switch-over. It tracks %d session infos.", localSessionInfosJids.size()));
         result.put("info", String.format("The field sessionInfosByClusterNode is used to track data in the cache from every other cluster node. It contains %d routes for %d cluster nodes.", sessionInfoKeysByClusterNode.values().stream().reduce(0, (subtotal, values) -> subtotal + values.size(), Integer::sum), sessionInfoKeysByClusterNode.size()));
 
-        result.put("data", String.format("%s contains these entries (these are shared in the cluster):\n%s", sessionInfoCache.getName(), cache.keySet()
-            .stream()
-            .collect(Collectors.joining("\n"))));
-        result.put("data", String.format("RoutingTable's getClientsRoutes contains these entries (these represent 'local' data):\n%s", localSessionInfosJids
-            .stream()
-            .collect(Collectors.joining("\n"))));
+        result.put("data", String.format("%s contains these entries (these are shared in the cluster):\n%s", sessionInfoCache.getName(), String.join("\n", cache.keySet())));
+        result.put("data", String.format("RoutingTable's getClientsRoutes contains these entries (these represent 'local' data):\n%s", String.join("\n", localSessionInfosJids)));
         result.put("data", String.format("sessionInfosByClusterNode contains these entries (these represent 'remote' data):\n%s", String.join("\n", remoteSessionInfosJidsWithNodeId)));
 
         if (!sessionInfoKeysByClusterNode.containsKey(XMPPServer.getInstance().getNodeID())) {
@@ -573,19 +569,19 @@ public class ConsistencyChecks {
         if (localSessionInfosDuplicates.isEmpty()) {
             result.put("pass", "There is no overlap in local session infos (they are all unique values).");
         } else {
-            result.put("fail", String.format("There is overlap in local session infos (they are not all unique values). These %d values are duplicated: %s", localSessionInfosDuplicates.size(), localSessionInfosDuplicates.stream().collect(Collectors.joining(", "))));
+            result.put("fail", String.format("There is overlap in local session infos (they are not all unique values). These %d values are duplicated: %s", localSessionInfosDuplicates.size(), String.join(", ", localSessionInfosDuplicates)));
         }
 
         if (remoteSessionInfosDuplicates.isEmpty()) {
             result.put("pass", "There is no overlap in sessionInfosByClusterNode (they are all unique values).");
         } else {
-            result.put("fail", String.format("There is overlap in sessionInfosByClusterNode (they are not all unique values). These %d values are duplicated: %s", remoteSessionInfosDuplicates.size(), remoteSessionInfosDuplicates.stream().collect(Collectors.joining(", "))));
+            result.put("fail", String.format("There is overlap in sessionInfosByClusterNode (they are not all unique values). These %d values are duplicated: %s", remoteSessionInfosDuplicates.size(), String.join(", ", remoteSessionInfosDuplicates)));
         }
 
         if (sessionInfosBothLocalAndRemote.isEmpty()) {
             result.put("pass", "There are no elements that are both 'remote' (in sessionInfosByClusterNode) as well as 'local' (in SessionManager's localSessionManager).");
         } else {
-            result.put("fail", String.format("There are %d elements that are both 'remote' (in sessionInfosByClusterNode) as well as 'local' (in SessionManager's localSessionManager): %s", sessionInfosBothLocalAndRemote.size(), sessionInfosBothLocalAndRemote.stream().collect(Collectors.joining(", "))));
+            result.put("fail", String.format("There are %d elements that are both 'remote' (in sessionInfosByClusterNode) as well as 'local' (in SessionManager's localSessionManager): %s", sessionInfosBothLocalAndRemote.size(), String.join(", ", sessionInfosBothLocalAndRemote)));
         }
 
         if (!ClusterManager.isClusteringStarted()) {
@@ -596,19 +592,19 @@ public class ConsistencyChecks {
             if (nonCachedLocalSessionInfos.isEmpty()) {
                 result.put("pass", String.format("All elements in SessionManager's localSessionManager exist in %s.", sessionInfoCache.getName()));
             } else {
-                result.put("fail", String.format("Not all elements in SessionManager's localSessionManager exist in %s. These %d entries do not: %s", sessionInfoCache.getName(), nonCachedLocalSessionInfos.size(), nonCachedLocalSessionInfos.stream().collect(Collectors.joining(", "))));
+                result.put("fail", String.format("Not all elements in SessionManager's localSessionManager exist in %s. These %d entries do not: %s", sessionInfoCache.getName(), nonCachedLocalSessionInfos.size(), String.join(", ", nonCachedLocalSessionInfos)));
             }
 
             if (nonCachedRemoteSessionInfos.isEmpty()) {
                 result.put("pass", String.format("All elements in sessionInfosByClusterNode exist in %s.", sessionInfoCache.getName()));
             } else {
-                result.put("fail", String.format("Not all elements in sessionInfosByClusterNode exist in %s. These %d entries do not: %s", sessionInfoCache.getName(), nonCachedRemoteSessionInfos.size(), nonCachedRemoteSessionInfos.stream().collect(Collectors.joining(", "))));
+                result.put("fail", String.format("Not all elements in sessionInfosByClusterNode exist in %s. These %d entries do not: %s", sessionInfoCache.getName(), nonCachedRemoteSessionInfos.size(), String.join(", ", nonCachedRemoteSessionInfos)));
             }
 
             if (nonLocallyStoredCachedSessionInfos.isEmpty()) {
                 result.put("pass", String.format("All cache entries of %s exist in sessionInfosByClusterNode and/or RoutingTable's getClientsRoutes.", sessionInfoCache.getName()));
             } else {
-                result.put("fail", String.format("Not all cache entries of %s exist in sessionInfosByClusterNode and/or RoutingTable's getClientsRoutes. These %d entries do not: %s", sessionInfoCache.getName(), nonLocallyStoredCachedSessionInfos.size(), nonLocallyStoredCachedSessionInfos.stream().collect(Collectors.joining(", "))));
+                result.put("fail", String.format("Not all cache entries of %s exist in sessionInfosByClusterNode and/or RoutingTable's getClientsRoutes. These %d entries do not: %s", sessionInfoCache.getName(), nonLocallyStoredCachedSessionInfos.size(), String.join(", ", nonLocallyStoredCachedSessionInfos)));
             }
         }
 
@@ -620,8 +616,6 @@ public class ConsistencyChecks {
         @Nonnull final Cache<String, ClientRoute> usersCache,
         @Nonnull final Cache<String, ClientRoute> anonymousUsersCache
     ) {
-        final Set<NodeID> clusterNodeIDs = ClusterManager.getNodesInfo().stream().map(ClusterNodeInfo::getNodeID).collect(Collectors.toSet());
-
         // Take snapshots of all data structures at as much the same time as possible.
         final ConcurrentMap<String, HashSet<String>> cache = new ConcurrentHashMap<>(usersSessionsCache);
         final Set<String> usersCacheKeys = usersCache.keySet();
@@ -706,9 +700,6 @@ public class ConsistencyChecks {
         final ConcurrentMap<OccupantManager.Occupant, NodeID> nodeByOccupant = new ConcurrentHashMap<>(nodeByOccupantInput);
         final Set<OccupantManager.Occupant> federatedOccupants = new HashSet<>(federatedOccupantsInput);
 
-        final List<String> allRoomNames = new ArrayList<>(cache.keySet());
-        Collections.sort(allRoomNames);
-
         final Set<String> roomsOnlyInLocalCache = localRoomsCache.keySet().stream().filter(jid -> !cache.containsKey(jid)).collect(Collectors.toSet());
 
         final Set<OccupantManager.Occupant> allOccupantsFromOccupantsByNode = occupantsByNode.values().stream()
@@ -761,14 +752,12 @@ public class ConsistencyChecks {
         result.put("intro", String.format("This section concerns the '%s' muc service.", mucServiceName));
         result.put("info", String.format("The cache named %s is used to share data in the cluster, which contains %d muc rooms.", clusteredRoomCacheInput.getName(), cache.size()));
 
-        result.put("data", String.format("%s contains these entries (these are shared in the cluster):\n%s", clusteredRoomCacheInput.getName(), cache.entrySet()
+        result.put("data", String.format("%s contains these entries (these are shared in the cluster):\n%s", clusteredRoomCacheInput.getName(), cache.keySet()
             .stream()
-            .map(Map.Entry::getKey)
             .sorted()
             .collect(Collectors.joining("\n"))));
-        result.put("data", String.format("Local rooms cache contains these entries :\n%s", localRoomsCache.entrySet()
+        result.put("data", String.format("Local rooms cache contains these entries :\n%s", localRoomsCache.keySet()
             .stream()
-            .map(Map.Entry::getKey)
             .sorted()
             .collect(Collectors.joining("\n"))));
         result.put("data", String.format("All non-federated occupants from occupant registration :\n%s", String.join("\n", allNonFederatedOccupantsJids)));

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -694,7 +694,8 @@ public class ConsistencyChecks {
         @Nonnull final Cache<String, MUCRoom> clusteredRoomCacheInput,
         @Nonnull final Map<String, MUCRoom> localRoomsInput,
         @Nonnull final Map<NodeID, Set<OccupantManager.Occupant>> occupantsByNodeInput,
-        @Nonnull final Map<OccupantManager.Occupant, Set<NodeID>> nodesByOccupantInput,
+        @Nonnull final Map<OccupantManager.Occupant, NodeID> nodeByOccupantInput,
+        @Nonnull final Set<OccupantManager.Occupant> federatedOccupantsInput,
         @Nonnull final String mucServiceName
     ) {
 
@@ -702,7 +703,8 @@ public class ConsistencyChecks {
         final ConcurrentMap<String, MUCRoom> cache = new ConcurrentHashMap<>(clusteredRoomCacheInput);
         final ConcurrentMap<String, MUCRoom> localRoomsCache = new ConcurrentHashMap<>(localRoomsInput);
         final ConcurrentMap<NodeID, Set<OccupantManager.Occupant>> occupantsByNode = new ConcurrentHashMap<>(occupantsByNodeInput);
-        final ConcurrentMap<OccupantManager.Occupant, Set<NodeID>> nodesByOccupant = new ConcurrentHashMap<>(nodesByOccupantInput);
+        final ConcurrentMap<OccupantManager.Occupant, NodeID> nodeByOccupant = new ConcurrentHashMap<>(nodeByOccupantInput);
+        final Set<OccupantManager.Occupant> federatedOccupants = new HashSet<>(federatedOccupantsInput);
 
         final List<String> allRoomNames = new ArrayList<>(cache.keySet());
         Collections.sort(allRoomNames);
@@ -712,7 +714,7 @@ public class ConsistencyChecks {
         final Set<OccupantManager.Occupant> allOccupantsFromOccupantsByNode = occupantsByNode.values().stream()
             .flatMap(Collection::stream)
             .collect(Collectors.toSet());
-        final Set<OccupantManager.Occupant> allOccupantsFromNodesByOccupant = nodesByOccupant.keySet();
+        final Set<OccupantManager.Occupant> allOccupantsFromNodesByOccupant = nodeByOccupant.keySet();
 
         final Set<OccupantManager.Occupant> occupantsByNodeNotPresentInNodesByOccupant = allOccupantsFromOccupantsByNode.stream()
             .filter(o -> !allOccupantsFromNodesByOccupant.contains(o))

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
@@ -782,7 +782,7 @@ public class ConsistencyChecks {
             result.put("fail", String.format("The registration of occupants by node is missing entries that are present in the registration of nodes by occupant. These %d entries are missing: %s", occupantsNotPresentInOccupantsByNode.size(), occupantsNotPresentInOccupantsByNode.stream().map(OccupantManager.Occupant::getNickname).collect(Collectors.joining(", "))));
         }
 
-        if (allOccupantJids.equals(allMucRolesOccupantsJids)) {
+        if (new HashSet<>(allOccupantJids).equals(new HashSet<>(allMucRolesOccupantsJids))) {
             result.put("pass", "The list of occupants registered by node equals the list of occupants seen in rooms.");
         } else {
             result.put("fail", String.format("The sum of the collection of non-federated (%d) and federated (%d) occupants is %d, which does not equal the list of occupants seen in rooms, which has %d elements", allNonFederatedOccupantsJids.size(), allFederatedOccupantsJids.size(), allOccupantJids.size(), allMucRolesOccupantsJids.size()));


### PR DESCRIPTION
When clustering, every Openfire cluster node tries to maintain a minimal set of data describing rooms and occupants. The primary reason to do this is to be able to reconstruct data in case of a cluster node unexpectedly dropping out of the cluster. This data is (mostly) managed by the OccupantManager class.

Prior to this commit, the OccupantManager associated every occupant with one or more cluster nodes (by cluster node ID). This commit changes that, in the following way:
- Users of the local/non-federated XMPP domain are associated with exactly one cluster node: the one that they're 'physically' connected to (eg: where their TCP connection terminates).
- Users of non-local/federated XMPP domains are no longer associated with any cluster node in particular.

The prior association of federated users with specific cluster nodes makes little sense. It _was_ based on the node where their server-to-server connection terminated. That, however, is a poor choice. Server-to-server connections may be teared down due to inactivity (without this leading to occupants being removed from a MUC). It is perfectly acceptable for the s2s connection to be re-established to another cluster node. It's also possible to have multiple s2s connections, potentially to different nodes in the local cluster. It is reasonable to assume that _any_ cluster node is able to (re)establish s2s with the domain of a federated user. This removes more reasons for keeping a (set of) nodeID(s) for a federated occupant.

It is assumed that drifts in data consistency are reduced/removed by no longer trying to maintain a occupant-to-clusternode binding for federated users.