### PR TITLE
OF-2904: Fix parsing issue of OtherName

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cert/SANCertificateIdentityMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,8 +157,13 @@ public class SANCertificateIdentityMapping implements CertificateIdentityMapping
 
         try ( final ASN1InputStream decoder = new ASN1InputStream( item ) )
         {
+            ASN1Primitive object = decoder.readObject();
+            if (object instanceof DLTaggedObject) {
+                final DLTaggedObject taggedObject = (DLTaggedObject) object;
+                object = (ASN1Sequence) taggedObject.getBaseObject();
+            }
+
             // By specification, OtherName instances must always be an ASN.1 Sequence.
-            final ASN1Primitive object = decoder.readObject();
             final ASN1Sequence otherNameSeq = (ASN1Sequence) object;
 
             // By specification, an OtherName instance consists of:

--- a/xmppserver/src/test/java/org/jivesoftware/util/CertificateManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/CertificateManagerTest.java
@@ -66,7 +66,6 @@ public class CertificateManagerTest
     public static final String KEY_ALGORITHM = "RSA";
     public static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
 
-    private static KeyPairGenerator keyPairGenerator;
     private static KeyPair subjectKeyPair;
     private static KeyPair issuerKeyPair;
     private static ContentSigner contentSigner;
@@ -74,7 +73,7 @@ public class CertificateManagerTest
     @BeforeAll
     public static void initialize() throws Exception
     {
-        keyPairGenerator = KeyPairGenerator.getInstance( KEY_ALGORITHM );
+        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KEY_ALGORITHM);
         keyPairGenerator.initialize( KEY_SIZE );
 
         subjectKeyPair = keyPairGenerator.generateKeyPair();
@@ -100,11 +99,11 @@ public class CertificateManagerTest
         final String subjectCommonName = "MySubjectCommonName";
 
         final X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
-                new X500Name( "CN=MyIssuer" ),                                          // Issuer
-                BigInteger.valueOf( Math.abs( new SecureRandom().nextInt() ) ),         // Random serial number
-                new Date( System.currentTimeMillis() - ( 1000L * 60 * 60 * 24 * 30 ) ), // Not before 30 days ago
-                new Date( System.currentTimeMillis() + ( 1000L * 60 * 60 * 24 * 99 ) ), // Not after 99 days from now
-                new X500Name( "CN=" + subjectCommonName ),                              // Subject
+                new X500Name( "CN=MyIssuer" ),                          // Issuer
+                BigInteger.valueOf( Math.abs( new SecureRandom().nextInt() ) ), // Random serial number
+                Date.from( Instant.now().plus(Duration.ofDays(30)) ),           // Not before 30 days ago
+                Date.from( Instant.now().minus(Duration.ofDays(99)) ),          // Not after 99 days from now
+                new X500Name( "CN=" + subjectCommonName ),              // Subject
                 subjectKeyPair.getPublic()
         );
 
@@ -139,11 +138,11 @@ public class CertificateManagerTest
         final String subjectAltNameXmppAddr = "MySubjectAltNameXmppAddr";
 
         final X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
-                new X500Name( "CN=MyIssuer" ),                                          // Issuer
-                BigInteger.valueOf( Math.abs( new SecureRandom().nextInt() ) ),         // Random serial number
-                new Date( System.currentTimeMillis() - ( 1000L * 60 * 60 * 24 * 30 ) ), // Not before 30 days ago
-                new Date( System.currentTimeMillis() + ( 1000L * 60 * 60 * 24 * 99 ) ), // Not after 99 days from now
-                new X500Name( "CN=" + subjectCommonName ),                              // Subject
+                new X500Name( "CN=MyIssuer" ),                          // Issuer
+                BigInteger.valueOf( Math.abs( new SecureRandom().nextInt() ) ), // Random serial number
+                Date.from( Instant.now().plus(Duration.ofDays(30)) ),           // Not before 30 days ago
+                Date.from( Instant.now().minus(Duration.ofDays(99)) ),          // Not after 99 days from now
+                new X500Name( "CN=" + subjectCommonName ),              // Subject
                 subjectKeyPair.getPublic()
         );
 
@@ -188,11 +187,11 @@ public class CertificateManagerTest
         final String subjectAltNameDnsSrv = "MySubjectAltNameXmppAddr";
 
         final X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
-                new X500Name( "CN=MyIssuer" ),                                          // Issuer
-                BigInteger.valueOf( Math.abs( new SecureRandom().nextInt() ) ),         // Random serial number
-                new Date( System.currentTimeMillis() - ( 1000L * 60 * 60 * 24 * 30 ) ), // Not before 30 days ago
-                new Date( System.currentTimeMillis() + ( 1000L * 60 * 60 * 24 * 99 ) ), // Not after 99 days from now
-                new X500Name( "CN=" + subjectCommonName ),                              // Subject
+                new X500Name( "CN=MyIssuer" ),                          // Issuer
+                BigInteger.valueOf( Math.abs( new SecureRandom().nextInt() ) ), // Random serial number
+                Date.from( Instant.now().plus(Duration.ofDays(30)) ),           // Not before 30 days ago
+                Date.from( Instant.now().minus(Duration.ofDays(99)) ),          // Not after 99 days from now
+                new X500Name( "CN=" + subjectCommonName ),              // Subject
                 subjectKeyPair.getPublic()
         );
 
@@ -237,11 +236,11 @@ public class CertificateManagerTest
         final String subjectAltNameDNS = "MySubjectAltNameDNS";
 
         final X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
-                new X500Name( "CN=MyIssuer" ),                                          // Issuer
-                BigInteger.valueOf( Math.abs( new SecureRandom().nextInt() ) ),         // Random serial number
-                new Date( System.currentTimeMillis() - ( 1000L * 60 * 60 * 24 * 30 ) ), // Not before 30 days ago
-                new Date( System.currentTimeMillis() + ( 1000L * 60 * 60 * 24 * 99 ) ), // Not after 99 days from now
-                new X500Name( "CN=" + subjectCommonName ),                              // Subject
+                new X500Name( "CN=MyIssuer" ),                          // Issuer
+                BigInteger.valueOf( Math.abs( new SecureRandom().nextInt() ) ), // Random serial number
+                Date.from( Instant.now().plus(Duration.ofDays(30)) ),           // Not before 30 days ago
+                Date.from( Instant.now().minus(Duration.ofDays(99)) ),          // Not after 99 days from now
+                new X500Name( "CN=" + subjectCommonName ),              // Subject
                 subjectKeyPair.getPublic()
         );
 
@@ -289,11 +288,11 @@ public class CertificateManagerTest
         final String subjectAltNameDNS = "MySubjectAltNameDNS";
 
         final X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
-                new X500Name( "CN=MyIssuer" ),                                          // Issuer
-                BigInteger.valueOf( Math.abs( new SecureRandom().nextInt() ) ),         // Random serial number
-                new Date( System.currentTimeMillis() - ( 1000L * 60 * 60 * 24 * 30 ) ), // Not before 30 days ago
-                new Date( System.currentTimeMillis() + ( 1000L * 60 * 60 * 24 * 99 ) ), // Not after 99 days from now
-                new X500Name( "CN=" + subjectCommonName ),                              // Subject
+                new X500Name( "CN=MyIssuer" ),                          // Issuer
+                BigInteger.valueOf( Math.abs( new SecureRandom().nextInt() ) ), // Random serial number
+                Date.from( Instant.now().plus(Duration.ofDays(30)) ),           // Not before 30 days ago
+                Date.from( Instant.now().minus(Duration.ofDays(99)) ),          // Not after 99 days from now
+                new X500Name( "CN=" + subjectCommonName ),              // Subject
                 subjectKeyPair.getPublic()
         );
 

--- a/xmppserver/src/test/java/org/jivesoftware/util/CertificateManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/CertificateManagerTest.java
@@ -21,12 +21,14 @@ import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.OtherName;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.jivesoftware.util.cert.SANCertificateIdentityMapping;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +43,7 @@ import java.security.SecureRandom;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
+import java.time.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -144,12 +147,17 @@ public class CertificateManagerTest
                 subjectKeyPair.getPublic()
         );
 
-        final DERSequence otherName = new DERSequence( new ASN1Encodable[] { XMPP_ADDR_OID, new DERUTF8String( subjectAltNameXmppAddr ) });
+        final OtherName otherName = new OtherName(XMPP_ADDR_OID, new DERUTF8String( subjectAltNameXmppAddr ) );
         final GeneralNames subjectAltNames = new GeneralNames( new GeneralName(GeneralName.otherName, otherName ) );
         builder.addExtension( Extension.subjectAlternativeName, true, subjectAltNames );
 
         final X509CertificateHolder certificateHolder = builder.build( contentSigner );
-        final X509Certificate cert = new JcaX509CertificateConverter().getCertificate( certificateHolder );
+        X509Certificate cert = new JcaX509CertificateConverter().getCertificate( certificateHolder );
+
+        // FIXME: Unsure why, but without this back-and-forth, tests will fail on Java 17.
+        final String value = CertificateManager.toPemRepresentation(cert);
+        final Collection<X509Certificate> chain = CertificateManager.parseCertificates(value);
+        cert = chain.iterator().next();
 
         // Execute system under test
         final List<String> serverIdentities = CertificateManager.getServerIdentities( cert );
@@ -159,7 +167,6 @@ public class CertificateManagerTest
         assertTrue( serverIdentities.contains( subjectAltNameXmppAddr ));
         assertFalse( serverIdentities.contains( subjectCommonName ) );
     }
-
 
     /**
      * {@link CertificateManager#getServerIdentities(X509Certificate)} should return:
@@ -189,12 +196,17 @@ public class CertificateManagerTest
                 subjectKeyPair.getPublic()
         );
 
-        final DERSequence otherName = new DERSequence( new ASN1Encodable[] {DNS_SRV_OID, new DERIA5String( "_xmpp-server."+subjectAltNameDnsSrv ) });
+        final OtherName otherName = new OtherName(DNS_SRV_OID, new DERIA5String( "_xmpp-server."+subjectAltNameDnsSrv ) );
         final GeneralNames subjectAltNames = new GeneralNames( new GeneralName(GeneralName.otherName, otherName ) );
         builder.addExtension( Extension.subjectAlternativeName, true, subjectAltNames );
 
         final X509CertificateHolder certificateHolder = builder.build( contentSigner );
-        final X509Certificate cert = new JcaX509CertificateConverter().getCertificate( certificateHolder );
+        X509Certificate cert = new JcaX509CertificateConverter().getCertificate( certificateHolder );
+
+        // FIXME: Unsure why, but without this back-and-forth, tests will fail on Java 17.
+        final String value = CertificateManager.toPemRepresentation(cert);
+        final Collection<X509Certificate> chain = CertificateManager.parseCertificates(value);
+        cert = chain.iterator().next();
 
         // Execute system under test
         final List<String> serverIdentities = CertificateManager.getServerIdentities( cert );
@@ -238,7 +250,12 @@ public class CertificateManagerTest
         builder.addExtension( Extension.subjectAlternativeName, false, generalNames );
 
         final X509CertificateHolder certificateHolder = builder.build( contentSigner );
-        final X509Certificate cert = new JcaX509CertificateConverter().getCertificate( certificateHolder );
+        X509Certificate cert = new JcaX509CertificateConverter().getCertificate( certificateHolder );
+
+        // FIXME: Unsure why, but without this back-and-forth, tests will fail on Java 17.
+        final String value = CertificateManager.toPemRepresentation(cert);
+        final Collection<X509Certificate> chain = CertificateManager.parseCertificates(value);
+        cert = chain.iterator().next();
 
         // Execute system under test
         final List<String> serverIdentities = CertificateManager.getServerIdentities( cert );
@@ -280,7 +297,7 @@ public class CertificateManagerTest
                 subjectKeyPair.getPublic()
         );
 
-        final DERSequence otherName = new DERSequence( new ASN1Encodable[] { XMPP_ADDR_OID, new DERUTF8String( subjectAltNameXmppAddr ) });
+        final OtherName otherName = new OtherName(XMPP_ADDR_OID, new DERUTF8String( subjectAltNameXmppAddr ) );
         final GeneralNames subjectAltNames = new GeneralNames( new GeneralName[] {
                 new GeneralName( GeneralName.otherName, otherName ),
                 new GeneralName( GeneralName.dNSName, subjectAltNameDNS )
@@ -288,7 +305,12 @@ public class CertificateManagerTest
         builder.addExtension( Extension.subjectAlternativeName, true, subjectAltNames );
 
         final X509CertificateHolder certificateHolder = builder.build( contentSigner );
-        final X509Certificate cert = new JcaX509CertificateConverter().getCertificate( certificateHolder );
+        X509Certificate cert = new JcaX509CertificateConverter().getCertificate( certificateHolder );
+
+        // FIXME: Unsure why, but without this back-and-forth, tests will fail on Java 17.
+        final String value = CertificateManager.toPemRepresentation(cert);
+        final Collection<X509Certificate> chain = CertificateManager.parseCertificates(value);
+        cert = chain.iterator().next();
 
         // Execute system under test
         final List<String> serverIdentities = CertificateManager.getServerIdentities( cert );
@@ -297,6 +319,105 @@ public class CertificateManagerTest
         assertEquals( 2, serverIdentities.size() );
         assertTrue( serverIdentities.contains( subjectAltNameXmppAddr ));
         assertFalse( serverIdentities.contains( subjectCommonName ) );
+    }
+
+    /**
+     * Tests a PEM generated by OpenSSL using this config file:
+     *
+     * <code>
+     * [ req ]
+     * default_bits       = 2048
+     * distinguished_name = req_distinguished_name
+     * req_extensions     = req_ext
+     * x509_extensions    = v3_ca # The main difference
+     * prompt = no
+     *
+     * [ req_distinguished_name ]
+     * C = US
+     * ST = YourState
+     * L = YourCity
+     * O = YourOrganization
+     * OU = YourUnit
+     * CN = yourdomain.com
+     *
+     * [ req_ext ]
+     * subjectAltName = @alt_names
+     *
+     * [ v3_ca ]
+     * subjectAltName = @alt_names
+     * basicConstraints = CA:TRUE
+     * keyUsage = digitalSignature, keyEncipherment
+     * extendedKeyUsage = serverAuth, clientAuth
+     *
+     * [ alt_names ]
+     * otherName.0 = 1.3.6.1.5.5.7.8.7;IA5:_xmpp-server.service.example.com
+     * otherName.1 = 1.3.6.1.5.5.7.8.7;IA5:_dns.service.example.net
+     * otherName.2 = 1.3.6.1.5.5.7.8.5;UTF8:user@example.com
+     * otherName.3 = 1.3.6.1.5.5.7.8.5;UTF8:not-a-user.example.com
+     * URI.1 = xmpp:third-one.net
+     * DNS.1 = yourdomain.com
+     * DNS.2 = anotherdomain.com
+     * IP.1 = 192.168.1.1
+     * </code>
+     *
+     * Using:
+     * <code>
+     * $ openssl req -new -key mykey.key -out mycsr.csr -config san.cnf
+     * $ openssl x509 -req -days 365 -in mycsr.csr -signkey mykey.key -out mycert.crt -extfile san.cnf -extensions v3_ca
+     * Signature ok
+     * subject=C = US, ST = YourState, L = YourCity, O = YourOrganization, OU = YourUnit, CN = yourdomain.com
+     * Getting Private key
+     * </code>
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2904">OF-2904</a>
+     */
+    @Test
+    public void testPrebuiltPEM() throws Exception
+    {
+        // Setup test fixture.
+        final Collection<X509Certificate> chain = CertificateManager.parseCertificates(
+            "-----BEGIN CERTIFICATE-----\n" +
+                "MIIErTCCA5WgAwIBAgIULIC8uiTUXMHADnhPH6YH2BoFcOIwDQYJKoZIhvcNAQEL\n" +
+                "BQAwezELMAkGA1UEBhMCVVMxEjAQBgNVBAgMCVlvdXJTdGF0ZTERMA8GA1UEBwwI\n" +
+                "WW91ckNpdHkxGTAXBgNVBAoMEFlvdXJPcmdhbml6YXRpb24xETAPBgNVBAsMCFlv\n" +
+                "dXJVbml0MRcwFQYDVQQDDA55b3VyZG9tYWluLmNvbTAeFw0yNDExMTAxNjI4MzZa\n" +
+                "Fw0yNTExMTAxNjI4MzZaMHsxCzAJBgNVBAYTAlVTMRIwEAYDVQQIDAlZb3VyU3Rh\n" +
+                "dGUxETAPBgNVBAcMCFlvdXJDaXR5MRkwFwYDVQQKDBBZb3VyT3JnYW5pemF0aW9u\n" +
+                "MREwDwYDVQQLDAhZb3VyVW5pdDEXMBUGA1UEAwwOeW91cmRvbWFpbi5jb20wggEi\n" +
+                "MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDMDg2nLepMRS6o3F5oSiP/U4yh\n" +
+                "5lOWSE24VQE4R0EMbTiQ1lATIA0AbYU0MbVfu2EU+6rcyml7wSwekVBdRq/KLcvH\n" +
+                "5mJjmQ25qHzJIFzxqNtUygY790job51zpOsIaFfg+MZkCdCWQK5G4qUr5bkfCKCN\n" +
+                "VCiFcTi1nJo/PIP5Cx+/NCq3iFUL//Dt4+UxADUhD9mdXODIFUYGAP0IDD5hL58g\n" +
+                "0IPNAAECky1fx4oSP1G0I8IYEnZ7V3RXvO82WZOlthJTtyysVTlIt6vy2cyG6WIg\n" +
+                "iuBYOyl3Uf1S//TAMQwDF6oBO43EkqJqEODe4HTdMODd+72LY/4HSbikyBvRAgMB\n" +
+                "AAGjggEnMIIBIzCB5gYDVR0RBIHeMIHboC4GCCsGAQUFBwgHoCIWIF94bXBwLXNl\n" +
+                "cnZlci5zZXJ2aWNlLmV4YW1wbGUuY29toCYGCCsGAQUFBwgHoBoWGF9kbnMuc2Vy\n" +
+                "dmljZS5leGFtcGxlLm5ldKAeBggrBgEFBQcIBaASDBB1c2VyQGV4YW1wbGUuY29t\n" +
+                "oCQGCCsGAQUFBwgFoBgMFm5vdC1hLXVzZXIuZXhhbXBsZS5jb22GEnhtcHA6dGhp\n" +
+                "cmQtb25lLm5ldIIOeW91cmRvbWFpbi5jb22CEWFub3RoZXJkb21haW4uY29thwTA\n" +
+                "qAEBMAwGA1UdEwQFMAMBAf8wCwYDVR0PBAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUF\n" +
+                "BwMBBggrBgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAQEADrekbzSNviLTvI8DXqBD\n" +
+                "JnNPPS98nzWgABscB5Xups+G7Jrj4aibNHonePXW8B6rOqEYeBBbIzCYRRRPbuGl\n" +
+                "kqksCmGa0/CWYX0uf4RoLaGy5BzZndJWYNPe/Hj5GbyLbFCFNyBOMDz0NyrwfVoH\n" +
+                "Yq0W2rkve2SWKp7iiiUc80qKj4tcTX25x5h8oLgv7Lh4OAGKXFr6TYk23wdDPjiC\n" +
+                "zZlXLN8TFw+RT7LQQc/Xi8XC/1ULbLalTEwh/xIaKju5P5CBTZO9xnVDc9LJ3hww\n" +
+                "TN04BDlf3U02OCoSr0SxiLmmDRJOLbzGJK2AEQPpHUM5URcd98Tf2GzyUvxfhHUc\n" +
+                "7A==\n" +
+                "-----END CERTIFICATE-----");
+        final SANCertificateIdentityMapping mapper = new SANCertificateIdentityMapping();
+
+        // Execute system under test.
+        final List<String> result = mapper.mapIdentity(chain.iterator().next());
+
+        // Verify results
+        assertTrue(result.contains("service.example.com"), "Expected the to contain 'service.example.com', as the certificate contains an id-on-dnsSRV OtherName entry with value '_xmpp-server.service.example.com'");
+        assertFalse(result.contains("service.example.net"), "Didn't expect the result to contain 'service.example.net. Although the certificate contains an id-on-dnsSRV OtherName entry with value '_dns.service.example.net', it service is not of an XMPP-type (but rather, DNS).");
+        assertTrue(result.contains("user@example.com"), "Expected the result to contain 'user@example.com', as the certificate contains that value in an id-on-xmppAddr OtherName entry.");
+        assertTrue(result.contains("not-a-user.example.com"), "Expected the result to contain 'not-a-user.example.com', as the certificate contains that value in an id-on-xmppAddr OtherName entry.");
+        assertFalse(result.contains("third-one.net"), "Didn't expect the result to contain 'third-one.net, which is provided in an URI entry in the certificate. URI entries are not defined as a valid source for JIDs in a certificate by RFC6120.");
+        assertTrue(result.contains("yourdomain.com"), "Expected the result to contain 'yourdomain.com', as the certificate contains that value in DNS entry.");
+        assertTrue(result.contains("anotherdomain.com"), "Expected the result to contain 'anotherdomain.com', as the certificate contains that value in DNS entry.");
+        assertFalse(result.contains("192.168.1.1"), "Didn't expect the result to contain '192.168.1.1, which is provided in an IP entry in the certificate. IP entries are not defined as a valid source for JIDs in a certificate by RFC6120.");
     }
 
     /**


### PR DESCRIPTION
OtherName values are tagged, which should be taken into account by the parser.

Unit tests that generate a certificate should include an EXPLIT tagged OtherName.

After two days of ... pain ... I've resorted to converting the BouncyCastle-generated certificate to PEM and back again, which for some reason that's beyond me appears to be required to make the parsing be successfull on both Java 17 and 21.

Adds additional unit test that uses a certificate generated by OpenSSL.

Many thanks to @dwd for invaluable help on this.
