### PR TITLE
OF-2834: Bump BouncyCastle from 1.76 to 1.78.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <jetty.version>10.0.18</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <netty.version>4.1.108.Final</netty.version>
-        <bouncycastle.version>1.76</bouncycastle.version>
+        <bouncycastle.version>1.78.1</bouncycastle.version>
         <slf4j.version>2.0.9</slf4j.version>
         <log4j.version>2.20.0</log4j.version>
     </properties>


### PR DESCRIPTION
The OWASP dep-scan tool (https://github.com/owasp-dep-scan/dep-scan) has identified various CVEs related to the version of the BouncyCastle dependency that we're currently using. This commit updates the library to resolve that issue.