### PR TITLE
OF-2818: Netty should not use 5MB buffers

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,8 +97,6 @@ public class OpenfireWebSocketServlet extends JettyWebSocketServlet {
             factory.getAvailableExtensionNames().remove("permessage-deflate");
         }
         final int messageSize = JiveGlobals.getIntProperty("xmpp.parser.buffer.size", 1048576);
-        factory.setInputBufferSize(messageSize * 5);
-        factory.setOutputBufferSize(messageSize * 5);
         factory.setMaxTextMessageSize(messageSize);
 
         // Jetty's idle policy cannot be modified - it will bluntly kill the connection. Ensure that it's longer than


### PR DESCRIPTION
This corrects a mistake where a configuration of having a _maximum_ buffer size was turned into having a _fixed_ buffer size.

Having 5MB buffers is bad, as with a limited amount of messages, a _lot_ of memory is being consumed.

This commit removes the hard-coded buffer size configuration, while retaining the maximum message length directive.

I've tested that, using a websocket client connection:
- a message of 128k characters can be sent using the default configuration;
- a message of 128k characters can not be sent when Openfire is reconfigured to use 4k for the `xmpp.parser.buffer.size` property