### PR TITLE
OF-2717: Plugins should use JSP compiler from new Jetty

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -25,7 +25,6 @@ jobs:
           cache: maven
       - name: Build with Maven # We install instead of package, because we want the result in the local mvn repo
         run: |
-          rm -rf ~/.m2/repository/* # For debugging purposes: ensure that nothing gets carried over from a previous build / cache.
           if [[ ${{ github.ref_name }} == 'main' ]]; then            
             ./mvnw -B install -Pcoverage --file pom.xml
           else

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,7 +28,7 @@ jobs:
           if [[ ${{ github.ref_name }} == 'main' ]]; then            
             ./mvnw -B install -Pcoverage --file pom.xml
           else
-            ./mvnw -B install
+            ./mvnw -B -Dmaven.test.skip=true install
           fi
       - name: Upload failed test reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -25,6 +25,7 @@ jobs:
           cache: maven
       - name: Build with Maven # We install instead of package, because we want the result in the local mvn repo
         run: |
+          rm -rf ~/.m2/repository/* # For debugging purposes: ensure that nothing gets carried over from a previous build / cache.
           if [[ ${{ github.ref_name }} == 'main' ]]; then            
             ./mvnw -B install -Pcoverage --file pom.xml
           else

--- a/build/ci/updater/pom.xml
+++ b/build/ci/updater/pom.xml
@@ -92,15 +92,11 @@
     </dependency>
   </dependencies>
 
-<repositories>
-        <repository>
-            <id>atlassian-public</id>
-            <url>https://maven.atlassian.com/repository/public</url>
-        </repository>
-        <repository>
-            <id>ej-technologies</id>
-            <url>https://maven.ej-technologies.com/repository</url>
-        </repository>
-    </repositories>
+  <repositories>
+    <repository>
+      <id>ej-technologies</id>
+      <url>https://maven.ej-technologies.com/repository</url>
+    </repository>
+  </repositories>
 
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -323,8 +323,8 @@
                 </plugin>
                 <!-- Compile the JSP pages -->
                 <plugin>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-jspc-maven-plugin</artifactId>
+                    <groupId>org.eclipse.jetty.ee8</groupId>
+                    <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
                     <version>${jetty.version}</version>
                     <configuration>
                         <webAppSourceDirectory>${project.build.sourceDirectory}/../web</webAppSourceDirectory>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -323,8 +323,8 @@
                 </plugin>
                 <!-- Compile the JSP pages -->
                 <plugin>
-                    <groupId>org.eclipse.jetty.ee8</groupId>
-                    <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-jspc-maven-plugin</artifactId>
                     <version>${jetty.version}</version>
                     <configuration>
                         <webAppSourceDirectory>${project.build.sourceDirectory}/../web</webAppSourceDirectory>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -550,20 +550,4 @@
 
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>atlassian-public</id>
-            <url>https://maven.atlassian.com/repository/public</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-                <checksumPolicy>warn</checksumPolicy>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-                <checksumPolicy>warn</checksumPolicy>
-            </releases>
-        </repository>
-    </repositories>
-
 </project>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -302,6 +302,17 @@
             <version>${standard-taglib.version}</version>
         </dependency>
 
+        <dependency> <!-- The Xalan dependencies prevent stacktraces being logged during JSPC -->
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>2.7.3</version>
+        </dependency>
+        <dependency> <!-- The Xalan dependencies prevent stacktraces being logged during JSPC -->
+            <groupId>xalan</groupId>
+            <artifactId>serializer</artifactId>
+            <version>2.7.3</version>
+        </dependency>
+
         <!-- Netty -->
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
In this version of Openfire, Jetty is updated from 10 to 12 (using EE8). When a plugin compiles its JSPs against this version of Openfire, it should use the JSP-compiler of that Jetty version (the Maven artifacts of the compiler have changed).

The change applied in this commit is the same change that was applied to Openfire's compilation of its (non-plugin) pages, as well as the documentation change in https://github.com/igniterealtime/Openfire/pull/2600