### PR TITLE
OF-2912 Fix dnsIssue flag on admin console

### DIFF
--- a/xmppserver/src/main/webapp/index.jsp
+++ b/xmppserver/src/main/webapp/index.jsp
@@ -327,6 +327,8 @@
                                             break;
                                         }
                                     }
+                                } else {
+                                    dnsIssue = false;
                                 }
                             }
                             return dnsIssue;


### PR DESCRIPTION
From my reading if
```java
dnsIssue = dnsSrvRecords.stream().anyMatch(r -> hostname.equalsIgnoreCase(r.getHostname()));
```
evaluates as true, the next section is skipped, but the flag should be inverted prior to returning