### PR TITLE
OF-2880: Admin console should not show directory listing

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -511,6 +511,7 @@ public class AdminConsolePlugin implements Plugin {
         final List<ContainerInitializer> initializers = new ArrayList<>();
         initializers.add(new ContainerInitializer(new JasperInitializer(), null));
         context.setAttribute("org.eclipse.jetty.containerInitializers", initializers);
+        context.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
         context.setClassLoader(Thread.currentThread().getContextClassLoader());
         context.setAttribute(InstanceManager.class.getName(), new SimpleInstanceManager());
         context.setConfigurations(new Configuration[]{

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -742,6 +742,8 @@ public final class HttpBindManager implements CertificateEventListener {
             if ( spankDirectory.canRead() )
             {
                 final WebAppContext context = new WebAppContext( null, spankDirectory.getPath(), "/" );
+                context.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
+
                 context.setWelcomeFiles( new String[] { "index.html" } );
 
                 // Add CSP headers for all HTTP responses (errors, etc.)


### PR DESCRIPTION
When browsing to `/images/` (or another endpoint with no welcome page), Openfire should not show the index of the directory.