### PR TITLE
OF-2864: Deprecate org.jivesoftware.util.Base64

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/admin/LdapUserTester.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/LdapUserTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.jivesoftware.admin;
 
-import org.jivesoftware.util.Base64;
 import org.jivesoftware.openfire.ldap.LdapManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +24,10 @@ import org.xmpp.packet.JID;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.*;
-import javax.naming.ldap.*;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.Rdn;
+import javax.naming.ldap.SortControl;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.*;
@@ -198,7 +200,7 @@ public class LdapUserTester {
                 if (ob instanceof String) {
                     answer = (String) ob;
                 } else {
-                    answer = Base64.encodeBytes((byte[]) ob);
+                    answer = Base64.getEncoder().encodeToString((byte[]) ob);
                 }
                 if ( mapping.isFirstMatchOnly()) {
                     // find and use the first non-null value.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/entitycaps/EntityCapabilitiesManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/entitycaps/EntityCapabilitiesManager.java
@@ -365,7 +365,7 @@ public class EntityCapabilitiesManager extends BasicModule implements IQResultLi
         // specified in Section 4 of RFC 4648 (note: the Base64 output
         // MUST NOT include whitespace and MUST set padding bits to zero).
         final String hashed = StringUtils.hash(s.toString(), algorithm);
-        return StringUtils.encodeBase64(StringUtils.decodeHex(hashed));
+        return Base64.getEncoder().encodeToString(StringUtils.decodeHex(hashed));
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
@@ -24,7 +24,6 @@ import org.jivesoftware.openfire.vcard.DefaultVCardProvider;
 import org.jivesoftware.openfire.vcard.PhotoResizer;
 import org.jivesoftware.openfire.vcard.VCardManager;
 import org.jivesoftware.openfire.vcard.VCardProvider;
-import org.jivesoftware.util.Base64;
 import org.jivesoftware.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +32,7 @@ import org.xmpp.packet.JID;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.ldap.Rdn;
+import java.util.Base64;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -200,7 +200,7 @@ public class LdapVCardProvider implements VCardProvider, PropertyEventListener {
                     if(ob instanceof String) {
                         value = (String)ob;
                     } else {
-                        value = Base64.encodeBytes((byte[])ob);
+                        value = Base64.getEncoder().encodeToString((byte[])ob);
                     }
                 }
                 Log.debug("LdapVCardProvider: Ldap attribute '" + attribute + "'=>'" + value + "'");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCvCardHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCvCardHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2020-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,10 @@ import org.jivesoftware.openfire.muc.MultiUserChatService;
 import org.jivesoftware.openfire.session.Session;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.openfire.vcard.VCardManager;
-import org.jivesoftware.util.*;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.LocaleUtils;
+import org.jivesoftware.util.StringUtils;
+import org.jivesoftware.util.SystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.IQ;
@@ -36,6 +39,7 @@ import org.xmpp.packet.Message;
 import org.xmpp.packet.PacketError;
 import org.xmpp.packet.Presence;
 
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.concurrent.locks.Lock;
@@ -285,7 +289,7 @@ public class IQMUCvCardHandler extends IQHandler
             return "";
         }
 
-        final byte[] photo = Base64.decode(element.getTextTrim());
+        final byte[] photo = Base64.getDecoder().decode(element.getTextTrim());
         return StringUtils.hash(photo, "SHA-1");
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/RespondingServerStanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.xmpp.packet.StreamError;
 
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -212,7 +213,7 @@ public class RespondingServerStanzaHandler extends StanzaHandler {
                 if (SASLAuthentication.EXTERNAL_S2S_SKIP_SENDING_AUTHZID.getValue()) {
                     auth.addText("=");
                 } else {
-                    auth.addText(StringUtils.encodeBase64(domainPair.getLocal()));
+                    auth.addText(Base64.getEncoder().encodeToString(domainPair.getLocal().getBytes(StandardCharsets.UTF_8)));
                 }
                 connection.deliverRawText(auth.asXML());
                 startedSASL = true;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,10 @@ import org.jivesoftware.openfire.sasl.JiveSharedSecretSaslServer;
 import org.jivesoftware.openfire.sasl.SaslFailureException;
 import org.jivesoftware.openfire.session.*;
 import org.jivesoftware.openfire.spi.ConnectionType;
-import org.jivesoftware.util.*;
+import org.jivesoftware.util.CertificateManager;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.PropertyEventListener;
+import org.jivesoftware.util.SystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -415,7 +418,7 @@ public class SASLAuthentication {
                             throw new SaslFailureException( Failure.INCORRECT_ENCODING );
                         }
 
-                        decoded = StringUtils.decodeBase64( encoded );
+                        decoded = Base64.getDecoder().decode(encoded);
                     }
 
                     // Process client response.
@@ -510,7 +513,7 @@ public class SASLAuthentication {
     private static void sendElement(Session session, String element, byte[] data) {
         final Element reply = DocumentHelper.createElement(QName.get(element, "urn:ietf:params:xml:ns:xmpp-sasl"));
         if (data != null) {
-            String data_b64 = StringUtils.encodeBase64(data).trim();
+            String data_b64 = Base64.getEncoder().encodeToString(data).trim();
             if (data_b64.isEmpty()) {
                 data_b64 = "=";
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -24,10 +24,8 @@ import org.jivesoftware.openfire.PacketRouter;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.auth.AuthToken;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
-import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.session.*;
 import org.jivesoftware.util.JiveGlobals;
-import org.jivesoftware.util.StringUtils;
 import org.jivesoftware.util.SystemProperty;
 import org.jivesoftware.util.XMPPDateTimeFormat;
 import org.jivesoftware.util.cache.CacheFactory;
@@ -38,10 +36,7 @@ import org.xmpp.packet.*;
 import java.math.BigInteger;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
-import java.util.Date;
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.StringTokenizer;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -253,7 +248,7 @@ public class StreamManager {
             this.resume = resume && offerResume;
             if ( this.resume ) {
                 // Create SM-ID.
-                smId = StringUtils.encodeBase64( session.getAddress().getResource() + "\0" + session.getStreamID().getID());
+                smId = Base64.getEncoder().encodeToString((session.getAddress().getResource() + "\0" + session.getStreamID().getID()).getBytes(StandardCharsets.UTF_8));
             }
         }
 
@@ -306,7 +301,7 @@ public class StreamManager {
         String resource;
         String streamId;
         try {
-            StringTokenizer toks = new StringTokenizer(new String(StringUtils.decodeBase64(previd), StandardCharsets.UTF_8), "\0");
+            StringTokenizer toks = new StringTokenizer(new String(Base64.getDecoder().decode(previd), StandardCharsets.UTF_8), "\0");
             resource = toks.nextToken();
             streamId = toks.nextToken();
         } catch (Exception e) {
@@ -605,7 +600,7 @@ public class StreamManager {
     public void onResume(JID serverAddress, long h) {
         Log.debug("Agreeing to resume");
         Element resumed = new DOMElement(QName.get("resumed", namespace));
-        resumed.addAttribute("previd", StringUtils.encodeBase64( session.getAddress().getResource() + "\0" + session.getStreamID().getID()));
+        resumed.addAttribute("previd", Base64.getEncoder().encodeToString((session.getAddress().getResource() + "\0" + session.getStreamID().getID()).getBytes(StandardCharsets.UTF_8)));
         resumed.addAttribute("h", Long.toString(serverProcessedStanzas.get()));
         final Connection connection = session.getConnection();
         assert connection != null; // While the client is resuming a session, the connection on which the session is resumed can't be null.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/PhotoResizer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/PhotoResizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.jivesoftware.openfire.vcard;
 
 import org.dom4j.Element;
-import org.jivesoftware.util.Base64;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +30,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
 import java.util.Iterator;
 
 /**
@@ -88,7 +88,7 @@ public class PhotoResizer
         final ImageWriter iw = (ImageWriter) it.next();
 
         // Extract the original avatar from the VCard.
-        final byte[] original = Base64.decode( element.getTextTrim() );
+        final byte[] original = Base64.getDecoder().decode( element.getTextTrim() );
 
         // Crop and shrink, if needed.
         final int targetDimension = JiveGlobals.getIntProperty( PROPERTY_TARGETDIMENSION, PROPERTY_TARGETDIMENSION_DEFAULT );
@@ -98,7 +98,7 @@ public class PhotoResizer
         if ( resized != null )
         {
             Log.debug( "Replacing original avatar in vcard with a resized variant." );
-            vCardElement.element( "PHOTO" ).element( "BINVAL" ).setText( Base64.encodeBytes( resized ) );
+            vCardElement.element( "PHOTO" ).element( "BINVAL" ).setText( Base64.getEncoder().encodeToString( resized ) );
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/AesEncryptor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/AesEncryptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,16 @@
  */
 package org.jivesoftware.util;
 
-import java.nio.charset.StandardCharsets;
-import java.security.Key;
-import java.security.Security;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.security.Security;
 
 /**
  * Utility class providing symmetric AES encryption/decryption. To strengthen
@@ -84,7 +83,7 @@ public class AesEncryptor implements Encryptor {
     public String encrypt(String value, byte[] iv) {
         if (value == null) { return null; }
         byte [] bytes = value.getBytes(StandardCharsets.UTF_8);
-        return Base64.encodeBytes(cipher(bytes, getKey(), iv == null ? INIT_PARM : iv, Cipher.ENCRYPT_MODE));
+        return java.util.Base64.getEncoder().encodeToString(cipher(bytes, getKey(), iv == null ? INIT_PARM : iv, Cipher.ENCRYPT_MODE));
     }
 
     /* (non-Javadoc)
@@ -98,7 +97,7 @@ public class AesEncryptor implements Encryptor {
     @Override
     public String decrypt(String value, byte[] iv) {
         if (value == null) { return null; }
-        byte [] bytes = cipher(Base64.decode(value), getKey(), iv == null ? INIT_PARM : iv, Cipher.DECRYPT_MODE);
+        byte [] bytes = cipher(java.util.Base64.getDecoder().decode(value), getKey(), iv == null ? INIT_PARM : iv, Cipher.DECRYPT_MODE);
         if (bytes == null) { return null; }
         return new String(bytes, StandardCharsets.UTF_8);
     }

--- a/xmppserver/src/main/java/org/jivesoftware/util/Base64.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Base64.java
@@ -82,7 +82,7 @@ package org.jivesoftware.util;
  * @version 2.2.1
  * @deprecated Use java.util.Base64 instead.
  */
-@Deprecated(forRemoval = true, since = "4.8.4") // Remove in or after Openfire 4.9.0
+@Deprecated(forRemoval = true, since = "4.9.0") // Remove in or after Openfire 4.10.0
 public class Base64
 {
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/Base64.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Base64.java
@@ -80,7 +80,9 @@ package org.jivesoftware.util;
  * @author Robert Harder
  * @author rob@iharder.net
  * @version 2.2.1
+ * @deprecated Use java.util.Base64 instead.
  */
+@Deprecated(forRemoval = true, since = "4.8.4") // Remove in or after Openfire 4.9.0
 public class Base64
 {
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/StringUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/StringUtils.java
@@ -398,7 +398,7 @@ public final class StringUtils {
      * @return a base64 encoded String.
      * @deprecated Use java.util.Base64 instead.
      */
-    @Deprecated(forRemoval = true, since = "4.8.4") // Remove in or after Openfire 4.9.0
+    @Deprecated(forRemoval = true, since = "4.9.0") // Remove in or after Openfire 4.10.0
     public static String encodeBase64(String data) {
         return java.util.Base64.getEncoder().encodeToString(data.getBytes(StandardCharsets.UTF_8));
     }
@@ -410,7 +410,7 @@ public final class StringUtils {
      * @return a base64 encode String.
      * @deprecated Use java.util.Base64 instead.
      */
-    @Deprecated(forRemoval = true, since = "4.8.4") // Remove in or after Openfire 4.9.0
+    @Deprecated(forRemoval = true, since = "4.9.0") // Remove in or after Openfire 4.10.0
     public static String encodeBase64(byte[] data) {
         // Encode the String. We pass in a flag to specify that line
         // breaks not be added. This is consistent with our previous base64
@@ -426,7 +426,7 @@ public final class StringUtils {
      * @return the decoded String.
      * @deprecated Use java.util.Base64 instead.
      */
-    @Deprecated(forRemoval = true, since = "4.8.4") // Remove in or after Openfire 4.9.0
+    @Deprecated(forRemoval = true, since = "4.9.0") // Remove in or after Openfire 4.10.0
     public static byte[] decodeBase64(String data) {
         return java.util.Base64.getDecoder().decode(data);
     }

--- a/xmppserver/src/main/java/org/jivesoftware/util/StringUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -396,10 +396,11 @@ public final class StringUtils {
      *
      * @param data a String to encode.
      * @return a base64 encoded String.
+     * @deprecated Use java.util.Base64 instead.
      */
+    @Deprecated(forRemoval = true, since = "4.8.4") // Remove in or after Openfire 4.9.0
     public static String encodeBase64(String data) {
-        byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
-        return encodeBase64(bytes);
+        return java.util.Base64.getEncoder().encodeToString(data.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
@@ -407,13 +408,15 @@ public final class StringUtils {
      *
      * @param data a byte array to encode.
      * @return a base64 encode String.
+     * @deprecated Use java.util.Base64 instead.
      */
+    @Deprecated(forRemoval = true, since = "4.8.4") // Remove in or after Openfire 4.9.0
     public static String encodeBase64(byte[] data) {
         // Encode the String. We pass in a flag to specify that line
         // breaks not be added. This is consistent with our previous base64
         // implementation. Section 2.1 of 3548 (base64 spec) also specifies
         // no line breaks by default.
-        return Base64.encodeBytes(data, Base64.DONT_BREAK_LINES);
+        return java.util.Base64.getEncoder().encodeToString(data);
     }
 
     /**
@@ -421,9 +424,11 @@ public final class StringUtils {
      *
      * @param data a base64 encoded String to decode.
      * @return the decoded String.
+     * @deprecated Use java.util.Base64 instead.
      */
+    @Deprecated(forRemoval = true, since = "4.8.4") // Remove in or after Openfire 4.9.0
     public static byte[] decodeBase64(String data) {
-        return Base64.decode(data);
+        return java.util.Base64.getDecoder().decode(data);
     }
 
     /**

--- a/xmppserver/src/main/webapp/login.jsp
+++ b/xmppserver/src/main/webapp/login.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2004-2010 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2010 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -25,11 +25,15 @@
 <%@ page import="org.jivesoftware.openfire.auth.*" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="org.jivesoftware.util.*" %>
 <%@ page import="org.jivesoftware.admin.LoginLimitManager" %>
 <%@ page import="java.net.URL" %>
 <%@ page import="java.lang.StringBuilder" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
+<%@ page import="org.jivesoftware.util.ParamUtils" %>
+<%@ page import="org.jivesoftware.util.CookieUtils" %>
+<%@ page import="java.util.Base64" %>
+<%@ page import="org.jivesoftware.util.StringUtils" %>
+<%@ page import="org.jivesoftware.util.LocaleUtils" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -123,7 +127,7 @@
         }
         try {
             if (secret != null && nodeID != null) {
-                if (StringUtils.hash(AdminConsolePlugin.secret).equals(secret) && ClusterManager.isClusterMember(Base64.decode(nodeID, Base64.URL_SAFE))) {
+                if (StringUtils.hash(AdminConsolePlugin.secret).equals(secret) && ClusterManager.isClusterMember(Base64.getUrlDecoder().decode(nodeID))) {
                     authToken = AuthToken.generateUserToken(loginUsername);
                 }
                 else {

--- a/xmppserver/src/main/webapp/system-clustering.jsp
+++ b/xmppserver/src/main/webapp/system-clustering.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@
 <%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" errorPage="error.jsp" %>
 <%@ page import="org.jivesoftware.openfire.cluster.ClusterNodeInfo" %>
 <%@ page import="org.jivesoftware.openfire.cluster.GetBasicStatistics" %>
-<%@ page import="org.jivesoftware.util.Base64" %>
 <%@ page import="org.jivesoftware.util.CookieUtils" %>
 <%@ page import="org.jivesoftware.util.JiveGlobals" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
@@ -346,7 +345,7 @@
                 for (ClusterNodeInfo nodeInfo : clusterNodesInfo) {
                     boolean isLocalMember =
                             XMPPServer.getInstance().getNodeID().equals(nodeInfo.getNodeID());
-                    String nodeID = Base64.encodeBytes(nodeInfo.getNodeID().toByteArray(), Base64.URL_SAFE);
+                    String nodeID = Base64.getUrlEncoder().encodeToString(nodeInfo.getNodeID().toByteArray());
                     Map<String, Object> nodeStats = null;
                     for (Map<String, Object> statsMap : statistics) {
                         if (statsMap == null) {

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/KeystoreTestUtils.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/KeystoreTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,15 +32,15 @@ import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.ContentVerifierProvider;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
-import org.jivesoftware.util.Base64;
 
 import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.security.*;
-import java.security.cert.*;
+import java.security.cert.X509Certificate;
 import java.sql.Date;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Base64;
 import java.util.zip.Adler32;
 
 /**
@@ -73,7 +73,7 @@ public class KeystoreTestUtils
      */
     public static String toPemFormat( X509Certificate certificate ) throws Exception {
         return String.valueOf(BEGIN_CERT) + '\n' +
-            Base64.encodeBytes(certificate.getEncoded()) + '\n' +
+            Base64.getMimeEncoder().encodeToString(certificate.getEncoded()) + '\n' +
             END_CERT + '\n';
     }
 

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
@@ -33,6 +33,7 @@ import javax.security.sasl.SaslException;
 import javax.xml.bind.DatatypeConverter;
 import java.nio.charset.StandardCharsets;
 import java.security.spec.KeySpec;
+import java.util.Base64;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -134,7 +135,7 @@ public class ScramSha1SaslServerTest
 
         final byte[] serverKey = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, saltedPassword).hmac(hardCodedServerKey);
         final byte[] serverSignature = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, serverKey).hmac(authMessage);
-        final String clientFinalMessage = clientFinalMessageBare + ",p=" + StringUtils.encodeBase64(clientProof);
+        final String clientFinalMessage = clientFinalMessageBare + ",p=" + Base64.getEncoder().encodeToString(clientProof);
 
         try {
             // Execute system under test: getting the final server message.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteInitiatingServerDummy.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/RemoteInitiatingServerDummy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.StreamID;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.spi.BasicStreamIDFactory;
-import org.jivesoftware.util.Base64;
 
 import javax.net.ssl.*;
 import java.io.IOException;
@@ -38,6 +37,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.*;
 
@@ -603,7 +603,7 @@ public class RemoteInitiatingServerDummy extends AbstractRemoteServerDummy
             final Document outbound = DocumentHelper.createDocument();
             final Element root = outbound.addElement(QName.get("auth", "urn:ietf:params:xml:ns:xmpp-sasl"));
             root.addAttribute("mechanism", "EXTERNAL");
-            root.setText(Base64.encodeBytes(XMPP_DOMAIN.getBytes()));
+            root.setText(Base64.getEncoder().encodeToString(XMPP_DOMAIN.getBytes()));
             send(root.asXML());
         }
 


### PR DESCRIPTION
Marked `org.jivesoftware.util.Base64` as deprecated, replaced all usage with `java.util.Base64`.

This replaces customer code with code provided by Java itself, reducing the maintenance load.