### PR TITLE
OF-2802: Upgrade Postgresql JDBC driver from 42.6.0 to 42.7.2

### DIFF
--- a/build/ci/updater/pom.xml
+++ b/build/ci/updater/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.6.0</version>
+      <version>42.7.2</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.jtds</groupId>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -470,7 +470,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.6.0</version>
+            <version>42.7.2</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.jtds</groupId>


### PR DESCRIPTION
This addresses CVE-2024-1597. Openfire does not seem to be affected by this, but as the reported severity is 10/10, static analyzers will undoubtedly cause a sense of urgency.

@akrherz This is updating to the latest/greatest. Is there a good reason for us to stick to the 4.6 branch of this driver?