### PR TITLE
OF-2397: Do not process subscription requests for shared contacts

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceSubscribeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -299,6 +299,9 @@ public class PresenceSubscribeHandler extends BasicModule implements ChannelHand
         try {
             if (roster.isRosterItem(target)) {
                 item = roster.getRosterItem(target);
+                if (item.isShared()) {
+                    throw new SharedGroupException("Target '" + target + "' is on the roster of '" + roster.getUsername() + "' as part of a shared group. As such, its presence subscription status cannot be modified with subscription requests.");
+                }
             }
             else {
                 if (Presence.Type.unsubscribed == type || Presence.Type.unsubscribe == type ||


### PR DESCRIPTION
When a contact is a contact by virtue of being in a shared group, the presence subscription between the roster owner and this contact is deemed to be static.

Presence subscriptions sent by the client of either party should not affect this status.

I've not tested this change at all. I'm not at all sure if it is complete (does it cover all applicable cases? does it also process messages sent by both the 'roster owner' as well as the contact itself)? I also worry about potential side-effects.

I'm creating this PR mostly as a means of getting started. Hopefully someone can pitch in and help test, and possibly improve this change.