### PR TITLE
OF-2832: LDAP MUC avatar

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
@@ -19,6 +19,7 @@ package org.jivesoftware.openfire.ldap;
 import org.dom4j.Document;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
+import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.openfire.vcard.DefaultVCardProvider;
 import org.jivesoftware.openfire.vcard.PhotoResizer;
 import org.jivesoftware.openfire.vcard.VCardManager;
@@ -207,8 +208,12 @@ public class LdapVCardProvider implements VCardProvider, PropertyEventListener {
             }
             return map;
         }
+        catch (UserNotFoundException e) {
+            Log.info("Unable to find LDAP data as user '{}' is not found in the directory service.", username, e);
+            return Collections.emptyMap();
+        }
         catch (Exception e) {
-            Log.error(e.getMessage(), e);
+            Log.warn("Unexpected exception while tyring to find LDAP data for user '{}'", username, e);
             return Collections.emptyMap();
         }
         finally {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -274,7 +274,8 @@ public class LdapVCardProvider implements VCardProvider, PropertyEventListener {
         Map<String, String> map = getLdapAttributes(username);
         Log.debug("LdapVCardProvider: Retrieving LDAP mapped vcard for " + username);
         if (map.isEmpty()) {
-            return null;
+            // No vcard for this user in LDAP? Return the to-be-merged data as-is.
+            return mergeVCard;
         }
         Element vcard = new VCard(template).getVCard(map);
         if (mergeVCard == null) {


### PR DESCRIPTION
Allows avatars to be stored in the local database for MUC rooms, when AD/LDAP integration is enabled.