### PR TITLE
OF-2717: Plugins should use JSP compiler from new Jetty

### DIFF
--- a/build/ci/updater/pom.xml
+++ b/build/ci/updater/pom.xml
@@ -92,15 +92,11 @@
     </dependency>
   </dependencies>
 
-<repositories>
-        <repository>
-            <id>atlassian-public</id>
-            <url>https://maven.atlassian.com/repository/public</url>
-        </repository>
-        <repository>
-            <id>ej-technologies</id>
-            <url>https://maven.ej-technologies.com/repository</url>
-        </repository>
-    </repositories>
+  <repositories>
+    <repository>
+      <id>ej-technologies</id>
+      <url>https://maven.ej-technologies.com/repository</url>
+    </repository>
+  </repositories>
 
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -323,8 +323,8 @@
                 </plugin>
                 <!-- Compile the JSP pages -->
                 <plugin>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-jspc-maven-plugin</artifactId>
+                    <groupId>org.eclipse.jetty.ee8</groupId>
+                    <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
                     <version>${jetty.version}</version>
                     <configuration>
                         <webAppSourceDirectory>${project.build.sourceDirectory}/../web</webAppSourceDirectory>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -539,20 +539,4 @@
 
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>atlassian-public</id>
-            <url>https://maven.atlassian.com/repository/public</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-                <checksumPolicy>warn</checksumPolicy>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-                <checksumPolicy>warn</checksumPolicy>
-            </releases>
-        </repository>
-    </repositories>
-
 </project>


### PR DESCRIPTION
In this version of Openfire, Jetty is updated from 10 to 12 (using EE8). When a plugin compiles its JSPs against this version of Openfire, it should use the JSP-compiler of that Jetty version (the Maven artifacts of the compiler have changed).