### PR TITLE
OF-2885: TaskEngine jobs with Future

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/TaskEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/TaskEngine.java
@@ -137,6 +137,27 @@ public class TaskEngine {
     }
 
     /**
+     * Submits a Callable task for execution and returns a Future
+     * representing that task.
+     *
+     * @param task the task to submit.
+     * @return a Future representing pending completion of the task
+     */
+    public <V> Future<V> submit(Callable<V> task) {
+        try {
+            return executor.submit(task);
+        } catch (Throwable t) {
+            Log.warn("Failed to schedule task; will retry using caller's thread.", t);
+            try {
+                final V result = task.call();
+                return CompletableFuture.completedFuture(result);
+            } catch (Exception e) {
+                return CompletableFuture.failedFuture(e);
+            }
+        }
+    }
+
+    /**
      * Schedules the specified task for execution after the specified delay.
      *
      * @param task  task to be scheduled.

--- a/xmppserver/src/test/java/org/jivesoftware/util/TaskEngineTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/TaskEngineTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit test to validate the functionality of @{link {@link TaskEngine}.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class TaskEngineTest
+{
+    /**
+     * Asserts that the Future instance that is returned when submitting a Runnable through
+     * {@link TaskEngine#submit(Runnable)} can be used find out the execution state of the job.
+     */
+    @Test
+    public void testRunnableFuture() throws Exception
+    {
+        // Setup test fixture.
+        final Runnable job = () -> {
+            // A very low-effort job.
+        };
+
+        // Execute system under test.
+        final Future<?> result = TaskEngine.getInstance().submit(job);
+
+        // Verify results.
+        assertNull(result.get(1, TimeUnit.MINUTES));
+    }
+
+    /**
+     * Asserts that the Future instance that is returned when submitting a Runnable through
+     * {@link TaskEngine#submit(Runnable)} returns an exception thrown during the execution of the job.
+     */
+    @Test
+    public void testRunnableFutureWithException() throws Exception
+    {
+        // Setup test fixture.
+        final Runnable job = () -> {
+            throw new RuntimeException("Thrown as part of a unit test.");
+        };
+
+        // Execute system under test.
+        final Future<?> result = TaskEngine.getInstance().submit(job);
+
+        // Verify results.
+        final ExecutionException ex = assertThrows(ExecutionException.class, () -> result.get(1, TimeUnit.MINUTES));
+        assertInstanceOf(RuntimeException.class, ex.getCause());
+        assertEquals("Thrown as part of a unit test.", ex.getCause().getMessage());
+    }
+
+    /**
+     * Asserts that the Future instance that is returned when submitting a Callable through
+     * {@link TaskEngine#submit(Callable)} can be used to obtain the value that is computed by the job.
+     */
+    @Test
+    public void testCallableFutureWithResult() throws Exception
+    {
+        // Setup test fixture.
+        final Callable<Integer> job = () -> 42;
+
+        // Execute system under test.
+        final Future<Integer> result = TaskEngine.getInstance().submit(job);
+
+        // Verify results.
+        assertEquals(42, result.get(1, TimeUnit.MINUTES));
+    }
+
+    /**
+     * Asserts that the Future instance that is returned when submitting a Callable through
+     * {@link TaskEngine#submit(Callable)} returns an exception thrown during the execution of the job.
+     */
+    @Test
+    public void testCallableFutureWithException() throws Exception
+    {
+        // Setup test fixture.
+        final Callable<Integer> job = () -> { throw new RuntimeException("Thrown as part of a unit test."); };
+
+        // Execute system under test.
+        final Future<Integer> result = TaskEngine.getInstance().submit(job);
+
+        // Verify results.
+        final ExecutionException ex = assertThrows(ExecutionException.class, () -> result.get(1, TimeUnit.MINUTES));
+        assertInstanceOf(RuntimeException.class, ex.getCause());
+        assertEquals("Thrown as part of a unit test.", ex.getCause().getMessage());
+    }
+}


### PR DESCRIPTION
This adds a method to TaskEngine that allows a job's result to be collected through a Future instance.