### PR TITLE
OF-2824: Addressing data consistency in caches of routing table 

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
@@ -114,9 +114,8 @@ public interface RoutingTable {
      *
      * @param route the address (a full JID) associated to the route.
      * @param destination the client session.
-     * @return true if route was added to the table or false if already present.
      */
-    boolean addClientRoute(JID route, LocalClientSession destination);
+    void addClientRoute(JID route, LocalClientSession destination);
 
     /**
      * Routes a packet to the specified address. The packet destination can be a

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ public interface RoutingTable {
      * get updated again. When running inside of a cluster this message {@code must} be sent
      * from the cluster node that is actually holding the client session.
      *
-     * @param route the address associated to the route.
+     * @param route the address (a full JID) associated to the route.
      * @param destination the client session.
      * @return true if route was added to the table or false if already present.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -805,8 +805,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
      * @param session the session that received an unavailable presence.
      */
     public void sessionUnavailable(LocalClientSession session) {
-        if (session.getAddress() != null && routingTable != null &&
-                session.getAddress().toBareJID().trim().length() != 0) {
+        if (routingTable != null && session.getAddress().toBareJID().trim().length() != 0) {
             // Update route to unavailable session (anonymous or not)
             routingTable.addClientRoute(session.getAddress(), session); // Note that _adding_ the route is not a typo, as previously assumed. See OF-2210 and OF-2012.
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import org.xmpp.packet.Packet;
 import org.xmpp.packet.Presence;
 import org.xmpp.packet.StreamError;
 
+import javax.annotation.Nonnull;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStoreException;
@@ -571,7 +572,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
      * @param auth the authentication token obtained from the AuthFactory.
      * @param resource the resource this session authenticated under.
      */
-    public void setAuthToken(AuthToken auth, String resource) {
+    public void setAuthToken(AuthToken auth, @Nonnull String resource) {
         final JID jid;
         if (auth.isAnonymous()) {
             jid = new JID(resource, getServerName(), resource);
@@ -588,6 +589,14 @@ public class LocalClientSession extends LocalSession implements ClientSession {
         }
         // Add session to the session manager. The session will be added to the routing table as well
         sessionManager.addSession(this);
+    }
+
+    @Override
+    public void setAddress(@Nonnull JID address){
+        if (address.getResource() == null) {
+            throw new IllegalArgumentException("Address is not a full JID: " + address);
+        }
+        super.setAddress(address);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ public abstract class LocalSession implements Session {
     /**
      * The Address this session is authenticated as.
      */
+    @Nonnull
     protected JID address;
 
     /**
@@ -199,13 +200,14 @@ public abstract class LocalSession implements Session {
     }
 
     /**
-      * Obtain the address of the user. The address is used by services like the core
+      * Obtain the address of the session. The address is used by services like the core
       * server packet router to determine if a packet should be sent to the handler.
       * Handlers that are working on behalf of the server should use the generic server
       * hostname address (e.g. server.com).
       *
       * @return the address of the packet handler.
       */
+    @Nonnull
     @Override
     public JID getAddress() {
         return address;
@@ -219,7 +221,7 @@ public abstract class LocalSession implements Session {
      *
      * @param address the new address of this session.
      */
-    public void setAddress(JID address){
+    public void setAddress(@Nonnull JID address){
         this.address = address;
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteIncomingServerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.jivesoftware.util.cache.ClusterTask;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Packet;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 
 /**
@@ -48,6 +49,7 @@ public class RemoteIncomingServerSession extends RemoteSession implements Incomi
         return authenticationMethod;
     }
 
+    @Nonnull
     public JID getAddress() {
         if (address == null) {
             RemoteSessionTask task = getRemoteSessionTask(RemoteSessionTask.Operation.getAddress);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.jivesoftware.util.cache.ClusterTask;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Packet;
 
+import javax.annotation.Nonnull;
 import java.net.UnknownHostException;
 import java.security.cert.Certificate;
 import java.util.Date;
@@ -42,7 +43,7 @@ import java.util.Map;
 public abstract class RemoteSession implements Session {
 
     protected byte[] nodeID;
-    protected JID address;
+    protected JID address; // Expected to be mostly non-null, but at least one subclass lazily initializes this!
 
     // Cache content that never changes
     protected StreamID streamID;
@@ -56,6 +57,7 @@ public abstract class RemoteSession implements Session {
         this.address = address;
     }
 
+    @Nonnull
     public JID getAddress() {
         return address;
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ public interface Session extends RoutableChannelHandler {
       *
       * @return the address of the packet handler.
       */
+    @Nonnull
     @Override
     JID getAddress();
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -288,7 +288,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             }
 
             Log.trace("Adding client full JID {} to users sessions cache under key {}", route, route.toBareJID());
-            // Acquires the same lock, which should not be an issue as the lock implementation (both Openfire's as Hazelcast's) is reentrant.
+            // Acquires the same lock, which should not be an issue as the lock implementation (both Openfire's and Hazelcast's) is reentrant.
             CacheUtil.addValueToMultiValuedCache(usersSessionsCache, route.toBareJID(), route.toFullJID(), HashSet::new);
         }
         finally {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -259,6 +259,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
     @Override
     public boolean addClientRoute(JID route, LocalClientSession destination) {
+        if (route.getResource() == null) {
+            throw new IllegalArgumentException("Route is not a full JID: " + route);
+        }
         boolean added;
         boolean available = destination.getPresence().isAvailable();
         Log.debug("Adding client route {}", route);
@@ -275,7 +278,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                 lockAn.unlock();
             }
             // Add the session to the list of user sessions
-            if (route.getResource() != null && (!available || added)) {
+            if (!available || added) {
                 Lock lock = usersSessionsCache.getLock(route.toBareJID());
                 lock.lock();
                 try {
@@ -297,7 +300,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                 lockU.unlock();
             }
             // Add the session to the list of user sessions
-            if (route.getResource() != null && (!available || added)) {
+            if (!available || added) {
                 Lock lock = usersSessionsCache.getLock(route.toBareJID());
                 lock.lock();
                 try {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -470,6 +470,11 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     }
 
     private ClientRoute getClientRouteForLocalUser(JID jid) {
+        if (jid.getNode() == null || jid.getResource() == null) {
+            Log.trace("getClientRouteForLocalUser() invoked with a JID that's not a full JID: {}", jid);
+            return null;
+        }
+
         final Lock lock = usersSessionsCache.getLock(jid.toBareJID());
         lock.lock();
         try {
@@ -912,6 +917,10 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
     @Override
     public boolean hasClientRoute(JID jid) {
+        if (jid.getNode() == null || jid.getResource() == null) {
+            Log.trace("hasClientRoute() invoked with a JID that's not a full JID: {}", jid);
+            return false;
+        }
         final Lock lock = usersSessionsCache.getLock(jid.toBareJID());
         lock.lock();
         try {
@@ -924,6 +933,10 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
 
     @Override
     public boolean isAnonymousRoute(JID jid) {
+        if (jid.getNode() == null || jid.getResource() == null) {
+            Log.trace("isAnonymousRoute() invoked with a JID that's not a full JID: {}", jid);
+            return false;
+        }
         final Lock lock = usersSessionsCache.getLock(jid.toBareJID());
         lock.lock();
         try {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -915,6 +915,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         final Lock lock = usersSessionsCache.getLock(jid.toBareJID());
         lock.lock();
         try {
+            // isAnonymousRoute() acquires the same lock, which should not be an issue as the lock implementation (both Openfire's and Hazelcast's) is reentrant.
             return usersCache.containsKey(jid.toFullJID()) || isAnonymousRoute(jid);
         } finally {
             lock.unlock();
@@ -1040,9 +1041,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                 }
 
                 Log.trace("Removing client full JID {} from users sessions cache under key {}", route.toFullJID(), route.toBareJID());
+                // Acquires the same lock, which should not be an issue as the lock implementation (both Openfire's and Hazelcast's) is reentrant.
                 CacheUtil.removeValueFromMultiValuedCache(usersSessionsCache, route.toBareJID(), route.toFullJID());
             }
-
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
The distinct commits in this PR each intend to address a separate issue, where the first three commits are preparing the code for easier application of the fourth commit.

The over-arching goal of all commits is to make the implementation of RoutingTable less error prone (in context of client sessions/routes). it does so by:
- adding strictness with regards to allowed `null` and bare vs. full JID usage
- simplifying the code (doing away with an optimization that I suspect plays a role in the cause of observed data inconsistency)
- replacing per-cache lock usage to usage of one lock, to guard the manipulation of three related caches. This intends to remove a potential synchronization issue.