### PR TITLE
OF-2884: Fix group user removal when making it admin

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/Group.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/Group.java
@@ -578,16 +578,6 @@ public class Group implements Cacheable, Externalizable {
                     groupManager.memberAddedPostProcess(Group.this, user, alreadyGroupUser);
                 }
 
-                // If the user was a member that became an admin or vice versa then remove the
-                // user from the other collection
-                if (alreadyGroupUser) {
-                    if (adminCollection) {
-                        members.remove(user);
-                    }
-                    else {
-                        administrators.remove(user);
-                    }
-                }
                 return true;
             }
             return false;


### PR DESCRIPTION
When a user of a group is made an 'admin' of the group, its removal from the 'members' group should not cause it to be removed from the group completely.