### PR TITLE
Using the more generic org.eclipse.jetty.server.Handler in place of t…

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -22,7 +22,6 @@ import org.eclipse.jetty.ee8.apache.jsp.JettyJasperInitializer;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.server.*;
-import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.Handler.Sequence;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
@@ -312,7 +311,7 @@ public final class HttpBindManager implements CertificateEventListener {
      *
      * This collection is mutable. Handlers can be added and removed at runtime.
      */
-    private final ContextHandlerCollection extensionHandlers = new ContextHandlerCollection(true);
+    private final Sequence extensionHandlers = new Sequence();
 
     /**
      * A task that, periodically, updates the 'last modified' date of all files in the Jetty 'tmp' directories. This


### PR DESCRIPTION
Using the more generic org.eclipse.jetty.server.Handler in place of the more specific org.eclipse.jetty.server.handler.ContextHandler implementation. According to the [Migration Guide](https://jetty.org/docs/jetty/12/programming-guide/migration/11-to-12.html#api-changes-handler-sequence), Handler.Sequence replaced HandlerCollection and HandlerList. ContextHandlerCollection is retained for its efficient child ContextHandler selection. Unless performance considerations or the need for a more restrictive implementation justify it, a more generic implementation reduces code complexity and provides greater functional possibilities for plugins.