### PR TITLE
OF-2863: CI - Update docker compose command to match GHA runners

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -263,7 +263,7 @@ jobs:
           mkdir olddb
           curl https://raw.githubusercontent.com/igniterealtime/Openfire/v3.9.3/src/database/openfire_sqlserver.sql > $GITHUB_WORKSPACE/olddb/openfire_sqlserver.sql
       - name: Start database server and install database
-        run: docker-compose -f ./build/ci/compose/mssql.yml up --detach
+        run: docker compose -f ./build/ci/compose/mssql.yml up --detach
       - name: Build & run update tester
         run: |
           pushd ./build/ci/updater
@@ -304,7 +304,7 @@ jobs:
           mkdir olddb
           curl https://raw.githubusercontent.com/igniterealtime/Openfire/v3.9.3/src/database/openfire_postgresql.sql > $GITHUB_WORKSPACE/olddb/openfire_postgresql.sql
       - name: Start database server and install database
-        run: docker-compose -f ./build/ci/compose/postgresql.yml up --detach
+        run: docker compose -f ./build/ci/compose/postgresql.yml up --detach
       - name: Build & run update tester
         run: |
           pushd ./build/ci/updater
@@ -345,7 +345,7 @@ jobs:
           mkdir olddb
           curl https://raw.githubusercontent.com/igniterealtime/Openfire/v3.9.3/src/database/openfire_mysql.sql > $GITHUB_WORKSPACE/olddb/openfire_mysql.sql
       - name: Start database server and install database
-        run: docker-compose -f ./build/ci/compose/mysql.yml up --detach
+        run: docker compose -f ./build/ci/compose/mysql.yml up --detach
       - name: Build & run update tester
         run: |
           pushd ./build/ci/updater


### PR DESCRIPTION
Swap `docker-compose` for `docker compose` to fit with modern Github Actions runners