### PR TITLE
Fix Maven warnings for distribution module

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>distribution</artifactId>
+    <packaging>pom</packaging>
 
     <name>Distribution</name>
     <description>Provides Openfire distributables.</description>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -32,6 +32,7 @@
                     <descriptors>
                         <descriptor>src/assembly/basic-distribution.xml</descriptor>
                     </descriptors>
+                    <attach>false</attach>
                 </configuration>
                 <executions>
                     <execution>

--- a/distribution/src/assembly/basic-distribution.xml
+++ b/distribution/src/assembly/basic-distribution.xml
@@ -109,7 +109,7 @@
             <includes>
                 <include>*.html</include>
             </includes>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>${file.separator}</outputDirectory>
         </fileSet>
 
         <!-- Copy the documentation/docs directory to dist -->


### PR DESCRIPTION
See individual commit messages and/or JIRA issues for details.

These changes should all be benign, but remove some warnings that are generated when Maven is building the project.