### PR TITLE
OF-2899: Connect manager connect fail when upgrade openfire 4.9.0.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -490,7 +490,11 @@ public abstract class StanzaHandler {
         document.getRootElement().add(features);
 
         // Include available SASL Mechanisms
-        features.add(SASLAuthentication.getSASLMechanisms(session));
+        final Element mechanismsElement=SASLAuthentication.getSASLMechanisms(session);
+        if (mechanismsElement!=null) {
+        	features.add(mechanismsElement);
+        }
+
         // Include specific features such as auth and register for client sessions
         final List<Element> specificFeatures = session.getAvailableStreamFeatures();
         if (specificFeatures != null) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -295,7 +295,10 @@ public class LocalClientSession extends LocalSession implements ClientSession {
                 Log.warn("Unable to access the identity store for client connections. StartTLS is not being offered as a feature for this session.", e);
             }
             // Include available SASL Mechanisms
-            features.add(SASLAuthentication.getSASLMechanisms(session));
+            final Element saslMechanisms = SASLAuthentication.getSASLMechanisms(session);
+            if (saslMechanisms != null) {
+                features.add(saslMechanisms);
+            }
             // Include Stream features
             final List<Element> specificFeatures = session.getAvailableStreamFeatures();
             if (specificFeatures != null) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -186,7 +186,10 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
                 }
 
                 // Include available SASL Mechanisms
-                features.add(SASLAuthentication.getSASLMechanisms(session));
+                final Element saslMechanisms = SASLAuthentication.getSASLMechanisms(session);
+                if (saslMechanisms != null) {
+                    features.add(saslMechanisms);
+                }
 
                 if (ServerDialback.isEnabled()) {
                     // Also offer server dialback (when TLS is not required). Server dialback may be offered


### PR DESCRIPTION
because .connect manager session(LocalConnectionMultiplexerSession) have't SASLMechanisms. we change org.jivesoftware.openfire.net.StanzaHandler.java tlsNegotiated method when getSASLMechanisms() method return null. not add to features: