### PR TITLE
OF-2893: Warn administrator when a wildcard pattern is loaded

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -2832,6 +2832,7 @@ plugin.admin.failed.minJavaVersion=The plugin requires Java specification versio
 plugin.admin.failed.missingParent=The plugin requires another plugin, named {0}, that currently is not installed.
 plugin.admin.failed.databaseScript=A plugin database install or update script failed. Review the logs for additional details.
 plugin.admin.failed.unknown=An exception occurred while loading plugin. Review the logs for additional details.
+plugin.admin.wildcards-exists=A plugin has loaded admin console authentication bypass patterns that includes a wildcard, but the System Property 'adminConsole.access.allow-wildcards-in-excludes' is disabled.
 
 # System Admin Console access
 system.admin.console.access.title=Admin Console Access

--- a/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
@@ -175,6 +175,13 @@ public class AuthCheckFilter implements Filter {
     }
 
     /**
+     * Indicates to the caller whether any of the currently loaded exclusions contains a wildcard
+     */
+    public static boolean excludesIncludeWildcards() {
+        return excludes.stream().anyMatch(e -> e.contains("*"));
+    }
+
+    /**
      * Returns true if a URL passes an exclude rule.
      *
      * @param url the URL to test.

--- a/xmppserver/src/main/webapp/plugin-admin.jsp
+++ b/xmppserver/src/main/webapp/plugin-admin.jsp
@@ -23,6 +23,7 @@
                  org.apache.commons.fileupload.disk.DiskFileItemFactory,
                  org.apache.commons.fileupload.servlet.ServletFileUpload"
         %>
+<%@ page import="org.jivesoftware.admin.AuthCheckFilter" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.container.PluginManager" %>
 <%@ page import="org.jivesoftware.openfire.update.UpdateManager" %>
@@ -367,6 +368,11 @@ tr.lowerhalf > td:last-child {
     <c:if test="${ webManager.XMPPServer.pluginManager.monitorTaskRunning }">
         <admin:infobox type="info">
             <fmt:message key="plugin.admin.monitortask_running" />
+        </admin:infobox>
+    </c:if>
+    <c:if test="${ AuthCheckFilter.excludesIncludeWildcards() && !AuthCheckFilter.ALLOW_WILDCARDS_IN_EXCLUDES.getValue() }">
+        <admin:infobox type="warning">
+            <fmt:message key="plugin.admin.wildcards-exists" />
         </admin:infobox>
     </c:if>
     <p>


### PR DESCRIPTION
Plugins like the REST API Plugin require wildcard routes (because they do HTTP calls that include username or JID in the path). Some of these require the new(-ish) adminConsole.access.allow-wildcards-in-excludes property to be set so that they can either be open, or so that they can apply their own authentication outside that of the normal Admin Console access.

Whilst there have been attempts to update documentation, not everyone reads it. This even trips up the folk most familiar with it (meaning: me, almost every time).

This adds a warning in the Plugin Admin page that displays when a loaded plugin has a wildcard exception declared, but the System Property is not set.

https://igniterealtime.atlassian.net/browse/OF-2893