### PR TITLE
Jetty 12.0.14 ee8 upgrade

### DIFF
--- a/documentation/plugin-dev-guide.html
+++ b/documentation/plugin-dev-guide.html
@@ -495,8 +495,8 @@ public class ExamplePlugin implements Plugin {
             &lt;/plugin&gt;
             &lt;!-- Compiles the Openfire Admin Console JSP pages. Remove this if the plugin has no JSP pages --&gt;
             &lt;plugin&gt;
-                &lt;groupId&gt;org.eclipse.jetty&lt;/groupId&gt;
-                &lt;artifactId&gt;jetty-jspc-maven-plugin&lt;/artifactId&gt;
+                &lt;groupId&gt;org.eclipse.jetty.ee8&lt;/groupId&gt;
+                &lt;artifactId&gt;jetty-ee8-jspc-maven-plugin&lt;/artifactId&gt;
             &lt;/plugin&gt;
         &lt;/plugins&gt;
     &lt;/build&gt;

--- a/documentation/plugins-affected-by-jetty12-upgrade.html
+++ b/documentation/plugins-affected-by-jetty12-upgrade.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Openfire: Overview</title>
+    <link type="text/css" rel="stylesheet" href="style.css">
+    <style>
+        dl {
+            display: unset;
+        }
+        dt {
+            margin-left: 4em;
+        }
+        dd {
+            margin-left: 6em;
+            margin-bottom: 1.5em;
+        }
+    </style>
+</head>
+<body>
+
+<article>
+
+    <header>
+        <img src="images/header_logo.gif" alt="Openfire Logo" />
+        <h1>Plugins Affected by Jetty 12 Upgrade</h1>
+    </header>
+
+    <h2>Overview</h2>
+    <p>
+        Openfire's upgrade to Jetty 12, using EE8 packages, is known to affect 16 plugins. Five types of errors have been identified across the affected plugins. The table below lists the plugins and the types of errors they are experiencing:
+    </p>
+
+    <section id="broken-plugins-list">
+
+        <table class="compliance">
+            <tbody>
+            <tr>
+                <th colspan="2">Broken Plugin Information</th>
+            </tr>
+            <tr>
+                <th>Plugin Name</th>
+                <th>Error Type</th>
+            </tr>
+            <tr>
+                <td>Candy</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/webapp/WebAppContext</td>
+            </tr>
+            <tr>
+                <td>Fastpath Service</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/webapp/WebAppContext</td>
+            </tr>
+            <tr>
+                <td>Galene</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/webapp/WebAppContext</td>
+            </tr>
+            <tr>
+                <td>Gitea</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/security/ConstraintSecurityHandler</td>
+            </tr>
+            <tr>
+                <td>HTTP File Upload</td>
+                <td>java.lang.VerifyError: Bad type on operand stack</td>
+            </tr>
+            <tr>
+                <td>inVerse</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/webapp/WebAppContext</td>
+            </tr>
+            <tr>
+                <td>IPFS</td>
+                <td>java.lang.NoSuchMethodError: 'java.lang.String org.jivesoftware.util.JiveGlobals.getHomeDirectory()</td>
+            </tr>
+            <tr>
+                <td>JSXC</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/webapp/WebAppContext</td>
+            </tr>
+            <tr>
+                <td>Monitoring Service</td>
+                <td>java.lang.VerifyError: Bad type on operand stack</td>
+            </tr>
+            <tr>
+                <td>NodeJs</td>
+                <td>java.lang.NoSuchMethodError: 'java.lang.String org.jivesoftware.util.JiveGlobals.getHomeDirectory()</td>
+            </tr>
+            <tr>
+                <td>Ohun</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/security/ConstraintSecurityHandler</td>
+            </tr>
+            <tr>
+                <td>Openfire WebSocket</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/websocket/servlet/WebSocketServlet</td>
+            </tr>
+            <tr>
+                <td>osw-openfire-plugin</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/webapp/WebAppContext</td>
+            </tr>
+            <tr>
+                <td>Pade</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/websocket/server/JettyWebSocketCreator</td>
+            </tr>
+            <tr>
+                <td>Random Avatar Generator Plugin</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/webapp/WebAppContext</td>
+            </tr>
+            <tr>
+                <td>xmppweb</td>
+                <td>java.lang.NoClassDefFoundError: org/eclipse/jetty/webapp/WebAppContext</td>
+            </tr>
+            </tbody>
+
+        </table>
+
+    </section>
+
+    <h2>Error Details and Potential Solutions</h2>
+    <p>
+        This section provides further details on the five types of errors observed and offers suggestions for addressing them.
+    </p>
+
+    <h3>java.lang.VerifyError</h3>
+    <section id="verify-error">
+    <fieldset>
+        <legend>Error found in openfire.log</legend>
+        <pre><code>java.lang.VerifyError: Bad type on operand stack
+        Exception Details:
+          Location:
+            org/eclipse/jetty/servlet/ServletContextHandler.setGzipHandler(Lorg/eclipse/jetty/server/handler/gzip/GzipHandler;)V @6: invokespecial
+          Reason:
+            Type 'org/eclipse/jetty/server/handler/gzip/GzipHandler' (current frame, stack[2]) is not assignable to 'org/eclipse/jetty/server/handler/HandlerWrapper'
+          Current Frame:
+            bci: @6
+            flags: { }
+            locals: { 'org/eclipse/jetty/servlet/ServletContextHandler', 'org/eclipse/jetty/server/handler/gzip/GzipHandler' }
+            stack: { 'org/eclipse/jetty/servlet/ServletContextHandler', 'org/eclipse/jetty/server/handler/gzip/GzipHandler', 'org/eclipse/jetty/server/handler/gzip/GzipHandler' }
+          Bytecode:
+            0000000: 2a2a b400 352b b700 762a 2bb5 0035 2ab7
+            0000010: 0018 b1
+            at org.jivesoftware.openfire.plugin.MonitoringPlugin.loadPublicWeb(MonitoringPlugin.java:279) ~[monitoring-2.6.1.jar:?]
+            at org.jivesoftware.openfire.plugin.MonitoringPlugin.initializePlugin(MonitoringPlugin.java:186) ~[monitoring-2.6.1.jar:?]
+            at org.jivesoftware.openfire.container.PluginManager.loadPlugin(PluginManager.java:640) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+            at org.jivesoftware.openfire.container.PluginMonitor$MonitorTask$4.call(PluginMonitor.java:380) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+            at org.jivesoftware.openfire.container.PluginMonitor$MonitorTask$4.call(PluginMonitor.java:368) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+            at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
+            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
+            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
+            at java.lang.Thread.run(Thread.java:840) [?:?]
+        </code></pre>
+    </fieldset>
+    <p>Consider using <a href="https://javadoc.jetty.org/jetty-12/org/eclipse/jetty/server/Handler.Wrapper.html">org.eclipse.jetty.server.Handler.Wrapper</a> to replace org.eclipse.jetty.server.handler.HandlerWrapper.</p>
+    </section>
+
+    <h3>org.eclipse.jetty.webapp.WebAppContext</h3>
+    <section id="web-app-context">
+        <fieldset>
+            <legend>Error found in openfire.log</legend>
+            <pre><code>java.lang.NoClassDefFoundError: org/eclipse/jetty/webapp/WebAppContext
+    at org.igniterealtime.openfire.plugin.inverse.InversePlugin.initializePlugin(InversePlugin.java:63) ~[inverse-10.1.7.1.jar:?]
+    at org.jivesoftware.openfire.container.PluginManager.loadPlugin(PluginManager.java:640) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+    at org.jivesoftware.openfire.container.PluginMonitor$MonitorTask$4.call(PluginMonitor.java:380) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+    at org.jivesoftware.openfire.container.PluginMonitor$MonitorTask$4.call(PluginMonitor.java:368) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+    at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
+    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
+    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
+    at java.lang.Thread.run(Thread.java:840) [?:?]
+Caused by: java.lang.ClassNotFoundException: org.eclipse.jetty.webapp.WebAppContext
+    at java.net.URLClassLoader.findClass(URLClassLoader.java:445) ~[?:?]
+    at java.lang.ClassLoader.loadClass(ClassLoader.java:592) ~[?:?]
+    at java.lang.ClassLoader.loadClass(ClassLoader.java:525) ~[?:?]
+    ... 8 more
+        </code></pre>
+        </fieldset>
+        <p>Consider using the EE8 WebAppContext from org.eclipse.jetty.ee8.webapp.WebAppContext to replace org.eclipse.jetty.webapp.WebAppContext.</p>
+    </section>
+
+    <h3>org.jivesoftware.util.JiveGlobals.getHomeDirectory()</h3>
+    <section id="get-home-directory">
+        <fieldset>
+            <legend>Error found in openfire.log</legend>
+            <pre><code>java.lang.NoSuchMethodError: 'java.lang.String org.jivesoftware.util.JiveGlobals.getHomeDirectory()'
+    at org.ifsoft.ipfs.openfire.PluginImpl.initializePlugin(PluginImpl.java:74) ~[ipfs-native.jar:?]
+    at org.jivesoftware.openfire.container.PluginManager.loadPlugin(PluginManager.java:640) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+    at org.jivesoftware.openfire.container.PluginMonitor$MonitorTask$4.call(PluginMonitor.java:380) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+    at org.jivesoftware.openfire.container.PluginMonitor$MonitorTask$4.call(PluginMonitor.java:368) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+    at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
+    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
+    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
+    at java.lang.Thread.run(Thread.java:840) [?:?]
+        </code></pre>
+        </fieldset>
+    </section>
+
+    <h3>org/eclipse/jetty/security/ConstraintSecurityHandler</h3>
+    <section id="constraint-security-handler">
+        <fieldset>
+            <legend>Error found in openfire.log</legend>
+            <pre><code>java.lang.NoClassDefFoundError: org/eclipse/jetty/security/ConstraintSecurityHandler
+    at java.lang.Class.getDeclaredConstructors0(Native Method) ~[?:?]
+    at java.lang.Class.privateGetDeclaredConstructors(Class.java:3373) ~[?:?]
+	at java.lang.Class.getConstructor0(Class.java:3578) ~[?:?]
+    at java.lang.Class.newInstance(Class.java:626) ~[?:?]
+	at org.jivesoftware.openfire.container.PluginManager.loadPlugin(PluginManager.java:587) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+	at org.jivesoftware.openfire.container.PluginMonitor$MonitorTask$4.call(PluginMonitor.java:380) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+	at org.jivesoftware.openfire.container.PluginMonitor$MonitorTask$4.call(PluginMonitor.java:368) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
+	at java.lang.Thread.run(Thread.java:840) [?:?]
+Caused by: java.lang.ClassNotFoundException: org.eclipse.jetty.security.ConstraintSecurityHandler
+	at java.net.URLClassLoader.findClass(URLClassLoader.java:445) ~[?:?]
+	at java.lang.ClassLoader.loadClass(ClassLoader.java:592) ~[?:?]
+	at java.lang.ClassLoader.loadClass(ClassLoader.java:525) ~[?:?]
+	... 11 more
+        </code></pre>
+        </fieldset>
+        <p>Consider using the EE8 ConstraintSecurityHandler from org.eclipse.jetty.ee8.security.ConstraintSecurityHandler to replace org.eclipse.jetty.security.ConstraintSecurityHandler.</p>
+    </section>
+
+    <h3>org/eclipse/jetty/websocket/server/JettyWebSocketCreator</h3>
+    <section id="jetty-websocket-creator">
+        <fieldset>
+            <legend>Error found in openfire.log</legend>
+            <pre><code>java.lang.NoClassDefFoundError: org/eclipse/jetty/websocket/server/JettyWebSocketCreator
+    at uk.ifsoft.openfire.plugins.pade.PadePlugin.initializePlugin(PadePlugin.java:117) ~[pade-1.8.3.jar:?]
+    at org.jivesoftware.openfire.container.PluginManager.loadPlugin(PluginManager.java:640) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+    at org.jivesoftware.openfire.container.PluginMonitor$MonitorTask$4.call(PluginMonitor.java:380) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+    at org.jivesoftware.openfire.container.PluginMonitor$MonitorTask$4.call(PluginMonitor.java:368) [xmppserver-4.10.0-SNAPSHOT.jar:4.10.0-SNAPSHOT]
+    at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
+    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
+    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
+    at java.lang.Thread.run(Thread.java:840) [?:?]
+Caused by: java.lang.ClassNotFoundException: org.eclipse.jetty.websocket.server.JettyWebSocketCreator
+    at java.net.URLClassLoader.findClass(URLClassLoader.java:445) ~[?:?]
+    at java.lang.ClassLoader.loadClass(ClassLoader.java:592) ~[?:?]
+    at java.lang.ClassLoader.loadClass(ClassLoader.java:525) ~[?:?]
+    ... 8 more
+        </code></pre>
+        </fieldset>
+        <p>Consider using the EE8 JettyWebSocketServlet from org.eclipse.jetty.ee8.websocket.server.JettyWebSocketServlet to replace org.eclipse.jetty.websocket.server.JettyWebSocketCreator.</p>
+    </section>
+
+    <footer>
+        <p>
+            An active support community for Openfire is available at
+            <a href="https://discourse.igniterealtime.org">https://discourse.igniterealtime.org</a>.
+        </p>
+    </footer>
+
+</article>
+
+</body>
+</html>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -122,7 +122,7 @@
         <!-- Versions -->
         <openfire.version>5.0.0-SNAPSHOT</openfire.version>
         <!-- Note; the following jetty.version should be identical to the jetty.version in xmppserver/pom.xml -->
-        <jetty.version>10.0.18</jetty.version>
+        <jetty.version>12.0.14</jetty.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 
         <!-- Versions -->
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
-        <jetty.version>10.0.18</jetty.version>
+        <jetty.version>12.0.14</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <netty.version>4.1.108.Final</netty.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -149,8 +149,8 @@
 
             <!-- Compile the JSP pages -->
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jspc-maven-plugin</artifactId>
+                <groupId>org.eclipse.jetty.ee8</groupId>
+                <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
                 <executions>
                     <execution>
@@ -257,13 +257,13 @@
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
+            <groupId>org.eclipse.jetty.ee8</groupId>
+            <artifactId>jetty-ee8-servlet</artifactId>
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
+            <groupId>org.eclipse.jetty.ee8</groupId>
+            <artifactId>jetty-ee8-webapp</artifactId>
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
@@ -272,23 +272,23 @@
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-plus</artifactId>
+            <groupId>org.eclipse.jetty.ee8</groupId>
+            <artifactId>jetty-ee8-plus</artifactId>
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-annotations</artifactId>
+            <groupId>org.eclipse.jetty.ee8</groupId>
+            <artifactId>jetty-ee8-annotations</artifactId>
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-jetty-server</artifactId>
+            <groupId>org.eclipse.jetty.ee8.websocket</groupId>
+            <artifactId>jetty-ee8-websocket-jetty-server</artifactId>
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>apache-jsp</artifactId>
+            <groupId>org.eclipse.jetty.ee8</groupId>
+            <artifactId>jetty-ee8-apache-jsp</artifactId>
             <version>${jetty.version}</version>
         </dependency>
         <dependency>

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -16,22 +16,21 @@
 
 package org.jivesoftware.openfire.http;
 
-import org.apache.jasper.servlet.JasperInitializer;
 import org.apache.tomcat.InstanceManager;
 import org.apache.tomcat.SimpleInstanceManager;
+import org.eclipse.jetty.ee8.apache.jsp.JettyJasperInitializer;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.plus.annotation.ContainerInitializer;
 import org.eclipse.jetty.server.*;
-import org.eclipse.jetty.server.handler.HandlerCollection;
-import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.Handler.Sequence;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee8.servlet.ServletHolder;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.eclipse.jetty.webapp.WebAppContext;
-import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.eclipse.jetty.ee8.webapp.WebAppContext;
+import org.eclipse.jetty.ee8.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.jivesoftware.openfire.Connection;
 import org.jivesoftware.openfire.ConnectionManager;
 import org.jivesoftware.openfire.JMXManager;
@@ -306,14 +305,14 @@ public final class HttpBindManager implements CertificateEventListener {
      * This collection should be regarded as immutable. When handlers are to be added/removed dynamically, this should
      * occur in {@link #extensionHandlers}, to which a reference is stored in this list by the constructor of this class.
      */
-    private final HandlerList handlerList = new HandlerList();
+    private final Sequence handlerList = new Sequence();
 
     /**
      * Contains all Jetty handlers that are added as an extension.
      *
      * This collection is mutable. Handlers can be added and removed at runtime.
      */
-    private final HandlerCollection extensionHandlers = new HandlerCollection( true );
+    private final ContextHandlerCollection extensionHandlers = new ContextHandlerCollection(true);
 
     /**
      * A task that, periodically, updates the 'last modified' date of all files in the Jetty 'tmp' directories. This
@@ -343,7 +342,7 @@ public final class HttpBindManager implements CertificateEventListener {
 
         // When everything else fails, use the static content handler. This one should be last, as it is mapping to the root context.
         // This means that it will catch everything and prevent the invocation of later handlers.
-        final Handler staticContentHandler = createStaticContentHandler();
+        final ServletContextHandler staticContentHandler = createStaticContentHandler();
         if ( staticContentHandler != null )
         {
             this.handlerList.addHandler( staticContentHandler );
@@ -385,9 +384,9 @@ public final class HttpBindManager implements CertificateEventListener {
             httpBindServer.start();
 
             if (handlerList.getHandlers() != null) {
-                Arrays.stream(handlerList.getHandlers()).forEach(handler -> {
+                Arrays.stream(handlerList.getHandlers().toArray()).forEach(handler  -> {
                     try {
-                        handler.start();
+                        ((Handler)handler).start();
                     } catch (Exception e) {
                         Log.warn("An exception occurred while trying to start handler: {}", handler, e);
                     }
@@ -396,9 +395,9 @@ public final class HttpBindManager implements CertificateEventListener {
             handlerList.start();
 
             if ( extensionHandlers.getHandlers() != null ) {
-                Arrays.stream(extensionHandlers.getHandlers()).forEach(handler -> {
+                Arrays.stream(handlerList.getHandlers().toArray()).forEach(handler  -> {
                     try {
-                        handler.start();
+                        ((Handler)handler).start();
                     } catch (Exception e) {
                         Log.warn("An exception occurred while trying to start extension handler: {}", handler, e);
                     }
@@ -432,9 +431,9 @@ public final class HttpBindManager implements CertificateEventListener {
         if (httpBindServer != null) {
             try {
                 if ( extensionHandlers.getHandlers() != null ) {
-                    Arrays.stream(extensionHandlers.getHandlers()).forEach(handler -> {
+                    Arrays.stream(handlerList.getHandlers().toArray()).forEach(handler  -> {
                         try {
-                            handler.stop();
+                            ((Handler)handler).stop();
                         } catch (Exception e) {
                             Log.warn("An exception occurred while trying to stop extension handler: {}", handler, e);
                         }
@@ -443,9 +442,9 @@ public final class HttpBindManager implements CertificateEventListener {
                 extensionHandlers.stop();
 
                 if ( handlerList.getHandlers() != null ) {
-                    Arrays.stream(handlerList.getHandlers()).forEach(handler -> {
+                    Arrays.stream(handlerList.getHandlers().toArray()).forEach(handler-> {
                         try {
-                            handler.stop();
+                            ((Handler)handler).stop();
                         } catch (Exception e) {
                             Log.warn("An exception occurred while trying to stop handler: {}", handler, e);
                         }
@@ -664,15 +663,13 @@ public final class HttpBindManager implements CertificateEventListener {
      *
      * @return A Jetty context handler (never null).
      */
-    protected Handler createBoshHandler()
+    protected ServletContextHandler createBoshHandler()
     {
         final int options = ServletContextHandler.SESSIONS;
         final ServletContextHandler context = new ServletContextHandler( null, "/http-bind", options );
 
         // Ensure the JSP engine is initialized correctly (in order to be able to cope with Tomcat/Jasper precompiled JSPs).
-        final List<ContainerInitializer> initializers = new ArrayList<>();
-        initializers.add( new ContainerInitializer( new JasperInitializer(), null ) );
-        context.setAttribute( "org.eclipse.jetty.containerInitializers", initializers );
+        context.addServletContainerInitializer(new JettyJasperInitializer());
         context.setAttribute( InstanceManager.class.getName(), new SimpleInstanceManager() );
 
         // Generic configuration of the context.
@@ -704,7 +701,7 @@ public final class HttpBindManager implements CertificateEventListener {
      *
      * @return A Jetty context handler (never null).
      */
-    protected Handler createWebsocketHandler()
+    protected ServletContextHandler createWebsocketHandler()
     {
         final ServletContextHandler context = new ServletContextHandler( null, "/ws", ServletContextHandler.SESSIONS );
         context.setAllowNullPathInfo(true);
@@ -734,7 +731,7 @@ public final class HttpBindManager implements CertificateEventListener {
      *
      * @return A Jetty context handler, or null when the static content could not be accessed.
      */
-    protected Handler createStaticContentHandler()
+    protected ServletContextHandler createStaticContentHandler()
     {
         final File spankDirectory = new File( JiveGlobals.getHomePath() + File.separator + "resources" + File.separator + "spank" );
         if ( spankDirectory.exists() )

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/TempFileToucherTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/TempFileToucherTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@
 
 package org.jivesoftware.openfire.http;
 
-import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.ee8.nested.ContextHandler;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.webapp.WebAppContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,9 +49,9 @@ public class TempFileToucherTask extends TimerTask
     public void run()
     {
         final FileTime now = FileTime.fromMillis( System.currentTimeMillis() );
-        for ( final Handler handler : this.server.getChildHandlersByClass( WebAppContext.class ) )
+        for (final ContextHandler.CoreContextHandler handler: this.server.getDescendants(ContextHandler.CoreContextHandler.class))
         {
-            final File tempDirectory = ((WebAppContext) handler).getTempDirectory();
+            final File tempDirectory = handler.getTempDirectory();
             try
             {
                 Log.debug( "Updating the last modified timestamp of content in Jetty's temporary storage in: {}", tempDirectory);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/OpenfireWebSocketServlet.java
@@ -15,8 +15,8 @@
  */
 package org.jivesoftware.openfire.websocket;
 
-import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
-import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
+import org.eclipse.jetty.ee8.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.ee8.websocket.server.JettyWebSocketServletFactory;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.http.HttpBindManager;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
@@ -17,9 +17,9 @@ package org.jivesoftware.openfire.websocket;
 
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.dom4j.io.XMPPPacketReader;
-import org.eclipse.jetty.websocket.api.RemoteEndpoint;
-import org.eclipse.jetty.websocket.api.Session;
-import org.eclipse.jetty.websocket.api.annotations.*;
+import org.eclipse.jetty.ee8.websocket.api.RemoteEndpoint;
+import org.eclipse.jetty.ee8.websocket.api.Session;
+import org.eclipse.jetty.ee8.websocket.api.annotations.*;
 import org.jivesoftware.openfire.*;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.handler.IQPingHandler;


### PR DESCRIPTION
Upgrading to Jetty 12.0.14 using the Java EE 8 platform.

Additional notes on previous commits:
- AdminConsolePlugin.java: Resource.newResource method is no longer available. Utilising ResourceFactory to construct new resource as suggested by Joakim.