### PR TITLE
OF-2901: Reduce verbosity of LDAP unencrypted connection warning

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1321,6 +1321,7 @@ system_property.ldap.pagedResultsSize=The maximum number of records to retrieve 
    The default value of -1 means rely on the paging of the LDAP server itself. \
    Note that if using ActiveDirectory, this should not be left at the default, and should not be set to more than the value of the ActiveDirectory MaxPageSize; 1,000 by default.
 system_property.ldap.useRangeRetrieval=Enable range retrieval for processing of large LDAP groups
+system_property.ldap.unencrypted-warning-suppression=Openfire will log a warning when interacting with LDAP using an unencrypted connection. To prevent flooding of the logfiles, subsequent warnings are suppressed for the duration configured by this property.
 system_property.xmpp.iqdiscoinfo.xformsoftwareversion=Set to false to not allow Software Version DataForm on InfoDisco response.
 system_property.plugins.servlet.allowLocalFileReading=Determines if the plugin servlets can be used to access files outside of Openfire's home directory.
 system_property.cert.storewatcher.enabled=Automatically reloads certificate stores when they're modified on disk.

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1196,6 +1196,7 @@ system_property.xmpp.muc.join.presence=Wissel statusinformatie uit als een nieuw
 system_property.xmpp.muc.join.self-presence-timeout=Maximale wachttijd voor omgeroepen status informatie tijdens het binnentreden van een MUC ruimte. 
 system_property.ldap.pagedResultsSize=Het maximaal aantal records per pagina om vanuit LDAP op te halen. De standaardwaarde van -1 betekent dat de paginatie-functionaliteit van van de LDAP-server zelf wordt gebruikt. Let op! Voor Active Directory moet de standaardwaarde van deze instelling niet gebruikt worden. Ook zou de waarde niet hoger moeten zijn dan de waarde van Active Directory's MaxPageSize: die standaard 1.000 is.
 system_property.ldap.useRangeRetrieval=Schakel reeks-gebaseerde verwerking van grote LDAP groepen in.
+system_property.ldap.unencrypted-warning-suppression=Openfire logt een waarschuwing wanneer er LDAP-interactie plaats vindt over een niet-versleutelde verbinding. Om een overvloed aan log-meldingen te voorkomen wordt deze waarschuwing tijdelijk onderdrukt, nadat ze is gelogt. De waarde die hier wordt geconfigureerd definieert hoe lang die onderdrukking duurt.
 system_property.xmpp.iqdiscoinfo.xformsoftwareversion=Zet op 'false' om Software Version DataFromop InfoDisco antwoorden te verbieden.
 system_property.plugins.servlet.allowLocalFileReading=Bepaalt of de servlets van de plugins gebruikt kunnen worden om bestanden buiten Openfire's home directory te benaderen.
 system_property.cert.storewatcher.enabled=Herlaad certificaatbestanden automatisch als ze worden aangepast op de harde schijf.


### PR DESCRIPTION
Introduces a new property that defines how long warnings are suppressed after they've been logged.