### PR TITLE
OF-2840: Minor improvements to XMPPDateTimeFormat parsing

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/XMPPDateTimeFormat.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/XMPPDateTimeFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Florian Schmaus, 2017-2019 Ignite Realtime Foundation. All rights reserved
+ * Copyright (C) 2013 Florian Schmaus, 2017-2024 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,9 @@ public class XMPPDateTimeFormat {
      * @throws ParseException if the date could not be parsed
      */
     public Date parseString(String dateString) throws ParseException {
+        if (dateString == null || dateString.isEmpty()) {
+            return null;
+        }
         Matcher xep82WoMillisMatcher = xep80DateTimeWoMillisPattern.matcher(dateString);
         Matcher xep82Matcher = xep80DateTimePattern.matcher(dateString);
 
@@ -121,7 +124,7 @@ public class XMPPDateTimeFormat {
                 }
             }
         }
-        throw new ParseException("Date String could not be parsed", 0);
+        throw new ParseException("Date String could not be parsed: \"" + dateString + "\"", 0);
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/util/XMPPDateTimeFormatTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/XMPPDateTimeFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,49 @@ public class XMPPDateTimeFormatTest {
         df.setTimeZone(TimeZone.getTimeZone("utc"));
         String date = df.format(parsedDate);
         assertEquals(date, "2013-01-25T18:07:22.768+0000");
+    }
+
+    @Test
+    public void testNull() throws Exception
+    {
+        // Setup fixture
+        final String testValue = null;
+
+        // Execute system under test
+        final Date result = xmppDateTimeFormat.parseString(testValue);
+
+        // Verify results
+        assertNull(result);
+    }
+
+    @Test
+    public void testEmpty() throws Exception
+    {
+        // Setup fixture
+        final String testValue = "";
+
+        // Execute system under test
+        final Date result = xmppDateTimeFormat.parseString(testValue);
+
+        // Verify results
+        assertNull(result);
+    }
+
+    @Test
+    public void testExceptionContainsOffendingValue() throws Exception
+    {
+        // Setup fixture
+        final String testValue = "This is not a valid date value";
+
+        // Execute system under test
+        try {
+            xmppDateTimeFormat.parseString(testValue);
+
+            // Verify results
+            fail("An exception should have been thrown (but was not).");
+        } catch (ParseException e) {
+            assertTrue(e.getMessage().contains(testValue));
+        }
     }
 
     @Test


### PR DESCRIPTION
Parsing should return null values (rather than throw an Exception) when null or empty values input values are used (to be more fault-tolerant). A parsing exception's message should include the offending value (to help diagnostics).