### PR TITLE
OF-2914: Reduce verbosity of logged messages when S2S fails.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -100,6 +100,10 @@ public class NettyConnection extends AbstractConnection
         return !isClosed();
     }
 
+    public SocketAddress getPeer() {
+        return channelHandlerContext.channel().remoteAddress();
+    }
+
     @Override
     public byte[] getAddress() throws UnknownHostException {
         final SocketAddress remoteAddress = channelHandlerContext.channel().remoteAddress();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -243,7 +243,7 @@ public class OutgoingSessionPromise {
             try {
                 channel = establishConnection();
             } catch (Exception e) {
-                Log.warn("An exception occurred while trying to establish a connection for {}", domainPair, e);
+                Log.debug("An exception occurred while trying to establish a connection for {}", domainPair, e);
                 channel = null;
             }
 


### PR DESCRIPTION
Moves most verbose (and likely confusing to most users) messages related to S2S / TLS failures from WARN to DEBUG level of logging (effectively hiding them). The messages are replaced by a more human-descriptive message informing the user what's going on.