### PR TITLE
OF-2807: Fix event handling for Group Property changes

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupPropertyMap.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupPropertyMap.java
@@ -536,7 +536,7 @@ public class DefaultGroupPropertyMap<K,V> extends PersistableMap<K,V> {
 
         // Clean up caches.
         DefaultGroupProvider.sharedGroupMetaCache.clear();
-        GroupManager.getInstance().propertyDeletedPostProcess(group, key, originalValue);
+        GroupManager.getInstance().propertyModifiedPostProcess(group, key, originalValue);
     }
 
     /**


### PR DESCRIPTION
When a GroupProperty is added, modified or deleted, an event listening mechanism is activated. This, among other things, is used to clean up cache content and push changes to rosters.

This commit fixes a problem with the 'modified' handler. It caused the wrong event to be emitted ('deleted', rather than 'modified').