### PR TITLE
OF-2819: Update Netty from 4.1.100 to 4.1.108

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
         <jetty.version>10.0.18</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
-        <netty.version>4.1.100.Final</netty.version>
+        <netty.version>4.1.108.Final</netty.version>
         <bouncycastle.version>1.76</bouncycastle.version>
         <slf4j.version>2.0.9</slf4j.version>
         <log4j.version>2.20.0</log4j.version>


### PR DESCRIPTION
Changes:
- https://netty.io/news/2023/11/09/4-1-101-Final.html
- https://netty.io/news/2023/12/13/4-1-103-Final.html
- https://netty.io/news/2023/12/15/4-1-104-Final.html
- https://netty.io/news/2024/01/16/4-1-105-Final.html
- https://netty.io/news/2024/01/19/4-1-106-Final.html
- https://netty.io/news/2024/02/13/4-1-107-Final.html
- https://netty.io/news/2024/03/21/4-1-108-Final.html

(Yes, that's correct - there is no 4.1.102)

Nothing stood out as scary. All appear to be bugfixes and performance tweaks.