### PR TITLE
OF-2729 / OF-2785: Reduce log level of to-be-expected exception

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
@@ -223,6 +223,8 @@ public class SocketUtil
                         entryFuture.get(maxWait.toMillis(), TimeUnit.MILLISECONDS);
                     }
                     Log.trace("Done iterating over a priority set for '{}'", xmppDomain);
+                } catch (CancellationException e) {
+                    Log.debug("DNS resolution for '{}' got cancelled. Stopping...", xmppDomain);
                 } catch (InterruptedException e) {
                     Log.debug("DNS resolution for '{}' got interrupted. Stopping...", xmppDomain);
                 } catch (Throwable e) {


### PR DESCRIPTION
When cancelling a DNS resolution (because a valid resolution was completed elsewhere), log this as something else than a problem.