### PR TITLE
OF-2892 Available Plugins page: redesign to make Documentation easier to see

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -3160,7 +3160,6 @@ plugin.available.file_size=File Size
 plugin.available.install=Install
 plugin.available.no_plugin=No new plugins available.
 plugin.available.download=Download and Install
-plugin.available.open_source= Open Source Plugins
 plugin.available.installation.success = plugin installed successfully.
 plugin.available.commercial_plugins = Commercial Plugins
 plugin.available.outdated = The list of plugins below requires a newer version of the server.

--- a/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
+++ b/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
@@ -2094,7 +2094,6 @@ plugin.available.author=Autor
 plugin.available.install=Instalovat
 plugin.available.no_plugin=Žádné doplňky nejsou dostupné.
 plugin.available.download=Stáhnout a nainstalovat
-plugin.available.open_source= Open Source doplňky
 plugin.available.installation.success = doplněk úspěšně nainstalován.
 plugin.available.commercial_plugins = Komerční doplňky
 plugin.available.outdated = Níže uvedený seznam doplňků vyžaduje novější verzi Openfire.

--- a/i18n/src/main/resources/openfire_i18n_de.properties
+++ b/i18n/src/main/resources/openfire_i18n_de.properties
@@ -2872,7 +2872,6 @@ plugin.available.author=Autor
 plugin.available.install=Installiere
 plugin.available.no_plugin=Keine neuen Plugins verfüegbar.
 plugin.available.download=Herunterladen und installieren
-plugin.available.open_source=Open-Source Plugins
 plugin.available.installation.success=Plugin erfolgreich installiert.
 plugin.available.commercial_plugins=Gewerbliche Plugins
 plugin.available.outdated=Die untere Pluginliste erfordert eine neuere Openfire Version.

--- a/i18n/src/main/resources/openfire_i18n_es.properties
+++ b/i18n/src/main/resources/openfire_i18n_es.properties
@@ -2823,7 +2823,6 @@ plugin.available.file_size=Tamaño de Archivo
 plugin.available.install=Instalar
 plugin.available.no_plugin=No se han encontrados nuevos plugins.
 plugin.available.download=Descargar e Instalar
-plugin.available.open_source= Plugins de Código Abierto
 plugin.available.installation.success = plugin instalado exitosamente.
 plugin.available.commercial_plugins = Plugins Comericales
 plugin.available.outdated = La lista de plugins a continuación requiere una nueva versión de Openfire.

--- a/i18n/src/main/resources/openfire_i18n_fr.properties
+++ b/i18n/src/main/resources/openfire_i18n_fr.properties
@@ -1944,7 +1944,6 @@ plugin.available.author = Auteur
 plugin.available.install = Installer
 plugin.available.no_plugin = Aucun nouveau plugin disponible.
 plugin.available.download = Télécharger et Installer
-plugin.available.open_source = Plugins Open Source
 plugin.available.installation.success = l&#39;installation du plugin est terminée.
 plugin.available.commercial_plugins = Plugins Commerciaux
 plugin.available.outdated = La liste des plugins suivant nécéssite une version plus récente de Openfire.

--- a/i18n/src/main/resources/openfire_i18n_he.properties
+++ b/i18n/src/main/resources/openfire_i18n_he.properties
@@ -2846,7 +2846,6 @@ plugin.available.file_size=גודל קובץ
 plugin.available.install=התקן
 plugin.available.no_plugin=No new plugins available.
 plugin.available.download=הורד והתקן
-plugin.available.open_source= תוספים קוד פתוח
 plugin.available.installation.success = תוסף הותקן בהצלחה.
 plugin.available.commercial_plugins = תוספים מסחריים
 plugin.available.outdated = The list of plugins below requires a newer version of the server.

--- a/i18n/src/main/resources/openfire_i18n_ja_JP.properties
+++ b/i18n/src/main/resources/openfire_i18n_ja_JP.properties
@@ -2051,7 +2051,6 @@ plugin.available.author=作者
 plugin.available.install=インストール
 plugin.available.no_plugin=利用可能な新規のプラグインがありません。
 plugin.available.download=ダウンロードとインストール
-plugin.available.open_source= オープンソースプラグイン
 plugin.available.installation.success = プラグインが正常にインストールされました。
 plugin.available.commercial_plugins = 商用プラグイン
 plugin.available.outdated = 下のプラグインのリストは、より新しいバージョンのサーバーが要求されます。

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -2827,7 +2827,6 @@ plugin.available.file_size=Bestandsgrootte
 plugin.available.install=Install
 plugin.available.no_plugin=No new plugins available.
 plugin.available.download=Download and Install
-plugin.available.open_source= Open Source Plugins
 plugin.available.installation.success = plugin installed successfully.
 plugin.available.commercial_plugins = Commercial Plugins
 plugin.available.outdated = The list of plugins below requires a newer version of Openfire.

--- a/i18n/src/main/resources/openfire_i18n_pl_PL.properties
+++ b/i18n/src/main/resources/openfire_i18n_pl_PL.properties
@@ -1964,7 +1964,6 @@ plugin.available.author=Autor
 plugin.available.install=Zainstaluj
 plugin.available.no_plugin=Brak nowych wtyczek.
 plugin.available.download=Ściągnij i zainstaluj
-plugin.available.open_source= Wtyczki Open Source
 plugin.available.installation.success = Zainstalowano wtyczkę.
 plugin.available.commercial_plugins = Wtyczki komercyjne
 plugin.available.outdated = Lista wtyczek poniżej wymaga nowszej wersji serwera Openfire.

--- a/i18n/src/main/resources/openfire_i18n_pt_BR.properties
+++ b/i18n/src/main/resources/openfire_i18n_pt_BR.properties
@@ -2063,7 +2063,6 @@ plugin.available.author=Autor
 plugin.available.install=Instalar
 plugin.available.no_plugin=Nenhum novo plugin disponível.
 plugin.available.download=Baixar e Instalar
-plugin.available.open_source= Plugins de Código Aberto
 plugin.available.installation.success = plugin instalado com sucesso.
 plugin.available.commercial_plugins = Plugins Comerciais
 plugin.available.outdated = A lista de plugins abaixo requerem uma versão mais nova do Openfire.

--- a/i18n/src/main/resources/openfire_i18n_pt_PT.properties
+++ b/i18n/src/main/resources/openfire_i18n_pt_PT.properties
@@ -2211,7 +2211,6 @@ plugin.available.author=Autor
 plugin.available.install=Instalar
 plugin.available.no_plugin=Nenhum novo plugin disponível.
 plugin.available.download=Baixar e Instalar
-plugin.available.open_source= Plugins de Código Aberto
 plugin.available.installation.success = plugin instalado com sucesso.
 plugin.available.commercial_plugins = Plugins Comerciais
 plugin.available.outdated = A lista de plugins abaixo requerem uma versão mais nova do Openfire.

--- a/i18n/src/main/resources/openfire_i18n_ru_RU.properties
+++ b/i18n/src/main/resources/openfire_i18n_ru_RU.properties
@@ -2570,7 +2570,6 @@ plugin.available.author=Разработчик
 plugin.available.install=Установить
 plugin.available.no_plugin=Нет новых плагинов.
 plugin.available.download=Скачать и установить
-plugin.available.open_source= Бесплатные плагины
 plugin.available.installation.success = плагин успешно установлен.
 plugin.available.commercial_plugins = Коммерческие плагины
 plugin.available.outdated = Список плагинов ниже требует более новой версии сервера.

--- a/i18n/src/main/resources/openfire_i18n_sk.properties
+++ b/i18n/src/main/resources/openfire_i18n_sk.properties
@@ -1951,7 +1951,6 @@ plugin.available.author=Autor
 plugin.available.install=Nainštalovať
 plugin.available.no_plugin=Nie sú dostupné žiadne nové zásuvné moduly.
 plugin.available.download=Stiahnuť a nainštalovať
-plugin.available.open_source= Open source zásuvné moduly
 plugin.available.installation.success = Zásuvný modul bol úspešne nainštalovaný.
 plugin.available.commercial_plugins = Komerčné zásuvné moduly
 plugin.available.outdated = Zoznam zásuvných modulov vyžaduje novšiu verziu servera.

--- a/i18n/src/main/resources/openfire_i18n_uk_UA.properties
+++ b/i18n/src/main/resources/openfire_i18n_uk_UA.properties
@@ -2838,7 +2838,6 @@ plugin.available.file_size=Розмір файлу
 plugin.available.install=Встановити
 plugin.available.no_plugin=Немає нових плагінів.
 plugin.available.download=Завантажте та встановіть
-plugin.available.open_source= Плагіни з відкритим кодом
 plugin.available.installation.success = плагін успішно встановлено.
 plugin.available.commercial_plugins = Комерційні плагіни
 plugin.available.outdated = Для наведеного нижче списку плагінів потрібна новіша версія сервера.

--- a/i18n/src/main/resources/openfire_i18n_zh_CN.properties
+++ b/i18n/src/main/resources/openfire_i18n_zh_CN.properties
@@ -2897,7 +2897,6 @@ plugin.available.file_size=文件大小
 plugin.available.install=安装
 plugin.available.no_plugin=没有可用的新插件。
 plugin.available.download=下载并安装
-plugin.available.open_source= 开源插件
 plugin.available.installation.success = 插件安装成功。
 plugin.available.commercial_plugins = 商用插件
 plugin.available.outdated = 下面的插件列表需要较新版本的服务器。

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/AvailablePlugin.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/AvailablePlugin.java
@@ -37,8 +37,6 @@ import org.slf4j.LoggerFactory;
 public class AvailablePlugin extends PluginMetadata
 {
     private static final Logger Log = LoggerFactory.getLogger( AvailablePlugin.class );
-    private static final DateFormat RELEASE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
-    private static final DateFormat RELEASE_DATE_DISPLAY_FORMAT = DateFormat.getDateInstance(DateFormat.MEDIUM);
 
     /**
      * URL from where the latest version of the plugin can be downloaded.
@@ -141,15 +139,7 @@ public class AvailablePlugin extends PluginMetadata
             minJavaVersion = new JavaSpecVersion( minJavaVersionValue );
         }
 
-        String releaseDate = null;
-        final String releaseDateString = plugin.attributeValue("releaseDate");
-        if( releaseDateString!= null) {
-            try {
-                releaseDate = RELEASE_DATE_DISPLAY_FORMAT.format(RELEASE_DATE_FORMAT.parse(releaseDateString));
-            } catch (final ParseException e) {
-                Log.warn("Unexpected exception parsing release date: " + releaseDateString, e);
-            }
-        }
+        final String releaseDate = plugin.attributeValue("releaseDate");
 
         long fileSize = -1;
         String fileSizeValue = plugin.attributeValue("fileSize");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/update/UpdateManager.java
@@ -730,6 +730,7 @@ public class UpdateManager extends BasicModule {
             Element component = xml.addElement("plugin");
             component.addAttribute("name", plugin.getName());
             component.addAttribute("latest", plugin.getVersion() != null ? plugin.getVersion().getVersionString() : null);
+            component.addAttribute("releaseDate", plugin.getReleaseDate());
             component.addAttribute("changelog", plugin.getChangelog() != null ? plugin.getChangelog().toExternalForm() : null );
             component.addAttribute("url", plugin.getDownloadURL() != null ? plugin.getDownloadURL().toExternalForm() : null );
             component.addAttribute("author", plugin.getAuthor());

--- a/xmppserver/src/main/webapp/available-plugins.jsp
+++ b/xmppserver/src/main/webapp/available-plugins.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
-  - Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -112,6 +112,10 @@
     border-style: solid;
     border-width: 1px 1px 1px 0;
     padding: 5px;
+}
+
+.regular:hover {
+    background-color: white;
 }
 
 .line-bottom-border {
@@ -256,7 +260,7 @@
                             </c:when>
                             <c:otherwise>
                                 <c:forEach items="${notInstalledPlugins}" var="notInstalledPlugin">
-                                    <tr id="${notInstalledPlugin.hashCode}">
+                                    <tr class="regular" id="${notInstalledPlugin.hashCode}">
                                         <td class="line-bottom-border" style="width: 1%">
                                             <c:choose>
                                                 <c:when test="${not empty notInstalledPlugin.icon}">

--- a/xmppserver/src/main/webapp/available-plugins.jsp
+++ b/xmppserver/src/main/webapp/available-plugins.jsp
@@ -276,14 +276,14 @@
                                         <td nowrap class="line-bottom-border">
                                             <c:if test="${not empty notInstalledPlugin.readme}">
                                                 <a href="${fn:escapeXml(notInstalledPlugin.readme)}"
-                                                    target="_blank" title="<fmt:message key="plugin.admin.documentation" />">
-                                                    <img src="images/doc-readme-16x16.gif">
+                                                    target="_blank">
+                                                    <fmt:message key="plugin.admin.documentation" />
                                                 </a>
                                             </c:if>
                                             <c:if test="${not empty notInstalledPlugin.changelog}">
                                                 <a href="${fn:escapeXml(notInstalledPlugin.changelog)}"
-                                                    target="_blank" title="<fmt:message key="plugin.admin.changelog" />">
-                                                    <img src="images/doc-changelog-16x16.gif">
+                                                    target="_blank">
+                                                    <fmt:message key="plugin.admin.changelog" />
                                                 </a>
                                             </c:if>
                                         </td>

--- a/xmppserver/src/main/webapp/available-plugins.jsp
+++ b/xmppserver/src/main/webapp/available-plugins.jsp
@@ -241,7 +241,7 @@
                         <tr style="background:#eee;">
                             <td class="table-header-left">&nbsp;</td>
                             <td nowrap colspan="2" class="table-header"><fmt:message key="plugin.available.name"/></td>
-                            <td nowrap class="table-header"><fmt:message key="plugin.available.description"/></td>
+                            <td class="table-header"><fmt:message key="plugin.available.description"/></td>
                             <td nowrap class="table-header"><fmt:message key="plugin.available.version"/></td>
                             <td nowrap class="table-header"><fmt:message key="plugin.available.author"/></td>
                             <td nowrap class="table-header"><fmt:message key="plugin.available.file_size"/></td>

--- a/xmppserver/src/main/webapp/available-plugins.jsp
+++ b/xmppserver/src/main/webapp/available-plugins.jsp
@@ -251,7 +251,7 @@
                         <c:choose>
                             <c:when test="${empty notInstalledPlugins}">
                                 <tr>
-                                    <td colspan="8" style="text-align: center"><fmt:message key="plugin.available.no_plugin"/></td>
+                                    <td colspan="6" style="text-align: center"><fmt:message key="plugin.available.no_plugin"/></td>
                                 </tr>
                             </c:when>
                             <c:otherwise>
@@ -315,7 +315,7 @@
                                         <td style="width: 1%" class="line-bottom-border">
                                             <img src="${fn:escapeXml(notInstalledPlugin.icon)}" width="16" height="16" alt=""/>
                                         </td>
-                                        <td colspan="6" nowrap class="line-bottom-border">${admin:escapeHTMLTags(notInstalledPlugin.name)} <fmt:message key="plugin.available.installation.success" /></td>
+                                        <td colspan="4" nowrap class="line-bottom-border">${admin:escapeHTMLTags(notInstalledPlugin.name)} <fmt:message key="plugin.available.installation.success" /></td>
                                         <td class="line-bottom-border" style="text-align: center">
                                             <img src="images/success-16x16.gif" alt=""/>
                                         </td>

--- a/xmppserver/src/main/webapp/available-plugins.jsp
+++ b/xmppserver/src/main/webapp/available-plugins.jsp
@@ -240,8 +240,7 @@
                     <thead>
                         <tr style="background:#eee;">
                             <td class="table-header-left">&nbsp;</td>
-                            <td nowrap colspan="2" class="table-header"><fmt:message key="plugin.available.name"/></td>
-                            <td class="table-header"><fmt:message key="plugin.available.description"/></td>
+                            <td class="table-header"><fmt:message key="plugin.available.name"/></td>
                             <td nowrap class="table-header"><fmt:message key="plugin.available.version"/></td>
                             <td nowrap class="table-header"><fmt:message key="plugin.available.author"/></td>
                             <td nowrap class="table-header"><fmt:message key="plugin.available.file_size"/></td>
@@ -268,12 +267,13 @@
                                                 </c:otherwise>
                                             </c:choose>
                                         </td>
-                                        <td style="width: 20%" nowrap class="line-bottom-border">
+                                        <td class="line-bottom-border">
                                             <c:if test="${not empty notInstalledPlugin.name}">
-                                                <c:out value="${notInstalledPlugin.name}"/>
+                                                <b><c:out value="${notInstalledPlugin.name}"/></b><br/>
                                             </c:if>
-                                        </td>
-                                        <td nowrap class="line-bottom-border">
+                                            <c:if test="${not empty notInstalledPlugin.description}">
+                                                <c:out value="${notInstalledPlugin.description}"/><br/>
+                                            </c:if>
                                             <c:if test="${not empty notInstalledPlugin.readme}">
                                                 <a href="${fn:escapeXml(notInstalledPlugin.readme)}"
                                                     target="_blank">
@@ -285,11 +285,6 @@
                                                     target="_blank">
                                                     <fmt:message key="plugin.admin.changelog" />
                                                 </a>
-                                            </c:if>
-                                        </td>
-                                        <td style="width: 60%" class="line-bottom-border">
-                                            <c:if test="${not empty notInstalledPlugin.description}">
-                                                <c:out value="${notInstalledPlugin.description}"/>
                                             </c:if>
                                         </td>
                                         <td style="width: 5%" nowrap class="line-bottom-border">

--- a/xmppserver/src/main/webapp/available-plugins.jsp
+++ b/xmppserver/src/main/webapp/available-plugins.jsp
@@ -240,7 +240,7 @@
                     <thead>
                         <tr style="background:#eee;">
                             <td class="table-header-left">&nbsp;</td>
-                            <td nowrap colspan="2" class="table-header"><fmt:message key="plugin.available.open_source"/></td>
+                            <td nowrap colspan="2" class="table-header"><fmt:message key="plugin.available.name"/></td>
                             <td nowrap class="table-header"><fmt:message key="plugin.available.description"/></td>
                             <td nowrap class="table-header"><fmt:message key="plugin.available.version"/></td>
                             <td nowrap class="table-header"><fmt:message key="plugin.available.author"/></td>

--- a/xmppserver/src/main/webapp/available-plugins.jsp
+++ b/xmppserver/src/main/webapp/available-plugins.jsp
@@ -257,7 +257,7 @@
                             <c:otherwise>
                                 <c:forEach items="${notInstalledPlugins}" var="notInstalledPlugin">
                                     <tr id="${notInstalledPlugin.hashCode}">
-                                        <td style="width: 1%" class="line-bottom-border">
+                                        <td class="line-bottom-border" style="width: 1%">
                                             <c:choose>
                                                 <c:when test="${not empty notInstalledPlugin.icon}">
                                                     <img src="${fn:escapeXml(notInstalledPlugin.icon)}" width="16" height="16" alt="Plugin">
@@ -267,7 +267,7 @@
                                                 </c:otherwise>
                                             </c:choose>
                                         </td>
-                                        <td class="line-bottom-border">
+                                        <td class="line-bottom-border" style="width: 60%;">
                                             <c:if test="${not empty notInstalledPlugin.name}">
                                                 <b><c:out value="${notInstalledPlugin.name}"/></b><br/>
                                             </c:if>
@@ -281,7 +281,7 @@
                                                 </a>
                                             </c:if>
                                         </td>
-                                        <td style="width: 5%" nowrap class="line-bottom-border">
+                                        <td class="line-bottom-border" style="width: 10%; white-space: nowrap;">
                                             <c:if test="${not empty notInstalledPlugin.version}">
                                                 <c:out value="${notInstalledPlugin.version}"/><br/>
                                             </c:if>
@@ -295,15 +295,15 @@
                                                 </a>
                                             </c:if>
                                         </td>
-                                        <td style="width: 15%" nowrap class="line-bottom-border">
+                                        <td class="line-bottom-border" style="width: 10%;">
                                             <c:if test="${not empty notInstalledPlugin.author}">
                                                 <c:out value="${notInstalledPlugin.author}"/>
                                             </c:if>
                                         </td>
-                                        <td style="width: 15%; text-align: right" nowrap class="line-bottom-border">
+                                        <td class="line-bottom-border" style="width: 5%; white-space: nowrap; text-align: right;">
                                             <c:out value="${admin:byteFormat( notInstalledPlugin.fileSize )}"/>
                                         </td>
-                                        <td style="width: 1%; text-align: center" class="line-bottom-border">
+                                        <td class="line-bottom-border" style="width: 1%; text-align: center;">
                                             <a href="javascript:downloadPlugin('${fn:escapeXml(notInstalledPlugin.downloadURL)}', '${notInstalledPlugin.version}', '${notInstalledPlugin.hashCode}')">
                                                 <span id="${notInstalledPlugin.hashCode}-image">
                                                     <img src="images/add-16x16.gif" alt="<fmt:message key="plugin.available.download" />">

--- a/xmppserver/src/main/webapp/available-plugins.jsp
+++ b/xmppserver/src/main/webapp/available-plugins.jsp
@@ -280,19 +280,19 @@
                                                     <fmt:message key="plugin.admin.documentation" />
                                                 </a>
                                             </c:if>
+                                        </td>
+                                        <td style="width: 5%" nowrap class="line-bottom-border">
+                                            <c:if test="${not empty notInstalledPlugin.version}">
+                                                <c:out value="${notInstalledPlugin.version}"/><br/>
+                                            </c:if>
+                                            <c:if test="${not empty notInstalledPlugin.releaseDate}">
+                                                <c:out value="${notInstalledPlugin.releaseDate}"/><br/>
+                                            </c:if>
                                             <c:if test="${not empty notInstalledPlugin.changelog}">
                                                 <a href="${fn:escapeXml(notInstalledPlugin.changelog)}"
                                                     target="_blank">
                                                     <fmt:message key="plugin.admin.changelog" />
                                                 </a>
-                                            </c:if>
-                                        </td>
-                                        <td style="width: 5%" nowrap class="line-bottom-border">
-                                            <c:if test="${not empty notInstalledPlugin.version}">
-                                                <c:out value="${notInstalledPlugin.version}"/>
-                                            </c:if>
-                                            <c:if test="${not empty notInstalledPlugin.releaseDate}">
-                                                <br><c:out value="${notInstalledPlugin.releaseDate}"/>
                                             </c:if>
                                         </td>
                                         <td style="width: 15%" nowrap class="line-bottom-border">

--- a/xmppserver/src/main/webapp/plugin-admin.jsp
+++ b/xmppserver/src/main/webapp/plugin-admin.jsp
@@ -463,13 +463,6 @@ tr.lowerhalf > td:last-child {
                     </a>
                 </c:if>
             </td>
-            <td style="width: 5%; white-space: nowrap; vertical-align: top">
-                <c:if test="${not empty plugin.version}">
-                    <span <c:if test="${not empty update}">id="${update.hashCode()}-version"</c:if>>
-                    <c:out value="${plugin.version}"/>
-                    </span>
-                </c:if>
-            </td>
             <td style="width: 15%; white-space: nowrap; vertical-align: top">
                 <c:if test="${not empty plugin.author}">
                     <c:out value="${plugin.author}"/>

--- a/xmppserver/src/main/webapp/plugin-admin.jsp
+++ b/xmppserver/src/main/webapp/plugin-admin.jsp
@@ -386,7 +386,7 @@ tr.lowerhalf > td:last-child {
  <tr style="background:#eee;">
 
     <td nowrap colspan="3" class="table-header-left"><fmt:message key="plugin.admin.name"/></td>
-    <td nowrap class="table-header"><fmt:message key="plugin.admin.description"/></td>
+    <td class="table-header"><fmt:message key="plugin.admin.description"/></td>
     <td nowrap class="table-header"><fmt:message key="plugin.admin.version"/></td>
     <td nowrap class="table-header"><fmt:message key="plugin.admin.author"/></td>
     <td nowrap class="table-header"><fmt:message key="plugin.admin.restart"/></td>

--- a/xmppserver/src/main/webapp/plugin-admin.jsp
+++ b/xmppserver/src/main/webapp/plugin-admin.jsp
@@ -384,9 +384,8 @@ tr.lowerhalf > td:last-child {
 <div class="light-gray-border" style="padding:10px;">
 <table style="width: 100%" class="update">
  <tr style="background:#eee;">
-
-    <td nowrap colspan="3" class="table-header-left"><fmt:message key="plugin.admin.name"/></td>
-    <td class="table-header"><fmt:message key="plugin.admin.description"/></td>
+    <td class="table-header-left">&nbsp;</td>
+    <td class="table-header"><fmt:message key="plugin.admin.name"/></td>
     <td nowrap class="table-header"><fmt:message key="plugin.admin.version"/></td>
     <td nowrap class="table-header"><fmt:message key="plugin.admin.author"/></td>
     <td nowrap class="table-header"><fmt:message key="plugin.admin.restart"/></td>
@@ -439,26 +438,29 @@ tr.lowerhalf > td:last-child {
                     </c:otherwise>
                 </c:choose>
             </td>
-            <td style="width: 20%; white-space: nowrap; vertical-align: top">
-                <c:out value="${plugin.name}"/>
-            </td>
-            <td style="white-space: nowrap; vertical-align: top">
+            <td>
+                <b><c:out value="${plugin.name}"/></b><br/>
+                <c:if test="${not empty plugin.description}">
+                    <c:out value="${plugin.description}"/><br/>
+                </c:if>
                 <c:if test="${not empty plugin.readme}">
                     <a href="plugin-showfile.jsp?plugin=${fn:escapeXml(plugin.canonicalName)}&showReadme=true&decorator=none"
                         target="_blank">
                         <fmt:message key="plugin.admin.documentation" />
                     </a>
                 </c:if>
+            </td>
+            <td style="width: 10%; white-space: nowrap; vertical-align: top">
+                <c:if test="${not empty plugin.version}">
+                    <span <c:if test="${not empty update}">id="${update.hashCode()}-version"</c:if>>
+                        <c:out value="${plugin.version}"/>
+                    </span><br/>
+                </c:if>
                 <c:if test="${not empty plugin.changelog}">
                     <a href="plugin-showfile.jsp?plugin=${fn:escapeXml(plugin.canonicalName)}&showChangelog=true&decorator=none"
                         target="_blank">
                         <fmt:message key="plugin.admin.changelog" />
                     </a>
-                </c:if>
-            </td>
-            <td style="width: 60%; vertical-align: top">
-                <c:if test="${not empty plugin.description}">
-                    <c:out value="${plugin.description}"/>
                 </c:if>
             </td>
             <td style="width: 5%; white-space: nowrap; vertical-align: top">

--- a/xmppserver/src/main/webapp/plugin-admin.jsp
+++ b/xmppserver/src/main/webapp/plugin-admin.jsp
@@ -445,14 +445,14 @@ tr.lowerhalf > td:last-child {
             <td style="white-space: nowrap; vertical-align: top">
                 <c:if test="${not empty plugin.readme}">
                     <a href="plugin-showfile.jsp?plugin=${fn:escapeXml(plugin.canonicalName)}&showReadme=true&decorator=none"
-                        target="_blank" title="<fmt:message key="plugin.admin.documentation" />">
-                        <img src="images/doc-readme-16x16.gif">
+                        target="_blank">
+                        <fmt:message key="plugin.admin.documentation" />
                     </a>
                 </c:if>
                 <c:if test="${not empty plugin.changelog}">
                     <a href="plugin-showfile.jsp?plugin=${fn:escapeXml(plugin.canonicalName)}&showChangelog=true&decorator=none"
-                        target="_blank" title="<fmt:message key="plugin.admin.changelog" />">
-                        <img src="images/doc-changelog-16x16.gif">
+                        target="_blank">
+                        <fmt:message key="plugin.admin.changelog" />
                     </a>
                 </c:if>
             </td>

--- a/xmppserver/src/main/webapp/plugin-admin.jsp
+++ b/xmppserver/src/main/webapp/plugin-admin.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
-  - Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -267,6 +267,10 @@ tr.regular td {
     border-color: #e3e3e3;
 }
 
+tr.regular:hover {
+    background-color: white;
+}
+
 tr.update td {
     font-size: 8pt;
     background: #E7FBDE;
@@ -313,6 +317,9 @@ tr.lowerhalf > td:first-child {
 tr.lowerhalf > td:last-child {
     border-right-width: 1px;
     border-bottom-width: 1px;
+}
+.table-data:hover {
+    background-color: white;
 }
 </style>
 

--- a/xmppserver/src/main/webapp/plugin-admin.jsp
+++ b/xmppserver/src/main/webapp/plugin-admin.jsp
@@ -450,7 +450,7 @@ tr.lowerhalf > td:last-child {
                     </a>
                 </c:if>
             </td>
-            <td style="width: 10%; white-space: nowrap; vertical-align: top">
+            <td style="width: 10%; white-space: nowrap;">
                 <c:if test="${not empty plugin.version}">
                     <span <c:if test="${not empty update}">id="${update.hashCode()}-version"</c:if>>
                         <c:out value="${plugin.version}"/>
@@ -463,19 +463,19 @@ tr.lowerhalf > td:last-child {
                     </a>
                 </c:if>
             </td>
-            <td style="width: 15%; white-space: nowrap; vertical-align: top">
+            <td style="width: 10%;">
                 <c:if test="${not empty plugin.author}">
                     <c:out value="${plugin.author}"/>
                 </c:if>
             </td>
-            <td style="width: 1%; text-align: center; vertical-align: top">
+            <td style="width: 1%; text-align: center;">
                 <c:if test="${pluginManager.isLoaded(plugin.canonicalName)}">
                     <a href="plugin-admin.jsp?csrf=${csrf}&reloadplugin=${admin:urlEncode( plugin.canonicalName )}"
                        title="<fmt:message key="plugin.admin.click_reload" />"
                     ><img src="images/refresh-16x16.gif" alt="<fmt:message key="global.refresh" /> ${plugin.name}"></a>
                 </c:if>
             </td>
-            <td style="width: 1%; text-align: center; vertical-align: top">
+            <td style="width: 1%; text-align: center;">
                 <a href="#" onclick="if (confirm('<fmt:message key="plugin.admin.confirm" />')) { location.replace('plugin-admin.jsp?csrf=${csrf}&deleteplugin=${admin:urlEncode( plugin.canonicalName )}'); } "
                    title="<fmt:message key="global.click_delete" />"
                         ><img src="images/delete-16x16.gif" alt="<fmt:message key="global.delete" /> ${plugin.name}"></a>
@@ -495,11 +495,7 @@ tr.lowerhalf > td:last-child {
                         </c:if>
                     </span>
                 </td>
-                <td style="${overrideStyle}">&nbsp;</td>
             </tr>
-
-            <tr><td></td></tr>
-
             <!-- End of unsupported section -->
         </c:if>
 


### PR DESCRIPTION
The Plugins and Available plugins pages have two icons for documentation (README) and changelog.

The icons are very small and placed together that makes it difficult to understand them.

The icons are only 16px and the only way to understand is to put a cursor over them to see a title. This wouldn't be possible to to from a mobile at all (minor issue).

As a solution we can switch to a table where each cell can have a few lines.

I moved the changelog icon into the Version column as a an additional row. The re

Similarly the Documentation link moved into the Description column, and the Description merged into the Plugin Name.


![available plugins](https://github.com/user-attachments/assets/62da2130-8753-4496-8a2d-c6fc39453939)

