### PR TITLE
OF-2877 Reproducible builds

### DIFF
--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -9,6 +9,10 @@
     <artifactId>i18n</artifactId>
     <name>Internationalization files for Openfire</name>
     <description>These files are shared among the starter and xmppserver modules</description>
+    <properties>
+        <!-- Use static build timestamp for reproducible builds -->
+        <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
+    </properties>
     <build>
         <resources>
             <resource>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -110,6 +110,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Use static build timestamp for reproducible builds -->
+        <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
 
         <!-- The name of the Openfire plugin (defaults to ${project.artifactId}. This value is somewhat particular:
            - * It is used as a Java package name (and thus, cannot contain characters like dashes and dots.
@@ -284,8 +286,14 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.4.2</version>
                     <configuration>
+                        <archive>
+                            <manifest>
+                                <!-- Don't add Created-By and Build-Jdk-Spec fields to manifest for reproducible builds -->
+                                <addDefaultEntries>false</addDefaultEntries>
+                            </manifest>
+                        </archive>
                         <excludes>
                             <exclude>**/*_jsp.java</exclude>
                         </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Use static build timestamp for reproducible builds -->
+        <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
 
         <!-- Versions -->
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
@@ -225,12 +227,14 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.4.2</version>
                     <configuration>
                         <archive>
                             <manifest>
                                 <addClasspath>false</addClasspath>
                                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                <!-- Don't add Created-By and Build-Jdk-Spec fields to manifest for reproducible builds -->
+                                <addDefaultEntries>false</addDefaultEntries>
                             </manifest>
                             <manifestEntries>
                                 <Built-By>Jive Software (www.igniterealtime.org)</Built-By>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -10,6 +10,8 @@
     <name>Starter for Openfire</name>
     <description>Starts Openfire and also launches the web admin interface in a web browser</description>
     <properties>
+        <!-- Use static build timestamp for reproducible builds -->
+        <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
     </properties>
     <build>
         <plugins>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -10,6 +10,8 @@
     <name>Core XMPP Server</name>
 
     <properties>
+        <!-- Use static build timestamp for reproducible builds -->
+        <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
         <warSourceDirectory>${basedir}/src/main/webapp</warSourceDirectory>
     </properties>
 
@@ -106,6 +108,8 @@
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
+                            <!-- Don't add Created-By and Build-Jdk-Spec fields to manifest for reproducible builds -->
+                            <addDefaultEntries>false</addDefaultEntries>
                         </manifest>
                     </archive>
                     <excludes>


### PR DESCRIPTION
Pin the build timestamp and disable Built-By, Created-By and Build-Jdk-Spec fields from generated manifest. The Maven JAR plugin is updated to latest version that has the new option addDefaultEntries

https://igniterealtime.atlassian.net/browse/OF-2877