### PR TITLE
Update aioxmpp testing

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -116,7 +116,8 @@ jobs:
           # OF-2849 test_publish_and_purge
           # OF-2850 test_publish_multiple_and_get_by_id
           # OF-2851 test_convert_field_datetime_default_locale
-          python -m pytest -p aioxmpp.e2etest --e2etest-config="openfire-config.ini" -k 'not test_publish_and_purge and not test_publish_multiple_and_get_by_id and not test_convert_field_datetime_default_locale' tests 2>&1 | tee output/aioxmpp.test.output.txt
+          # OF-2853 test_set_topic
+          python -m pytest -p aioxmpp.e2etest --e2etest-config="openfire-config.ini" -k 'not (test_set_topic or test_publish_and_purge or test_publish_multiple_and_get_by_id or test_convert_field_datetime_default_locale)' tests 2>&1 | tee output/aioxmpp.test.output.txt
           if [ ${PIPESTATUS[0]} -ne 0 ]; then false; fi;
       - name: Expose test output
         if: always()

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -80,11 +80,7 @@ jobs:
       - name: untar distribution # sharing artifacts that consist of many files can be slow. Share one file instead.
         run: tar -xf distribution-artifact.tar
       - name: Checkout aioxmpp devel/head
-        uses: actions/checkout@v4
-        with:
-          repository: horazont/aioxmpp
-          ref: devel
-          path: aioxmpp
+        run: git clone https://codeberg.org/jssfr/aioxmpp.git aioxmpp
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -113,7 +113,10 @@ jobs:
         run: |
           set -e
           mkdir output
-          python -m pytest -p aioxmpp.e2etest --e2etest-config="openfire-config.ini" --e2etest-only -k 'not test_set_topic and not test_publish_and_purge and not test_publish_multiple_and_get_by_id' tests 2>&1 | tee output/aioxmpp.test.output.txt
+          # OF-2849 test_publish_and_purge
+          # OF-2850 test_publish_multiple_and_get_by_id
+          # OF-2851 test_convert_field_datetime_default_locale
+          python -m pytest -p aioxmpp.e2etest --e2etest-config="openfire-config.ini" -k 'not test_publish_and_purge and not test_publish_multiple_and_get_by_id and not test_convert_field_datetime_default_locale' tests 2>&1 | tee output/aioxmpp.test.output.txt
           if [ ${PIPESTATUS[0]} -ne 0 ]; then false; fi;
       - name: Expose test output
         if: always()


### PR DESCRIPTION
This PR:

1. Updates the aioxmpp git repo to its present home
2. Enables all tests that pass locally for me on Openfire 4.8.3

A before and after

```diff
- 46 passed, 4575 skipped, 4 deselected, 133 warnings in 7.01s
+ 4599 passed, 23 skipped, 3 deselected, 188 warnings in 31.61s
```

I have created Jira issues for the three tests currently being skipped and documented those within the CI config.  Watch how many of these tests now fail here :)

PS.  I have brought `aioxmpp` into [conda-forge](https://conda-forge.org/).  So our CI could be updated to make more speedy usage of it, but the difference is likely negligible 