### PR TITLE
OF-2777: Allow groups to be shared with other groups

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/Group.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -341,7 +341,23 @@ public class Group implements Cacheable, Externalizable {
             return result;
         }
 
-        result.addAll(provider.getVisibleGroupNames(this.name));
+        final String value = properties.get(SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY);
+        if (value == null) {
+            // When in this getSharedWith, I don't think that the value can be null. I'm not confident enough to add this as an 'assert' though.
+            Log.warn("Unable to get shared-with-users-in-group-names for group, as property '{}' unexpectedly has a null value for group: {}", SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY, this);
+            return result;
+        }
+
+        // Value is a comma-seperated list of group-names
+        for (final String groupName : value.split(",")) {
+            if (!groupName.trim().isEmpty()) {
+                result.add(groupName.trim());
+            }
+        }
+        // A group is always shared with itself when it's shared with other groups.
+        if (!result.contains(this.name)) {
+            result.add(this.name);
+        }
         return result;
     }
 

--- a/xmppserver/src/main/webapp/group-edit.jsp
+++ b/xmppserver/src/main/webapp/group-edit.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -321,6 +321,7 @@
     pageContext.setAttribute( "errors", errors );
     pageContext.setAttribute( "groupInfoChanged", groupInfoChanged );
     pageContext.setAttribute( "group", group );
+    pageContext.setAttribute( "onlySharedWithOwnGroup", groupNames.isEmpty() || (groupNames.size() == 1 && groupNames.contains(group.getName())));
     pageContext.setAttribute( "groupNames", groupNames );
 
     final List<JID> allMembers = new ArrayList<>();
@@ -495,7 +496,7 @@
                         <table>
                             <tr>
                                 <td style="width: 1%; white-space: nowrap">
-                                    <input type="radio" name="showGroup" value="onlyGroup" id="rb001" ${( group.sharedWith eq "nobody" ) or ( group.sharedWith eq "usersOfGroups" and empty groupNames ) ? "checked" : "" }>
+                                    <input type="radio" name="showGroup" value="onlyGroup" id="rb001" ${( group.sharedWith eq "nobody" ) or ( group.sharedWith eq "usersOfGroups" and onlySharedWithOwnGroup ) ? "checked" : "" }>
                                 </td>
                                 <td>
                                     <label for="rb001"><fmt:message key="group.edit.share_group_only" /></label>
@@ -511,7 +512,7 @@
                             </tr>
                             <tr>
                                 <td style="width: 1%; white-space: nowrap">
-                                    <input type="radio" name="showGroup" value="spefgroups" id="rb003" ${group.sharedWith eq "usersOfGroups" and not empty groupNames ? "checked" : ""}>
+                                    <input type="radio" name="showGroup" value="spefgroups" id="rb003" ${group.sharedWith eq "usersOfGroups" and not onlySharedWithOwnGroup ? "checked" : ""}>
                                 </td>
                                 <td>
                                     <label for="rb003"><fmt:message key="group.edit.share_roster_groups" /></label>


### PR DESCRIPTION
When a group is to be shared with other groups, this is stored in the database as a group property of name `sharedRoster.showInRoster` having a value of `onlyGroup`. The group property value for `sharedRoster.groupList` controls to what groups this group is shared. It either is a comma-separated list (denoting group names), or it's empty. An empty value signals that the group is shared only with members of the same group.

This commit corrects how these values are managed in the database.

This change largely fixes OF-2777, although one issue remains (or is possibly introduced by this change): When _disabling_ roster sharing for a group that was previously shared with other groups, then contacts (roster items) are NOT removed from the rosters of people that no longer have the shared group.