### PR TITLE
OF-2910: No longer use Atlassian's Maven repository

### DIFF
--- a/build/ci/updater/pom.xml
+++ b/build/ci/updater/pom.xml
@@ -92,15 +92,11 @@
     </dependency>
   </dependencies>
 
-<repositories>
-        <repository>
-            <id>atlassian-public</id>
-            <url>https://maven.atlassian.com/repository/public</url>
-        </repository>
-        <repository>
-            <id>ej-technologies</id>
-            <url>https://maven.ej-technologies.com/repository</url>
-        </repository>
-    </repositories>
+  <repositories>
+    <repository>
+      <id>ej-technologies</id>
+      <url>https://maven.ej-technologies.com/repository</url>
+    </repository>
+  </repositories>
 
 </project>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -539,20 +539,4 @@
 
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>atlassian-public</id>
-            <url>https://maven.atlassian.com/repository/public</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-                <checksumPolicy>warn</checksumPolicy>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-                <checksumPolicy>warn</checksumPolicy>
-            </releases>
-        </repository>
-    </repositories>
-
 </project>


### PR DESCRIPTION
Atlassian's Maven repository serves us a dependency (`com.github.jgonian:commons-ip-math:1.32`) that appears to be different from the dependency served under the same Maven coordinates by Maven-Central. Atlassian's one makes Openfire fail at runtime.

Atlassian has announced that they'll stop serving third-party artifacts in early 2025.

This commit removes Atlassian's Maven repository from Openfire's Maven configuration. There was one artifact used by Openfire in Atlassian's repository that couldn't be obtained elsewhere (`com.cenqua.shaj:shaj:0.5`). This has now been added to Ignite's own Maven repository.