### PR TITLE
OF-2896 & OF-2897: Fix memory leak when dealing with pre-authenticated Sessions

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1406,6 +1406,7 @@ system_property.xmpp.xmlutil.parser.core-pool-size=The number of threads to keep
 system_property.xmpp.xmlutil.parser.maximum-pool-size=The maximum number of threads to allow in the SAX Reader pool.
 system_property.xmpp.xmlutil.parser.keep_alive_time=When the number of threads in the SAX reader pool is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
 system_property.xmpp.client.backup-packet-delivery.enabled=Enable / disable backup delivery of stanzas to the 'offline message store' of the corresponding user when a stanza failed to be delivered on a client connection. When disabled, stanzas that can not be delivered on the connection are discarded.
+system_property.xmpp.client.preauth.timeout=Time after which connected client connections that never authenticated can be disconnected.
 
 system_property.xmpp.command.limit=The maximum allowed simultaneous command sessions per user.
 system_property.xmpp.command.timeout=The maximum allowed duration of a command session (all stages of a command need to have provided by the user within this time).

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1158,6 +1158,7 @@ system_property.ldap.override.avatar=Zet op 'true' om avatars op te slaan in de 
 system_property.xmpp.domain=Het XMPP domein van deze server. Verander deze instelling niet rechtstreeks. Voer het installatie-proces nogmaals uit om deze instelling te wijzigen.
 system_property.xmpp.xml.xml-declaration.suppress=Bepaalt of een XML declaration wordt gegenereerd voordat een 'stream' open tag wordt verzonden.
 system_property.xmpp.xml.xml-declaration.suppress-newline=Bepaalt of na de XML declaration de 'stream' open tag op een nieuwe lijn wordt geplaatst.
+system_property.xmpp.client.preauth.timeout=Tijd waarna de verbinding van clienten die zijn verbonden, maar nooit hebben geauthenticeerd, kunnen worden afgesloten.
 system_property.plugins.upload.magic-number.values.enabled=Schakelt verificatie van de 'magic bytes' in om te verifieren dat een geuploade file een Openfire plugin is.
 system_property.plugins.upload.magic-number.values.expected-value=Een reeks van hexadecimale karakters die de 'magic bytes' representeren. Deze kunnen worden gebruikt om een geupload bestand te valideren als Openfire plugin.
 plugins.upload.pluginxml-check.enabled=Controleer of het bestand 'plugin.xml' bestaad in geuploade plugins.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -413,6 +413,7 @@ public class IQRouter extends BasicModule {
                     && !XMPPServer.getInstance().isRemote(recipientJID)
                     && !userManager.isRegisteredUser(recipientJID, false)
                     && !UserManager.isPotentialFutureLocalUser(recipientJID)
+                    && !sessionManager.isAnonymousRoute(recipientJID.getNode())
                     && sessionManager.getSession(recipientJID) == null
                     && !(recipientJID.asBareJID().equals(packet.getFrom().asBareJID()) && sessionManager.isPreAuthenticatedSession(packet.getFrom())) // A pre-authenticated session queries the server about itself.
                 )

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,11 +63,8 @@ public class IQBindHandler extends IQHandler {
         LocalClientSession session = (LocalClientSession) sessionManager.getSession(packet.getFrom());
         // If no session was found then answer an error (if possible)
         if (session == null) {
-            Log.error("Error during resource binding. Session not found in " +
-                    sessionManager.getPreAuthenticatedKeys() +
-                    " for key " +
-                    packet.getFrom());
-            // This error packet will probably won't make it through
+            Log.warn("Error during resource binding. No session found for '{}'", packet.getFrom());
+            // This error packet probably won't make it through
             IQ reply = IQ.createResultIQ(packet);
             reply.setChildElement(packet.getChildElement().createCopy());
             reply.setError(PacketError.Condition.internal_server_error);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
@@ -95,6 +95,7 @@ public abstract class IQHandler extends BasicModule implements ChannelHandler {
         if (iq.isRequest() && recipientJID != null && recipientJID.getNode() != null
             && !XMPPServer.getInstance().isRemote(recipientJID)
             && !UserManager.getInstance().isRegisteredUser(recipientJID, false)
+            && !sessionManager.isAnonymousRoute(recipientJID.getNode())
             && !UserManager.isPotentialFutureLocalUser(recipientJID) && sessionManager.getSession(recipientJID) == null
             && !(recipientJID.asBareJID().equals(iq.getFrom().asBareJID()) && sessionManager.isPreAuthenticatedSession(iq.getFrom())) // A pre-authenticated session queries the server about itself.
         )

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRegisterHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRegisterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -164,11 +164,8 @@ public class IQRegisterHandler extends IQHandler implements ServerFeaturesProvid
         IQ reply = null;
         // If no session was found then answer an error (if possible)
         if (session == null) {
-            Log.error("Error during registration. Session not found in " +
-                    sessionManager.getPreAuthenticatedKeys() +
-                    " for key " +
-                    packet.getFrom());
-            // This error packet will probably won't make it through
+            Log.warn("Error during registration. No session found for '{}'", packet.getFrom());
+            // This error packet probably won't make it through
             reply = IQ.createResultIQ(packet);
             reply.setChildElement(packet.getChildElement().createCopy());
             reply.setError(PacketError.Condition.internal_server_error);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -66,6 +66,14 @@ public final class ConnectionSettings {
 
         public static final String MAX_THREADS = "xmpp.client.processing.threads";
 
+        public static final SystemProperty<Duration> PREAUTH_TIMEOUT_PROPERTY = SystemProperty.Builder.ofType(Duration.class)
+            .setKey("xmpp.client.preauth.timeout")
+            .setDefaultValue(Duration.ofMinutes(5))
+            .setMinValue(Duration.ofMillis(-1))
+            .setChronoUnit(ChronoUnit.MILLIS)
+            .setDynamic(Boolean.TRUE)
+            .build();
+
         /**
          * Used to configure throttling at the network level
          *


### PR DESCRIPTION
A collection of pre-authenticated sessions was maintained incorrectly (using a type-unsafe key that was both used as a stream-ID and a JID), which caused every session that was ever created to remain a part of that collection, until the server got restarted. This introduces a memory leak (and possibly functional issues, although those have never been reported).
    
The second commit resolves the problem. It hides access to the collection to enforce proper maintenance. A more type-safe key is used, which should help prevent future issues like these.
    
The changes in the second commit affect the API. I've opted to not include backwards-compatibility (with deprecation), as I believe the per-existing API to be simply broken. Any usage of that API should be revisited, which is enforced by removing the API.

The first commit introduces a periodic clean-up of pre-authenticated client sessions. This ensures that clients that are connected indefinitely before authenticating are eventually closed. Note that the XMPP specification mandates SASL, requiring every connection to be authenticated (which _may_ use the ANONYMOUS mechanism).