### PR TITLE
Passthrough unrecognized openfire.sh arguments

### DIFF
--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -132,7 +132,8 @@ case $arguments in
     sed "s/example.org/$HOSTNAME/g" $OPENFIRE_HOME/conf/openfire-demoboot.xml > $OPENFIRE_HOME/conf/openfire.xml
     ;;
     *)
-	# unknown option
+	# unknown option, pass through the Java command
+	JAVACMD="$JAVACMD $arguments"
     ;;
 esac
 done


### PR DESCRIPTION
openfire.sh can be invoked with a number of arguments (eg `-demoboot`, `-debug`). Prior to this commit, unrecognized arguments were ignored.

With this commit, unrecognized argumetns are passed through to the java command that starts Openfire. This allows anyone to add arguments, like system properties, by doing something like `./bin/openfire.sh -Dfoo=bar`