### PR TITLE
OF-2858: Fix error condition for MUC PM

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -919,7 +919,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         catch ( NotFoundException e )
         {
             Log.debug("Rejecting private message from occupant '{}' to room '{}'. User addressing a non-existent recipient.", packet.getFrom(), room.getName(), e);
-            sendErrorPacket(packet, PacketError.Condition.recipient_unavailable, "The intended recipient of your private message is not available.");
+            sendErrorPacket(packet, PacketError.Condition.item_not_found, "The intended recipient of your private message is not available.");
         }
     }
 


### PR DESCRIPTION
When sending a private message to a user that's not an occupant of the room, XEP-0045 section 7.5 defines that a different error condition is to be used than the one that Openfire has been using. This commit corrects the error condition.