### PR TITLE
Documentation: Admin Console Recovery to use localhost

### DIFF
--- a/documentation/one-time-access-token-guide.html
+++ b/documentation/one-time-access-token-guide.html
@@ -62,7 +62,7 @@
                 </fieldset>
             </li>
             <li>Start Openfire</li>
-            <li>For best results, use an incognito/private browsing web browser session to view the Openfire admin console <code>http://ipaddress:9090</code> or <code>https://ipaddress:9091</code>
+            <li>For best results, use an incognito/private browsing web browser session to view the Openfire admin console <code>http://localhost:9090</code> or <code>https://localhost:9091</code> (You can replace 'localhost' with a network name or IP address, but by default, Openfire's Admin Console is accesible only from the server itself).
                 <figure>
                     <img src="images/one-time-access-token-login.png" alt="Login screen prompting for one-time access token.">
                     <figcaption>Openfire's admin console login screen that is prompting for the one-time access token.</figcaption>


### PR DESCRIPTION
Replace 'ipaddress' with 'localhost' to avoid confusion.

Adds a note on Admin Console binding by default only on the loopback interfaces of a server.