### PR TITLE
Improvements to Docker file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,13 +10,10 @@ Dockerfile
 
 build
 !build/docker
-distribution
-!distribution/target/distribution-base
 documentation
-i18n
-plugins
-starter
-xmppserver
+
+# Any intermediate build stuff.
+**/target
 
 # Deeper stuff
 **/.DS_Store
@@ -26,3 +23,4 @@ xmppserver
 **/.project
 **/.settings
 **/*.iml
+**/*.class

--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,7 @@ documentation
 **/.settings
 **/*.iml
 **/*.class
+
+# Make sure mvn stuff is present though.
+!.mvn/wrapper
+!.mvn/wrapper/maven-wrapper.properties

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -246,7 +246,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: false ## ${{ needs.check_branch.output.is_publishable_branch == 'true' }}
-          tags: openfire/${{ needs.check_branch.outputs.branch_tag }}
+          tags: openfire:${{ needs.check_branch.outputs.branch_tag }}
 
   sqlserver:
     name: Test SQL Server Upgrades

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -139,6 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       is_publishable_branch: ${{ steps.check-branch.outputs.is_publishable_branch }}
+      branch_tag: ${{ steps.check-branch.outputs.branch_tag }}
     steps:
       - name: check branch ${{ github.ref }} is either main or a version number
         id: check-branch

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -146,7 +146,7 @@ jobs:
         run: |
           if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
             echo "is_publishable_branch=true" >> "${GITHUB_OUTPUT}"
-            echo "branch_tag=latest" >> "${GITHUB_OUTPUT}"
+            echo "branch_tag=development" >> "${GITHUB_OUTPUT}"
           elif [[ ]${{ github.ref }} =~ refs\/heads\/[0-9]+\.[0-9]+ ]]; then            
             echo "is_publishable_branch=true" >> "${GITHUB_OUTPUT}"
             echo -n "branch_tag=" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -143,10 +143,16 @@ jobs:
       - name: check branch ${{ github.ref }} is either main or a version number
         id: check-branch
         run: |
-          if [[ ${{ github.ref }} == 'refs/heads/main' || ${{ github.ref }} =~ refs\/heads\/[0-9]+\.[0-9]+ ]]; then            
+          if [[ ${{ github.ref }} == 'refs/heads/main'; then
             echo "is_publishable_branch=true" >> $GITHUB_OUTPUT
+            echo "branch_tag=latest" >> $GITHUB_OUTPUT
+          elif ${{ github.ref }} =~ refs\/heads\/[0-9]+\.[0-9]+ ]]; then            
+            echo "is_publishable_branch=true" >> $GITHUB_OUTPUT
+            echo -n "branch_tag=" >> $GITHUT_OUTPUT
+            sed -e '!refs/heads/!!' >> $GITHUB_OUTPUT
           else
             echo "is_publishable_branch=false" >> $GITHUB_OUTPUT
+            echo "branch_tag=rando" >> $GITHHUB_OUTPUT
           fi
 
   connectivity:
@@ -229,6 +235,18 @@ jobs:
               - 'build/ci/**'
               - '.github/workflows/continuous-integration-workflow.yml'
               - 'xmppserver/pom.xml'
+
+  docker:
+    name: Build (and maybe push) Docker image
+    needs:
+      - check_branch
+    runs-on: ubuntu-latest
+    steps: # could log into docker hub here, so we can push the image.
+      - name: Build docker image
+        uses: docker/build-push-action@v6
+        with:
+          push: false ## ${{ needs.check_branch.output.is_publishable_branch == 'true' }}
+          tags: openfire/${{ needs.check_branch.outputs.branch_tag }}
 
   sqlserver:
     name: Test SQL Server Upgrades

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -143,10 +143,10 @@ jobs:
       - name: check branch ${{ github.ref }} is either main or a version number
         id: check-branch
         run: |
-          if [[ ${{ github.ref }} == 'refs/heads/main'; then
+          if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
             echo "is_publishable_branch=true" >> $GITHUB_OUTPUT
             echo "branch_tag=latest" >> $GITHUB_OUTPUT
-          elif ${{ github.ref }} =~ refs\/heads\/[0-9]+\.[0-9]+ ]]; then            
+          elif [[ ]${{ github.ref }} =~ refs\/heads\/[0-9]+\.[0-9]+ ]]; then            
             echo "is_publishable_branch=true" >> $GITHUB_OUTPUT
             echo -n "branch_tag=" >> $GITHUT_OUTPUT
             sed -e '!refs/heads/!!' >> $GITHUB_OUTPUT

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -144,15 +144,15 @@ jobs:
         id: check-branch
         run: |
           if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
-            echo "is_publishable_branch=true" >> $GITHUB_OUTPUT
-            echo "branch_tag=latest" >> $GITHUB_OUTPUT
+            echo "is_publishable_branch=true" >> "${GITHUB_OUTPUT}"
+            echo "branch_tag=latest" >> "${GITHUB_OUTPUT}"
           elif [[ ]${{ github.ref }} =~ refs\/heads\/[0-9]+\.[0-9]+ ]]; then            
-            echo "is_publishable_branch=true" >> $GITHUB_OUTPUT
-            echo -n "branch_tag=" >> $GITHUT_OUTPUT
-            sed -e '!refs/heads/!!' >> $GITHUB_OUTPUT
+            echo "is_publishable_branch=true" >> "${GITHUB_OUTPUT}"
+            echo -n "branch_tag=" >> "${GITHUB_OUTPUT}"
+            sed -e '!refs/heads/!!' >> "${GITHUB_OUTPUT}"
           else
-            echo "is_publishable_branch=false" >> $GITHUB_OUTPUT
-            echo "branch_tag=rando" >> $GITHHUB_OUTPUT
+            echo "is_publishable_branch=false" >> "${GITHUB_OUTPUT}"
+            echo "branch_tag=rando" >> "${GITHUB_OUTPUT}"
           fi
 
   connectivity:

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN mv ${OPENFIRE_DIR}/conf ${OPENFIRE_DIR}/conf_org \
     && mv ${OPENFIRE_DIR}/plugins ${OPENFIRE_DIR}/plugins_org \
     && mv ${OPENFIRE_DIR}/resources/security ${OPENFIRE_DIR}/resources/security_org
 
-LABEL maintainer="florian.kinder@fankserver.com"
+LABEL org.opencontainers.image.authors="dave@cridland.net,dan@caseley.me.uk"
 WORKDIR /usr/local/openfire
 
 EXPOSE 3478 3479 5005 5222 5223 5229 5262 5263 5275 5276 7070 7443 7777 9090 9091

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,6 @@ RUN adduser --disabled-password --quiet --system --home $OPENFIRE_DATA_DIR --gec
 # Final stage, build the runtime container:
 FROM eclipse-temurin:17-jre AS runtime
 
-RUN apt-get update -qq
-RUN apt-get install -yyq sudo
-
 ENV OPENFIRE_USER=openfire \
     OPENFIRE_DIR=/usr/local/openfire \
     OPENFIRE_DATA_DIR=/var/lib/openfire \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,18 +44,21 @@ ENV OPENFIRE_USER=openfire \
     OPENFIRE_LOG_DIR=/var/log/openfire
 
 RUN apt-get update -qq
-RUN apt-get install -yyq sudo adduser
+RUN apt-get install -yyq adduser
 RUN adduser --disabled-password --quiet --system --home $OPENFIRE_DATA_DIR --gecos "Openfire XMPP server" --group $OPENFIRE_USER
 
 # Final stage, build the runtime container:
 FROM eclipse-temurin:17-jre AS runtime
+
+RUN apt-get update -qq
+RUN apt-get install -yyq sudo
 
 ENV OPENFIRE_USER=openfire \
     OPENFIRE_DIR=/usr/local/openfire \
     OPENFIRE_DATA_DIR=/var/lib/openfire \
     OPENFIRE_LOG_DIR=/var/log/openfire
 
-COPY --from=skeleton-runtime /etc/passwd /etc/shadow /etc/
+COPY --from=skeleton-runtime /etc/passwd /etc/shadow /etc/group /etc/
 COPY --chown=openfire::openfire --from=skeleton-runtime $OPENFIRE_DATA_DIR $OPENFIRE_DATA_DIR
 COPY --chmod=0755 --from=build /usr/src/build/docker/entrypoint.sh /sbin/entrypoint.sh
 COPY --chown=openfire:openfire --from=build /usr/src/distribution/target/distribution-base /usr/local/openfire

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,35 @@
+# This stage extracts all the pom.xml files.
+# It'll get rebuilt with any source change, but that's OK.
+FROM eclipse-temurin:17 AS poms
+WORKDIR /usr/src
+COPY . .
+# Wipe any files not called pom.xml or *.jar
+RUN find . -type f -and \! -name pom.xml -and \! -name '*.jar' -delete
+# Clear up any (now) empty diretories
+RUN find . -type d -empty -delete
+# Just for debug:
+RUN find
+
+# Now we build:
+FROM openjdk:11-jdk AS build
+# Set up Maven. No need to clean caches, this doesn't end up in the runtime container
+RUN apt-get update -qq
+RUN apt-get install -qqy maven
+WORKDIR /tmp/
+RUN mkdir /tmp/m2_home
+ENV M2_HOME=/tmp/m2_home
+WORKDIR /usr/src
+
+# First, copy in just the pom.xml files and fetch the dependencies:
+COPY --from=poms /usr/src/ .
+RUN mvn -e -B dependency:go-offline
+# Above here is only affected by the pom.xml files, so the cache is stable.
+
+# Now, copy in all the source, and actually build it, skipping the tests.
+COPY . .
+RUN mvn -e -B package -Dmaven.test.skip
+
+# Final stage, build the runtime container:
 FROM eclipse-temurin:17
 
 ENV OPENFIRE_USER=openfire \
@@ -10,10 +42,8 @@ RUN apt-get update -qq \
     && adduser --disabled-password --quiet --system --home $OPENFIRE_DATA_DIR --gecos "Openfire XMPP server" --group $OPENFIRE_USER \
     && rm -rf /var/lib/apt/lists/*
 
-COPY ./build/docker/entrypoint.sh /sbin/entrypoint.sh
-RUN chmod 755 /sbin/entrypoint.sh
-
-COPY --chown=openfire:openfire ./distribution/target/distribution-base /usr/local/openfire
+COPY --chmod=0755 --from=build /usr/src/build/docker/entrypoint.sh /sbin/entrypoint.sh
+COPY --chown=openfire:openfire --from=build /usr/src/distribution/target/distribution-base /usr/local/openfire
 RUN mv ${OPENFIRE_DIR}/conf ${OPENFIRE_DIR}/conf_org \
     && mv ${OPENFIRE_DIR}/plugins ${OPENFIRE_DIR}/plugins_org \
     && mv ${OPENFIRE_DIR}/resources/security ${OPENFIRE_DIR}/resources/security_org
@@ -23,4 +53,5 @@ WORKDIR /usr/local/openfire
 
 EXPOSE 3478 3479 5005 5222 5223 5229 5262 5263 5275 5276 7070 7443 7777 9090 9091
 VOLUME ["${OPENFIRE_DATA_DIR}"]
+VOLUME ["${OPENFIRE_LOG_DIR}"]
 ENTRYPOINT [ "/sbin/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,10 @@ WORKDIR /tmp/
 RUN mkdir /tmp/m2_home
 ENV M2_HOME=/tmp/m2_home
 WORKDIR /usr/src
-COPY mvnw .
+COPY mvnw ./
 RUN chmod +x mvnw
-RUN /bin/sh -c 'echo Yes'
-RUN ls -l ./mvnw
-RUN ls -l /bin/sh
-RUN /bin/bash -x /usr/src/mvnw
+RUN mkdir -p .mvn
+COPY .mvn/wrapper .mvn/wrapper
 
 # First, copy in just the pom.xml files and fetch the dependencies:
 COPY --from=poms /usr/src/ .

--- a/build/docker/entrypoint.sh
+++ b/build/docker/entrypoint.sh
@@ -17,13 +17,14 @@ initialize_data_dir() {
 
   # initialize the data volume
   if [[ ! -d ${OPENFIRE_DATA_DIR}/conf ]]; then
-    sudo -HEu ${OPENFIRE_USER} cp -a ${OPENFIRE_DIR}/conf_org ${OPENFIRE_DATA_DIR}/conf
-    sudo -HEu ${OPENFIRE_USER} cp -a ${OPENFIRE_DIR}/plugins_org ${OPENFIRE_DATA_DIR}/plugins
-    sudo -HEu ${OPENFIRE_USER} cp -a ${OPENFIRE_DIR}/resources/security_org ${OPENFIRE_DATA_DIR}/conf/security
+    cp -a ${OPENFIRE_DIR}/conf_org ${OPENFIRE_DATA_DIR}/conf
+    cp -a ${OPENFIRE_DIR}/plugins_org ${OPENFIRE_DATA_DIR}/plugins
+    cp -a ${OPENFIRE_DIR}/resources/security_org ${OPENFIRE_DATA_DIR}/conf/security
   fi
-  sudo -HEu ${OPENFIRE_USER} mkdir -p ${OPENFIRE_DATA_DIR}/{plugins,embedded-db}
-  sudo -HEu ${OPENFIRE_USER} rm -rf ${OPENFIRE_DATA_DIR}/plugins/admin
-  sudo -HEu ${OPENFIRE_USER} ln -sf ${OPENFIRE_DIR}/plugins_org/admin ${OPENFIRE_DATA_DIR}/plugins/admin
+  mkdir -p ${OPENFIRE_DATA_DIR}/{plugins,embedded-db}
+  rm -rf ${OPENFIRE_DATA_DIR}/plugins/admin
+  ln -sf ${OPENFIRE_DIR}/plugins_org/admin ${OPENFIRE_DATA_DIR}/plugins/admin
+  chown -R ${OPENFIRE_USER}:${OPENFIRE_USER} ${OPENFIRE_DATA_DIR}
 
   # create version file
   CURRENT_VERSION=

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,12 @@
             <plugins>
 
                 <plugin>
+                    <groupId>de.qaware.maven</groupId>
+                    <artifactId>go-offline-maven-plugin</artifactId>
+                    <version>1.2.8</version>
+                </plugin>
+
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.1.1</version>


### PR DESCRIPTION
This changes the Dockerfile quite radically, so that Openfire is built within Docker rather than outside of it. This should simplify building the image, and also make the results more repeatable.

In order to maximize the use of the cache while keeping the image size under control, this uses three stages:

* The first stage locates and extracts all the POM files and any JAR files. This stage will be re-run on any change, but it short.
* The second stage takes the output of the first stage and gathers dependencies. These will be cached, unless the output of the first stage (ie, the dependency information) changes. Then it copies in the full source, and builds it.
* Finally, the runtime container is setup much as it was before, except that the runtime files are copied from the build stage rather than the filesystem directly.

The result is that a repeat build of the docker image now takes about two minutes, but can trivially be done on any docker platform (even without Java installed locally).

Notes:
* The build stage should be able to run the `mvn package` in offline mode, but maven (being maven) wants to download more during this stage.
* The `.dockerignore` file has of course been changed, but someone who understands Java better than I might well improve it further.