### PR TITLE
OF-2825: Moved implementation of Service Discovery security considerations to individual providers

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.openfire.disco;
 
 import org.dom4j.Element;
+import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.xmpp.forms.DataForm;
 import org.xmpp.packet.JID;
 
@@ -82,6 +83,7 @@ public interface DiscoInfoProvider {
      * @param node      the requested disco node.
      * @param senderJID the XMPPAddress of user that sent the disco info request.
      * @return true if we can provide information related to the requested name and node.
+     * @throws org.jivesoftware.openfire.auth.UnauthorizedException When senderJID is not authorized to discover information
      */
-    boolean hasInfo( String name, String node, JID senderJID );
+    boolean hasInfo( String name, String node, JID senderJID ) throws UnauthorizedException;
 }


### PR DESCRIPTION
Instead of applying the security considerations of section 8, XEP-0030 globally, they now are applied to the individual discovery data providers. This prevents them to be applied to providers where they do not apply (eg: MUC, that doesn't apply presence subscription based authorization at all).