### PR TITLE
OF-2890: Fix CSRF error on admin setup (directory services)

### DIFF
--- a/xmppserver/src/main/webapp/setup/setup-admin-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-admin-settings.jsp
@@ -154,7 +154,7 @@
     Cookie csrfCookie = CookieUtils.getCookie( request, "csrf");
     String csrfParam = ParamUtils.getParameter(request, "csrf");
 
-    if (addAdmin || deleteAdmins)
+    if (!doTest && (addAdmin || deleteAdmins))
     {
         if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
             errors.put( "csrf", "CSRF failure!");

--- a/xmppserver/src/main/webapp/setup/setup-admin-settings_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-admin-settings_test.jsp
@@ -21,6 +21,7 @@
 <%@ page import="java.net.URLDecoder" %>
 <%@ page import="org.jivesoftware.util.CookieUtils" %>
 <%@ page import="javax.naming.ldap.Rdn" %>
+<%@ page import="org.jivesoftware.util.StringUtils" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -35,19 +36,19 @@
         return;
     }
 
-    Cookie csrfCookie = CookieUtils.getCookie( request, "csrf");
-    String csrfParam = ParamUtils.getParameter(request, "csrf");
+    Object csrfSession = session.getAttribute("embeddedcsrf");
+    String csrfParam = ParamUtils.getParameter(request, "embeddedcsrf");
 
     String errorDetail = "";
     boolean success = false;
 
-    if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
+    if (request.getMethod().equals("POST") && (csrfSession == null || !csrfSession.equals(csrfParam))) {
         errorDetail = "CSRF failure!";
     }
 
-    // Used embedded in another page. Do not reset the csrf value. // csrfParam = StringUtils.randomString(15);
-    CookieUtils.setCookie(request, response, "csrf", csrfParam, -1);
-    pageContext.setAttribute("csrf", csrfParam);
+    csrfParam = StringUtils.randomString(15);
+    session.setAttribute("embeddedcsrf", csrfParam);
+    pageContext.setAttribute("embeddedcsrf", csrfParam);
 
     Map<String, String> settings = (Map<String, String>) session.getAttribute("ldapSettings");
     Map<String, String> userSettings =
@@ -108,7 +109,7 @@
 
             <c:if test="${not success}">
             <form action="setup-admin-settings.jsp" name="testform" method="post">
-                <input type="hidden" name="csrf" value="${csrf}"/>
+                <input type="hidden" name="embeddedcsrf" value="${embeddedcsrf}"/>
                 <input type="hidden" name="ldap" value="true">
                 <input type="hidden" name="test" value="true">
                 <input type="hidden" name="username" value="${admin:urlEncode(username)}">


### PR DESCRIPTION
This fixes a bug that prevented the successful password-check of a newly configured admin.

The page that performs the test is embedded as a dialog in another page. To prevent collisions with the 'csrf' parameter, the parameter on the embedded page is renamed to 'embeddedcsrf'. CSRF processing on the parent page is not performed if the page reload related to the embedded page (CSRF checking is performed there).