### PR TITLE
OF-2919: Prevent exception after S2S TLS fails

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyOutboundConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyOutboundConnectionHandler.java
@@ -17,7 +17,6 @@
 package org.jivesoftware.openfire.nio;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import org.dom4j.*;
 import org.jivesoftware.openfire.Connection;
@@ -150,7 +149,6 @@ public class NettyOutboundConnectionHandler extends NettyConnectionHandler {
             } else {
                 // SSL Handshake has failed
                 Log.debug("TLS negotiation with '{}' was unsuccessful", domainPair.getRemote(), event.cause());
-                ctx.pipeline().remove(SslHandler.class);
 
                 if (isCertificateException(event) && configRequiresStrictCertificateValidation()) {
                     Log.warn("TLS negotiation with '{}' was unsuccessful, caused by a certificate issue. Aborting session, as by configuration Openfire is prohibited to set up a connection with a peer that provides an invalid certificate.", domainPair.getRemote(), event.cause());


### PR DESCRIPTION
When TLS fails in a server-to-server connection, this frequently is followed up with another exception, mentioning that a `^W` character couldn't be parsed as valid XMPP.

This End-of-Transmission character is likely sent by the peer, as the end of the (failed) TLS handshake. Openfire should let the TLS handler process that character. This prevents the XMPP handler from having to process it.