### PR TITLE
OF-2729: Ipv6-related admin console tweaks

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1778,6 +1778,7 @@ server.session.summary.not_session=No Sessions
 server.session.summary.last_update=List last updated
 server.session.label.host=Host
 server.session.label.connection=Connection
+server.session.label.protocol=Protocol
 server.session.label.creation=Creation Date
 server.session.label.last_active=Last Activity
 server.session.label.close_connect=Close Connection

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1609,6 +1609,7 @@ server.session.summary.not_session=Geen sessies
 server.session.summary.last_update=Lijst laatst ge�pdate
 server.session.label.host=Computernaam
 server.session.label.connection=Verbinding
+server.session.label.protocol=Protocol
 server.session.label.creation=Aangemaakt
 server.session.label.last_active=Laatste activiteit
 server.session.label.close_connect=Verbinding sluiten

--- a/xmppserver/src/main/webapp/server-session-details.jsp
+++ b/xmppserver/src/main/webapp/server-session-details.jsp
@@ -261,22 +261,22 @@
                 <c:if test="${not empty inSessions}">
                     <table style="width: 100%">
                         <tr>
-                            <th style="width: 20%;" colspan="2"><fmt:message key="server.session.details.incoming_session" /> <fmt:message key="server.session.details.streamid" /></th>
+                            <th colspan="2"><fmt:message key="server.session.details.incoming_session" /> <fmt:message key="server.session.details.streamid" /></th>
                             <c:if test="${clusteringEnabled}">
-                                <th style="width: 1%; "><fmt:message key="server.session.details.node"/></th>
+                                <th><fmt:message key="server.session.details.node"/></th>
                             </c:if>
-                            <th style="width: 10%;"><fmt:message key="server.session.details.authentication"/></th>
-                            <th style="width: 10%;"><fmt:message key="server.session.details.tls_version"/></th>
-                            <th style="width: 10%;"><fmt:message key="server.session.details.cipher"/></th>
-                            <th style="width: 10%;"><fmt:message key="server.session.label.creation" /></th>
-                            <th style="width: 10%;"><fmt:message key="server.session.label.last_active" /></th>
-                            <th style="width: 1%;"><fmt:message key="server.session.details.incoming_statistics" /></th>
-                            <th style="width: 1%;"><fmt:message key="server.session.details.outgoing_statistics" /></th>
+                            <th><fmt:message key="server.session.details.authentication"/></th>
+                            <th><fmt:message key="server.session.details.tls_version"/></th>
+                            <th><fmt:message key="server.session.details.cipher"/></th>
+                            <th><fmt:message key="server.session.label.creation" /></th>
+                            <th><fmt:message key="server.session.label.last_active" /></th>
+                            <th><fmt:message key="server.session.details.incoming_statistics" /></th>
+                            <th><fmt:message key="server.session.details.outgoing_statistics" /></th>
                         </tr>
 
                         <c:forEach items="${inSessions}" var="session">
                             <tr>
-                                <td style="width: 1%">
+                                <td>
                                     <c:choose>
                                         <c:when test="${session.encrypted}">
                                             <img src="images/lock.gif" alt="An encrypted connection">
@@ -299,7 +299,7 @@
                                         </c:choose>
                                     </td>
                                 </c:if>
-                                <td >
+                                <td>
                                     <c:choose>
                                         <c:when test="${session.isUsingServerDialback()}">
                                             <fmt:message key="server.session.details.dialback"/>
@@ -326,17 +326,17 @@
                 <c:if test="${not empty outSessions}">
                     <table style="width: 100%">
                         <tr>
-                            <th style="width: 20%;" colspan="2"><fmt:message key="server.session.details.outgoing_session" /> <fmt:message key="server.session.details.streamid" /></th>
+                            <th colspan="2"><fmt:message key="server.session.details.outgoing_session" /> <fmt:message key="server.session.details.streamid" /></th>
                             <c:if test="${clusteringEnabled}">
-                                <th style="width: 1%; "><fmt:message key="server.session.details.node"/></th>
+                                <th><fmt:message key="server.session.details.node"/></th>
                             </c:if>
-                            <th style="width: 10%; "><fmt:message key="server.session.details.authentication"/></th>
-                            <th style="width: 10%; "><fmt:message key="server.session.details.tls_version"/></th>
-                            <th style="width: 10%; "><fmt:message key="server.session.details.cipher"/></th>
-                            <th style="width: 10%; "><fmt:message key="server.session.label.creation" /></th>
-                            <th style="width: 10%; "><fmt:message key="server.session.label.last_active" /></th>
-                            <th style="width: 1%; "><fmt:message key="server.session.details.incoming_statistics" /></th>
-                            <th style="width: 1%; "><fmt:message key="server.session.details.outgoing_statistics" /></th>
+                            <th><fmt:message key="server.session.details.authentication"/></th>
+                            <th><fmt:message key="server.session.details.tls_version"/></th>
+                            <th><fmt:message key="server.session.details.cipher"/></th>
+                            <th><fmt:message key="server.session.label.creation" /></th>
+                            <th><fmt:message key="server.session.label.last_active" /></th>
+                            <th><fmt:message key="server.session.details.incoming_statistics" /></th>
+                            <th><fmt:message key="server.session.details.outgoing_statistics" /></th>
                         </tr>
 
                         <c:forEach items="${outSessions}" var="session">

--- a/xmppserver/src/main/webapp/server-session-row.jspf
+++ b/xmppserver/src/main/webapp/server-session-row.jspf
@@ -4,9 +4,9 @@
 <%@ page import="org.jivesoftware.openfire.session.IncomingServerSession,
                  org.jivesoftware.util.JiveGlobals,
                  org.jivesoftware.util.StringUtils,
-                 java.net.URLEncoder,
                  java.util.Calendar,
                  java.util.Date"%>
+ <%@ page import="java.net.*" %>
 
  <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -65,19 +65,44 @@
         <td style="width: 1%">
             <img src="images/incoming_32x16.gif" width="32" height="16" title="<fmt:message key='server.session.connection.incoming' />" alt="<fmt:message key='server.session.connection.incoming' />">
         </td>
-        <td style="width: 10%"><fmt:message key="server.session.connection.incoming" /></td>
+        <td><fmt:message key="server.session.connection.incoming" /></td>
     <% } else if (inSessions.isEmpty() && !outSessions.isEmpty()) { %>
         <td style="width: 1%">
             <img src="images/outgoing_32x16.gif" width="32" height="16" title="<fmt:message key='server.session.connection.outgoing' />" alt="<fmt:message key='server.session.connection.outgoing' />">
         </td>
-        <td style="width: 10%"><fmt:message key="server.session.connection.outgoing" /></td>
+        <td><fmt:message key="server.session.connection.outgoing" /></td>
     <% } else { %>
         <td style="width: 1%">
             <img src="images/both_32x16.gif" width="32" height="16" title="<fmt:message key='server.session.connection.both' />" alt="<fmt:message key='server.session.connection.both' />">
         </td>
-        <td style="width: 10%"><fmt:message key="server.session.connection.both" /></td>
+        <td><fmt:message key="server.session.connection.both" /></td>
     <% } %>
 
+    <%
+        final boolean hasIPv4 = inSessions.stream().anyMatch(s-> {
+            try {
+                return InetAddress.getByName(s.getHostAddress()) instanceof Inet4Address;
+            } catch (UnknownHostException e) {
+                return false;
+            }
+        });
+        final boolean hasIPv6 = inSessions.stream().anyMatch(s-> {
+            try {
+                return InetAddress.getByName(s.getHostAddress()) instanceof Inet6Address;
+            } catch (UnknownHostException e) {
+                return false;
+            }
+        });
+    %>
+    <% if (hasIPv4 && hasIPv6) { %>
+    <td><fmt:message key="server.session.connection.both" /></td>
+    <% } else if (hasIPv4) { %>
+    <td><fmt:message key="global.ipv4" /></td>
+    <% } else if (hasIPv6) { %>
+    <td><fmt:message key="global.ipv6" /></td>
+    <% } else { %>
+    <td></td>
+    <% } %>
     <%
         Date creationDate = null;
         Date lastActiveDate = null;
@@ -128,10 +153,10 @@
 
     %>
 
-    <td style="text-align: center; width: 20%" nowrap>
+    <td style="text-align: center;" nowrap>
         <%= creationDateString %>
     </td>
-    <td style="text-align: center; width: 20%" nowrap>
+    <td style="text-align: center;" nowrap>
         <%= lastActivityString %>
     </td>
 

--- a/xmppserver/src/main/webapp/server-session-summary.jsp
+++ b/xmppserver/src/main/webapp/server-session-summary.jsp
@@ -170,6 +170,7 @@
         <th>&nbsp;</th>
         <th nowrap><fmt:message key="server.session.label.host" /></th>
         <th nowrap colspan="3"><fmt:message key="server.session.label.connection" /></th>
+        <th nowrap><fmt:message key="server.session.label.protocol" /></th>
         <th nowrap style="text-align: center;"><fmt:message key="server.session.label.creation" /></th>
         <th nowrap style="text-align: center;"><fmt:message key="server.session.label.last_active" /></th>
         <th nowrap style="text-align: center;"><fmt:message key="server.session.label.close_connect" /></th>
@@ -180,7 +181,7 @@
         if (domainNames.isEmpty()) {
     %>
         <tr>
-            <td colspan="9">
+            <td colspan="10">
 
                 <fmt:message key="server.session.summary.not_session" />
 


### PR DESCRIPTION
Adding a 'family type' in the S2S session overview, that signals if a connection to a remote domain is using IPv4 or IPv6 (or both).

Layout of the table is done better by the browser than our guestimates based on width.