### PR TITLE
OF-2826: Setup should check access to config files

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1837,6 +1837,8 @@ setup.env.check.class=Classes
 setup.env.check.jive=Openfire Home found
 setup.env.check.not_home=Home not found. Define system property "openfireHome" or create and add the openfire_init.xml file to the classpath
 setup.env.check.doc=Please read the installation documentation and try setting up your environment again. After making changes, restart your appserver and load this page again.
+setup.env.check.config_found=Successfully loaded configuration file <tt>{0}</tt>
+setup.env.check.config_not_loaded=Unable to loaded configuration file <tt>{0}</tt>. Check if the file exist and if Openfire has read and write access to it.
 
 # Setup admin settings Page
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1675,6 +1675,8 @@ setup.env.check.class=Klassen
 setup.env.check.jive=Openfire Home folder gevonden
 setup.env.check.not_home=Home niet gevonden. Specifi&euml;er de systeemeigenschap "openfireHome" of cre&euml;er het bestand openfire_init.xml en voeg het toe aan het klassenpad
 setup.env.check.doc=Zie de installatiedocumentatie en probeer uw systeem opnieuw te installeren. Na het maken van de wijzigingen, herstart dan uw appserver en laad deze pagina opnieuw.
+setup.env.check.config_found=Configuratiebestand successvol geladen: <tt>{0}</tt>
+setup.env.check.config_not_loaded=Kon configuratiebestand <tt>{0}</tt> niet laden. Controleer dat het bestand bestaat en dat Openfire het bestand mag lezen en schrijven.
 
 # Setup admin settings Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1201,8 +1201,25 @@ public class JiveGlobals {
      *
      * @return the name of the config file.
      */
-    static String getConfigName() {
+    public static String getConfigName() {
         return JIVE_CONFIG_FILENAME;
+    }
+
+    /**
+     * Returns the name of the local security config file.
+     *
+     * @return the name of the security config file.
+     */
+    public static String getSecurityConfigName() {
+        return JIVE_SECURITY_FILENAME;
+    }
+
+    public static Path getConfigLocation() {
+        return home.resolve(JIVE_CONFIG_FILENAME);
+    }
+
+    public static Path getSecurityConfigLocation() {
+        return home.resolve(JIVE_SECURITY_FILENAME);
     }
 
     /**

--- a/xmppserver/src/main/webapp/setup/index.jsp
+++ b/xmppserver/src/main/webapp/setup/index.jsp
@@ -86,6 +86,10 @@
     pageContext.setAttribute( "servlet22Installed", servlet22Installed );
     pageContext.setAttribute( "jsp11Installed", jsp11Installed );
     pageContext.setAttribute( "jiveJarsInstalled", jiveJarsInstalled );
+    pageContext.setAttribute( "configLocation", JiveGlobals.getConfigLocation() );
+    pageContext.setAttribute( "configLocationExistsAndAccessible", Files.isWritable(JiveGlobals.getConfigLocation()) );
+    pageContext.setAttribute( "securityConfigLocation", JiveGlobals.getSecurityConfigLocation() );
+    pageContext.setAttribute( "securityConfigLocationExistsAndAccessible", Files.isWritable(JiveGlobals.getSecurityConfigLocation()) );
     pageContext.setAttribute( "openfireHomeExists", openfireHomeExists );
     pageContext.setAttribute( "openfireHome", openfireHome );
     pageContext.setAttribute( "localizedTitle", LocaleUtils.getLocalizedString("title") );
@@ -151,7 +155,7 @@
     </c:if>
 
     <c:choose>
-        <c:when test="${not jreVersionCompatible or not servlet22Installed or not jsp11Installed or not jiveJarsInstalled or not openfireHomeExists}">
+        <c:when test="${not jreVersionCompatible or not servlet22Installed or not jsp11Installed or not jiveJarsInstalled or not openfireHomeExists or not configFailedLoading}">
             <div class="error">
                 <fmt:message key="setup.env.check.error"/> <fmt:message key="title"/> <fmt:message key="setup.title"/>.
             </div>
@@ -235,6 +239,48 @@
                             </tr>
                         </c:otherwise>
                     </c:choose>
+                    <c:if test="${openfireHomeExists}">
+                        <c:choose>
+                            <c:when test="${configLocationExistsAndAccessible}">
+                                <tr>
+                                    <td><img src="../images/check.gif" width="13" height="13"></td>
+                                    <td><fmt:message key="setup.env.check.config_found">
+                                            <fmt:param><c:out value="${configLocation}"/></fmt:param>
+                                        </fmt:message>
+                                    </td>
+                                </tr>
+                            </c:when>
+                            <c:otherwise>
+                                <tr>
+                                    <td><img src="../images/x.gif" width="13" height="13"></td>
+                                    <td><fmt:message key="setup.env.check.config_not_loaded">
+                                            <fmt:param><c:out value="${configLocation}"/></fmt:param>
+                                        </fmt:message>
+                                    </td>
+                                </tr>
+                            </c:otherwise>
+                        </c:choose>
+                        <c:choose>
+                            <c:when test="${securityConfigLocationExistsAndAccessible}">
+                                <tr>
+                                    <td><img src="../images/check.gif" width="13" height="13"></td>
+                                    <td><fmt:message key="setup.env.check.config_found">
+                                        <fmt:param><c:out value="${configLocation}"/></fmt:param>
+                                    </fmt:message>
+                                    </td>
+                                </tr>
+                            </c:when>
+                            <c:otherwise>
+                                <tr>
+                                    <td><img src="../images/x.gif" width="13" height="13"></td>
+                                    <td><fmt:message key="setup.env.check.config_not_loaded">
+                                        <fmt:param><c:out value="${configLocation}"/></fmt:param>
+                                    </fmt:message>
+                                    </td>
+                                </tr>
+                            </c:otherwise>
+                        </c:choose>
+                    </c:if>
                 </table>
             </div>
 


### PR DESCRIPTION
When configuration files do not exist, then errors pop up during setup. This commit adds explicit file checks to ensure that a more descriptive error is shown prior to the setup being started.

![image](https://github.com/user-attachments/assets/c03e9bd9-1abb-4773-a819-d27cbfceaa83)
