### PR TITLE
Always run database tests if we're gonna publish

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -230,9 +230,9 @@ jobs:
 
   sqlserver:
     name: Test SQL Server Upgrades
-    needs: [build, should-do-database-upgrade-tests]
+    needs: [build, should-do-database-upgrade-tests, check_branch]
     runs-on: ubuntu-latest
-    if: ${{ needs.should-do-database-upgrade-tests.outputs.check == 'true' }}
+    if: ${{ needs.should-do-database-upgrade-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
     steps:
       - name: Checkout Openfire
         uses: actions/checkout@v4
@@ -271,9 +271,9 @@ jobs:
 
   postgres:
     name: Test Postgres Upgrades
-    needs: [build, should-do-database-upgrade-tests]
+    needs: [build, should-do-database-upgrade-tests, check_branch]
     runs-on: ubuntu-latest
-    if: ${{ needs.should-do-database-upgrade-tests.outputs.check == 'true' }}
+    if: ${{ needs.should-do-database-upgrade-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
     steps:
       - name: Checkout Openfire
         uses: actions/checkout@v4
@@ -312,9 +312,9 @@ jobs:
 
   mysql:
     name: Test MySQL Upgrades
-    needs: [build, should-do-database-upgrade-tests]
+    needs: [build, should-do-database-upgrade-tests, check_branch]
     runs-on: ubuntu-latest
-    if: ${{ needs.should-do-database-upgrade-tests.outputs.check == 'true' }}
+    if: ${{ needs.should-do-database-upgrade-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
     steps:
       - name: Checkout Openfire
         uses: actions/checkout@v4
@@ -351,10 +351,9 @@ jobs:
           java -jar ./target/updaterunner-1.0.0-jar-with-dependencies.jar
 
   publish-maven:
-
     name: Publish to Maven
     runs-on: ubuntu-latest
-    needs: [aioxmpp, connectivity, smack, check_branch]
+    needs: [aioxmpp, connectivity, smack, check_branch, sqlserver, postgres, mysql]
     if: ${{github.repository == 'igniterealtime/Openfire' && github.event_name == 'push' && needs.check_branch.outputs.is_publishable_branch == 'true'}}
 
     steps:


### PR DESCRIPTION
* Have the database test jobs depend on the check_branch job that determines if this run will result in a publish
* Have the database tests run if either the relevant files have changed or the run will result in a publish (previously it was just the first check)
* Have the publish job await the database tests as well as the other tests

The publish now depends on jobs that might not run, but that seems fine, since the database tests will always run if the publish job would run (and at other times too)