### PR TITLE
OF-2872: Fix XML parsing when previous buffer couldn't be fully parsed

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
@@ -392,14 +392,14 @@ public class XMLLightweightParser {
     {
         final CharBuffer charBuffer = CharBuffer.allocate(in.capacity());
         encoder.reset();
-        final ByteBuffer nioBuffer = in.nioBuffer();
+        final ByteBuffer nioBuffer = in.nioBuffer(); // Note: this NIO buffer has its position initialized on 0, even if the ByteBuffer that it's obtained from has a read-index that is higher (see OF-2872).
         encoder.decode(nioBuffer, charBuffer, false);
         final char[] buf = new char[charBuffer.position()];
         charBuffer.flip();
         charBuffer.get(buf);
 
         // Netty won't update the reader-index of the original buffer when its nio-buffer representation is read from. Adjust the position of the original buffer.
-        in.readerIndex(nioBuffer.position());
+        in.readerIndex(in.readerIndex() + nioBuffer.position());
 
         return buf;
     }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/nio/XMLLightweightParserTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/nio/XMLLightweightParserTest.java
@@ -341,4 +341,27 @@ public class XMLLightweightParserTest {
         assertEquals('\u308C', result[1]);
         assertEquals(6, in.readerIndex());
     }
+
+    /**
+     * Verifies that {@link XMLLightweightParser#decode(ByteBuf)} updates the reader index of the provided buffer,
+     * specifically when the provided byte buffer has a reader index that's higher than 0.
+     *
+     * <a href="https://igniterealtime.atlassian.net/browse/OF-2872">Issue OF-2872</a>
+     */
+    @Test
+    public void testReaderWriterIndices() throws Exception
+    {
+        // Setup test fixture
+        final XMLLightweightParser parser = new XMLLightweightParser();
+        final ByteBuf in = ByteBufAllocator.DEFAULT.buffer(10);
+        in.writeBytes("foo".getBytes(StandardCharsets.UTF_8));
+        in.readerIndex(3); // fake a read of the first three characters.
+
+        // Execute system under test.
+        in.writeBytes("bar".getBytes(StandardCharsets.UTF_8));
+        parser.decode(in);
+
+        // Verify result.
+        assertEquals(6, in.readerIndex());
+    }
 }


### PR DESCRIPTION
The previous code failed to properly update the read index of the ByteBuffer that is being read, in cases where the ByteBuffer that is parsed had an initial read index higher than 0.

Through manual testing, I've observed this to fix an issue where client connections that send Cyrillic characters get disconnected with a "Stopped parsing never ending stanza" exception.