### PR TITLE
OF-2827: JDBCAuthProvider should not lowercase/trim provided username

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/JDBCAuthProvider.java
@@ -212,7 +212,6 @@ public class JDBCAuthProvider implements AuthProvider, PropertyEventListener {
         if (username == null || password == null) {
             throw new UnauthorizedException();
         }
-        username = username.trim().toLowerCase();
         if (username.contains("@")) {
             // Check that the specified domain matches the server's domain
             int index = username.indexOf("@");


### PR DESCRIPTION
By lowercasing the input, a username with a capital letter can't be used.

The closely related JDBCUserProvider does not lowercase/trim values. It is probably best that both providers treat usernames in the same way.

I'm wondering if we even need a configuration option to make this behavior configurable. Isn't it just plain 'wrong' to have inconsistent processing of the `username` values - that's never going to work, is it?