### PR TITLE
OF-2906: Fix setup page that checks config files

### DIFF
--- a/xmppserver/src/main/webapp/setup/index.jsp
+++ b/xmppserver/src/main/webapp/setup/index.jsp
@@ -155,7 +155,7 @@
     </c:if>
 
     <c:choose>
-        <c:when test="${not jreVersionCompatible or not servlet22Installed or not jsp11Installed or not jiveJarsInstalled or not openfireHomeExists or not configFailedLoading}">
+        <c:when test="${not jreVersionCompatible or not servlet22Installed or not jsp11Installed or not jiveJarsInstalled or not openfireHomeExists or not configLocationExistsAndAccessible or not securityConfigLocationExistsAndAccessible}">
             <div class="error">
                 <fmt:message key="setup.env.check.error"/> <fmt:message key="title"/> <fmt:message key="setup.title"/>.
             </div>
@@ -265,7 +265,7 @@
                                 <tr>
                                     <td><img src="../images/check.gif" width="13" height="13"></td>
                                     <td><fmt:message key="setup.env.check.config_found">
-                                        <fmt:param><c:out value="${configLocation}"/></fmt:param>
+                                        <fmt:param><c:out value="${securityConfigLocation}"/></fmt:param>
                                     </fmt:message>
                                     </td>
                                 </tr>
@@ -274,7 +274,7 @@
                                 <tr>
                                     <td><img src="../images/x.gif" width="13" height="13"></td>
                                     <td><fmt:message key="setup.env.check.config_not_loaded">
-                                        <fmt:param><c:out value="${configLocation}"/></fmt:param>
+                                        <fmt:param><c:out value="${securityConfigLocation}"/></fmt:param>
                                     </fmt:message>
                                     </td>
                                 </tr>


### PR DESCRIPTION
Fixes a copy/paste error that prevented the security config file from being parsed properly.

Fixes an error where a non-existing variable is checked, thus never passing the check.

This is an untested fix for the problem that is apparent on https://discourse.igniterealtime.org/t/reinstalled-openfire-but-now-get-an-error-that-it-doesnt-meet-server-requirements/94891/1