### PR TITLE
Remove code marked for deprecation in 4.9.0 or later

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -239,22 +239,11 @@ public interface Connection extends Closeable {
     boolean isClosed();
 
     /**
-     * Returns true if this connection is secure.
-     *
-     * @return true if the connection is secure (e.g. TLS)
-     * @deprecated Renamed. Use {@link #isEncrypted()} instead.
-     */
-    @Deprecated // Remove in Openfire 4.9 or later.
-    boolean isSecure();
-
-    /**
      * Returns true if this connection is encrypted.
      *
      * @return true if the connection is encrypted (e.g. uses TLS)
      */
-    default boolean isEncrypted() {
-        return isSecure();
-    }
+    boolean isEncrypted();
 
     /**
      * Registers a listener for close event notification. Registrations after

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
@@ -150,14 +150,6 @@ public interface RoutingTable {
     void routePacket(JID jid, Packet packet) throws PacketException;
 
     /**
-     * @deprecated Replaced by {@link #routePacket(JID, Packet)}
-     */
-    @Deprecated // Remove in or after Openfire 4.9.0.
-    default void routePacket(JID jid, Packet packet, boolean fromServer) throws PacketException {
-        routePacket(jid, packet);
-    }
-
-    /**
      * Returns true if a registered user or anonymous user with the specified full JID is
      * currently logged. When running inside of a cluster a true value will be returned
      * as long as the user is connected to any cluster node.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionPacketRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionPacketRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,7 +139,7 @@ public class SessionPacketRouter implements PacketRouter {
     public static boolean isInvalidStanzaSentPriorToResourceBinding(final Packet stanza, final ClientSession session)
     {
         // Openfire sets 'authenticated' only after resource binding.
-        if (session.getStatus() == Session.STATUS_AUTHENTICATED) {
+        if (session.getStatus() == Session.Status.AUTHENTICATED) {
             return false;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/SessionData.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/SessionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class SessionData {
         return owner;
     }
 
-    @Deprecated // replaced by getCreationInstant. Remove in Openfire 4.9.0 or later.
+    @Deprecated(since = "4.8.1", forRemoval = true) // replaced by getCreationInstant. Remove in Openfire 4.10.0 or later.
     public long getCreationStamp() {
         return creationStamp.toEpochMilli();
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/ExternalComponentManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/ExternalComponentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,11 @@
 package org.jivesoftware.openfire.component;
 
 import org.jivesoftware.database.DbConnectionManager;
-import org.jivesoftware.openfire.ConnectionManager;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.component.ExternalComponentConfiguration.Permission;
 import org.jivesoftware.openfire.session.ComponentSession;
 import org.jivesoftware.openfire.session.Session;
-import org.jivesoftware.openfire.spi.ConnectionType;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.ModificationNotAllowedException;
 import org.slf4j.Logger;
@@ -66,64 +64,6 @@ public class ExternalComponentManager {
      */
     private static List<ExternalComponentManagerListener> listeners =
             new CopyOnWriteArrayList<>();
-
-    /**
-     * @param enabled enables or disables the service
-     * @deprecated Obtain and use the corresponding {@link org.jivesoftware.openfire.spi.ConnectionListener} instead.
-     * @throws ModificationNotAllowedException if the status of the service cannot be changed
-     */
-    @Deprecated
-    public static void setServiceEnabled(boolean enabled) throws ModificationNotAllowedException {
-        // Alert listeners about this event
-        for (ExternalComponentManagerListener listener : listeners) {
-            try {
-                listener.serviceEnabled(enabled);
-            } catch (Exception e) {
-                Log.warn("An exception occurred while dispatching a 'serviceEnabled' event!", e);
-            }
-        }
-        ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
-        connectionManager.enable(ConnectionType.COMPONENT, false, enabled);
-    }
-
-    /**
-     * @deprecated Obtain and use the corresponding {@link org.jivesoftware.openfire.spi.ConnectionListener} instead.
-     * @return {@code true} if the service is enabled, otherwise {@code false}
-     */
-    @Deprecated
-    public static boolean isServiceEnabled() {
-        ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
-        return connectionManager.isEnabled(ConnectionType.COMPONENT, false);
-    }
-
-    /**
-     * @param port The port to use
-     * @deprecated Obtain and use the corresponding {@link org.jivesoftware.openfire.spi.ConnectionListener} instead.
-     * @throws ModificationNotAllowedException if the server cannot be modified
-     */
-    @Deprecated
-    public static void setServicePort(int port) throws ModificationNotAllowedException {
-        // Alert listeners about this event
-        for (ExternalComponentManagerListener listener : listeners) {
-            try {
-                listener.portChanged(port);  
-            } catch (Exception e) {
-                Log.warn("An exception occurred while dispatching a 'portChanged' event!", e);
-            }
-        }
-        ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
-        connectionManager.setPort(ConnectionType.COMPONENT, false, port);
-    }
-
-    /**
-     * @deprecated Obtain and use the corresponding {@link org.jivesoftware.openfire.spi.ConnectionListener} instead.
-     * @return the port number
-     */
-    @Deprecated
-    public static int getServicePort() {
-        ConnectionManager connectionManager = XMPPServer.getInstance().getConnectionManager();
-        return connectionManager.getPort(ConnectionType.COMPONENT, false);
-    }
 
     /**
      * Allows an external component to connect to the local server with the specified configuration.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.GuardedBy;
 import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.*;
@@ -390,7 +389,7 @@ public class PluginManager
      * @return the plugin.
      */
     // TODO: (2019-03-26) Remove with Openfire 5.0
-    @Deprecated
+    @Deprecated(since = "4.4", forRemoval = true)
     public synchronized Plugin getPlugin( String canonicalName )
     {
         return pluginsLoaded.get( canonicalName.toLowerCase() );
@@ -413,17 +412,6 @@ public class PluginManager
             .map(PluginMetadata::getCanonicalName)
             // Finally, find the plugin
             .flatMap(canonicalName -> Optional.ofNullable(pluginsLoaded.get(canonicalName)));
-    }
-
-    /**
-     * @deprecated Use #getPluginPath() instead.
-     * @param plugin the plugin to get the directory for
-     * @return the plugin's directory
-     */
-    @Deprecated
-    public File getPluginDirectory( Plugin plugin )
-    {
-        return getPluginPath( plugin ).toFile();
     }
 
     /**
@@ -1007,94 +995,6 @@ public class PluginManager
             loader = classloaders.get( plugin );
         }
         return loader.loadClass( className );
-    }
-
-    /**
-     * @deprecated Moved to {@link PluginMetadataHelper#getName(Plugin)}.
-     * @param plugin the plugin to get the name for
-     * @return the name of the plugin, as defined in the plugin.xml
-     */
-    @Deprecated
-    public String getName( Plugin plugin )
-    {
-        return PluginMetadataHelper.getName( plugin );
-    }
-
-    /**
-     * @deprecated Moved to {@link PluginMetadataHelper#getDescription(Plugin)}.
-     * @param plugin the plugin to get the description for
-     * @return the description of the plugin
-     */
-    @Deprecated
-    public String getDescription( Plugin plugin )
-    {
-        return PluginMetadataHelper.getDescription( plugin );
-    }
-
-    /**
-     * @deprecated Moved to {@link PluginMetadataHelper#getAuthor(Plugin)}.
-     * @param plugin the plugin to get the author for
-     * @return the author of the plugin
-     */
-    @Deprecated
-    public String getAuthor( Plugin plugin )
-    {
-        return PluginMetadataHelper.getAuthor( plugin );
-    }
-
-    /**
-     * @deprecated Moved to {@link PluginMetadataHelper#getVersion(Plugin)}.
-     * @param plugin the plugin to get the version for
-     * @return the version of the plugin
-     */
-    @Deprecated
-    public String getVersion( Plugin plugin )
-    {
-        return PluginMetadataHelper.getVersion( plugin ).getVersionString();
-    }
-
-    /**
-     * @deprecated Moved to {@link PluginMetadataHelper#getMinServerVersion(Plugin)}.
-     * @param plugin the plugin to get the minimum server version for
-     * @return the minimum server version for the plugin
-     */
-    @Deprecated
-    public String getMinServerVersion( Plugin plugin )
-    {
-        return PluginMetadataHelper.getMinServerVersion( plugin ).getVersionString();
-    }
-
-    /**
-     * @deprecated Moved to {@link PluginMetadataHelper#getDatabaseKey(Plugin)}.
-     * @param plugin the plugin to get the database key for
-     * @return the database key for the plugin
-     */
-    @Deprecated
-    public String getDatabaseKey( Plugin plugin )
-    {
-        return PluginMetadataHelper.getDatabaseKey( plugin );
-    }
-
-    /**
-     * @deprecated Moved to {@link PluginMetadataHelper#getDatabaseVersion(Plugin)}.
-     * @param plugin the plugin to get the database version for
-     * @return the database version for the plugin
-     */
-    @Deprecated
-    public int getDatabaseVersion( Plugin plugin )
-    {
-        return PluginMetadataHelper.getDatabaseVersion( plugin );
-    }
-
-    /**
-     * @deprecated Moved to {@link PluginMetadataHelper#getLicense(Plugin)}.
-     * @param plugin the plugin to get the licence for
-     * @return the licence for the plugin
-     */
-    @Deprecated
-    public String getLicense( Plugin plugin )
-    {
-        return PluginMetadataHelper.getLicense( plugin );
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,14 +107,6 @@ public class HttpConnection {
      */
     public synchronized boolean isClosed() {
         return isClosed;
-    }
-
-    /**
-     * @deprecated Renamed. See {@link #isEncrypted()}
-     */
-    @Deprecated // Remove in Openfire 4.9 or later.
-    public boolean isSecure() {
-        return isEncrypted();
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -344,17 +344,6 @@ public abstract class SocketReader implements Runnable {
      * @return a name that identifies the type of reader and the unique instance.
      */
     abstract String getName();
-
-    /**
-     * Close the connection since TLS was mandatory and the entity never negotiated TLS. Before
-     * closing the connection a stream error will be sent to the entity.
-     *
-     * @deprecated Renamed. Use {@link #closeNeverEncryptedConnection()} instead.
-     */
-    @Deprecated // Remove in Openfire 4.9 or later.
-    void closeNeverSecuredConnection() {
-        closeNeverEncryptedConnection();
-    }
 
     /**
      * Close the connection since TLS was mandatory and the entity never negotiated TLS. Before

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReadingMode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReadingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ abstract class SocketReadingMode {
         catch (SSLHandshakeException e) {
             // RFC6120, section 5.4.3.2 "STARTTLS Failure" - close the socket *without* sending any more data (<failure/> nor </stream>).
             Log.info( "STARTTLS negotiation (with: {}) failed.", socketReader.connection, e );
-            socketReader.connection.forceClose();
+            socketReader.connection.close(null, false);
             return false;
         }
         catch (IOException | RuntimeException e) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -627,17 +627,6 @@ public abstract class StanzaHandler {
         stream.addAttribute("version", Session.MAJOR_VERSION + "." + Session.MINOR_VERSION);
 
         return document;
-    }
-
-    /**
-     * Close the connection since TLS was mandatory and the entity never negotiated TLS. Before
-     * closing the connection a stream error will be sent to the entity.
-     *
-     * @deprecated Renamed. Use {@link #closeNeverEncryptedConnection()}
-     */
-    @Deprecated // remove in Openfire 4.9 or later.
-    protected void closeNeverSecuredConnection() {
-        closeNeverEncryptedConnection();
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,12 +93,6 @@ public abstract class VirtualConnection extends AbstractConnection
     @Override
     public void startCompression() {
         //Ignore
-    }
-
-    @Override
-    @Deprecated // Remove in Openfire 4.9 or later.
-    public boolean isSecure() {
-        return isEncrypted();
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -273,12 +273,6 @@ public class NettyConnection extends AbstractConnection
     }
 
     @Override
-    @Deprecated // Remove in Openfire 4.9 or later.
-    public boolean isSecure() {
-        return isEncrypted();
-    }
-
-    @Override
     public boolean isEncrypted() {
         return isEncrypted;
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -341,18 +341,6 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
         return features.iterator();
     }
 
-
-    /**
-     * Returns true if the PEP service is enabled in the server.
-     *
-     * @return true if the PEP service is enabled in the server.
-     * @deprecated Replaced by {@link #ENABLED}.
-     */
-    @Deprecated // Can be removed in Openfire 4.9.0 or later.
-    public boolean isEnabled() {
-        return ENABLED.getValue();
-    }
-
     // *****************************************************************
     // *** Generic module management ends here. From this point on   ***
     // *** more specific PEP related implementation after this point ***

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -489,12 +489,6 @@ public abstract class LocalSession implements Session {
     }
 
     @Override
-    @Deprecated // Remove in Openfire 4.9 or later.
-    public boolean isSecure() {
-        return isEncrypted();
-    }
-
-    @Override
     public boolean isEncrypted() {
         return Optional.ofNullable(conn)
             .map(Connection::isEncrypted)
@@ -544,14 +538,6 @@ public abstract class LocalSession implements Session {
             ", isDetached=" + isDetached() +
             ", serverName='" + serverName + '\'' +
             '}';
-    }
-
-    /**
-     * @deprecated Replaced by {@link Session#decodeVersion(String)}
-     */
-    @Deprecated // Remove in or after Openfire 4.9.0
-    protected static int[] decodeVersion(String version) {
-        return Session.decodeVersion(version);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
@@ -151,11 +151,6 @@ public abstract class RemoteSession implements Session {
         return clusterTaskResult == null ? false : (Boolean) clusterTaskResult;
     }
 
-    @Deprecated // Remove in Openfire 4.9 or later.
-    public boolean isSecure() {
-        return isEncrypted();
-    }
-
     public boolean isEncrypted() {
         ClusterTask<Object> task = getRemoteSessionTask(RemoteSessionTask.Operation.isEncrypted);
         final Object clusterTaskResult = doSynchronousClusterTask(task);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -186,7 +186,6 @@ public abstract class RemoteSessionTask implements ClusterTask<Object> {
         getSoftwareVersion,
         close,
         isClosed,
-        @Deprecated isSecure, // Replaced with 'isEncrypted', replace in Openfire 4.9 or later.
         isEncrypted,
         getHostAddress,
         getHostName,

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
@@ -59,24 +59,6 @@ public interface Session extends RoutableChannelHandler {
     }
 
     /**
-     * @deprecated Use {@link Status#CLOSED} instead.
-     */
-    @Deprecated // Remove in or after Openfire 4.9.
-    Status STATUS_CLOSED = Status.CLOSED;
-
-    /**
-     * @deprecated Use {@link Status#CONNECTED} instead.
-     */
-    @Deprecated // Remove in or after Openfire 4.9.
-    Status STATUS_CONNECTED = Status.CONNECTED;
-
-    /**
-     * @deprecated Use {@link Status#AUTHENTICATED} instead.
-     */
-    @Deprecated // Remove in or after Openfire 4.9.
-    Status STATUS_AUTHENTICATED = Status.AUTHENTICATED;
-
-    /**
       * Obtain the address of the user. The address is used by services like the core
       * server packet router to determine if a packet should be sent to the handler.
       * Handlers that are working on behalf of the server should use the generic server
@@ -160,22 +142,11 @@ public interface Session extends RoutableChannelHandler {
     };
 
     /**
-     * Returns true if this connection is secure.
-     *
-     * @return true if the connection is secure (e.g. TLS)
-     * @deprecated Renamed. Use {@link #isEncrypted()} instead.
-     */
-    @Deprecated // Remove in Openfire 4.9 or later.
-    boolean isSecure();
-
-    /**
      * Returns true if this session uses encrypted connections.
      *
      * @return true if the session is encrypted (e.g. TLS)
      */
-    default boolean isEncrypted() {
-        return isSecure();
-    }
+    boolean isEncrypted();
 
     /**
      * Returns true if this session is authenticated (eg: SASL or Dialback authentication has completed successfully).

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
@@ -202,11 +202,6 @@ public class WebSocketClientConnectionHandler
         return wsSession != null && wsSession.isOpen();
     }
 
-    @Deprecated // Remove in Openfire 4.9 or later.
-    synchronized boolean isWebSocketSecure() {
-        return isWebSocketEncrypted();
-    }
-
     synchronized boolean isWebSocketEncrypted() {
         return wsSession != null && wsSession.isSecure();
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,12 +167,6 @@ public class WebSocketConnection extends VirtualConnection
     @Override
     public boolean validate() {
         return socket.isWebSocketOpen();
-    }
-
-    @Override
-    @Deprecated // Remove in Openfire 4.9 or later.
-    public boolean isSecure() {
-        return isEncrypted();
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveConstants.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.jivesoftware.util;
 
-import java.time.Duration;
-
 /**
  * Contains constant values representing various objects in Jive.
  */
@@ -30,19 +28,4 @@ public class JiveConstants {
     public static final int SECURITY_AUDIT = 25;
     public static final int MUC_SERVICE = 26;
     public static final int MUC_MESSAGE_ID = 27;
-
-    @Deprecated // Use Duration.ofSeconds(1).toMillis() instead. Remove in Openfire 4.9 or later.
-    public static final long SECOND = Duration.ofSeconds(1).toMillis();
-
-    @Deprecated // Use Duration.ofMinutes(1).toMillis() instead. Remove in Openfire 4.9 or later.
-    public static final long MINUTE = Duration.ofMinutes(1).toMillis();
-
-    @Deprecated // Use Duration.ofHours(1).toMillis() instead. Remove in Openfire 4.9 or later.
-    public static final long HOUR = Duration.ofHours(1).toMillis();
-
-    @Deprecated // Use Duration.ofDays(1).toMillis() instead. Remove in Openfire 4.9 or later.
-    public static final long DAY = Duration.ofDays(1).toMillis();
-
-    @Deprecated // Use Duration.ofDays(7).toMillis() instead. Remove in Openfire 4.9 or later.
-    public static final long WEEK = Duration.ofDays(7).toMillis();
 }

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -257,36 +257,12 @@ public class JiveGlobals {
      * Returns the location of the <code>home</code> directory.
      *
      * @return the location of the home dir.
-     * @deprecated Replaced by {@link #getHomePath()}
-     */
-    @Deprecated(since = "4.8.0") // Remove in or after Openfire 4.9.0.
-    public static String getHomeDirectory() {
-        return getHomePath().toString();
-    }
-
-    /**
-     * Returns the location of the <code>home</code> directory.
-     *
-     * @return the location of the home dir.
      */
     public static Path getHomePath() {
         if (openfireProperties == null) {
             loadOpenfireProperties();
         }
         return home;
-    }
-
-    /**
-     * Sets the location of the <code>home</code> directory. The directory must exist and the
-     * user running the application must have read and write permissions over the specified
-     * directory.
-     *
-     * @param homeDir the location of the home dir.
-     * @deprecated Replaced by {@link #setHomePath(Path)}
-     */
-    @Deprecated(since = "4.8.0") // Remove in or after Openfire 4.9.0.
-    public static void setHomeDirectory(String homeDir) {
-        setHomePath(new File(homeDir).toPath());
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/util/TaskEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/TaskEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,14 +137,6 @@ public class TaskEngine {
     }
 
     /**
-     * @deprecated Replaced by schedule({@link TimerTask, Duration}
-     */
-    @Deprecated // Remove in Openfire 4.9.0 or later.
-    public void schedule(TimerTask task, long delay) {
-        timer.schedule(new TimerTaskWrapper(task), delay);
-    }
-
-    /**
      * Schedules the specified task for execution after the specified delay.
      *
      * @param task  task to be scheduled.
@@ -159,14 +151,6 @@ public class TaskEngine {
     }
 
     /**
-     * @deprecated Replaced by schedule({@link TimerTask, Instant}
-     */
-    @Deprecated // Remove in Openfire 4.9.0 or later.
-    public void schedule(TimerTask task, Date time) {
-        timer.schedule(new TimerTaskWrapper(task), time);
-    }
-
-    /**
      * Schedules the specified task for execution at the specified time.  If
      * the time is in the past, the task is scheduled for immediate execution.
      *
@@ -178,16 +162,6 @@ public class TaskEngine {
      */
     public void schedule(TimerTask task, Instant time) {
         timer.schedule(new TimerTaskWrapper(task), Date.from(time));
-    }
-
-    /**
-     * @deprecated Replaced by schedule({@link TimerTask, Duration, Duration}
-     */
-    @Deprecated // Remove in Openfire 4.9.0 or later.
-    public void schedule(TimerTask task, long delay, long period) {
-        TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
-        wrappedTasks.put(task, taskWrapper);
-        timer.schedule(taskWrapper, delay, period);
     }
 
     /**
@@ -228,16 +202,6 @@ public class TaskEngine {
     }
 
     /**
-     * @deprecated Replaced by schedule({@link TimerTask, Instant, Duration}
-     */
-    @Deprecated // Remove in Openfire 4.9.0 or later.
-    public void schedule(TimerTask task, Date firstTime, long period) {
-        TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
-        wrappedTasks.put(task, taskWrapper);
-        timer.schedule(taskWrapper, firstTime, period);
-    }
-
-    /**
      * Schedules the specified task for repeated <i>fixed-delay execution</i>,
      * beginning at the specified time. Subsequent executions take place at
      * approximately regular intervals, separated by the specified period.
@@ -270,16 +234,6 @@ public class TaskEngine {
         TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
         wrappedTasks.put(task, taskWrapper);
         timer.schedule(taskWrapper, Date.from(firstTime), period.toMillis());
-    }
-
-    /**
-     * @deprecated Replaced by scheduleAtFixedRate({@link TimerTask, Duration, Duration}
-     */
-    @Deprecated // Remove in Openfire 4.9.0 or later.
-    public void scheduleAtFixedRate(TimerTask task, long delay, long period) {
-        TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
-        wrappedTasks.put(task, taskWrapper);
-        timer.scheduleAtFixedRate(taskWrapper, delay, period);
     }
 
     /**
@@ -317,16 +271,6 @@ public class TaskEngine {
         TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
         wrappedTasks.put(task, taskWrapper);
         timer.scheduleAtFixedRate(taskWrapper, delay.toMillis(), period.toMillis());
-    }
-
-    /**
-     * @deprecated Replaced by scheduleAtFixedRate({@link TimerTask, Instant, Duration}
-     */
-    @Deprecated // Remove in Openfire 4.9.0 or later.
-    public void scheduleAtFixedRate(TimerTask task, Date firstTime, long period) {
-        TimerTaskWrapper taskWrapper = new TimerTaskWrapper(task);
-        wrappedTasks.put(task, taskWrapper);
-        timer.scheduleAtFixedRate(taskWrapper, firstTime, period);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -26,7 +26,10 @@ import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginClassLoader;
 import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.openfire.session.RemoteSessionLocatorImpl;
-import org.jivesoftware.util.*;
+import org.jivesoftware.util.InitializationException;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.PropertyEventDispatcher;
+import org.jivesoftware.util.PropertyEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
@@ -582,7 +585,7 @@ public class CacheFactory {
      * @param cache the cache used for holding the lock.
      * @return an existing lock on the specified key or creates a new one if none was found.
      */
-    @Deprecated
+    @Deprecated(since = "4.5", forRemoval = true)
     public static synchronized Lock getLock(Object key, Cache cache) {
         if (localOnly.contains(cache.getName())) {
             return localCacheFactoryStrategy.getLock(key, cache);


### PR DESCRIPTION
Code that was marked for removal in version 4.9.0 should be removed.

Note that we shouldn’t remove code when the mark was applied in versions 4.8.1 or later. In those cases, lets bump up the removal to the next minor version (4.10.0). This allows developers to have one ‘full’ release cycle to be aware of deprecation, and adjust their code accordingly.