### PR TITLE
OF-2875 CI: Add build deb job

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -504,3 +504,21 @@ jobs:
           done
           echo "Openfire Admin is reachable."
           docker logs openfire
+
+  build-deb-artifact:
+    name: Generate DEB artifact
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Defend against another commit quickly following the first
+          # We want the one that's been tested, rather than the head of main
+          ref: ${{ github.event.push.after }}
+      - name: Download distribution artifact from build job.
+        uses: actions/download-artifact@v4
+        with:
+          name: distribution-java11
+          path: distribution/target/distribution-base
+      - name: Run build script
+        run: bash build/debian/build_debs.sh


### PR DESCRIPTION
This adds a step that builds the deb artifact.  It is not published anywhere at the moment, but is good to check that it works without having to mess with bamboo