### PR TITLE
OF-2867: Admin console server-session-details fix

### DIFF
--- a/xmppserver/src/main/webapp/server-session-details.jsp
+++ b/xmppserver/src/main/webapp/server-session-details.jsp
@@ -301,10 +301,10 @@
                                 </c:if>
                                 <td >
                                     <c:choose>
-                                        <c:when test="${session.usingServerDialback}">
+                                        <c:when test="${session.isUsingServerDialback()}">
                                             <fmt:message key="server.session.details.dialback"/>
                                         </c:when>
-                                        <c:when test="${session.usingSaslExternal}">
+                                        <c:when test="${session.isUsingSaslExternal()}">
                                             <fmt:message key="server.session.details.tlsauth"/>
                                         </c:when>
                                         <c:otherwise>
@@ -366,10 +366,10 @@
                                 </c:if>
                                 <td >
                                     <c:choose>
-                                        <c:when test="${session.usingServerDialback}">
+                                        <c:when test="${session.isUsingServerDialback()}">
                                             <fmt:message key="server.session.details.dialback"/>
                                         </c:when>
-                                        <c:when test="${session.usingSaslExternal}">
+                                        <c:when test="${session.isUsingSaslExternal()}">
                                             <fmt:message key="server.session.details.tlsauth"/>
                                         </c:when>
                                         <c:otherwise>


### PR DESCRIPTION
Fixing reference to `usingServerDialback` and `usingSaslExternal` (that are no true 'properties', and thus cannot be referenced like ones).

This fixes an earlier fix for OF-2867