### PR TITLE
OF-2786: Happy Eyeballs (for outbound S2S connections)

### DIFF
--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -139,7 +139,7 @@ esac
 done
 
 
-JAVACMD="${JAVACMD} -Dlog4j.configurationFile=${OPENFIRE_LIB}/log4j2.xml -Dlog4j2.formatMsgNoLookups=true -Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true"
+JAVACMD="${JAVACMD} -Dlog4j.configurationFile=${OPENFIRE_LIB}/log4j2.xml -Dlog4j2.formatMsgNoLookups=true -Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Djava.net.preferIPv6Addresses=system"
 
 if [ -z "$LOCALCLASSPATH" ] ; then
 	LOCALCLASSPATH=$OPENFIRE_LIB/startup.jar

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginServlet.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.container;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.dom4j.Document;
 import org.jivesoftware.admin.FlashMessageTag;
 import org.jivesoftware.admin.PluginFilter;
@@ -488,7 +489,7 @@ public class PluginServlet extends HttpServlet {
         return servlet;
     }
 
-    // Package protected to facilitate unit testing
+    @VisibleForTesting
     static <T> T getWildcardMappedObject(final Map<String, T> mapping, final String query) {
         T value = mapping.get(query);
         if (value == null) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/DNSUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/DNSUtil.java
@@ -108,7 +108,7 @@ public class DNSUtil {
      *
      * @param domain the domain.
      * @param defaultPort default port to return if the DNS look up fails.
-     * @return a list of  HostAddresses, which encompasses the hostname and port
+     * @return SRV records (grouped by priority) which encompasses the hostname and port
      *         that the XMPP server can be reached at for the specified domain.
      * @see <a href="https://tools.ietf.org/html/rfc6120#section-3.2">XMPP CORE</a>
      * @see <a href="https://xmpp.org/extensions/xep-0368.html">XEP-0368</a>

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/DNSUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/DNSUtil.java
@@ -406,24 +406,18 @@ public class DNSUtil {
      * @deprecated Replaced by {@link SrvRecord#prioritize(SrvRecord[])}
      */
     @Deprecated(since = "4.10.0", forRemoval = true) // Remove in or after Openfire 4.11.0
-    public static List<Set<WeightedHostAddress>> prioritize(WeightedHostAddress[] records) {
-        return prioritize(Arrays.asList(records));
-    }
+    public static List<WeightedHostAddress> prioritize(WeightedHostAddress[] records) {
+        final List<WeightedHostAddress> result = new LinkedList<>();
 
-    /**
-     * @deprecated Replaced by {@link SrvRecord#prioritize(Collection)}
-     */
-    @Deprecated(since = "4.10.0", forRemoval = true) // Remove in or after Openfire 4.11.0
-    public static List<Set<WeightedHostAddress>> prioritize(final Collection<WeightedHostAddress> records) {
-        final Set<SrvRecord> delegates = records.stream().map(WeightedHostAddress::getDelegate).collect(Collectors.toSet());
+        // sort by priority (ascending)
+        final Set<SrvRecord> delegates = Arrays.stream(records).map(WeightedHostAddress::getDelegate).collect(Collectors.toSet());
         final List<Set<SrvRecord>> prioritized = SrvRecord.prioritize(delegates);
-        final List<Set<WeightedHostAddress>> result = new LinkedList<>();
         for (Set<SrvRecord> set : prioritized) {
             final LinkedHashSet<WeightedHostAddress> orderedSet = new LinkedHashSet<>(); // Retain the order in the set!
             for (final SrvRecord e : set) {
                 orderedSet.add(new WeightedHostAddress(e));
             }
-            result.add(orderedSet);
+            result.addAll(orderedSet);
         }
         return result;
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/HappyEyeballsResolver.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/HappyEyeballsResolver.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.openfire.net;
 
+import com.google.common.annotations.VisibleForTesting;
 import net.jcip.annotations.GuardedBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +95,7 @@ public class HappyEyeballsResolver
         }
     }
 
-    // Exposed for unit testing.
+    @VisibleForTesting
     void solve(final Supplier<Set<IndexedResolvedServiceAddress>> supplier, final int index) {
         CompletableFuture.supplyAsync(supplier, executor)
             .exceptionally(t -> { addException(t, index); return null; })

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/HappyEyeballsResolver.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/HappyEyeballsResolver.java
@@ -1,0 +1,324 @@
+package org.jivesoftware.openfire.net;
+
+import net.jcip.annotations.GuardedBy;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.Supplier;
+
+public class HappyEyeballsResolver
+{
+    private final Duration resolutionDelay;
+
+    private final ThreadPoolExecutor executor;
+
+    private final List<DNSUtil.HostAddress> hostAddresses;
+
+    @GuardedBy("this")
+    private final PriorityQueue<IndexedInetAddress> resolvedHosts;
+
+    @GuardedBy("this")
+    private final ConcurrentMap<Integer, Integer> resultCountByIndex = new ConcurrentHashMap<>();
+
+    @GuardedBy("this")
+    private int preferredNextIndex = 0;
+
+    @GuardedBy("this")
+    private boolean preferredNextFamilyIsIpv4;
+
+    public HappyEyeballsResolver(final List<DNSUtil.HostAddress> hostAddresses)
+    {
+        this(hostAddresses, false, Duration.ofMillis(50));
+    }
+
+    public HappyEyeballsResolver(final List<DNSUtil.HostAddress> hostAddresses, final boolean preferIpv4, final Duration resolutionDelay)
+    {
+        executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(hostAddresses.size());
+        this.hostAddresses = hostAddresses;
+        this.resolvedHosts = new PriorityQueue<>(hostAddresses.size()*3, Comparator.comparing(IndexedInetAddress::getIndex));
+        this.preferredNextFamilyIsIpv4 = preferIpv4;
+        this.resolutionDelay = resolutionDelay;
+    }
+
+    public Duration getResolutionDelay()
+    {
+        return resolutionDelay;
+    }
+
+    public synchronized void start() throws ExecutionException, InterruptedException
+    {
+        for (int i = 0; i < hostAddresses.size(); i++)
+        {
+            int index = i;
+            // Happy Eyeballs dictates that first an AAAA and only then A query is sent out for each host. The Java API
+            // that we're using doesn't give us granular control like that: it's requesting both at the same time.
+            final Supplier<Set<IndexedInetAddress>> solve = () -> {
+                final DNSUtil.HostAddress hostAddress = hostAddresses.get(index);
+                try {
+                    return IndexedInetAddress.from(index, InetAddress.getAllByName(hostAddress.getHost()), hostAddress.getPort(), hostAddress.isDirectTLS());
+                } catch (UnknownHostException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+            solve(solve, index);
+        }
+    }
+
+    // Exposed for unit testing.
+    void solve(final Supplier<Set<IndexedInetAddress>> supplier, final int index) {
+        CompletableFuture.supplyAsync(supplier, executor)
+            .exceptionally(t -> { addException(t, index); return null; })
+            .thenAccept(results -> addResults(results, index));
+    }
+
+    public synchronized boolean isDone() {
+        return executor.getCompletedTaskCount() == hostAddresses.size();
+    }
+
+    public void shutdown() {
+        if (!isDone()) {
+            // Happy Eyeballs tells us to keep resolving for a while, to populate caches.
+            new Thread(() -> {
+                try {
+                    Thread.sleep(Duration.ofSeconds(1).toMillis());
+                    executor.shutdown();
+                } catch (InterruptedException e) {
+                    executor.shutdownNow();
+                }
+            }).start();
+        } else {
+            executor.shutdown();
+        }
+    }
+
+    public void shutdownNow() {
+        executor.shutdownNow();
+    }
+
+    synchronized private void addResults(final Set<IndexedInetAddress> results, final int index)
+    {
+        resolvedHosts.addAll(results);
+        resultCountByIndex.merge(index, results.size(), Integer::sum);
+        notifyAll();
+    }
+
+    synchronized private void addException(final Throwable t, final int index)
+    {
+        notifyAll(); // prevents threads waiting forever, after a lookup fails.
+    }
+
+    synchronized private XmppServiceAddress getPreferredImmediately()
+    {
+        final Iterator<IndexedInetAddress> iterator = resolvedHosts.iterator();
+        while (iterator.hasNext()) {
+            final IndexedInetAddress resolvedAddress = iterator.next();
+            if (resolvedAddress.getIndex() == preferredNextIndex && (resolvedAddress.isIPv6() != preferredNextFamilyIsIpv4)) {
+                iterator.remove();
+
+                final int remainingCount = resultCountByIndex.merge(resolvedAddress.getIndex(), -1, Integer::sum);
+                assert remainingCount >= 0 : "After completing a test, the amount of remaining tasks cannot be negative (but was for index '"+resolvedAddress.getIndex()+"': " + remainingCount + ").";
+                if (remainingCount == 0) {
+                    do {
+                        preferredNextIndex++;
+                    }
+                    // If this value was set and is now 0, then all of its addresses have already been used up. Move up the next index!
+                    while (resultCountByIndex.containsKey(preferredNextIndex) && resultCountByIndex.get(preferredNextIndex) == 0);
+                }
+                preferredNextFamilyIsIpv4 = resolvedAddress.isIPv6();
+                return XmppServiceAddress.from(resolvedAddress);
+            }
+        }
+        return null;
+    }
+
+    synchronized private XmppServiceAddress getAlternativeImmediately()
+    {
+        IndexedInetAddress result = null;
+        final Iterator<IndexedInetAddress> iterator = resolvedHosts.iterator(); // iterates over index order.
+        while (iterator.hasNext()) {
+            final IndexedInetAddress resolvedAddress = iterator.next();
+            // Preferably, use the index.
+            if (resolvedAddress.getIndex() == preferredNextIndex) {
+                result = resolvedAddress;
+                iterator.remove();
+                break;
+            }
+
+            // If there's not a host for this index yet, prefer the first host for the preferred family.
+            if (resolvedAddress.isIPv6() != preferredNextFamilyIsIpv4) {
+                result = resolvedAddress;
+                iterator.remove();
+            }
+        }
+
+        // If after iterating over all currently available hosts, there's not a host for the preferred family yet,
+        // prefer the first host by index.
+        if (result == null && !resolvedHosts.isEmpty()) {
+            result = resolvedHosts.poll();
+        }
+
+        if (result != null) {
+            preferredNextFamilyIsIpv4 = result.isIPv6();
+            resultCountByIndex.put(result.getIndex(), resultCountByIndex.get(result.getIndex()) - 1);
+            // If this value was set and is now 0, then all of its addresses have already been used up. Move up the next index!
+            while (resultCountByIndex.containsKey(preferredNextIndex) && resultCountByIndex.get(preferredNextIndex) == 0) {
+                preferredNextIndex++;
+            }
+            return XmppServiceAddress.from(result);
+        }
+
+        return null;
+    }
+
+    public synchronized XmppServiceAddress getNext() throws InterruptedException
+    {
+        final Instant deadline = Instant.now().plus(resolutionDelay);
+
+        XmppServiceAddress result;
+        while ((result = getPreferredImmediately()) == null) {
+            final Instant now = Instant.now();
+            final long sleepTime = Duration.between(now, deadline).toMillis();
+            if (sleepTime <= 0) {
+                break;
+            }
+            wait(sleepTime);
+        }
+
+        if (result == null) {
+            result = getAlternativeImmediately();
+        }
+
+        return result;
+    }
+
+    public static class XmppServiceAddress
+    {
+        private final InetSocketAddress socketAddress;
+        private final boolean isDirectTLS;
+
+        static XmppServiceAddress from(final IndexedInetAddress address)
+        {
+            return new XmppServiceAddress(new InetSocketAddress(address.getInetAddress(), address.getPort()), address.isDirectTLS());
+        }
+
+        public XmppServiceAddress(final InetSocketAddress socketAddress, final boolean isDirectTLS)
+        {
+            this.socketAddress = socketAddress;
+            this.isDirectTLS = isDirectTLS;
+        }
+
+        public InetSocketAddress getSocketAddress()
+        {
+            return socketAddress;
+        }
+
+        public boolean isDirectTLS()
+        {
+            return isDirectTLS;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            XmppServiceAddress that = (XmppServiceAddress) o;
+            return isDirectTLS == that.isDirectTLS && Objects.equals(socketAddress, that.socketAddress);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(socketAddress, isDirectTLS);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "XmppServiceAddress{" +
+                "socketAddress=" + socketAddress +
+                ", isDirectTLS=" + isDirectTLS +
+                '}';
+        }
+    }
+
+    static class IndexedInetAddress {
+        final int index;
+        final InetAddress inetAddress;
+        final int port;
+        final boolean isDirectTLS;
+
+        IndexedInetAddress(final int index, final InetAddress inetAddress, final int port, final boolean isDirectTLS)
+        {
+            this.index = index;
+            this.inetAddress = inetAddress;
+            this.port = port;
+            this.isDirectTLS = isDirectTLS;
+        }
+
+        public static Set<IndexedInetAddress> from(final int index, final InetAddress[] addresses, final int port, final boolean isDirectTLS)
+        {
+            final Set<IndexedInetAddress> result = new HashSet<>();
+            for (InetAddress address : addresses) {
+                result.add(new IndexedInetAddress(index, address, port, isDirectTLS));
+            }
+            return result;
+        }
+
+        public int getIndex()
+        {
+            return index;
+        }
+
+        public InetAddress getInetAddress()
+        {
+            return inetAddress;
+        }
+
+        public int getPort()
+        {
+            return port;
+        }
+
+        public boolean isDirectTLS()
+        {
+            return isDirectTLS;
+        }
+
+        public boolean isIPv6() {
+            return inetAddress instanceof Inet6Address;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            IndexedInetAddress that = (IndexedInetAddress) o;
+            return index == that.index && port == that.port && isDirectTLS == that.isDirectTLS && Objects.equals(inetAddress, that.inetAddress);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(index, inetAddress, port, isDirectTLS);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "IndexedInetAddress{" +
+                "index=" + index +
+                ", inetAddress=" + inetAddress +
+                ", port=" + port +
+                ", isDirectTLS=" + isDirectTLS +
+                '}';
+        }
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/IndexedResolvedServiceAddress.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/IndexedResolvedServiceAddress.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.net;
+
+import net.jcip.annotations.Immutable;
+
+import java.net.InetAddress;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A specialized {@link ResolvedServiceAddress} that can be ordered.
+ *
+ * This class is (only) intended to be used by {@link HappyEyeballsResolver} which uses the ordering to generate results
+ * in the order defined by SRV's 'priority' and 'weight' attributes.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+@Immutable
+class IndexedResolvedServiceAddress extends ResolvedServiceAddress implements Comparable<IndexedResolvedServiceAddress>
+{
+    final int index;
+
+    public IndexedResolvedServiceAddress(final int index, final InetAddress inetAddress, final int port, final boolean isDirectTLS)
+    {
+        super(inetAddress, port, isDirectTLS);
+        this.index = index;
+    }
+
+    public static Set<IndexedResolvedServiceAddress> from(final int index, final InetAddress[] addresses, final int port, final boolean isDirectTLS)
+    {
+        final Set<IndexedResolvedServiceAddress> result = new HashSet<>();
+        for (InetAddress address : addresses) {
+            result.add(new IndexedResolvedServiceAddress(index, address, port, isDirectTLS));
+        }
+        return result;
+    }
+
+    public int getIndex()
+    {
+        return index;
+    }
+
+    @Override
+    public int compareTo(IndexedResolvedServiceAddress o) {
+        return Integer.compare(index, o.index);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        IndexedResolvedServiceAddress that = (IndexedResolvedServiceAddress) o;
+        return index == that.index;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(super.hashCode(), index);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "IndexedResolvedServiceAddress{" +
+            "index=" + index +
+            ", inetAddress=" + inetAddress +
+            ", port=" + port +
+            ", isDirectTLS=" + isDirectTLS +
+            '}';
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ResolvedServiceAddress.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ResolvedServiceAddress.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.net;
+
+import net.jcip.annotations.Immutable;
+
+import javax.annotation.Nonnull;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Objects;
+
+/**
+ * A representation of an Internet Protocol-based socket address (an IP address and port) for a (presumably XMPP) service.
+ *
+ * Instances of this class are intended to represent results of DNS resolution, intended to be used when setting up a
+ * network connection to a remote XMPP service.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+@Immutable
+public class ResolvedServiceAddress
+{
+    final InetAddress inetAddress;
+    final int port;
+    final boolean isDirectTLS;
+
+    public ResolvedServiceAddress(final @Nonnull InetAddress inetAddress, int port, boolean isDirectTLS)
+    {
+        this.inetAddress = inetAddress;
+        this.port = port;
+        this.isDirectTLS = isDirectTLS;
+    }
+
+    public InetAddress getInetAddress()
+    {
+        return inetAddress;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
+    public boolean isDirectTLS()
+    {
+        return isDirectTLS;
+    }
+
+    public boolean isIPv6()
+    {
+        return inetAddress instanceof Inet6Address;
+    }
+
+    public InetSocketAddress generateSocketAddress()
+    {
+        return new InetSocketAddress(inetAddress, port);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResolvedServiceAddress that = (ResolvedServiceAddress) o;
+        return port == that.port && isDirectTLS == that.isDirectTLS && Objects.equals(inetAddress, that.inetAddress);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(inetAddress, port, isDirectTLS);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ResolvedServiceAddress{" +
+            "inetAddress=" + inetAddress +
+            ", port=" + port +
+            ", isDirectTLS=" + isDirectTLS +
+            '}';
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
@@ -18,17 +18,20 @@ package org.jivesoftware.openfire.net;
 import org.jivesoftware.openfire.server.RemoteServerManager;
 import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.ScheduledExecutorCompletionService;
+import org.jivesoftware.util.SystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
+import java.net.Inet4Address;
+import java.net.InetAddress;
 import java.net.Socket;
-import java.util.AbstractMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * Utility class to generate Socket instances.
@@ -38,6 +41,72 @@ import java.util.stream.Collectors;
 public class SocketUtil
 {
     private final static Logger Log = LoggerFactory.getLogger( SocketUtil.class );
+
+    /**
+     * A fixed delay for how long to wait before starting the next connection attempt, as defined in section 5 of
+     * RFC 8305 "Happy Eyeballs Version 2: Better Connectivity Using Concurrency".
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc8305#section-5">RFC 8305, section 5</a>
+     */
+    public static final SystemProperty<Duration> CONNECTION_ATTEMPT_DELAY = SystemProperty.Builder.ofType(Duration.class)
+        .setKey("xmpp.server.connection-attempt-delay")
+        .setChronoUnit(ChronoUnit.MILLIS)
+        .setDefaultValue(Duration.ofMillis(250))
+        .setMinValue(Duration.ofMillis(100))
+        .setMaxValue(Duration.ofSeconds(2))
+        .setDynamic(true)
+        .build();
+
+    /**
+     * The time to wait for a response for the 'preferred IP family' after receiving a response for another family, as
+     * defined in section 3 of RFC 8305 "Happy Eyeballs Version 2: Better Connectivity Using Concurrency".
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc8305#section-5">RFC 8305, section 5</a>
+     */
+    public static final SystemProperty<Duration> RESOLUTION_DELAY = SystemProperty.Builder.ofType(Duration.class)
+        .setKey("xmpp.server.resolution-delay")
+        .setChronoUnit(ChronoUnit.MILLIS)
+        .setDefaultValue(Duration.ofMillis(50))
+        .setMinValue(Duration.ofMillis(0))
+        .setDynamic(true)
+        .build();
+
+    /**
+     * The maximum amount of time to wait for successful resolution of a host of a target domain.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc8305#section-5">RFC 8305, section 5</a>
+     */
+    public static final SystemProperty<Duration> RESOLUTION_TIMEOUT = SystemProperty.Builder.ofType(Duration.class)
+        .setKey("xmpp.server.resolution-timeout")
+        .setChronoUnit(ChronoUnit.MILLIS)
+        .setDefaultValue(Duration.ofMinutes(5))
+        .setMinValue(Duration.ofMillis(0))
+        .setDynamic(true)
+        .build();
+
+    Socket solve(ScheduledThreadPoolExecutor e, List<Callable<Socket>> solvers, Duration delay) throws InterruptedException
+    {
+        final ScheduledExecutorCompletionService<Socket> cs = new ScheduledExecutorCompletionService<>(e);
+        final int n = solvers.size();
+        final List<Future<Socket>> futures = new ArrayList<>(n);
+        Socket result = null;
+        try {
+            solvers.forEach(solver -> futures.add(cs.schedule(solver, delay)));
+            for (int i = n; i > 0; i--) {
+                try {
+                    final Socket r = cs.take().get();
+                    if (r != null) {
+                        result = r;
+                        break;
+                    }
+                } catch (ExecutionException ignore) {
+                }
+            }
+        } finally {
+            futures.forEach(future -> future.cancel(true));
+        }
+        return result;
+    }
 
     /**
      * Creates a socket connection to an XMPP domain.
@@ -60,59 +129,132 @@ public class SocketUtil
     {
         Log.debug( "Creating a socket connection to XMPP domain '{}' ...", xmppDomain );
 
-        Log.debug( "Use DNS to resolve remote hosts for the provided XMPP domain '{}' (default port: {}) ...", xmppDomain, port );
-        final List<DNSUtil.HostAddress> remoteHosts = DNSUtil.resolveXMPPDomain( xmppDomain, port ).stream().flatMap(Set::stream).collect(Collectors.toList());
-        Log.debug( "Found {} host(s) for XMPP domain '{}'.", remoteHosts.size(), xmppDomain );
-        remoteHosts.forEach( remoteHost -> Log.debug( "- {} ({})", remoteHost.toString(), (remoteHost.isDirectTLS() ? "direct TLS" : "no direct TLS" ) ) );
+        final Instant deadline = Instant.now().plus(RESOLUTION_TIMEOUT.getValue());
+        final List<Future<Map.Entry<Socket, Boolean>>> futures = new ArrayList<>();
+        final BlockingQueue<Future<Map.Entry<Socket, Boolean>>> resolvedHostsQueue = new LinkedBlockingQueue<>();
+        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(8); // TODO make configurable
+        executor.setRemoveOnCancelPolicy(true);
+        final ScheduledExecutorCompletionService<Map.Entry<Socket, Boolean>> completionService = new ScheduledExecutorCompletionService<>(executor, resolvedHostsQueue);
 
-        Socket socket = null;
-        final int socketTimeout = RemoteServerManager.getSocketTimeout();
-        for ( DNSUtil.HostAddress remoteHost : remoteHosts )
-        {
-            final String realHostname = remoteHost.getHost();
-            final int realPort = remoteHost.getPort();
-            final boolean directTLS = remoteHost.isDirectTLS();
+        final Thread r = new Thread(() -> {
+            Instant nextJobNotBefore = Instant.EPOCH;
 
-            if (!JiveGlobals.getBooleanProperty(ConnectionSettings.Server.ENABLE_OLD_SSLPORT, true) && directTLS) {
-                Log.debug("Skipping directTLS host, as we're ourselves not accepting directTLS S2S");
-                continue;
-            }
+            Log.debug( "Use DNS to resolve remote hosts for the provided XMPP domain '{}' (default port: {}) ...", xmppDomain, port );
+            final List<Set<DNSUtil.WeightedHostAddress>> remoteHosts = DNSUtil.resolveXMPPDomain(xmppDomain, port);
+            for (final Set<DNSUtil.WeightedHostAddress> prioritySet : remoteHosts) {
+                if (executor.isTerminating() || executor.isTerminated() || executor.isShutdown()) {
+                    Log.trace("Aborting resolution, as the executor is being shut down (likely cause: we successfully identified a result).");
+                    return;
+                }
+                final boolean preferIpv4 = InetAddress.getLoopbackAddress() instanceof Inet4Address; // Follow the preference of the JVM.
+                final HappyEyeballsResolver resolver = new HappyEyeballsResolver(new LinkedList<>(prioritySet), preferIpv4, RESOLUTION_DELAY.getValue());
+                try {
+                    resolver.start();
+                    while (!resolver.isDone() && !executor.isTerminating() && !executor.isTerminated() && !executor.isShutdown() && Instant.now().isBefore(deadline)) {
+                        final HappyEyeballsResolver.XmppServiceAddress resolvedAddress = resolver.getNext(); // Blocks.
+                        Log.trace("Next resolved address for '{}': {}", xmppDomain, resolvedAddress);
+                        if (resolvedAddress == null) {
+                            continue;
+                        }
 
-            if (!JiveGlobals.getBooleanProperty(ConnectionSettings.Server.SOCKET_ACTIVE, true) && !directTLS) {
-                Log.debug("Skipping non direct TLS host, as we're ourselves not accepting non direct S2S");
-                continue;
-            }
+                        if (!JiveGlobals.getBooleanProperty(ConnectionSettings.Server.ENABLE_OLD_SSLPORT, true) && resolvedAddress.isDirectTLS()) {
+                            Log.debug("Skipping directTLS address, as we're ourselves not accepting directTLS S2S: {}", resolvedAddress);
+                            continue;
+                        }
 
-            try
-            {
-                // (re)initialize the socket.
-                socket = new Socket();
+                        if (!JiveGlobals.getBooleanProperty(ConnectionSettings.Server.SOCKET_ACTIVE, true) && !resolvedAddress.isDirectTLS()) {
+                            Log.debug("Skipping non directTLS address, as we're ourselves not accepting non direct S2S: {}", resolvedAddress);
+                            continue;
+                        }
 
-                Log.debug( "Trying to create socket connection to XMPP domain '{}' using remote host: {}:{} (blocks up to {} ms) ...", xmppDomain, realHostname, realPort, socketTimeout );
-                socket.connect( new InetSocketAddress( realHostname, realPort ), socketTimeout );
-                Log.debug( "Successfully created socket connection to XMPP domain '{}' using remote host: {}:{}!", xmppDomain, realHostname, realPort );
-                return new AbstractMap.SimpleEntry<>(socket, directTLS);
-            }
-            catch ( Exception e )
-            {
-                Log.debug( "An exception occurred while trying to create a socket connection to XMPP domain '{}' using remote host {}:{}", xmppDomain, realHostname, realPort, e );
-                Log.warn( "Unable to create a socket connection to XMPP domain '{}' using remote host: {}:{}. Cause: {} (a full stacktrace is logged on debug level)", xmppDomain, realHostname, realPort, e.getMessage() );
-                try
-                {
-                    if ( socket != null )
-                    {
-                        socket.close();
-                        socket = null;
+                        final Callable<Map.Entry<Socket, Boolean>> callable = () -> {
+                            final int socketTimeout = RemoteServerManager.getSocketTimeout();
+//                            SocketChannel socketChannel = null;
+                            Socket socket = null; // TODO migrate to SocketChannel so that a connection attempt can be interrupted (when another one was already successful).
+                            try {
+//                                socketChannel = SocketChannel.open();
+//                                socketChannel.connect(resolvedAddress.getSocketAddress())
+
+                                // (re)initialize the socket.
+                                socket = new Socket();
+
+                                Log.debug("Trying to create socket connection to XMPP domain '{}' using remote address: {} (blocks up to {} ms) ...", xmppDomain, resolvedAddress.getSocketAddress(), socketTimeout);
+                                socket.connect(resolvedAddress.getSocketAddress(), socketTimeout);
+                                Log.debug("Successfully created socket connection to XMPP domain '{}' using remote address: {}!", xmppDomain, resolvedAddress.getSocketAddress());
+
+                                return new AbstractMap.SimpleEntry<>(socket, resolvedAddress.isDirectTLS());
+                            } catch (Exception e) {
+                                Log.debug("An exception occurred while trying to create a socket connection to XMPP domain '{}' using remote address {}", xmppDomain, resolvedAddress.getSocketAddress(), e);
+                                Log.warn("Unable to create a socket connection to XMPP domain '{}' using remote address: {}. Cause: {} (a full stacktrace is logged on debug level)", xmppDomain, resolvedAddress.getSocketAddress(), e.getMessage());
+                                try {
+                                    if (socket != null) {
+                                        socket.close();
+                                    }
+                                } catch (IOException ex) {
+                                    Log.debug("An additional exception occurred while trying to close a socket when creating a connection to {} failed.", resolvedAddress.getSocketAddress(), ex);
+                                }
+                            }
+                            return null;
+                        };
+
+                        final Duration delay;
+                        if (Instant.now().isBefore(nextJobNotBefore)) {
+                            final Duration delta = Duration.between(Instant.now(), nextJobNotBefore);
+                            if (delta.isNegative()) {
+                                delay = Duration.ZERO;
+                            } else {
+                                delay = delta;
+                            }
+                        } else {
+                            delay = Duration.ZERO;
+                        }
+
+                        Log.trace("Scheduling connection attempt for '{}' to {} after a delay of {}", xmppDomain, resolvedAddress, delay);
+                        try {
+                            futures.add(completionService.schedule(callable, delay));
+                        } catch (RejectedExecutionException e) {
+                            // Likely reason: the executor is shutting down because a successful connection was established.
+                            Log.debug("Unable to schedule a connection attempt (for '{}' to {} after a delay of {}). Likely cause: teardown of the attempt, because another connection has already been successful", xmppDomain, resolvedAddress, delay, e);
+                        }
+
+                        nextJobNotBefore = Instant.now().plus(delay).plus(CONNECTION_ATTEMPT_DELAY.getValue());
                     }
-                }
-                catch ( IOException ex )
-                {
-                    Log.debug( "An additional exception occurred while trying to close a socket when creating a connection to {}:{} failed.", realHostname, realPort, ex );
+                    Log.trace("Done iterating over a priority set for '{}'", xmppDomain);
+                } catch (InterruptedException e) {
+                    Log.debug("DNS resolution for '{}' got interrupted. Stopping...", xmppDomain);
+                } catch (Throwable e) {
+                    Log.warn("Unexpected exception while setting up a connection to {}", xmppDomain, e);
+                } finally {
+                    resolver.shutdown();
                 }
             }
+            Log.trace("Done iterating over all priority sets for '{}'", xmppDomain);
+        }, "happy-eyeball-resolving-" + xmppDomain);
+        r.start();
+
+        Map.Entry<Socket, Boolean> result = null;
+        try {
+            while (result == null && r.isAlive() && Instant.now().isBefore(deadline)) {
+                try {
+                    result = completionService.poll(10, TimeUnit.SECONDS).get();
+                } catch (ExecutionException e) {
+                    Log.debug("Resolution of XMPP domain '{}' threw an exception (that is being ignored).", xmppDomain, e);
+                }
+            }
+        } catch (InterruptedException e) {
+            Log.debug("Resolution of XMPP domain '{}' got interrupted. Aborting...", xmppDomain, e);
+        } finally {
+            Log.debug("Finished resolving XMPP domain '{}'", xmppDomain);
+            futures.forEach(future -> future.cancel(true));
+            executor.shutdown();
         }
 
-        Log.warn( "Unable to create a socket connection to XMPP domain '{}': Unable to connect to any of its remote hosts.", xmppDomain );
-        return null;
+        r.interrupt();
+        if (result == null) {
+            Log.warn( "Unable to create a socket connection to XMPP domain '{}': Unable to connect to any of its remote hosts.", xmppDomain );
+        } else {
+            Log.debug("Successfully created a socket connection to XMPP domain '{}', using: {} ({})", xmppDomain, result.getKey().getRemoteSocketAddress(), result.getValue() ? "directTLS" : "not directTLS" );
+        }
+        return result;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import java.net.Socket;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Utility class to generate Socket instances.
@@ -59,7 +61,7 @@ public class SocketUtil
         Log.debug( "Creating a socket connection to XMPP domain '{}' ...", xmppDomain );
 
         Log.debug( "Use DNS to resolve remote hosts for the provided XMPP domain '{}' (default port: {}) ...", xmppDomain, port );
-        final List<DNSUtil.HostAddress> remoteHosts = DNSUtil.resolveXMPPDomain( xmppDomain, port );
+        final List<DNSUtil.HostAddress> remoteHosts = DNSUtil.resolveXMPPDomain( xmppDomain, port ).stream().flatMap(Set::stream).collect(Collectors.toList());
         Log.debug( "Found {} host(s) for XMPP domain '{}'.", remoteHosts.size(), xmppDomain );
         remoteHosts.forEach( remoteHost -> Log.debug( "- {} ({})", remoteHost.toString(), (remoteHost.isDirectTLS() ? "direct TLS" : "no direct TLS" ) ) );
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SrvRecord.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SrvRecord.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.net;
+
+import net.jcip.annotations.Immutable;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.*;
+
+/**
+ * A (partial) representation of an SRV record, containing an (unresolved) hostname, port, priority and weight attributes.
+ * It is expected to be used primarily to represent the result of an SRV query.
+ *
+ * This representation does not include other attributes of an SRV record, such as the service name, transport protocol
+ * and time-to-live.
+ *
+ * An indicator is included that signals if the address is to be used with DirectTLS (as opposed to STARTTLS) encryption.
+ * This value can be thought of as being a derivative of the 'service' that was looked up, as for example, a lookup
+ * result for 'xmpp-server' would not be DirectTLS, as opposed to a lookup result for 'xmpps-server', that would be
+ * DirectTLS
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+@Immutable
+public class SrvRecord implements Serializable
+{
+    private final String hostname;
+    private final int port;
+    private final boolean isDirectTLS;
+    private final int priority;
+    private final int weight;
+
+    public static SrvRecord from(final @Nonnull String[] srvRecordEntries, final boolean directTLS)
+    {
+        final String hostname = srvRecordEntries[srvRecordEntries.length - 1];
+        final int port = Integer.parseInt(srvRecordEntries[srvRecordEntries.length - 2]);
+        final int weight = Integer.parseInt(srvRecordEntries[srvRecordEntries.length - 3]);
+        final int priority = Integer.parseInt(srvRecordEntries[srvRecordEntries.length - 4]);
+        return new SrvRecord(hostname.endsWith(".") ? hostname.substring(0, hostname.length()-1) : hostname, port, directTLS, priority, weight);
+    }
+
+    public SrvRecord(final @Nonnull String hostname, final int port, final boolean isDirectTLS)
+    {
+        this(hostname, port, isDirectTLS, 0, 0);
+    }
+
+    public SrvRecord(final @Nonnull String hostname, final int port, final boolean isDirectTLS, final int priority, final int weight)
+    {
+        this.hostname = hostname;
+        this.port = port;
+        this.isDirectTLS = isDirectTLS;
+        this.priority = priority;
+        this.weight = weight;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public boolean isDirectTLS()
+    {
+        return isDirectTLS;
+    }
+
+    public int getPriority()
+    {
+        return priority;
+    }
+
+    public int getWeight()
+    {
+        return weight;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SrvRecord srvRecord = (SrvRecord) o;
+        return port == srvRecord.port && isDirectTLS == srvRecord.isDirectTLS && priority == srvRecord.priority && weight == srvRecord.weight && Objects.equals(hostname, srvRecord.hostname);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(hostname, port, isDirectTLS, priority, weight);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SrvRecord{" +
+            "hostname='" + hostname + '\'' +
+            ", port=" + port +
+            ", isDirectTLS=" + isDirectTLS +
+            ", priority=" + priority +
+            ", weight=" + weight +
+            '}';
+    }
+
+    public static List<Set<SrvRecord>> prioritize(SrvRecord[] records) {
+        return prioritize(Arrays.asList(records));
+    }
+
+    public static List<Set<SrvRecord>> prioritize(final Collection<SrvRecord> records)
+    {
+        final List<Set<SrvRecord>> result = new LinkedList<>();
+
+        // sort by priority (ascending)
+        SortedMap<Integer, Set<SrvRecord>> byPriority = new TreeMap<>();
+        for(final SrvRecord record : records) {
+            if (byPriority.containsKey(record.getPriority())) {
+                byPriority.get(record.getPriority()).add(record);
+            } else {
+                final Set<SrvRecord> set = new HashSet<>();
+                set.add(record);
+                byPriority.put(record.getPriority(), set);
+            }
+        }
+
+        // now, randomize each priority set by weight.
+        for(Map.Entry<Integer, Set<SrvRecord>> weights : byPriority.entrySet()) {
+
+            final List<SrvRecord> zeroWeights = new LinkedList<>();
+            final Set<SrvRecord> priorityGroupResults = new LinkedHashSet<>(); // A set that retains order (which we'll randomize)
+
+            int totalWeight = 0;
+            final Iterator<SrvRecord> i = weights.getValue().iterator();
+            while (i.hasNext()) {
+                final SrvRecord next = i.next();
+                if (next.getWeight() == 0) {
+                    // set aside, as these should be considered last according to the RFC.
+                    zeroWeights.add(next);
+                    i.remove();
+                    continue;
+                }
+
+                totalWeight += next.getWeight();
+            }
+
+            int iterationWeight = totalWeight;
+            Iterator<SrvRecord> iter = weights.getValue().iterator();
+            while (iter.hasNext()) {
+                int needle = new Random().nextInt(iterationWeight);
+
+                while (true) {
+                    final SrvRecord record = iter.next();
+                    needle -= record.getWeight();
+                    if (needle <= 0) {
+                        priorityGroupResults.add(record);
+                        iter.remove();
+                        iterationWeight -= record.getWeight();
+                        break;
+                    }
+                }
+                iter = weights.getValue().iterator();
+            }
+
+            // Append the hosts with zero priority (shuffled)
+            Collections.shuffle(zeroWeights);
+            priorityGroupResults.addAll(zeroWeights);
+
+            // Finally, add the entire priority group to the larger result.
+            result.add(priorityGroupResults);
+        }
+
+        return result;
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.session;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import org.dom4j.Element;
@@ -245,7 +246,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
      * @param port default port to use to establish the connection.
      * @return new outgoing session to a remote domain, or null.
      */
-    // package-protected to facilitate unit testing..
+    @VisibleForTesting
     static LocalOutgoingServerSession createOutgoingSession(@Nonnull final DomainPair domainPair, int port) {
         final Logger log = LoggerFactory.getLogger(Log.getName() + "[Create outgoing session for: " + domainPair + "]");
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.openfire.streammanagement;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.QName;
@@ -454,7 +455,7 @@ public class StreamManager {
         return validateClientAcknowledgement(h, oldH, lastUnackedX);
     }
 
-    // Package protected to facilitate unit testing.
+    @VisibleForTesting
     static boolean validateClientAcknowledgement(final long h, final long oldH, final Long lastUnackedX) {
         if (lastUnackedX == null) {
             // No unacked stanzas.

--- a/xmppserver/src/main/java/org/jivesoftware/util/ScheduledExecutorCompletionService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ScheduledExecutorCompletionService.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.util;
+
+import javax.annotation.Nonnull;
+import java.time.Duration;
+import java.util.concurrent.*;
+
+/**
+ * A CompletionService that allows solvers to be scheduled.
+ *
+ * This implementation borrows a lot from {@link ExecutorCompletionService}, which sadly is not designed to be extensible.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class ScheduledExecutorCompletionService<V> implements CompletionService<V>
+{
+    private final ScheduledThreadPoolExecutor executor;
+    private final BlockingQueue<Future<V>> completionQueue;
+
+    /**
+     * FutureTask extension to enqueue upon completion.
+     */
+    private static class QueueingFuture<V> extends FutureTask<Void> {
+        QueueingFuture(RunnableFuture<V> task,
+                       BlockingQueue<Future<V>> completionQueue) {
+            super(task, null);
+            this.task = task;
+            this.completionQueue = completionQueue;
+        }
+        private final Future<V> task;
+        private final BlockingQueue<Future<V>> completionQueue;
+        protected void done() { completionQueue.add(task); }
+    }
+
+    private RunnableFuture<V> newTaskFor(Callable<V> task) {
+        return new FutureTask<>(task);
+    }
+
+    private RunnableFuture<V> newTaskFor(Runnable task, V result) {
+        return new FutureTask<>(task, result);
+    }
+
+    /**
+     * Creates an ExecutorCompletionService using the supplied
+     * executor for base task execution and a
+     * {@link LinkedBlockingQueue} as a completion queue.
+     *
+     * @param executor the executor to use
+     * @throws NullPointerException if executor is {@code null}
+     */
+    public ScheduledExecutorCompletionService(ScheduledThreadPoolExecutor executor) {
+        if (executor == null)
+            throw new NullPointerException();
+        this.executor = executor;
+        this.completionQueue = new LinkedBlockingQueue<>();
+    }
+
+    /**
+     * Creates an ExecutorCompletionService using the supplied
+     * executor for base task execution and the supplied queue as its
+     * completion queue.
+     *
+     * @param executor the executor to use
+     * @param completionQueue the queue to use as the completion queue
+     *        normally one dedicated for use by this service. This
+     *        queue is treated as unbounded -- failed attempted
+     *        {@code Queue.add} operations for completed tasks cause
+     *        them not to be retrievable.
+     * @throws NullPointerException if executor or completionQueue are {@code null}
+     */
+    public ScheduledExecutorCompletionService(ScheduledThreadPoolExecutor executor,
+                                     BlockingQueue<Future<V>> completionQueue) {
+        if (executor == null || completionQueue == null)
+            throw new NullPointerException();
+        this.executor = executor;
+        this.completionQueue = completionQueue;
+    }
+
+    /**
+     * @throws RejectedExecutionException {@inheritDoc}
+     * @throws NullPointerException       {@inheritDoc}
+     */
+    @Nonnull
+    public Future<V> submit(@Nonnull Callable<V> task) {
+        if (task == null) throw new NullPointerException();
+        RunnableFuture<V> f = newTaskFor(task);
+        executor.execute(new QueueingFuture<>(f, completionQueue));
+        return f;
+    }
+
+    /**
+     * @throws RejectedExecutionException {@inheritDoc}
+     * @throws NullPointerException       {@inheritDoc}
+     */
+    @Nonnull
+    public Future<V> submit(@Nonnull Runnable task, V result) {
+        if (task == null) throw new NullPointerException();
+        RunnableFuture<V> f = newTaskFor(task, result);
+        executor.execute(new QueueingFuture<>(f, completionQueue));
+        return f;
+    }
+
+    public Future<V> schedule(Callable<V> task, Duration delay)
+    {
+        return schedule(task, delay.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    public Future<V> schedule(Callable<V> task, long delay, TimeUnit unit)
+    {
+        if (task == null) throw new NullPointerException();
+        RunnableFuture<V> f = newTaskFor(task);
+        executor.schedule(new QueueingFuture<>(f, completionQueue), delay, unit);
+        return f;
+    }
+
+    public Future<V> take() throws InterruptedException {
+        return completionQueue.take();
+    }
+
+    public Future<V> poll() {
+        return completionQueue.poll();
+    }
+
+    public Future<V> poll(long timeout, @Nonnull TimeUnit unit)
+        throws InterruptedException {
+        return completionQueue.poll(timeout, unit);
+    }
+}

--- a/xmppserver/src/main/webapp/dns-check-resulttable.jspf
+++ b/xmppserver/src/main/webapp/dns-check-resulttable.jspf
@@ -13,10 +13,10 @@
         </thead>
         <tbody>
         <c:forEach var="dnsSrvRecord" items="${dnsSrvRecords}" varStatus="varStatus">
-            <tr class="${dnsSrvRecord.host.toLowerCase() eq hostname.toLowerCase() ? 'jive-highlight' : ''}">
+            <tr class="${dnsSrvRecord.hostname.toLowerCase() eq hostname.toLowerCase() ? 'jive-highlight' : ''}">
                 <td style="width: 16px; white-space: nowrap; text-align: center">
                     <c:choose>
-                        <c:when test="${unknownHosts.contains(dnsSrvRecord.host)}">
+                        <c:when test="${unknownHosts.contains(dnsSrvRecord.hostname)}">
                             <img src="images/warning-16x16.gif" alt="<fmt:message key="system.dns.srv.check.tooltip-unknown-hostname" />">
                         </c:when>
                         <c:otherwise>
@@ -25,11 +25,11 @@
                     </c:choose>
                 </td>
                 <td style="width: 50%">
-                    <tt><c:out value="${dnsSrvRecord.host}"/></tt>
+                    <tt><c:out value="${dnsSrvRecord.hostname}"/></tt>
                 </td>
                 <td style="white-space: nowrap; text-align: center;">
                     <c:choose>
-                        <c:when test="${ipv4Capable.contains(dnsSrvRecord.host)}">
+                        <c:when test="${ipv4Capable.contains(dnsSrvRecord.hostname)}">
                             <img src="images/check-16x16.gif" alt="<fmt:message key="system.dns.srv.check.tooltip-ipv4-records-detected" />"/>
                         </c:when>
                         <c:otherwise>
@@ -39,7 +39,7 @@
                 </td>
                 <td style="white-space: nowrap; text-align: center;">
                     <c:choose>
-                        <c:when test="${ipv6Capable.contains(dnsSrvRecord.host)}">
+                        <c:when test="${ipv6Capable.contains(dnsSrvRecord.hostname)}">
                             <img src="images/check-16x16.gif" alt="<fmt:message key="system.dns.srv.check.tooltip-ipv6-records-detected" />"/>
                         </c:when>
                         <c:otherwise>

--- a/xmppserver/src/main/webapp/dns-check.jsp
+++ b/xmppserver/src/main/webapp/dns-check.jsp
@@ -23,6 +23,7 @@
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionConfiguration" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
 <%@ page import="org.jivesoftware.openfire.ConnectionManager" %>
+<%@ page import="org.jivesoftware.openfire.net.SrvRecord" %>
 <%@ page import="java.util.stream.Collectors" %>
 <%@ page import="java.util.stream.Stream" %>
 <%@ page import="java.net.InetAddress" %>
@@ -41,16 +42,16 @@
 <%
     final String xmppDomain = XMPPServer.getInstance().getServerInfo().getXMPPDomain();
     final String hostname = XMPPServer.getInstance().getServerInfo().getHostname();
-    final List<DNSUtil.WeightedHostAddress> dnsSrvRecordsClient = DNSUtil.srvLookup( "xmpp-client", "tcp", xmppDomain );
-    final List<DNSUtil.WeightedHostAddress> dnsSrvRecordsServer = DNSUtil.srvLookup( "xmpp-server", "tcp", xmppDomain );
-    final List<DNSUtil.WeightedHostAddress> dnsSrvRecordsClientTLS = DNSUtil.srvLookup( "xmpps-client", "tcp", xmppDomain );
-    final List<DNSUtil.WeightedHostAddress> dnsSrvRecordsServerTLS = DNSUtil.srvLookup( "xmpps-server", "tcp", xmppDomain );
+    final List<SrvRecord> dnsSrvRecordsClient = DNSUtil.srvLookup( "xmpp-client", "tcp", xmppDomain );
+    final List<SrvRecord> dnsSrvRecordsServer = DNSUtil.srvLookup( "xmpp-server", "tcp", xmppDomain );
+    final List<SrvRecord> dnsSrvRecordsClientTLS = DNSUtil.srvLookup( "xmpps-client", "tcp", xmppDomain );
+    final List<SrvRecord> dnsSrvRecordsServerTLS = DNSUtil.srvLookup( "xmpps-server", "tcp", xmppDomain );
 
     // Check if A and AAAA records exist for each discovered hostname.
     final Set<String> unknownHosts = new HashSet<>();
     final Set<String> hostnames = Stream.of(dnsSrvRecordsClient, dnsSrvRecordsClientTLS, dnsSrvRecordsServer, dnsSrvRecordsServerTLS)
         .flatMap(Collection::stream)
-        .map(DNSUtil.HostAddress::getHost).collect(Collectors.toSet());
+        .map(SrvRecord::getHostname).collect(Collectors.toSet());
     final Set<String> ipv4Capable = hostnames.stream().filter(host -> {
         try {
             for (InetAddress i : InetAddress.getAllByName(host)) {
@@ -78,18 +79,18 @@
     }).collect(Collectors.toSet());
 
     boolean detectedRecordForHostname = false;
-    for ( final DNSUtil.WeightedHostAddress dnsSrvRecord : dnsSrvRecordsClient )
+    for ( final SrvRecord dnsSrvRecord : dnsSrvRecordsClient )
     {
-        if ( hostname.equalsIgnoreCase( dnsSrvRecord.getHost() ) )
+        if ( hostname.equalsIgnoreCase( dnsSrvRecord.getHostname() ) )
         {
             detectedRecordForHostname = true;
             break;
         }
     }
 
-    for ( final DNSUtil.WeightedHostAddress dnsSrvRecord : dnsSrvRecordsServer )
+    for ( final SrvRecord dnsSrvRecord : dnsSrvRecordsServer )
     {
-        if ( hostname.equalsIgnoreCase( dnsSrvRecord.getHost() ) )
+        if ( hostname.equalsIgnoreCase( dnsSrvRecord.getHostname() ) )
         {
             detectedRecordForHostname = true;
             break;

--- a/xmppserver/src/main/webapp/index.jsp
+++ b/xmppserver/src/main/webapp/index.jsp
@@ -33,6 +33,7 @@
 <%@ page import="org.jivesoftware.openfire.ConnectionManager" %>
 <%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 <%@ page import="org.jivesoftware.admin.servlet.BlogPostServlet" %>
+<%@ page import="org.jivesoftware.openfire.net.SrvRecord" %>
 <%@ page import="java.net.InetAddress" %>
 <%@ page import="java.net.UnknownHostException" %>
 <%@ page import="org.jivesoftware.util.*" %>
@@ -315,12 +316,12 @@
                             final String hostname = XMPPServer.getInstance().getServerInfo().getHostname();
                             boolean dnsIssue = false;
                             if (!xmppDomain.equalsIgnoreCase(hostname)) {
-                                final List<DNSUtil.WeightedHostAddress> dnsSrvRecords = DNSUtil.srvLookup("xmpp-client", "tcp", xmppDomain);
-                                dnsIssue = dnsSrvRecords.stream().anyMatch(r -> hostname.equalsIgnoreCase(r.getHost()));
+                                final List<SrvRecord> dnsSrvRecords = DNSUtil.srvLookup("xmpp-client", "tcp", xmppDomain);
+                                dnsIssue = dnsSrvRecords.stream().anyMatch(r -> hostname.equalsIgnoreCase(r.getHostname()));
                                 if (!dnsIssue) {
-                                    for (final DNSUtil.WeightedHostAddress dnsSrvRecord : dnsSrvRecords) {
+                                    for (final SrvRecord dnsSrvRecord : dnsSrvRecords) {
                                         try {
-                                            InetAddress.getAllByName(dnsSrvRecord.getHost());
+                                            InetAddress.getAllByName(dnsSrvRecord.getHostname());
                                         } catch (UnknownHostException e) {
                                             dnsIssue = true;
                                             break;

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/net/DNSUtilTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/net/DNSUtilTest.java
@@ -34,6 +34,7 @@ public class DNSUtilTest {
      * DNS SRV xmpp-server records for jabber.org (as they were last 2012).
      */
     @Test
+    @Deprecated // This tests a deprecated implementation. A test for the replacement code already exists. Simply delete this when the deprecated code gets removed.
     public void testJabberDotOrgMock() throws Exception {
         // setup
         final DNSUtil.WeightedHostAddress fallback = new DNSUtil.WeightedHostAddress("fallback.jabber.org", 5269, false, 31, 31);
@@ -56,6 +57,7 @@ public class DNSUtilTest {
      * A basic check that verifies that when one hosts exists, it gets returned in the output.
      */
     @Test
+    @Deprecated // This tests a deprecated implementation. A test for the replacement code already exists. Simply delete this when the deprecated code gets removed.
     public void testOneHost() throws Exception {
         // setup
         final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, false, 1, 1);
@@ -72,6 +74,7 @@ public class DNSUtilTest {
      * A check equal to {@link #testOneHost()}, but using (the edge-case) priority value of zero.
      */
     @Test
+    @Deprecated // This tests a deprecated implementation. A test for the replacement code already exists. Simply delete this when the deprecated code gets removed.
     public void testOneHostZeroPriority() throws Exception {
         // setup
         final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, false, 0, 1);
@@ -88,6 +91,7 @@ public class DNSUtilTest {
      * A check equal to {@link #testOneHost()}, but using (the edge-case) weight value of zero.
      */
     @Test
+    @Deprecated // This tests a deprecated implementation. A test for the replacement code already exists. Simply delete this when the deprecated code gets removed.
     public void testOneHostZeroWeight() throws Exception {
         // setup
         final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, false, 1, 0);
@@ -105,6 +109,7 @@ public class DNSUtilTest {
      * in the result, ordered (ascending) by their priority.
      */
     @Test
+    @Deprecated // This tests a deprecated implementation. A test for the replacement code already exists. Simply delete this when the deprecated code gets removed.
     public void testDifferentPriorities() throws Exception {
         // setup
         final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, false, 1, 1);
@@ -125,6 +130,7 @@ public class DNSUtilTest {
      * A test equal to {@link #testDifferentPriorities()}, but with one of the priorities set to zero.
      */
     @Test
+    @Deprecated // This tests a deprecated implementation. A test for the replacement code already exists. Simply delete this when the deprecated code gets removed.
     public void testZeroPriority() throws Exception {
         // setup
         final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, false, 0, 1);
@@ -148,6 +154,7 @@ public class DNSUtilTest {
      * record. This indicates that the returning list is at the very least not always ordered in the exact same way.
      */
     @Test
+    @Deprecated // This tests a deprecated implementation. A test for the replacement code already exists. Simply delete this when the deprecated code gets removed.
     public void testSameWeights() throws Exception {
         // setup
         final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, false, 1, 10);
@@ -186,6 +193,7 @@ public class DNSUtilTest {
      * A test equal to {@link #testSameWeights()}, but using records with a weight of zero.
      */
     @Test
+    @Deprecated // This tests a deprecated implementation. A test for the replacement code already exists. Simply delete this when the deprecated code gets removed.
     public void testZeroWeights() throws Exception {
         // setup
         final DNSUtil.WeightedHostAddress hostA = new DNSUtil.WeightedHostAddress("hostA", 5222, false, 1, 0);
@@ -195,8 +203,8 @@ public class DNSUtilTest {
         // do magic
         boolean hostAWasFirst = false;
         boolean hostBWasFirst = false;
-        final int maxTries = Integer.MAX_VALUE;
-        for (int i=0; i<maxTries; i++) {
+        final int maxTries = 1000000;
+        for (int i=0; i<=maxTries; i++) {
             final List<Set<DNSUtil.WeightedHostAddress>> result = DNSUtil.prioritize(hosts);
             if (hostA.equals(result.get(0).iterator().next())) {
                 hostAWasFirst = true;
@@ -210,7 +218,7 @@ public class DNSUtilTest {
                 break;
             }
 
-            if (i%1000000==0 && i>0) {
+            if (i%(maxTries/10)==0 && i>0) {
                 System.err.println("The last " + i + " iterations of this test all had the same result, which is very unlikely to occur (there should be an even distribution between two possible outcomes). We'll iterate up to "+ maxTries +" times, but you might want to abort the unit test at this point...");
             }
         }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/net/DNSUtilTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/net/DNSUtilTest.java
@@ -42,15 +42,14 @@ public class DNSUtilTest {
         final DNSUtil.WeightedHostAddress hermes   = new DNSUtil.WeightedHostAddress("hermes.jabber.org",   5269, false, 30, 30);
 
         // do magic
-        final List<Set<DNSUtil.WeightedHostAddress>> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{fallback, hermes6, hermes});
+        final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{fallback, hermes6, hermes});
 
         // verify
-        assertEquals(2, result.size(), "There are two distinct priority values in the input, so two priority groups should be part of the result.");
-        assertEquals(2, result.get(0).size(), "The priority group with the lowest priority value (30) should have two entries in it");
-        assertEquals(1, result.get(1).size(), "The priority group with the highest priority value (31) should have one entry in it");
-        assertTrue(result.get(0).contains(hermes), "The 'hermes' host should have been included somewhere in the first priority group.");
-        assertTrue(result.get(0).contains(hermes6), "The 'hermes6' host should have been included somewhere in the first priority group.");
-        assertTrue(result.get(1).contains(fallback), "The 'fallback' host should have been included somewhere in the second priority group.");
+        assertEquals(3, result.size(), "There were three records in the input, the output should have contained the same amount.");
+        assertTrue(result.contains(hermes), "The 'hermes' host should have been included somewhere in the output.");
+        assertTrue(result.contains(hermes6), "The 'hermes6' host should have been included somewhere in the output.");
+        assertTrue(result.contains(fallback), "The 'fallback' host should have been included somewhere in the output.");
+        assertEquals(fallback, result.get(2), "The 'fallback' host should have been the last record in the result.");
     }
 
     /**
@@ -63,11 +62,11 @@ public class DNSUtilTest {
         final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, false, 1, 1);
 
         // do magic
-        final List<Set<DNSUtil.WeightedHostAddress>> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{host});
+        final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{host});
 
         // verify
         assertEquals( 1, result.size() );
-        assertEquals(host, result.get(0).iterator().next());
+        assertEquals(host, result.get(0));
     }
 
     /**
@@ -80,11 +79,11 @@ public class DNSUtilTest {
         final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, false, 0, 1);
 
         // do magic
-        final List<Set<DNSUtil.WeightedHostAddress>> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{host});
+        final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{host});
 
         // verify
         assertEquals(1, result.size());
-        assertEquals(host, result.get(0).iterator().next());
+        assertEquals(host, result.get(0));
     }
 
     /**
@@ -97,11 +96,11 @@ public class DNSUtilTest {
         final DNSUtil.WeightedHostAddress host = new DNSUtil.WeightedHostAddress("host", 5222, false, 1, 0);
 
         // do magic
-        final List<Set<DNSUtil.WeightedHostAddress>> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{host});
+        final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{host});
 
         // verify
         assertEquals(1, result.size());
-        assertEquals(host, result.get(0).iterator().next());
+        assertEquals(host, result.get(0));
     }
 
     /**
@@ -117,13 +116,13 @@ public class DNSUtilTest {
         final DNSUtil.WeightedHostAddress hostC = new DNSUtil.WeightedHostAddress("hostC", 5222, false, 2, 1);
 
         // do magic
-        final List<Set<DNSUtil.WeightedHostAddress>> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{hostA, hostB, hostC});
+        final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{hostA, hostB, hostC});
 
         // verify
         assertEquals(3, result.size());
-        assertEquals(hostA, result.get(0).iterator().next());
-        assertEquals(hostC, result.get(1).iterator().next());
-        assertEquals(hostB, result.get(2).iterator().next());
+        assertEquals(hostA, result.get(0));
+        assertEquals(hostC, result.get( 1 ));
+        assertEquals(hostB, result.get(2));
     }
 
     /**
@@ -138,13 +137,13 @@ public class DNSUtilTest {
         final DNSUtil.WeightedHostAddress hostC = new DNSUtil.WeightedHostAddress("hostC", 5222, false, 1, 1);
 
         // do magic
-        final List<Set<DNSUtil.WeightedHostAddress>> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{hostA, hostB, hostC});
+        final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(new DNSUtil.WeightedHostAddress[]{hostA, hostB, hostC});
 
         // verify
         assertEquals(3, result.size());
-        assertEquals(hostA, result.get(0).iterator().next());
-        assertEquals(hostC, result.get(1).iterator().next());
-        assertEquals(hostB, result.get(2).iterator().next());
+        assertEquals(hostA, result.get(0));
+        assertEquals(hostC, result.get(1));
+        assertEquals(hostB, result.get(2));
     }
 
     /**
@@ -166,12 +165,12 @@ public class DNSUtilTest {
         boolean hostBWasFirst = false;
         final int maxTries = Integer.MAX_VALUE;
         for (int i=0; i<maxTries; i++) {
-            final List<Set<DNSUtil.WeightedHostAddress>> result = DNSUtil.prioritize(hosts);
-            if (hostA.equals(result.get(0).iterator().next())) {
+            final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(hosts);
+            if (hostA.equals(result.get(0))) {
                 hostAWasFirst = true;
             }
 
-            if (hostB.equals(result.get(0).iterator().next())) {
+            if (hostB.equals(result.get(0))) {
                 hostBWasFirst = true;
             }
 
@@ -205,12 +204,12 @@ public class DNSUtilTest {
         boolean hostBWasFirst = false;
         final int maxTries = 1000000;
         for (int i=0; i<=maxTries; i++) {
-            final List<Set<DNSUtil.WeightedHostAddress>> result = DNSUtil.prioritize(hosts);
-            if (hostA.equals(result.get(0).iterator().next())) {
+            final List<DNSUtil.WeightedHostAddress> result = DNSUtil.prioritize(hosts);
+            if (hostA.equals(result.get(0))) {
                 hostAWasFirst = true;
             }
 
-            if (hostB.equals(result.get(0).iterator().next())) {
+            if (hostB.equals(result.get(0))) {
                 hostBWasFirst = true;
             }
 

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/net/HappyEyeballsResolverTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/net/HappyEyeballsResolverTest.java
@@ -38,87 +38,87 @@ public class HappyEyeballsResolverTest
     static final Duration RESOLUTION_DELAY = Duration.ofMillis(50); // If this test is giving flappy results, try increasing this value. If it needs to increase over 50ms, then the implementation is not efficient enough on the server to comply with the specification.
 
     // Host 'prio0' configuration.
-    static final DNSUtil.HostAddress HOST_PRIO0 = new DNSUtil.HostAddress("prio0.example.org", 5269, false);
+    static final SrvRecord HOST_PRIO0 = new SrvRecord("prio0.example.org", 5269, false);
     static final InetAddress HOST_PRIO0_IPV4_ADDRESS;
     static final InetAddress HOST_PRIO0_IPV6_ADDRESS;
 
     static {
         try {
-            HOST_PRIO0_IPV4_ADDRESS = InetAddress.getByAddress(HOST_PRIO0.getHost(), new byte[] {(byte) 198, (byte) 51, (byte) 100, (byte) 1});
-            HOST_PRIO0_IPV6_ADDRESS = InetAddress.getByAddress(HOST_PRIO0.getHost(), new byte[] {(byte) 0x20, (byte) 0x01, (byte) 0x0d, (byte) 0xB8, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 1 });
+            HOST_PRIO0_IPV4_ADDRESS = InetAddress.getByAddress(HOST_PRIO0.getHostname(), new byte[] {(byte) 198, (byte) 51, (byte) 100, (byte) 1});
+            HOST_PRIO0_IPV6_ADDRESS = InetAddress.getByAddress(HOST_PRIO0.getHostname(), new byte[] {(byte) 0x20, (byte) 0x01, (byte) 0x0d, (byte) 0xB8, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 1 });
         } catch (UnknownHostException e) {
             throw new RuntimeException(e);
         }
     }
 
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV4ONLY = () -> HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS}, 5269, false);
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV6ONLY = () -> HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_BOTHFAMS = () -> HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS, HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV4ONLY_DELAYED_SHORT = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO0_IPV4ONLY = () -> IndexedResolvedServiceAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS}, 5269, false);
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO0_IPV6ONLY = () -> IndexedResolvedServiceAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO0_BOTHFAMS = () -> IndexedResolvedServiceAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS, HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO0_IPV4ONLY_DELAYED_SHORT = () -> {
         try { Thread.sleep(RESOLUTION_DELAY.dividedBy(2).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS}, 5269, false);
     };
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV4ONLY_DELAYED_LONG = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO0_IPV4ONLY_DELAYED_LONG = () -> {
         try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS}, 5269, false);
     };
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV6ONLY_DELAYED_SHORT = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO0_IPV6ONLY_DELAYED_SHORT = () -> {
         try { Thread.sleep(RESOLUTION_DELAY.dividedBy(2).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
     };
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV6ONLY_DELAYED_LONG = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO0_IPV6ONLY_DELAYED_LONG = () -> {
         try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
     };
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_BOTHFAMS_DELAYED_SHORT = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO0_BOTHFAMS_DELAYED_SHORT = () -> {
         try { Thread.sleep((RESOLUTION_DELAY.dividedBy(2)).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS, HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS, HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
     };
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_BOTHFAMS_DELAYED_LONG = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO0_BOTHFAMS_DELAYED_LONG = () -> {
         try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS, HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS, HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
     };
 
     // Host 'prio1' configuration.
-    static final DNSUtil.HostAddress HOST_PRIO1 = new DNSUtil.HostAddress("prio1.example.org", 5269, false);
+    static final SrvRecord HOST_PRIO1 = new SrvRecord("prio1.example.org", 5269, false);
     static final InetAddress HOST_PRIO1_IPV4_ADDRESS;
     static final InetAddress HOST_PRIO1_IPV6_ADDRESS;
 
     static {
         try {
-            HOST_PRIO1_IPV4_ADDRESS = InetAddress.getByAddress(HOST_PRIO1.getHost(), new byte[] {(byte) 198, (byte) 51, (byte) 100, (byte) 2});
-            HOST_PRIO1_IPV6_ADDRESS = InetAddress.getByAddress(HOST_PRIO1.getHost(), new byte[] {(byte) 0x20, (byte) 0x01, (byte) 0x0d, (byte) 0xB8, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 2 });
+            HOST_PRIO1_IPV4_ADDRESS = InetAddress.getByAddress(HOST_PRIO1.getHostname(), new byte[] {(byte) 198, (byte) 51, (byte) 100, (byte) 2});
+            HOST_PRIO1_IPV6_ADDRESS = InetAddress.getByAddress(HOST_PRIO1.getHostname(), new byte[] {(byte) 0x20, (byte) 0x01, (byte) 0x0d, (byte) 0xB8, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 2 });
         } catch (UnknownHostException e) {
             throw new RuntimeException(e);
         }
     }
 
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV4ONLY = () -> HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS}, 5269, false);
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV6ONLY = () -> HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_BOTHFAMS = () -> HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS, HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV4ONLY_DELAYED_SHORT = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO1_IPV4ONLY = () -> IndexedResolvedServiceAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS}, 5269, false);
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO1_IPV6ONLY = () -> IndexedResolvedServiceAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO1_BOTHFAMS = () -> IndexedResolvedServiceAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS, HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO1_IPV4ONLY_DELAYED_SHORT = () -> {
         try { Thread.sleep(RESOLUTION_DELAY.dividedBy(2).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS}, 5269, false);
     };
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV4ONLY_DELAYED_LONG = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO1_IPV4ONLY_DELAYED_LONG = () -> {
         try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS}, 5269, false);
     };
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV6ONLY_DELAYED_SHORT = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO1_IPV6ONLY_DELAYED_SHORT = () -> {
         try { Thread.sleep(RESOLUTION_DELAY.dividedBy(2).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
     };
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV6ONLY_DELAYED_LONG = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO1_IPV6ONLY_DELAYED_LONG = () -> {
         try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
     };
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_BOTHFAMS_DELAYED_SHORT = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO1_BOTHFAMS_DELAYED_SHORT = () -> {
         try { Thread.sleep(RESOLUTION_DELAY.dividedBy(2).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS, HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS, HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
     };
-    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_BOTHFAMS_DELAYED_LONG = () -> {
+    static final Supplier<Set<IndexedResolvedServiceAddress>> SOLVER_PRIO1_BOTHFAMS_DELAYED_LONG = () -> {
         try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
-        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS, HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+        return IndexedResolvedServiceAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS, HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
     };
 
     @ParameterizedTest
@@ -126,18 +126,18 @@ public class HappyEyeballsResolverTest
     public void testFirstResultWhenSingleHostTwoRecords(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0);
+        final List<SrvRecord> input = List.of(HOST_PRIO0);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
         try {
             systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS, 0);
-            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+            final ResolvedServiceAddress result = systemUnderTest.getNext();
 
             // Verify results.
             assertNotNull(result);
             final InetAddress expected = preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS;
-            assertEquals(expected, result.getSocketAddress().getAddress());
+            assertEquals(expected, result.getInetAddress());
         } finally {
             // Clean up test fixture.
             systemUnderTest.shutdownNow();
@@ -149,14 +149,14 @@ public class HappyEyeballsResolverTest
     public void testFirstResultWhenNoRecords(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0);
-        final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> mockSolver = () -> { throw new RuntimeException("Exception thrown as part of unit testing.\"", new UnknownHostException("Nested exception thrown as part of unit testing.")); };
+        final List<SrvRecord> input = List.of(HOST_PRIO0);
+        final Supplier<Set<IndexedResolvedServiceAddress>> mockSolver = () -> { throw new RuntimeException("Exception thrown as part of unit testing.\"", new UnknownHostException("Nested exception thrown as part of unit testing.")); };
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
         try {
             systemUnderTest.solve(mockSolver, 0);
-            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+            final ResolvedServiceAddress result = systemUnderTest.getNext();
 
             // Verify results.
             assertNull(result);
@@ -171,13 +171,13 @@ public class HappyEyeballsResolverTest
     public void testFirstResultWhenRecordsProvidedAfterResolutionDelay(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0);
+        final List<SrvRecord> input = List.of(HOST_PRIO0);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
         try {
             systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS_DELAYED_LONG, 0);
-            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+            final ResolvedServiceAddress result = systemUnderTest.getNext();
 
             // Verify results.
             assertNull(result);
@@ -192,13 +192,13 @@ public class HappyEyeballsResolverTest
     public void testFirstResultWhenOnlyIpv4Record(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0);
+        final List<SrvRecord> input = List.of(HOST_PRIO0);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
         try {
             systemUnderTest.solve(SOLVER_PRIO0_IPV4ONLY, 0);
-            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+            final ResolvedServiceAddress result = systemUnderTest.getNext();
 
             // Verify results.
             assertNotNull(result);
@@ -213,13 +213,13 @@ public class HappyEyeballsResolverTest
     public void testFirstResultWhenOnlyIpv6Record(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0);
+        final List<SrvRecord> input = List.of(HOST_PRIO0);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
         try {
             systemUnderTest.solve(SOLVER_PRIO0_IPV6ONLY, 0);
-            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+            final ResolvedServiceAddress result = systemUnderTest.getNext();
 
             // Verify results.
             assertNotNull(result);
@@ -234,19 +234,19 @@ public class HappyEyeballsResolverTest
     public void testFirstResultWhenTwoHostsFourRecords(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+        final List<SrvRecord> input = List.of(HOST_PRIO0, HOST_PRIO1);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
         try {
             systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS, 0);
             systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS, 1);
-            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+            final ResolvedServiceAddress result = systemUnderTest.getNext();
 
             // Verify results.
             assertNotNull(result);
             final InetAddress expected = preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS;
-            assertEquals(expected, result.getSocketAddress().getAddress());
+            assertEquals(expected, result.generateSocketAddress().getAddress());
         } finally {
             // Clean up test fixture.
             systemUnderTest.shutdownNow();
@@ -258,19 +258,19 @@ public class HappyEyeballsResolverTest
     public void testFirstResultWhenPreferredHostProvidedFirst(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+        final List<SrvRecord> input = List.of(HOST_PRIO0, HOST_PRIO1);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
         try {
             systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS, 0);
             systemUnderTest.solve(SOLVER_PRIO1_BOTHFAMS_DELAYED_SHORT, 1);
-            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+            final ResolvedServiceAddress result = systemUnderTest.getNext();
 
             // Verify results.
             assertNotNull(result);
             final InetAddress expected = preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS;
-            assertEquals(expected, result.getSocketAddress().getAddress());
+            assertEquals(expected, result.generateSocketAddress().getAddress());
         } finally {
             // Clean up test fixture.
             systemUnderTest.shutdownNow();
@@ -282,19 +282,19 @@ public class HappyEyeballsResolverTest
     public void testFirstResultWhenPreferredHostProvidedSecondButWithinResolutionDelay(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+        final List<SrvRecord> input = List.of(HOST_PRIO0, HOST_PRIO1);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
         try {
             systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS_DELAYED_SHORT, 0);
             systemUnderTest.solve(SOLVER_PRIO1_BOTHFAMS, 1);
-            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+            final ResolvedServiceAddress result = systemUnderTest.getNext();
 
             // Verify results.
             assertNotNull(result);
             final InetAddress expected = preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS;
-            assertEquals(expected, result.getSocketAddress().getAddress());
+            assertEquals(expected, result.generateSocketAddress().getAddress());
         } finally {
             // Clean up test fixture.
             systemUnderTest.shutdownNow();
@@ -306,19 +306,19 @@ public class HappyEyeballsResolverTest
     public void testFirstResultWhenPreferredHostProvidedSecondAfterResolutionDelay(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+        final List<SrvRecord> input = List.of(HOST_PRIO0, HOST_PRIO1);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
         try {
             systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS_DELAYED_LONG, 0);
             systemUnderTest.solve(SOLVER_PRIO1_BOTHFAMS, 1);
-            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+            final ResolvedServiceAddress result = systemUnderTest.getNext();
 
             // Verify results.
             assertNotNull(result);
             final InetAddress expected = preferIpv4 ? HOST_PRIO1_IPV4_ADDRESS : HOST_PRIO1_IPV6_ADDRESS;
-            assertEquals(expected, result.getSocketAddress().getAddress());
+            assertEquals(expected, result.generateSocketAddress().getAddress());
         } finally {
             // Clean up test fixture.
             systemUnderTest.shutdownNow();
@@ -330,7 +330,7 @@ public class HappyEyeballsResolverTest
     public void testAllResults(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+        final List<SrvRecord> input = List.of(HOST_PRIO0, HOST_PRIO1);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
@@ -338,9 +338,9 @@ public class HappyEyeballsResolverTest
             systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS, 0);
             systemUnderTest.solve(SOLVER_PRIO1_BOTHFAMS, 1);
 
-            final List<HappyEyeballsResolver.XmppServiceAddress> results = new LinkedList<>();
+            final List<ResolvedServiceAddress> results = new LinkedList<>();
             for (int i = 0; i < 10; i++) {
-                final HappyEyeballsResolver.XmppServiceAddress nextResult = systemUnderTest.getNext();
+                final ResolvedServiceAddress nextResult = systemUnderTest.getNext();
                 if (nextResult != null) {
                     results.add(nextResult);
                 }
@@ -351,10 +351,10 @@ public class HappyEyeballsResolverTest
 
             // Verify results.
             assertEquals(4, results.size());
-            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(0).getSocketAddress().getAddress());
-            assertEquals(preferIpv4 ? HOST_PRIO0_IPV6_ADDRESS : HOST_PRIO0_IPV4_ADDRESS, results.get(1).getSocketAddress().getAddress());
-            assertEquals(preferIpv4 ? HOST_PRIO1_IPV4_ADDRESS : HOST_PRIO1_IPV6_ADDRESS, results.get(2).getSocketAddress().getAddress());
-            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(3).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(0).getInetAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV6_ADDRESS : HOST_PRIO0_IPV4_ADDRESS, results.get(1).getInetAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV4_ADDRESS : HOST_PRIO1_IPV6_ADDRESS, results.get(2).getInetAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(3).getInetAddress());
         } finally {
             // Clean up test fixture.
             systemUnderTest.shutdownNow();
@@ -366,7 +366,7 @@ public class HappyEyeballsResolverTest
     public void testAllResultsWhenPreferredHostProvidedSecondButWithinResolutionDelay(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+        final List<SrvRecord> input = List.of(HOST_PRIO0, HOST_PRIO1);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
@@ -374,9 +374,9 @@ public class HappyEyeballsResolverTest
             systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS_DELAYED_SHORT, 0);
             systemUnderTest.solve(SOLVER_PRIO1_BOTHFAMS, 1);
 
-            final List<HappyEyeballsResolver.XmppServiceAddress> results = new LinkedList<>();
+            final List<ResolvedServiceAddress> results = new LinkedList<>();
             for (int i = 0; i < 10; i++) {
-                final HappyEyeballsResolver.XmppServiceAddress nextResult = systemUnderTest.getNext();
+                final ResolvedServiceAddress nextResult = systemUnderTest.getNext();
                 if (nextResult != null) {
                     results.add(nextResult);
                 }
@@ -387,10 +387,10 @@ public class HappyEyeballsResolverTest
 
             // Verify results.
             assertEquals(4, results.size());
-            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(0).getSocketAddress().getAddress());
-            assertEquals(preferIpv4 ? HOST_PRIO0_IPV6_ADDRESS : HOST_PRIO0_IPV4_ADDRESS, results.get(1).getSocketAddress().getAddress());
-            assertEquals(preferIpv4 ? HOST_PRIO1_IPV4_ADDRESS : HOST_PRIO1_IPV6_ADDRESS, results.get(2).getSocketAddress().getAddress());
-            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(3).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(0).getInetAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV6_ADDRESS : HOST_PRIO0_IPV4_ADDRESS, results.get(1).getInetAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV4_ADDRESS : HOST_PRIO1_IPV6_ADDRESS, results.get(2).getInetAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(3).getInetAddress());
         } finally {
             // Clean up test fixture.
             systemUnderTest.shutdownNow();
@@ -402,7 +402,7 @@ public class HappyEyeballsResolverTest
     public void testAllResultsWhenPreferredFamilyProvidedSecondButWithinResolutionDelay(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+        final List<SrvRecord> input = List.of(HOST_PRIO0, HOST_PRIO1);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
@@ -410,9 +410,9 @@ public class HappyEyeballsResolverTest
             systemUnderTest.solve(preferIpv4 ? SOLVER_PRIO0_IPV4ONLY_DELAYED_SHORT : SOLVER_PRIO0_IPV6ONLY_DELAYED_SHORT, 0);
             systemUnderTest.solve(preferIpv4 ? SOLVER_PRIO1_IPV6ONLY : SOLVER_PRIO1_IPV4ONLY, 1);
 
-            final List<HappyEyeballsResolver.XmppServiceAddress> results = new LinkedList<>();
+            final List<ResolvedServiceAddress> results = new LinkedList<>();
             for (int i = 0; i < 10; i++) {
-                final HappyEyeballsResolver.XmppServiceAddress nextResult = systemUnderTest.getNext();
+                final ResolvedServiceAddress nextResult = systemUnderTest.getNext();
                 if (nextResult != null) {
                     results.add(nextResult);
                 }
@@ -423,8 +423,8 @@ public class HappyEyeballsResolverTest
 
             // Verify results.
             assertEquals(2, results.size());
-            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(0).getSocketAddress().getAddress());
-            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(1).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(0).getInetAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(1).getInetAddress());
         } finally {
             // Clean up test fixture.
             systemUnderTest.shutdownNow();
@@ -436,7 +436,7 @@ public class HappyEyeballsResolverTest
     public void testAllResultsWhenPreferredFamilyProvidedSecondAfterResolutionDelay(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+        final List<SrvRecord> input = List.of(HOST_PRIO0, HOST_PRIO1);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
@@ -444,9 +444,9 @@ public class HappyEyeballsResolverTest
             systemUnderTest.solve(preferIpv4 ? SOLVER_PRIO0_IPV4ONLY_DELAYED_LONG : SOLVER_PRIO0_IPV6ONLY_DELAYED_LONG, 0);
             systemUnderTest.solve(preferIpv4 ? SOLVER_PRIO1_IPV6ONLY : SOLVER_PRIO1_IPV4ONLY, 1);
 
-            final List<HappyEyeballsResolver.XmppServiceAddress> results = new LinkedList<>();
+            final List<ResolvedServiceAddress> results = new LinkedList<>();
             for (int i = 0; i < 10; i++) {
-                final HappyEyeballsResolver.XmppServiceAddress nextResult = systemUnderTest.getNext();
+                final ResolvedServiceAddress nextResult = systemUnderTest.getNext();
                 if (nextResult != null) {
                     results.add(nextResult);
                 }
@@ -457,8 +457,8 @@ public class HappyEyeballsResolverTest
 
             // Verify results.
             assertEquals(2, results.size());
-            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(0).getSocketAddress().getAddress());
-            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(1).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(0).getInetAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(1).getInetAddress());
         } finally {
             // Clean up test fixture.
             systemUnderTest.shutdownNow();
@@ -470,7 +470,7 @@ public class HappyEyeballsResolverTest
     public void testAllResultsFamilyInterleavedWhenPreferredFamilyProvidedSecondAfterResolutionDelay(final boolean preferIpv4) throws Exception
     {
         // Setup test fixture.
-        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+        final List<SrvRecord> input = List.of(HOST_PRIO0, HOST_PRIO1);
 
         // Execute system under test.
         final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
@@ -478,9 +478,9 @@ public class HappyEyeballsResolverTest
             systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS_DELAYED_LONG, 0);
             systemUnderTest.solve(preferIpv4 ? SOLVER_PRIO1_IPV6ONLY : SOLVER_PRIO1_IPV4ONLY, 1);
 
-            final List<HappyEyeballsResolver.XmppServiceAddress> results = new LinkedList<>();
+            final List<ResolvedServiceAddress> results = new LinkedList<>();
             for (int i = 0; i < 10; i++) {
-                final HappyEyeballsResolver.XmppServiceAddress nextResult = systemUnderTest.getNext();
+                final ResolvedServiceAddress nextResult = systemUnderTest.getNext();
                 if (nextResult != null) {
                     results.add(nextResult);
                 }
@@ -491,9 +491,9 @@ public class HappyEyeballsResolverTest
 
             // Verify results.
             assertEquals(3, results.size());
-            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(0).getSocketAddress().getAddress());
-            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(1).getSocketAddress().getAddress());
-            assertEquals(preferIpv4 ? HOST_PRIO0_IPV6_ADDRESS : HOST_PRIO0_IPV4_ADDRESS, results.get(2).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(0).getInetAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(1).getInetAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV6_ADDRESS : HOST_PRIO0_IPV4_ADDRESS, results.get(2).getInetAddress());
         } finally {
             // Clean up test fixture.
             systemUnderTest.shutdownNow();

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/net/HappyEyeballsResolverTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/net/HappyEyeballsResolverTest.java
@@ -1,0 +1,502 @@
+/*
+ * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.net;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link org.jivesoftware.openfire.net.DNSUtil}.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class HappyEyeballsResolverTest
+{
+    static final Duration RESOLUTION_DELAY = Duration.ofMillis(50); // If this test is giving flappy results, try increasing this value. If it needs to increase over 50ms, then the implementation is not efficient enough on the server to comply with the specification.
+
+    // Host 'prio0' configuration.
+    static final DNSUtil.HostAddress HOST_PRIO0 = new DNSUtil.HostAddress("prio0.example.org", 5269, false);
+    static final InetAddress HOST_PRIO0_IPV4_ADDRESS;
+    static final InetAddress HOST_PRIO0_IPV6_ADDRESS;
+
+    static {
+        try {
+            HOST_PRIO0_IPV4_ADDRESS = InetAddress.getByAddress(HOST_PRIO0.getHost(), new byte[] {(byte) 198, (byte) 51, (byte) 100, (byte) 1});
+            HOST_PRIO0_IPV6_ADDRESS = InetAddress.getByAddress(HOST_PRIO0.getHost(), new byte[] {(byte) 0x20, (byte) 0x01, (byte) 0x0d, (byte) 0xB8, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 1 });
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV4ONLY = () -> HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS}, 5269, false);
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV6ONLY = () -> HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_BOTHFAMS = () -> HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS, HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV4ONLY_DELAYED_SHORT = () -> {
+        try { Thread.sleep(RESOLUTION_DELAY.dividedBy(2).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS}, 5269, false);
+    };
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV4ONLY_DELAYED_LONG = () -> {
+        try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS}, 5269, false);
+    };
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV6ONLY_DELAYED_SHORT = () -> {
+        try { Thread.sleep(RESOLUTION_DELAY.dividedBy(2).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+    };
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_IPV6ONLY_DELAYED_LONG = () -> {
+        try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+    };
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_BOTHFAMS_DELAYED_SHORT = () -> {
+        try { Thread.sleep((RESOLUTION_DELAY.dividedBy(2)).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS, HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+    };
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO0_BOTHFAMS_DELAYED_LONG = () -> {
+        try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(0, new InetAddress[]{HOST_PRIO0_IPV4_ADDRESS, HOST_PRIO0_IPV6_ADDRESS}, 5269, false);
+    };
+
+    // Host 'prio1' configuration.
+    static final DNSUtil.HostAddress HOST_PRIO1 = new DNSUtil.HostAddress("prio1.example.org", 5269, false);
+    static final InetAddress HOST_PRIO1_IPV4_ADDRESS;
+    static final InetAddress HOST_PRIO1_IPV6_ADDRESS;
+
+    static {
+        try {
+            HOST_PRIO1_IPV4_ADDRESS = InetAddress.getByAddress(HOST_PRIO1.getHost(), new byte[] {(byte) 198, (byte) 51, (byte) 100, (byte) 2});
+            HOST_PRIO1_IPV6_ADDRESS = InetAddress.getByAddress(HOST_PRIO1.getHost(), new byte[] {(byte) 0x20, (byte) 0x01, (byte) 0x0d, (byte) 0xB8, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 2 });
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV4ONLY = () -> HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS}, 5269, false);
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV6ONLY = () -> HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_BOTHFAMS = () -> HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS, HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV4ONLY_DELAYED_SHORT = () -> {
+        try { Thread.sleep(RESOLUTION_DELAY.dividedBy(2).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS}, 5269, false);
+    };
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV4ONLY_DELAYED_LONG = () -> {
+        try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS}, 5269, false);
+    };
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV6ONLY_DELAYED_SHORT = () -> {
+        try { Thread.sleep(RESOLUTION_DELAY.dividedBy(2).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+    };
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_IPV6ONLY_DELAYED_LONG = () -> {
+        try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+    };
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_BOTHFAMS_DELAYED_SHORT = () -> {
+        try { Thread.sleep(RESOLUTION_DELAY.dividedBy(2).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS, HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+    };
+    static final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> SOLVER_PRIO1_BOTHFAMS_DELAYED_LONG = () -> {
+        try { Thread.sleep(RESOLUTION_DELAY.multipliedBy(3).toMillis()); } catch (InterruptedException e) { throw new RuntimeException(e); }
+        return HappyEyeballsResolver.IndexedInetAddress.from(1, new InetAddress[]{HOST_PRIO1_IPV4_ADDRESS, HOST_PRIO1_IPV6_ADDRESS}, 5269, false);
+    };
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testFirstResultWhenSingleHostTwoRecords(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS, 0);
+            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+
+            // Verify results.
+            assertNotNull(result);
+            final InetAddress expected = preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS;
+            assertEquals(expected, result.getSocketAddress().getAddress());
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testFirstResultWhenNoRecords(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0);
+        final Supplier<Set<HappyEyeballsResolver.IndexedInetAddress>> mockSolver = () -> { throw new RuntimeException("Exception thrown as part of unit testing.\"", new UnknownHostException("Nested exception thrown as part of unit testing.")); };
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(mockSolver, 0);
+            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+
+            // Verify results.
+            assertNull(result);
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testFirstResultWhenRecordsProvidedAfterResolutionDelay(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS_DELAYED_LONG, 0);
+            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+
+            // Verify results.
+            assertNull(result);
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testFirstResultWhenOnlyIpv4Record(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(SOLVER_PRIO0_IPV4ONLY, 0);
+            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+
+            // Verify results.
+            assertNotNull(result);
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testFirstResultWhenOnlyIpv6Record(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(SOLVER_PRIO0_IPV6ONLY, 0);
+            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+
+            // Verify results.
+            assertNotNull(result);
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testFirstResultWhenTwoHostsFourRecords(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS, 0);
+            systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS, 1);
+            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+
+            // Verify results.
+            assertNotNull(result);
+            final InetAddress expected = preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS;
+            assertEquals(expected, result.getSocketAddress().getAddress());
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testFirstResultWhenPreferredHostProvidedFirst(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS, 0);
+            systemUnderTest.solve(SOLVER_PRIO1_BOTHFAMS_DELAYED_SHORT, 1);
+            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+
+            // Verify results.
+            assertNotNull(result);
+            final InetAddress expected = preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS;
+            assertEquals(expected, result.getSocketAddress().getAddress());
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testFirstResultWhenPreferredHostProvidedSecondButWithinResolutionDelay(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS_DELAYED_SHORT, 0);
+            systemUnderTest.solve(SOLVER_PRIO1_BOTHFAMS, 1);
+            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+
+            // Verify results.
+            assertNotNull(result);
+            final InetAddress expected = preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS;
+            assertEquals(expected, result.getSocketAddress().getAddress());
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testFirstResultWhenPreferredHostProvidedSecondAfterResolutionDelay(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS_DELAYED_LONG, 0);
+            systemUnderTest.solve(SOLVER_PRIO1_BOTHFAMS, 1);
+            final HappyEyeballsResolver.XmppServiceAddress result = systemUnderTest.getNext();
+
+            // Verify results.
+            assertNotNull(result);
+            final InetAddress expected = preferIpv4 ? HOST_PRIO1_IPV4_ADDRESS : HOST_PRIO1_IPV6_ADDRESS;
+            assertEquals(expected, result.getSocketAddress().getAddress());
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testAllResults(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS, 0);
+            systemUnderTest.solve(SOLVER_PRIO1_BOTHFAMS, 1);
+
+            final List<HappyEyeballsResolver.XmppServiceAddress> results = new LinkedList<>();
+            for (int i = 0; i < 10; i++) {
+                final HappyEyeballsResolver.XmppServiceAddress nextResult = systemUnderTest.getNext();
+                if (nextResult != null) {
+                    results.add(nextResult);
+                }
+                if (results.size() == 4) {
+                    break;
+                }
+            }
+
+            // Verify results.
+            assertEquals(4, results.size());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(0).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV6_ADDRESS : HOST_PRIO0_IPV4_ADDRESS, results.get(1).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV4_ADDRESS : HOST_PRIO1_IPV6_ADDRESS, results.get(2).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(3).getSocketAddress().getAddress());
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testAllResultsWhenPreferredHostProvidedSecondButWithinResolutionDelay(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS_DELAYED_SHORT, 0);
+            systemUnderTest.solve(SOLVER_PRIO1_BOTHFAMS, 1);
+
+            final List<HappyEyeballsResolver.XmppServiceAddress> results = new LinkedList<>();
+            for (int i = 0; i < 10; i++) {
+                final HappyEyeballsResolver.XmppServiceAddress nextResult = systemUnderTest.getNext();
+                if (nextResult != null) {
+                    results.add(nextResult);
+                }
+                if (results.size() == 4) {
+                    break;
+                }
+            }
+
+            // Verify results.
+            assertEquals(4, results.size());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(0).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV6_ADDRESS : HOST_PRIO0_IPV4_ADDRESS, results.get(1).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV4_ADDRESS : HOST_PRIO1_IPV6_ADDRESS, results.get(2).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(3).getSocketAddress().getAddress());
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testAllResultsWhenPreferredFamilyProvidedSecondButWithinResolutionDelay(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(preferIpv4 ? SOLVER_PRIO0_IPV4ONLY_DELAYED_SHORT : SOLVER_PRIO0_IPV6ONLY_DELAYED_SHORT, 0);
+            systemUnderTest.solve(preferIpv4 ? SOLVER_PRIO1_IPV6ONLY : SOLVER_PRIO1_IPV4ONLY, 1);
+
+            final List<HappyEyeballsResolver.XmppServiceAddress> results = new LinkedList<>();
+            for (int i = 0; i < 10; i++) {
+                final HappyEyeballsResolver.XmppServiceAddress nextResult = systemUnderTest.getNext();
+                if (nextResult != null) {
+                    results.add(nextResult);
+                }
+                if (results.size() == 2) {
+                    break;
+                }
+            }
+
+            // Verify results.
+            assertEquals(2, results.size());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(0).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(1).getSocketAddress().getAddress());
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testAllResultsWhenPreferredFamilyProvidedSecondAfterResolutionDelay(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(preferIpv4 ? SOLVER_PRIO0_IPV4ONLY_DELAYED_LONG : SOLVER_PRIO0_IPV6ONLY_DELAYED_LONG, 0);
+            systemUnderTest.solve(preferIpv4 ? SOLVER_PRIO1_IPV6ONLY : SOLVER_PRIO1_IPV4ONLY, 1);
+
+            final List<HappyEyeballsResolver.XmppServiceAddress> results = new LinkedList<>();
+            for (int i = 0; i < 10; i++) {
+                final HappyEyeballsResolver.XmppServiceAddress nextResult = systemUnderTest.getNext();
+                if (nextResult != null) {
+                    results.add(nextResult);
+                }
+                if (results.size() == 2) {
+                    break;
+                }
+            }
+
+            // Verify results.
+            assertEquals(2, results.size());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(0).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(1).getSocketAddress().getAddress());
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testAllResultsFamilyInterleavedWhenPreferredFamilyProvidedSecondAfterResolutionDelay(final boolean preferIpv4) throws Exception
+    {
+        // Setup test fixture.
+        final List<DNSUtil.HostAddress> input = List.of(HOST_PRIO0, HOST_PRIO1);
+
+        // Execute system under test.
+        final HappyEyeballsResolver systemUnderTest = new HappyEyeballsResolver(input, preferIpv4, RESOLUTION_DELAY);
+        try {
+            systemUnderTest.solve(SOLVER_PRIO0_BOTHFAMS_DELAYED_LONG, 0);
+            systemUnderTest.solve(preferIpv4 ? SOLVER_PRIO1_IPV6ONLY : SOLVER_PRIO1_IPV4ONLY, 1);
+
+            final List<HappyEyeballsResolver.XmppServiceAddress> results = new LinkedList<>();
+            for (int i = 0; i < 10; i++) {
+                final HappyEyeballsResolver.XmppServiceAddress nextResult = systemUnderTest.getNext();
+                if (nextResult != null) {
+                    results.add(nextResult);
+                }
+                if (results.size() == 3) {
+                    break;
+                }
+            }
+
+            // Verify results.
+            assertEquals(3, results.size());
+            assertEquals(preferIpv4 ? HOST_PRIO1_IPV6_ADDRESS : HOST_PRIO1_IPV4_ADDRESS, results.get(0).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV4_ADDRESS : HOST_PRIO0_IPV6_ADDRESS, results.get(1).getSocketAddress().getAddress());
+            assertEquals(preferIpv4 ? HOST_PRIO0_IPV6_ADDRESS : HOST_PRIO0_IPV4_ADDRESS, results.get(2).getSocketAddress().getAddress());
+        } finally {
+            // Clean up test fixture.
+            systemUnderTest.shutdownNow();
+        }
+    }
+}

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/net/SrvRecordTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/net/SrvRecordTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.net;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SrvRecordTest
+{
+    /**
+     * Asserts that {@link SrvRecord#from(String[], boolean)} correctly parses an SRV record.
+     */
+    @Test
+    public void testParseSrvRecord() throws Exception
+    {
+        // Setup test fixture.
+        final String input = "1 0 5269 xmpp.example.org";
+
+        // Execute system under test.
+        final SrvRecord result = SrvRecord.from(input.split(" "), true);
+
+        // Verify results.
+        assertNotNull(result);
+        assertEquals(1, result.getPriority());
+        assertEquals(0, result.getWeight());
+        assertEquals(5269, result.getPort());
+        assertEquals("xmpp.example.org", result.getHostname());
+    }
+
+    /**
+     * Runs {@link SrvRecord#prioritize(SrvRecord[])} on a copy of the
+     * DNS SRV xmpp-server records for jabber.org (as they were last 2012).
+     */
+    @Test
+    public void testJabberDotOrgMock() throws Exception {
+        // setup
+        final SrvRecord fallback = new SrvRecord("fallback.jabber.org", 5269, false, 31, 31);
+        final SrvRecord hermes6  = new SrvRecord("hermes6.jabber.org",  5269, false, 30, 30);
+        final SrvRecord hermes   = new SrvRecord("hermes.jabber.org",   5269, false, 30, 30);
+
+        // do magic
+        final List<Set<SrvRecord>> result = SrvRecord.prioritize(new SrvRecord[]{fallback, hermes6, hermes});
+
+        // verify
+        assertEquals(2, result.size(), "There are two distinct priority values in the input, so two priority groups should be part of the result.");
+        assertEquals(2, result.get(0).size(), "The priority group with the lowest priority value (30) should have two entries in it");
+        assertEquals(1, result.get(1).size(), "The priority group with the highest priority value (31) should have one entry in it");
+        assertTrue(result.get(0).contains(hermes), "The 'hermes' host should have been included somewhere in the first priority group.");
+        assertTrue(result.get(0).contains(hermes6), "The 'hermes6' host should have been included somewhere in the first priority group.");
+        assertTrue(result.get(1).contains(fallback), "The 'fallback' host should have been included somewhere in the second priority group.");
+    }
+
+    /**
+     * A basic check that verifies that when one hosts exists, it gets returned in the output.
+     */
+    @Test
+    public void testOneHost() throws Exception {
+        // setup
+        final SrvRecord host = new SrvRecord("host", 5222, false, 1, 1);
+
+        // do magic
+        final List<Set<SrvRecord>> result = SrvRecord.prioritize(new SrvRecord[]{host});
+
+        // verify
+        assertEquals( 1, result.size() );
+        assertEquals(host, result.get(0).iterator().next());
+    }
+
+    /**
+     * A check equal to {@link #testOneHost()}, but using (the edge-case) priority value of zero.
+     */
+    @Test
+    public void testOneHostZeroPriority() throws Exception {
+        // setup
+        final SrvRecord host = new SrvRecord("host", 5222, false, 0, 1);
+
+        // do magic
+        final List<Set<SrvRecord>> result = SrvRecord.prioritize(new SrvRecord[]{host});
+
+        // verify
+        assertEquals(1, result.size());
+        assertEquals(host, result.get(0).iterator().next());
+    }
+
+    /**
+     * A check equal to {@link #testOneHost()}, but using (the edge-case) weight value of zero.
+     */
+    @Test
+    public void testOneHostZeroWeight() throws Exception {
+        // setup
+        final SrvRecord host = new SrvRecord("host", 5222, false, 1, 0);
+
+        // do magic
+        final List<Set<SrvRecord>> result = SrvRecord.prioritize(new SrvRecord[]{host});
+
+        // verify
+        assertEquals(1, result.size());
+        assertEquals(host, result.get(0).iterator().next());
+    }
+
+    /**
+     * Verifies that when a couple of records exist that all have a particular priority, those records are all included
+     * in the result, ordered (ascending) by their priority.
+     */
+    @Test
+    public void testDifferentPriorities() throws Exception {
+        // setup
+        final SrvRecord hostA = new SrvRecord("hostA", 5222, false, 1, 1);
+        final SrvRecord hostB = new SrvRecord("hostB", 5222, false, 3, 1);
+        final SrvRecord hostC = new SrvRecord("hostC", 5222, false, 2, 1);
+
+        // do magic
+        final List<Set<SrvRecord>> result = SrvRecord.prioritize(new SrvRecord[]{hostA, hostB, hostC});
+
+        // verify
+        assertEquals(3, result.size());
+        assertEquals(hostA, result.get(0).iterator().next());
+        assertEquals(hostC, result.get(1).iterator().next());
+        assertEquals(hostB, result.get(2).iterator().next());
+    }
+
+    /**
+     * A test equal to {@link #testDifferentPriorities()}, but with one of the priorities set to zero.
+     */
+    @Test
+    public void testZeroPriority() throws Exception {
+        // setup
+        final SrvRecord hostA = new SrvRecord("hostA", 5222, false, 0, 1);
+        final SrvRecord hostB = new SrvRecord("hostB", 5222, false, 2, 1);
+        final SrvRecord hostC = new SrvRecord("hostC", 5222, false, 1, 1);
+
+        // do magic
+        final List<Set<SrvRecord>> result = SrvRecord.prioritize(new SrvRecord[]{hostA, hostB, hostC});
+
+        // verify
+        assertEquals(3, result.size());
+        assertEquals(hostA, result.get(0).iterator().next());
+        assertEquals(hostC, result.get(1).iterator().next());
+        assertEquals(hostB, result.get(2).iterator().next());
+    }
+
+    /**
+     * A test that verifies that hosts with equal weight are alternately first in the resulting list.
+     *
+     * The test that is done here re-executes until each of the input records was included in the output as the first
+     * record. This indicates that the returning list is at the very least not always ordered in the exact same way.
+     */
+    @Test
+    public void testSameWeights() throws Exception {
+        // setup
+        final SrvRecord hostA = new SrvRecord("hostA", 5222, false, 1, 10);
+        final SrvRecord hostB = new SrvRecord("hostB", 5222, false, 1, 10);
+        final SrvRecord[] hosts = new SrvRecord[] { hostA, hostB };
+
+        // do magic
+        boolean hostAWasFirst = false;
+        boolean hostBWasFirst = false;
+        final int maxTries = Integer.MAX_VALUE;
+        for (int i=0; i<maxTries; i++) {
+            final List<Set<SrvRecord>> result = SrvRecord.prioritize(hosts);
+            if (hostA.equals(result.get(0).iterator().next())) {
+                hostAWasFirst = true;
+            }
+
+            if (hostB.equals(result.get(0).iterator().next())) {
+                hostBWasFirst = true;
+            }
+
+            if (hostAWasFirst && hostBWasFirst) {
+                break;
+            }
+
+            if (i%1000000==0 && i>0) {
+                System.err.println("The last " + i + " iterations of this test all had the same result, which is very unlikely to occur (there should be an even distribution between two possible outcomes). We'll iterate up to "+ maxTries +" times, but you might want to abort the unit test at this point...");
+            }
+        }
+
+        // verify
+        assertTrue( hostAWasFirst );
+        assertTrue( hostBWasFirst );
+    }
+
+    /**
+     * A test equal to {@link #testSameWeights()}, but using records with a weight of zero.
+     */
+    @Test
+    public void testZeroWeights() throws Exception {
+        // setup
+        final SrvRecord hostA = new SrvRecord("hostA", 5222, false, 1, 0);
+        final SrvRecord hostB = new SrvRecord("hostB", 5222, false, 1, 0);
+        final SrvRecord[] hosts = new SrvRecord[] { hostA, hostB };
+
+        // do magic
+        boolean hostAWasFirst = false;
+        boolean hostBWasFirst = false;
+        final int maxTries = Integer.MAX_VALUE;
+        for (int i=0; i<maxTries; i++) {
+            final List<Set<SrvRecord>> result = SrvRecord.prioritize(hosts);
+            if (hostA.equals(result.get(0).iterator().next())) {
+                hostAWasFirst = true;
+            }
+
+            if (hostB.equals(result.get(0).iterator().next())) {
+                hostBWasFirst = true;
+            }
+
+            if (hostAWasFirst && hostBWasFirst) {
+                break;
+            }
+
+            if (i%1000000==0 && i>0) {
+                System.err.println("The last " + i + " iterations of this test all had the same result, which is very unlikely to occur (there should be an even distribution between two possible outcomes). We'll iterate up to "+ maxTries +" times, but you might want to abort the unit test at this point...");
+            }
+        }
+
+        // verify
+        assertTrue(hostAWasFirst);
+        assertTrue(hostBWasFirst);
+    }
+}

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalIncomingServerSessionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalIncomingServerSessionTest.java
@@ -19,6 +19,7 @@ import org.jivesoftware.Fixtures;
 import org.jivesoftware.openfire.*;
 import org.jivesoftware.openfire.keystore.*;
 import org.jivesoftware.openfire.net.DNSUtil;
+import org.jivesoftware.openfire.net.SrvRecord;
 import org.jivesoftware.openfire.spi.ConnectionListener;
 import org.jivesoftware.openfire.spi.ConnectionManagerImpl;
 import org.jivesoftware.openfire.spi.ConnectionType;
@@ -246,7 +247,7 @@ public class LocalIncomingServerSessionTest
 
             remoteInitiatingServerDummy.init();
             if (remoteInitiatingServerDummy.getDialbackAuthoritativeServerPort() > 0) {
-                DNSUtil.setDnsOverride(Map.of(RemoteInitiatingServerDummy.XMPP_DOMAIN, new DNSUtil.HostAddress("localhost", remoteInitiatingServerDummy.getDialbackAuthoritativeServerPort(), false)));
+                DNSUtil.setDnsOverride(Map.of(RemoteInitiatingServerDummy.XMPP_DOMAIN, new SrvRecord("localhost", remoteInitiatingServerDummy.getDialbackAuthoritativeServerPort(), false)));
             }
 
             // execute system under test.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalOutgoingServerSessionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalOutgoingServerSessionTest.java
@@ -22,6 +22,7 @@ import org.jivesoftware.openfire.RoutingTable;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.keystore.*;
 import org.jivesoftware.openfire.net.DNSUtil;
+import org.jivesoftware.openfire.net.SrvRecord;
 import org.jivesoftware.openfire.spi.ConnectionConfiguration;
 import org.jivesoftware.openfire.spi.ConnectionListener;
 import org.jivesoftware.openfire.spi.ConnectionType;
@@ -183,7 +184,7 @@ public class LocalOutgoingServerSessionTest
     {
         remoteReceivingServerDummy = new RemoteReceivingServerDummy();
         remoteReceivingServerDummy.open();
-        DNSUtil.setDnsOverride(Map.of(RemoteReceivingServerDummy.XMPP_DOMAIN, new DNSUtil.HostAddress("localhost", remoteReceivingServerDummy.getPort(), false)));
+        DNSUtil.setDnsOverride(Map.of(RemoteReceivingServerDummy.XMPP_DOMAIN, new SrvRecord("localhost", remoteReceivingServerDummy.getPort(), false)));
     }
 
     @AfterEach


### PR DESCRIPTION
The commits in this PR implement (much of the) Happy Eyeballs algorithm, as defined in the protoXEP in https://xmpp.org/extensions/inbox/xep-happy-eyeballs.html

The commits in this PR isolate distinct changes, which preferably are not to be squashed together.

This commit also explicitly sets `-Djava.net.preferIPv6Addresses=system` which causes the Java virtual machine to follow the system's preference with regards to IPv6 vs IPv4 usage (as opposed to the default, which is 'IPv4', at least in Java 11. Is there a more appropriate way of going about this?

Some aspects that are excluded from this implementation:
- Separate resolution of A and AAAA records (the Java API does that in one go - it seems silly to bypass that only to adhere to the specifications)
- Much of the 'sorting' as defined in [RFC 8305](http://tools.ietf.org/html/rfc8305) [[3](https://xmpp.org/extensions/inbox/xep-happy-eyeballs.html#nt-idm45857903655040)], Section 4. The implementation in this PR is driven by the SRV priority and weight attributes. Other selection mechanisms may be subject of future enhancement.

I've tested the implementation against various endpoints provided by badxmpp.org (eg `srv20.badxmpp.org` and `drop.badxmpp.org` which give encouraging results.

There likely is room to clean up the implementation through refactoring. One of the reasons that I'm asking for a review of this is to get feedback on how to do that best.