### PR TITLE
OF-2848: Ensure `<destroy/>` element in presence unavailable when MUC is destroyed

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -1304,15 +1304,12 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
                 final Element item = fragment.addElement("item");
                 item.addAttribute("affiliation", "none");
                 item.addAttribute("role", "none");
+                final Element destroy = fragment.addElement("destroy");
                 if (alternateJID != null) {
-                    fragment.addElement("destroy").addAttribute("jid", alternateJID.toString());
+                    destroy.addAttribute("jid", alternateJID.toString());
                 }
-                if (reason != null && reason.length() > 0) {
-                    Element destroy = fragment.element("destroy");
-                    if (destroy == null) {
-                        destroy = fragment.addElement("destroy");
-                    }
-                    destroy.addElement("reason").setText(reason);
+                if (reason != null && !reason.isBlank()) {
+                    destroy.addElement("reason").setText(reason.trim());
                 }
 
                 // Not needed to create a defensive copy of the stanza. It's not used anywhere else.


### PR DESCRIPTION
Prior to this change, this element was present only when one of the optional attributes was provided.