### PR TITLE
OF-2825: Allow self to query for disco#info

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -149,7 +149,7 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
         // a <service-unavailable/> error if [...] The requesting entity is not authorized to receive presence from the
         // target entity (i.e., via the target having a presence subscription to the requesting entity of type "both" or
         // "from") or is not otherwise trusted (e.g., another server in a trusted network).</blockquote>
-        if (packet.getTo() != null && packet.getTo().getNode() != null && packet.getTo().getResource() == null) {
+        if (packet.getTo() != null && packet.getTo().getNode() != null && packet.getTo().getResource() == null && !packet.getTo().asBareJID().equals(packet.getFrom().asBareJID())) {
             boolean isRequestingEntityAuthorized;
             try {
                 final User user = UserManager.getInstance().getUser(packet.getTo().getNode());


### PR DESCRIPTION
The previous fix for OF-2825 erroneously prevented a user to query for its own disco#info.