### PR TITLE
OF-2760: Adds option to retire a MUC room name on deletion

### DIFF
--- a/distribution/src/database/openfire_db2.sql
+++ b/distribution/src/database/openfire_db2.sql
@@ -211,7 +211,7 @@ CREATE TABLE ofMucRoom (
   canDiscoverJID      INTEGER       NOT NULL,
   logEnabled          INTEGER       NOT NULL,
   preserveHistOnDel   INTEGER       NOT NULL,
-  tombstone           INTEGER       NOT NULL,
+  retireOnDeletion    INTEGER       NOT NULL,
   subject             VARCHAR(100),
   rolesToBroadcast    INTEGER       NOT NULL,
   useReservedNick     INTEGER       NOT NULL,
@@ -235,10 +235,10 @@ CREATE TABLE ofMucRoomProp (
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
 );
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 
 CREATE TABLE ofMucAffiliation (

--- a/distribution/src/database/openfire_db2.sql
+++ b/distribution/src/database/openfire_db2.sql
@@ -238,6 +238,7 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/openfire_db2.sql
+++ b/distribution/src/database/openfire_db2.sql
@@ -238,6 +238,8 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  alternateJID        VARCHAR(2000),
+  reason              VARCHAR(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );

--- a/distribution/src/database/openfire_db2.sql
+++ b/distribution/src/database/openfire_db2.sql
@@ -211,6 +211,7 @@ CREATE TABLE ofMucRoom (
   canDiscoverJID      INTEGER       NOT NULL,
   logEnabled          INTEGER       NOT NULL,
   preserveHistOnDel   INTEGER       NOT NULL,
+  tombstone           INTEGER       NOT NULL,
   subject             VARCHAR(100),
   rolesToBroadcast    INTEGER       NOT NULL,
   useReservedNick     INTEGER       NOT NULL,
@@ -234,6 +235,11 @@ CREATE TABLE ofMucRoomProp (
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
 );
 
+CREATE TABLE ofMucRoomTombstone (
+  serviceID           INTEGER       NOT NULL,
+  name                VARCHAR(50)   NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+);
 
 CREATE TABLE ofMucAffiliation (
   roomID              INTEGER       NOT NULL,
@@ -393,7 +399,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 35);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_hsqldb.sql
+++ b/distribution/src/database/openfire_hsqldb.sql
@@ -233,6 +233,7 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree (
   serviceID           BIGINT        NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/openfire_hsqldb.sql
+++ b/distribution/src/database/openfire_hsqldb.sql
@@ -206,7 +206,7 @@ CREATE TABLE ofMucRoom (
   roomPassword        VARCHAR(50)   NULL,
   canDiscoverJID      INTEGER       NOT NULL,
   logEnabled          INTEGER       NOT NULL,
-  tombstone           INTEGER       NOT NULL,
+  retireOnDeletion    INTEGER       NOT NULL,
   preserveHistOnDel   INTEGER       NOT NULL,
   subject             VARCHAR(100)  NULL,
   rolesToBroadcast    INTEGER       NOT NULL,
@@ -230,10 +230,10 @@ CREATE TABLE ofMucRoomProp (
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
 );
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
   serviceID           BIGINT        NOT NULL,
   name                VARCHAR(50)   NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 
 CREATE TABLE ofMucAffiliation (

--- a/distribution/src/database/openfire_hsqldb.sql
+++ b/distribution/src/database/openfire_hsqldb.sql
@@ -233,6 +233,8 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree (
   serviceID           BIGINT        NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  alternateJID        VARCHAR(2000),
+  reason              VARCHAR(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );

--- a/distribution/src/database/openfire_hsqldb.sql
+++ b/distribution/src/database/openfire_hsqldb.sql
@@ -206,6 +206,7 @@ CREATE TABLE ofMucRoom (
   roomPassword        VARCHAR(50)   NULL,
   canDiscoverJID      INTEGER       NOT NULL,
   logEnabled          INTEGER       NOT NULL,
+  tombstone           INTEGER       NOT NULL,
   preserveHistOnDel   INTEGER       NOT NULL,
   subject             VARCHAR(100)  NULL,
   rolesToBroadcast    INTEGER       NOT NULL,
@@ -227,6 +228,12 @@ CREATE TABLE ofMucRoomProp (
   name                  VARCHAR(100)    NOT NULL,
   propValue             VARCHAR(4000)   NOT NULL,
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
+);
+
+CREATE TABLE ofMucRoomTombstone (
+  serviceID           BIGINT        NOT NULL,
+  name                VARCHAR(50)   NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
 );
 
 CREATE TABLE ofMucAffiliation (
@@ -379,7 +386,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 35);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
 
 // Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -223,6 +223,7 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree (
    serviceID           BIGINT        NOT NULL,
    name                VARCHAR(50)   NOT NULL,
+   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
    PRIMARY KEY (serviceID,name)
 );
 

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -221,10 +221,12 @@ CREATE TABLE ofMucRoomProp (
 );
 
 CREATE TABLE ofMucRoomRetiree (
-   serviceID           BIGINT        NOT NULL,
-   name                VARCHAR(50)   NOT NULL,
-   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-   PRIMARY KEY (serviceID,name)
+  serviceID           BIGINT        NOT NULL,
+  name                VARCHAR(50)   NOT NULL,
+  alternateJID        VARCHAR(2000),
+  reason              VARCHAR(1024),
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (serviceID,name)
 );
 
 CREATE TABLE ofMucAffiliation (

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -196,6 +196,7 @@ CREATE TABLE ofMucRoom (
   roomPassword        VARCHAR(50)   NULL,
   canDiscoverJID      TINYINT       NOT NULL,
   logEnabled          TINYINT       NOT NULL,
+  tombstone           TINYINT       NOT NULL,
   preserveHistOnDel   TINYINT       NOT NULL,
   subject             VARCHAR(100)  NULL,
   rolesToBroadcast    TINYINT       NOT NULL,
@@ -217,6 +218,12 @@ CREATE TABLE ofMucRoomProp (
   name                  VARCHAR(100)    NOT NULL,
   propValue             TEXT            NOT NULL,
   PRIMARY KEY (roomID, name)
+);
+
+CREATE TABLE ofMucRoomTombstone (
+   serviceID           BIGINT        NOT NULL,
+   name                VARCHAR(50)   NOT NULL,
+   PRIMARY KEY (serviceID,name)
 );
 
 CREATE TABLE ofMucAffiliation (
@@ -369,7 +376,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 35);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
 
 # Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -196,7 +196,7 @@ CREATE TABLE ofMucRoom (
   roomPassword        VARCHAR(50)   NULL,
   canDiscoverJID      TINYINT       NOT NULL,
   logEnabled          TINYINT       NOT NULL,
-  tombstone           TINYINT       NOT NULL,
+  retireOnDeletion    TINYINT       NOT NULL,
   preserveHistOnDel   TINYINT       NOT NULL,
   subject             VARCHAR(100)  NULL,
   rolesToBroadcast    TINYINT       NOT NULL,
@@ -220,7 +220,7 @@ CREATE TABLE ofMucRoomProp (
   PRIMARY KEY (roomID, name)
 );
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
    serviceID           BIGINT        NOT NULL,
    name                VARCHAR(50)   NOT NULL,
    PRIMARY KEY (serviceID,name)

--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -230,6 +230,8 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree(
   serviceID           INT           NOT NULL,
   name                VARCHAR2(50)  NOT NULL,
+  alternateJID        VARCHAR2(2000),
+  reason              VARCHAR2(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );

--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -203,6 +203,7 @@ CREATE TABLE ofMucRoom(
   roomPassword        VARCHAR2(50)  NULL,
   canDiscoverJID      INTEGER       NOT NULL,
   logEnabled          INTEGER       NOT NULL,
+  tombstone           INTEGER       NOT NULL,
   preserveHistOnDel   INTEGER       NOT NULL,
   subject             VARCHAR2(100) NULL,
   rolesToBroadcast    INTEGER       NOT NULL,
@@ -224,6 +225,12 @@ CREATE TABLE ofMucRoomProp (
   name                  VARCHAR2(100)   NOT NULL,
   propValue             VARCHAR2(1024)  NOT NULL,
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
+);
+
+CREATE TABLE ofMucRoomTombstone(
+  serviceID           INT           NOT NULL,
+  name                VARCHAR2(50)  NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
 );
 
 CREATE TABLE ofMucAffiliation (
@@ -377,7 +384,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 35);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -230,6 +230,7 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree(
   serviceID           INT           NOT NULL,
   name                VARCHAR2(50)  NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -203,7 +203,7 @@ CREATE TABLE ofMucRoom(
   roomPassword        VARCHAR2(50)  NULL,
   canDiscoverJID      INTEGER       NOT NULL,
   logEnabled          INTEGER       NOT NULL,
-  tombstone           INTEGER       NOT NULL,
+  retireOnDeletion    INTEGER       NOT NULL,
   preserveHistOnDel   INTEGER       NOT NULL,
   subject             VARCHAR2(100) NULL,
   rolesToBroadcast    INTEGER       NOT NULL,
@@ -227,10 +227,10 @@ CREATE TABLE ofMucRoomProp (
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
 );
 
-CREATE TABLE ofMucRoomTombstone(
+CREATE TABLE ofMucRoomRetiree(
   serviceID           INT           NOT NULL,
   name                VARCHAR2(50)  NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 
 CREATE TABLE ofMucAffiliation (

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -211,7 +211,7 @@ CREATE TABLE ofMucRoom (
   roomPassword        VARCHAR(50)   NULL,
   canDiscoverJID      INTEGER       NOT NULL,
   logEnabled          INTEGER       NOT NULL,
-  tombstone           INTEGER       NOT NULL,
+  retireOnDeletion    INTEGER       NOT NULL,
   preserveHistOnDel   INTEGER       NOT NULL,
   subject             VARCHAR(100)  NULL,
   rolesToBroadcast    INTEGER       NOT NULL,
@@ -235,10 +235,10 @@ CREATE TABLE ofMucRoomProp (
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
 );
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 
 CREATE TABLE ofMucAffiliation (

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -238,6 +238,7 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -238,6 +238,8 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  alternateJID        VARCHAR(2000),
+  reason              VARCHAR(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -211,6 +211,7 @@ CREATE TABLE ofMucRoom (
   roomPassword        VARCHAR(50)   NULL,
   canDiscoverJID      INTEGER       NOT NULL,
   logEnabled          INTEGER       NOT NULL,
+  tombstone           INTEGER       NOT NULL,
   preserveHistOnDel   INTEGER       NOT NULL,
   subject             VARCHAR(100)  NULL,
   rolesToBroadcast    INTEGER       NOT NULL,
@@ -232,6 +233,12 @@ CREATE TABLE ofMucRoomProp (
   name                  VARCHAR(100)    NOT NULL,
   propValue             TEXT            NOT NULL,
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
+);
+
+CREATE TABLE ofMucRoomTombstone (
+  serviceID           INTEGER       NOT NULL,
+  name                VARCHAR(50)   NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
 );
 
 CREATE TABLE ofMucAffiliation (
@@ -385,7 +392,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 35);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -209,7 +209,7 @@ CREATE TABLE ofMucRoom (
   roomPassword        NVARCHAR(50)  NULL,
   canDiscoverJID      INT           NOT NULL,
   logEnabled          INT           NOT NULL,
-  tombstone           INT           NOT NULL,
+  retireOnDeletion    INT           NOT NULL,
   preserveHistOnDel   INT           NOT NULL,
   subject             NVARCHAR(100) NULL,
   rolesToBroadcast    INT           NOT NULL,
@@ -233,10 +233,10 @@ CREATE TABLE ofMucRoomProp (
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
 );
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 
 CREATE TABLE ofMucAffiliation (

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -236,6 +236,8 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
+  alternateJID        NVARCHAR(2000),
+  reason              NVARCHAR(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -236,6 +236,7 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -209,6 +209,7 @@ CREATE TABLE ofMucRoom (
   roomPassword        NVARCHAR(50)  NULL,
   canDiscoverJID      INT           NOT NULL,
   logEnabled          INT           NOT NULL,
+  tombstone           INT           NOT NULL,
   preserveHistOnDel   INT           NOT NULL,
   subject             NVARCHAR(100) NULL,
   rolesToBroadcast    INT           NOT NULL,
@@ -230,6 +231,12 @@ CREATE TABLE ofMucRoomProp (
   name                  NVARCHAR(100)   NOT NULL,
   propValue             NVARCHAR(2000)  NOT NULL,
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
+);
+
+CREATE TABLE ofMucRoomTombstone (
+  serviceID           INT           NOT NULL,
+  name                NVARCHAR(50)  NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
 );
 
 CREATE TABLE ofMucAffiliation (
@@ -382,7 +389,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 35);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -208,7 +208,7 @@ CREATE TABLE ofMucRoom (
   roomPassword        NVARCHAR(50)  NULL,
   canDiscoverJID      INT           NOT NULL,
   logEnabled          INT           NOT NULL,
-  tombstone           INT           NOT NULL,
+  retireOnDeletion    INT           NOT NULL,
   preserveHistOnDel   INT           NOT NULL,
   subject             NVARCHAR(100) NULL,
   rolesToBroadcast    INT           NOT NULL,
@@ -232,10 +232,10 @@ CREATE TABLE ofMucRoomProp (
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
 )
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 )
 
 CREATE TABLE ofMucAffiliation (

--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -208,6 +208,7 @@ CREATE TABLE ofMucRoom (
   roomPassword        NVARCHAR(50)  NULL,
   canDiscoverJID      INT           NOT NULL,
   logEnabled          INT           NOT NULL,
+  tombstone           INT           NOT NULL,
   preserveHistOnDel   INT           NOT NULL,
   subject             NVARCHAR(100) NULL,
   rolesToBroadcast    INT           NOT NULL,
@@ -229,6 +230,12 @@ CREATE TABLE ofMucRoomProp (
   name                  NVARCHAR(100)   NOT NULL,
   propValue             TEXT            NOT NULL,
   CONSTRAINT ofMucRoomProp_pk PRIMARY KEY (roomID, name)
+)
+
+CREATE TABLE ofMucRoomTombstone (
+  serviceID           INT           NOT NULL,
+  name                NVARCHAR(50)  NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
 )
 
 CREATE TABLE ofMucAffiliation (
@@ -382,7 +389,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1)
 INSERT INTO ofID (idType, id) VALUES (26, 2)
 INSERT INTO ofID (idType, id) VALUES (27, 1)
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 35)
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 36)
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -235,6 +235,8 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
+  alternateJID        NVARCHAR(2000),
+  reason              NVARCHAR(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 )

--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -235,6 +235,7 @@ CREATE TABLE ofMucRoomProp (
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 )
 

--- a/distribution/src/database/upgrade/36/openfire_db2.sql
+++ b/distribution/src/database/upgrade/36/openfire_db2.sql
@@ -3,6 +3,7 @@ ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_db2.sql
+++ b/distribution/src/database/upgrade/36/openfire_db2.sql
@@ -1,9 +1,9 @@
-ALTER TABLE ofMucRoom ADD COLUMN tombstone INTEGER DEFAULT 0 NOT NULL;
+ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 
 UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_db2.sql
+++ b/distribution/src/database/upgrade/36/openfire_db2.sql
@@ -1,0 +1,9 @@
+ALTER TABLE ofMucRoom ADD COLUMN tombstone INTEGER DEFAULT 0 NOT NULL;
+
+CREATE TABLE ofMucRoomTombstone (
+  serviceID           INTEGER       NOT NULL,
+  name                VARCHAR(50)   NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+);
+
+UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_db2.sql
+++ b/distribution/src/database/upgrade/36/openfire_db2.sql
@@ -3,6 +3,8 @@ ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  alternateJID        VARCHAR(2000),
+  reason              VARCHAR(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );

--- a/distribution/src/database/upgrade/36/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/36/openfire_hsqldb.sql
@@ -3,6 +3,8 @@ ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           BIGINT        NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  alternateJID        VARCHAR(2000),
+  reason              VARCHAR(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );

--- a/distribution/src/database/upgrade/36/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/36/openfire_hsqldb.sql
@@ -3,6 +3,7 @@ ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           BIGINT        NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/36/openfire_hsqldb.sql
@@ -1,0 +1,9 @@
+ALTER TABLE ofMucRoom ADD COLUMN tombstone INTEGER DEFAULT 0 NOT NULL;
+
+CREATE TABLE ofMucRoomTombstone (
+  serviceID           BIGINT        NOT NULL,
+  name                VARCHAR(50)   NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+);
+
+UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/36/openfire_hsqldb.sql
@@ -1,9 +1,9 @@
-ALTER TABLE ofMucRoom ADD COLUMN tombstone INTEGER DEFAULT 0 NOT NULL;
+ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
   serviceID           BIGINT        NOT NULL,
   name                VARCHAR(50)   NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 
 UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/36/openfire_mysql.sql
@@ -1,0 +1,9 @@
+ALTER TABLE ofMucRoom ADD COLUMN tombstone TINYINT NOT NULL DEFAULT 0;
+
+CREATE TABLE ofMucRoomTombstone (
+  serviceID           BIGINT        NOT NULL,
+  name                VARCHAR(50)   NOT NULL,
+  PRIMARY KEY (serviceID,name)
+);
+
+UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/36/openfire_mysql.sql
@@ -3,6 +3,7 @@ ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion TINYINT NOT NULL DEFAULT 0;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           BIGINT        NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (serviceID,name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/36/openfire_mysql.sql
@@ -1,6 +1,6 @@
-ALTER TABLE ofMucRoom ADD COLUMN tombstone TINYINT NOT NULL DEFAULT 0;
+ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion TINYINT NOT NULL DEFAULT 0;
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
   serviceID           BIGINT        NOT NULL,
   name                VARCHAR(50)   NOT NULL,
   PRIMARY KEY (serviceID,name)

--- a/distribution/src/database/upgrade/36/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/36/openfire_mysql.sql
@@ -3,6 +3,8 @@ ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion TINYINT NOT NULL DEFAULT 0;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           BIGINT        NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  alternateJID        VARCHAR(2000),
+  reason              VARCHAR(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (serviceID,name)
 );

--- a/distribution/src/database/upgrade/36/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/36/openfire_oracle.sql
@@ -1,9 +1,9 @@
-ALTER TABLE ofMucRoom ADD tombstone INTEGER DEFAULT 0 NOT NULL;
+ALTER TABLE ofMucRoom ADD retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 
-CREATE TABLE ofMucRoomTombstone(
+CREATE TABLE ofMucRoomRetiree(
   serviceID           INT           NOT NULL,
   name                VARCHAR2(50)  NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 
 UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/36/openfire_oracle.sql
@@ -3,6 +3,8 @@ ALTER TABLE ofMucRoom ADD retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree(
   serviceID           INT           NOT NULL,
   name                VARCHAR2(50)  NOT NULL,
+  alternateJID        VARCHAR2(2000),
+  reason              VARCHAR2(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );

--- a/distribution/src/database/upgrade/36/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/36/openfire_oracle.sql
@@ -3,6 +3,7 @@ ALTER TABLE ofMucRoom ADD retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree(
   serviceID           INT           NOT NULL,
   name                VARCHAR2(50)  NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/36/openfire_oracle.sql
@@ -1,0 +1,9 @@
+ALTER TABLE ofMucRoom ADD tombstone INTEGER DEFAULT 0 NOT NULL;
+
+CREATE TABLE ofMucRoomTombstone(
+  serviceID           INT           NOT NULL,
+  name                VARCHAR2(50)  NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+);
+
+UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/36/openfire_postgresql.sql
@@ -3,6 +3,7 @@ ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/36/openfire_postgresql.sql
@@ -1,9 +1,9 @@
-ALTER TABLE ofMucRoom ADD COLUMN tombstone INTEGER DEFAULT 0 NOT NULL;
+ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 
 UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/36/openfire_postgresql.sql
@@ -1,0 +1,9 @@
+ALTER TABLE ofMucRoom ADD COLUMN tombstone INTEGER DEFAULT 0 NOT NULL;
+
+CREATE TABLE ofMucRoomTombstone (
+  serviceID           INTEGER       NOT NULL,
+  name                VARCHAR(50)   NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+);
+
+UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/36/openfire_postgresql.sql
@@ -3,6 +3,8 @@ ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion INTEGER DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INTEGER       NOT NULL,
   name                VARCHAR(50)   NOT NULL,
+  alternateJID        VARCHAR(2000),
+  reason              VARCHAR(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );

--- a/distribution/src/database/upgrade/36/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/36/openfire_sqlserver.sql
@@ -3,6 +3,8 @@ ALTER TABLE ofMucRoom ADD retireOnDeletion INT DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
+  alternateJID        NVARCHAR(2000),
+  reason              NVARCHAR(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );

--- a/distribution/src/database/upgrade/36/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/36/openfire_sqlserver.sql
@@ -1,0 +1,9 @@
+ALTER TABLE ofMucRoom ADD tombstone INT DEFAULT 0 NOT NULL;
+
+CREATE TABLE ofMucRoomTombstone (
+  serviceID           INT           NOT NULL,
+  name                NVARCHAR(50)  NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+);
+
+UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/36/openfire_sqlserver.sql
@@ -1,9 +1,9 @@
-ALTER TABLE ofMucRoom ADD tombstone INT DEFAULT 0 NOT NULL;
+ALTER TABLE ofMucRoom ADD retireOnDeletion INT DEFAULT 0 NOT NULL;
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 
 UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/36/openfire_sqlserver.sql
@@ -3,6 +3,7 @@ ALTER TABLE ofMucRoom ADD retireOnDeletion INT DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/36/openfire_sybase.sql
@@ -3,6 +3,7 @@ ALTER TABLE ofMucRoom ADD retireOnDeletion INT DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 )
 

--- a/distribution/src/database/upgrade/36/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/36/openfire_sybase.sql
@@ -1,9 +1,9 @@
-ALTER TABLE ofMucRoom ADD tombstone INT DEFAULT 0 NOT NULL;
+ALTER TABLE ofMucRoom ADD retireOnDeletion INT DEFAULT 0 NOT NULL;
 
-CREATE TABLE ofMucRoomTombstone (
+CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
-  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+  CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 )
 
 UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/36/openfire_sybase.sql
@@ -1,0 +1,9 @@
+ALTER TABLE ofMucRoom ADD tombstone INT DEFAULT 0 NOT NULL;
+
+CREATE TABLE ofMucRoomTombstone (
+  serviceID           INT           NOT NULL,
+  name                NVARCHAR(50)  NOT NULL,
+  CONSTRAINT ofMucRoomTombstone_pk PRIMARY KEY (serviceID, name)
+)
+
+UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/36/openfire_sybase.sql
@@ -3,6 +3,8 @@ ALTER TABLE ofMucRoom ADD retireOnDeletion INT DEFAULT 0 NOT NULL;
 CREATE TABLE ofMucRoomRetiree (
   serviceID           INT           NOT NULL,
   name                NVARCHAR(50)  NOT NULL,
+  alternateJID        NVARCHAR(2000),
+  reason              NVARCHAR(1024),
   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 )

--- a/documentation/database-guide.html
+++ b/documentation/database-guide.html
@@ -91,7 +91,7 @@
                 <li><a href="#ofMucRoom">ofMucRoom</a></li>
 
                 <li><a href="#ofMucRoomProp">ofMucRoomProp</a></li>
-                <li><a href="#ofMucRoomTombstone">ofMucRoomTombstone</a></li>
+                <li><a href="#ofMucRoomRetiree">ofMucRoomRetiree</a></li>
                 <li><a href="#ofMucAffiliation">ofMucAffiliation</a></li>
                 <li><a href="#ofMucMember">ofMucMember</a></li>
                 <li><a href="#ofMucConversationLog">ofMucConversationLog</a></li>
@@ -985,10 +985,10 @@
                 <td>Flag indicating whether room conversations are logged or not</td>
             </tr>
             <tr>
-                <td>tombstone</td>
+                <td>retireOnDeletion</td>
                 <td>NUMBER</td>
                 <td>n/a</td>
-                <td>Flag indicating whether room name should be tomb-stoned on deletion (prevented from future use)</td>
+                <td>Flag indicating whether room name should be retired on deletion (prevented from future use)</td>
             </tr>
             <tr>
                 <td>subject</td>
@@ -1057,10 +1057,10 @@
         </table>
         &nbsp;<a href="#top" class="top">top of page</a>
 
-        <table id="ofMucRoomTombstone" class="dbtable">
+        <table id="ofMucRoomRetiree" class="dbtable">
             <tbody>
             <tr>
-                <th colspan="4">ofMucRoomTombstone (Groupchat room name tombstones)</th>
+                <th colspan="4">ofMucRoomRetiree (Retired Groupchat room names)</th>
             </tr>
             <tr>
                 <th>Column Name</th>
@@ -1078,7 +1078,7 @@
                 <td>name</td>
                 <td>VARCHAR</td>
                 <td>50</td>
-                <td>Name of the tomb-stoned room (Primary Key)</td>
+                <td>Name of the retired room (Primary Key)</td>
             </tr>
             </tbody>
         </table>

--- a/documentation/database-guide.html
+++ b/documentation/database-guide.html
@@ -91,6 +91,7 @@
                 <li><a href="#ofMucRoom">ofMucRoom</a></li>
 
                 <li><a href="#ofMucRoomProp">ofMucRoomProp</a></li>
+                <li><a href="#ofMucRoomTombstone">ofMucRoomTombstone</a></li>
                 <li><a href="#ofMucAffiliation">ofMucAffiliation</a></li>
                 <li><a href="#ofMucMember">ofMucMember</a></li>
                 <li><a href="#ofMucConversationLog">ofMucConversationLog</a></li>
@@ -984,6 +985,12 @@
                 <td>Flag indicating whether room conversations are logged or not</td>
             </tr>
             <tr>
+                <td>tombstone</td>
+                <td>NUMBER</td>
+                <td>n/a</td>
+                <td>Flag indicating whether room name should be tomb-stoned on deletion (prevented from future use)</td>
+            </tr>
+            <tr>
                 <td>subject</td>
                 <td>VARCHAR</td>
                 <td>100</td>
@@ -1045,6 +1052,33 @@
                 <td>VARCHAR</td>
                 <td>4000</td>
                 <td>Property Value</td>
+            </tr>
+            </tbody>
+        </table>
+        &nbsp;<a href="#top" class="top">top of page</a>
+
+        <table id="ofMucRoomTombstone" class="dbtable">
+            <tbody>
+            <tr>
+                <th colspan="4">ofMucRoomTombstone (Groupchat room name tombstones)</th>
+            </tr>
+            <tr>
+                <th>Column Name</th>
+                <th>Type</th>
+                <th>Length</th>
+                <th>Description</th>
+            </tr>
+            <tr class="primary-key">
+                <td>serviceID</td>
+                <td>NUMBER</td>
+                <td>n/a</td>
+                <td>ID of associated MUC service (Primary Key)</td>
+            </tr>
+            <tr class="primary-key">
+                <td>name</td>
+                <td>VARCHAR</td>
+                <td>50</td>
+                <td>Name of the tomb-stoned room (Primary Key)</td>
             </tr>
             </tbody>
         </table>

--- a/documentation/database-guide.html
+++ b/documentation/database-guide.html
@@ -1080,6 +1080,24 @@
                 <td>50</td>
                 <td>Name of the retired room (Primary Key)</td>
             </tr>
+            <tr>
+                <td>alternateJID</td>
+                <td>VARCHAR</td>
+                <td>2000</td>
+                <td>Optional JID specified on room deletion</td>
+            </tr>
+            <tr>
+                <td>reason</td>
+                <td>VARCHAR</td>
+                <td>1024</td>
+                <td>Optional text explaining why the room was retired</td>
+            </tr>
+            <tr>
+                <td>retiredAt</td>
+                <td>TIMESTAMP</td>
+                <td>n/a</td>
+                <td>When the room was retired (defaults to current timestamp)</td>
+            </tr>
             </tbody>
         </table>
         &nbsp;<a href="#top" class="top">top of page</a>

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -381,6 +381,7 @@ muc.form.conf.owner_roomsecret=Password
 muc.form.conf.owner_whois=Role that May Discover Real JIDs of Occupants
 muc.form.conf.anyone=Anyone
 muc.form.conf.owner_enablelogging=Log Room Conversations
+muc.form.conf.owner_retireondel=Retire room name on deletion to prevent reuse
 muc.form.conf.owner_preservehistondel=Preserve Chat History on Room Deletion
 muc.form.conf.owner_reservednick=Only login with registered nickname
 muc.form.conf.owner_canchangenick=Allow Occupants to change nicknames

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -764,6 +764,7 @@ muc.default.settings.title=Default Room Settings
 muc.default.settings.info=Use the form below to configure the default room settings which are used to create new chat rooms via XMPP.
 muc.default.settings.public_room=List Room in Directory
 muc.default.settings.persistent_room=Make Room Persistent
+muc.default.settings.tombstone=Prevent name reuse on deletion
 muc.default.settings.moderated=Make Room Moderated
 muc.default.settings.members_only=Make Room Members-only
 muc.default.settings.can_anyone_discover_jid=Can anyone discover real JIDs of occupants
@@ -859,7 +860,8 @@ muc.room.edit.form.warning.room_is_locked=This room is locked since {0}. It is l
   Users cannot join the room, until the room owner unlocks the room.
 muc.room.edit.form.error_created_id=Error creating the room. A room with the request ID already exists.
 muc.room.edit.form.error_created_privileges=Error creating the room. You do not have enough \
-        privileges to create rooms.
+privileges to create rooms.
+muc.room.edit.form.error_room_tombstoned=Error creating the room. The specified room ID has been retired.
 muc.room.edit.form.valid_hint=Please enter a valid ID, e.g. "test_room". Room ID&#39;s cannot contain \
         spaces or other characters prohibited in JID nodes.
 muc.room.edit.form.room_name=Room Name
@@ -3625,6 +3627,7 @@ commands.admin.muc.createmucroom.note.roomname-missing=Room name must be specifi
 commands.admin.muc.createmucroom.note.persistent-invalid=The 'room is persistent' value is invalid. Needs to be a boolean value.
 commands.admin.muc.createmucroom.note.public-invalid=The 'room is public' value is invalid. Needs to be a boolean value.
 commands.admin.muc.createmucroom.note.no-permission=No permission to create rooms.
+commands.admin.muc.createmucroom.note.tombstoned=The specified room name has been retired for this service.
 
 commands.admin.user.adduser.label=Add a User
 commands.admin.user.adduser.form.title=Adding a user

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -935,12 +935,14 @@ muc.room.summary.service=Service
 muc.room.retirees.title=Retired Group Chat Rooms
 muc.room.retirees.info=This list shows all currently retired Group Chat Room names in the service
 muc.room.retirees.info2=. When you delete a retired room name from below you bring it out of retirement, it is then available to use when creating new rooms.
-
 muc.room.retirees.deleted=Room successfully brought out of retirement.
 muc.room.retirees.total=Total Retirees
 muc.room.retirees.sorted=Sorted by Room Name
 muc.room.retirees.per_page=Retirees per page
 muc.room.retirees.no_retirees=No retired rooms in the Group Chat service.
+muc.room.retirees.alternate_jid=Alternate JID
+muc.room.retirees.reason=Reason
+muc.room.retirees.retired_at=Retired At
 
 # MUC service summary Page
 

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -934,7 +934,7 @@ muc.room.summary.service=Service
 # Muc room Retirees Page
 muc.room.retirees.title=Retired Group Chat Rooms
 muc.room.retirees.info=This list shows all currently retired Group Chat Room names in the service
-muc.room.retirees.info2=. When you bring a name out of retirement, it becomes available when creating new rooms.
+muc.room.retirees.info2=. When you delete a retired room name from below you bring it out of retirement, it is then available to use when creating new rooms.
 
 muc.room.retirees.deleted=Room successfully brought out of retirement.
 muc.room.retirees.total=Total Retirees

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -227,6 +227,8 @@ tab.tab-groupchat.descr=Click to manage group chat settings
                 sidebar.muc-room-federation.descr=Click to edit the room&#39;s FMUC settings
                 sidebar.muc-room-delete=Delete Room
                 sidebar.muc-room-delete.descr=Click to delete the room
+        sidebar.muc-room-retirees=Retired Rooms
+        sidebar.muc-room-retirees.descr=Click to view retired rooms
         sidebar.muc-room-create=Create New Room
         sidebar.muc-room-create.descr=Click to add a new room to the service
 tab.tab-plugins=Plugins
@@ -764,7 +766,7 @@ muc.default.settings.title=Default Room Settings
 muc.default.settings.info=Use the form below to configure the default room settings which are used to create new chat rooms via XMPP.
 muc.default.settings.public_room=List Room in Directory
 muc.default.settings.persistent_room=Make Room Persistent
-muc.default.settings.tombstone=Prevent name reuse on deletion
+muc.default.settings.retire=Retire room names on deletion to prevent reuse
 muc.default.settings.moderated=Make Room Moderated
 muc.default.settings.members_only=Make Room Members-only
 muc.default.settings.can_anyone_discover_jid=Can anyone discover real JIDs of occupants
@@ -861,7 +863,7 @@ muc.room.edit.form.warning.room_is_locked=This room is locked since {0}. It is l
 muc.room.edit.form.error_created_id=Error creating the room. A room with the request ID already exists.
 muc.room.edit.form.error_created_privileges=Error creating the room. You do not have enough \
 privileges to create rooms.
-muc.room.edit.form.error_room_tombstoned=Error creating the room. The specified room ID has been retired.
+muc.room.edit.form.error_room_retired=Error creating the room. The specified room ID has been retired.
 muc.room.edit.form.valid_hint=Please enter a valid ID, e.g. "test_room". Room ID&#39;s cannot contain \
         spaces or other characters prohibited in JID nodes.
 muc.room.edit.form.room_name=Room Name
@@ -928,6 +930,17 @@ muc.room.summary.alt_persistent=Room is persistent
 muc.room.summary.alt_temporary=Room is temporary
 muc.room.summary.alt_locked=Room is locked (it is likely in process of being created).
 muc.room.summary.service=Service
+
+# Muc room Retirees Page
+muc.room.retirees.title=Retired Group Chat Rooms
+muc.room.retirees.info=This list shows all currently retired Group Chat Room names in the service
+muc.room.retirees.info2=. When you bring a name out of retirement, it becomes available when creating new rooms.
+
+muc.room.retirees.deleted=Room successfully brought out of retirement.
+muc.room.retirees.total=Total Retirees
+muc.room.retirees.sorted=Sorted by Room Name
+muc.room.retirees.per_page=Retirees per page
+muc.room.retirees.no_retirees=No retired rooms in the Group Chat service.
 
 # MUC service summary Page
 
@@ -3627,7 +3640,7 @@ commands.admin.muc.createmucroom.note.roomname-missing=Room name must be specifi
 commands.admin.muc.createmucroom.note.persistent-invalid=The 'room is persistent' value is invalid. Needs to be a boolean value.
 commands.admin.muc.createmucroom.note.public-invalid=The 'room is public' value is invalid. Needs to be a boolean value.
 commands.admin.muc.createmucroom.note.no-permission=No permission to create rooms.
-commands.admin.muc.createmucroom.note.tombstoned=The specified room name has been retired for this service.
+commands.admin.muc.createmucroom.note.retired=The specified room name has been retired for this service.
 
 commands.admin.user.adduser.label=Add a User
 commands.admin.user.adduser.form.title=Adding a user

--- a/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
@@ -68,7 +68,7 @@ public class SchemaManager {
     /**
      * Current Openfire database schema version.
      */
-    private static final int DATABASE_VERSION = 35;
+    private static final int DATABASE_VERSION = 36;
 
     /**
      * Checks the Openfire database schema to ensure that it's installed and up to date.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/muc/CreateMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/muc/CreateMUCRoom.java
@@ -135,7 +135,11 @@ public class CreateMUCRoom extends AdHocCommand {
             }
             catch (NotAllowedException e) {
                 note.addAttribute("type", "error");
-                note.setText(LocaleUtils.getLocalizedString("commands.admin.muc.createmucroom.note.no-permission", preferredLocale));
+                String localeKey = switch(e.getReason()) {
+                    case ROOM_TOMBSTONED -> "commands.admin.muc.createmucroom.note.tombstoned";
+                    case INSUFFICIENT_PERMISSIONS -> "commands.admin.muc.createmucroom.note.no-permission";
+                };
+                note.setText(LocaleUtils.getLocalizedString(localeKey, preferredLocale));
                 return;
             }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/muc/CreateMUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/muc/CreateMUCRoom.java
@@ -136,7 +136,7 @@ public class CreateMUCRoom extends AdHocCommand {
             catch (NotAllowedException e) {
                 note.addAttribute("type", "error");
                 String localeKey = switch(e.getReason()) {
-                    case ROOM_TOMBSTONED -> "commands.admin.muc.createmucroom.note.tombstoned";
+                    case ROOM_RETIRED -> "commands.admin.muc.createmucroom.note.retired";
                     case INSUFFICIENT_PERMISSIONS -> "commands.admin.muc.createmucroom.note.no-permission";
                 };
                 note.setText(LocaleUtils.getLocalizedString(localeKey, preferredLocale));

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -196,6 +196,11 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
     private boolean persistent;
 
     /**
+     * Prevent the room name from being re-used after the room has been destroyed.
+     */
+    private boolean tombstone;
+
+    /**
      * Moderated rooms enable only participants to speak. Users that join the room and aren't
      * participants can't speak (they are just visitors).
      */
@@ -370,6 +375,7 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
         this.maxUsers = MUCPersistenceManager.getIntProperty(mucService.getServiceName(), "room.maxUsers", 30);
         this.publicRoom = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.publicRoom", true);
         this.persistent = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.persistent", false);
+        this.tombstone = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.tombstone", false);
         this.moderated = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.moderated", false);
         this.membersOnly = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.membersOnly", false);
         this.canOccupantsInvite = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.canOccupantsInvite", false);
@@ -3384,6 +3390,30 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
      */
     public void setModerated(boolean moderated) {
         this.moderated = moderated;
+    }
+
+
+    /**
+     * Returns whether the room should be tomb-stoned on deletion.
+     *
+     * Tomb-stoning a room means that this room's name is retired on room deletion and cannot be used again.
+     * This is useful when a room is deleted, but the room's name should not be re-used.
+     *
+     * @return true if the room should be tomb-stoned on deletion
+     */
+    public boolean isTombstone() {
+        return tombstone;
+    }
+
+    /**
+     * Sets whether the room should be tomb-stoned on deletion.
+     *
+     * Tomb-stoning a room means that this room's name is retired on room deletion and cannot be used again.
+     *
+     * @param tombstone true if the room should be tomb-stoned on deletion
+     */
+    public void setTombstone(boolean tombstone) {
+        this.tombstone = tombstone;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -1387,7 +1387,7 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
         }
 
         // Remove the room from the DB if the room was persistent
-        MUCPersistenceManager.deleteFromDB(this);
+        MUCPersistenceManager.deleteFromDB(this, alternateJID, reason);
         // Remove the history of the room from memory (preventing it to pop up in a new room by the same name).
         roomHistory.purge();
         // Fire event that the room has been destroyed

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -198,7 +198,7 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
     /**
      * Prevent the room name from being re-used after the room has been destroyed.
      */
-    private boolean tombstone;
+    private boolean retireOnDeletion;
 
     /**
      * Moderated rooms enable only participants to speak. Users that join the room and aren't
@@ -375,7 +375,7 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
         this.maxUsers = MUCPersistenceManager.getIntProperty(mucService.getServiceName(), "room.maxUsers", 30);
         this.publicRoom = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.publicRoom", true);
         this.persistent = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.persistent", false);
-        this.tombstone = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.tombstone", false);
+        this.retireOnDeletion = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.retireOnDeletion", false);
         this.moderated = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.moderated", false);
         this.membersOnly = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.membersOnly", false);
         this.canOccupantsInvite = MUCPersistenceManager.getBooleanProperty(mucService.getServiceName(), "room.canOccupantsInvite", false);
@@ -3394,26 +3394,25 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
 
 
     /**
-     * Returns whether the room should be tomb-stoned on deletion.
+     * Returns whether the room should be retired on deletion.
      *
-     * Tomb-stoning a room means that this room's name is retired on room deletion and cannot be used again.
-     * This is useful when a room is deleted, but the room's name should not be re-used.
+     * Retiring a room means that this room's name cannot be used again on room deletion
      *
-     * @return true if the room should be tomb-stoned on deletion
+     * @return true if the room should be retired on deletion
      */
-    public boolean isTombstone() {
-        return tombstone;
+    public boolean isRetireOnDeletion() {
+        return retireOnDeletion;
     }
 
     /**
-     * Sets whether the room should be tomb-stoned on deletion.
+     * Sets whether the room should be retired on deletion.
      *
-     * Tomb-stoning a room means that this room's name is retired on room deletion and cannot be used again.
+     * Retiring a room means that this room's name cannot be used again after room deletion.
      *
-     * @param tombstone true if the room should be tomb-stoned on deletion
+     * @param retire true if the room should be retired on deletion
      */
-    public void setTombstone(boolean tombstone) {
-        this.tombstone = tombstone;
+    public void setRetireOnDeletion(boolean retire) {
+        this.retireOnDeletion = retire;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomRetiree.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomRetiree.java
@@ -1,0 +1,36 @@
+package org.jivesoftware.openfire.muc;
+
+import java.util.Date;
+
+/**
+ * Represents information about a retired MUC room.
+ */
+public class MUCRoomRetiree {
+    private final String name;
+    private final String alternateJID;
+    private final String reason;
+    private final Date retiredAt;
+
+    public MUCRoomRetiree(String name, String alternateJID, String reason, Date retiredAt) {
+        this.name = name;
+        this.alternateJID = alternateJID;
+        this.reason = reason;
+        this.retiredAt = retiredAt;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAlternateJID() {
+        return alternateJID;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public Date getRetiredAt() {
+        return retiredAt;
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomRetiree.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomRetiree.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.openfire.muc;
 
 import java.util.Date;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
@@ -1041,11 +1041,16 @@ public class MultiUserChatManager extends BasicModule implements MUCServicePrope
             con = DbConnectionManager.getConnection();
 
             if ((startIndex == 0) && (numResults == Integer.MAX_VALUE)) {
-                pstmt = con.prepareStatement(GET_RETIREES);
+                // MSSQL differentiates between client-cursored and server-cursored result sets. For server-cursored result
+                // sets, the fetch buffer and scroll window are the same size (as opposed to fetch buffer containing all
+                // the rows). To hint that a server-cursored result set is desired, it should be configured to be 'forward
+                // only' as well as 'read only'.
+                pstmt = con.prepareStatement(GET_RETIREES, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
                 pstmt.setLong(1, serviceID);
                 // Set the fetch size. This will prevent some JDBC drivers from trying
                 // to load the entire result set into memory.
                 DbConnectionManager.setFetchSize(pstmt, 500);
+                pstmt.setFetchDirection(ResultSet.FETCH_FORWARD);
                 rs = pstmt.executeQuery();
                 while (rs.next()) {
                     retirees.add(rs.getString("name"));

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
@@ -1013,7 +1013,7 @@ public class MultiUserChatManager extends BasicModule implements MUCServicePrope
                 count = rs.getInt(1);
             }
         } catch (SQLException e) {
-            Log.error("An unexpected exception occurred while trying to count the number of MUC room retirees.", e);
+            Log.error("An unexpected exception occurred while trying to count the number of MUC room retirees for serviceID '{}'", serviceID , e);
         } finally {
             DbConnectionManager.closeConnection(rs, pstmt, con);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/NotAllowedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/NotAllowedException.java
@@ -23,7 +23,7 @@ import java.io.PrintWriter;
  * Exception used for representing that the user is not allowed to perform the requested operation
  * in the MUCRoom. There are many reasons why a not-allowed error could occur such as: a user tries
  * to join a room that has reached its limit of max number of occupants, or attempts to create a
- * room that has been tomb-stoned. A 405 error code is returned to the user that requested the
+ * room that has been retired. A 405 error code is returned to the user that requested the
  * invalid operation.
  *
  * @author Gaston Dombiak
@@ -34,7 +34,7 @@ public class NotAllowedException extends Exception {
 
     public enum Reason {
         INSUFFICIENT_PERMISSIONS,  // Default reason
-        ROOM_TOMBSTONED
+        ROOM_RETIRED
     }
 
     private final Reason reason;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/NotAllowedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/NotAllowedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,11 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 
 /**
- * Exception used for representing that the user is not allowed to perform the requested operation 
- * in the MUCRoom. There are many reasons why a not-allowed error could occur such as: a user tries 
- * to join a room that has reached its limit of max number of occupants. A 405 error code is 
- * returned to the user that requested the invalid operation.
+ * Exception used for representing that the user is not allowed to perform the requested operation
+ * in the MUCRoom. There are many reasons why a not-allowed error could occur such as: a user tries
+ * to join a room that has reached its limit of max number of occupants, or attempts to create a
+ * room that has been tomb-stoned. A 405 error code is returned to the user that requested the
+ * invalid operation.
  *
  * @author Gaston Dombiak
  */
@@ -31,23 +32,54 @@ public class NotAllowedException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
+    public enum Reason {
+        INSUFFICIENT_PERMISSIONS,  // Default reason
+        ROOM_TOMBSTONED
+    }
+
+    private final Reason reason;
+
     private Throwable nestedThrowable = null;
 
     public NotAllowedException() {
-        super();
+        this(Reason.INSUFFICIENT_PERMISSIONS);
     }
 
     public NotAllowedException(String msg) {
-        super(msg);
+        this(msg, Reason.INSUFFICIENT_PERMISSIONS);
     }
 
     public NotAllowedException(Throwable nestedThrowable) {
-        this.nestedThrowable = nestedThrowable;
+        this(Reason.INSUFFICIENT_PERMISSIONS, nestedThrowable);
     }
 
     public NotAllowedException(String msg, Throwable nestedThrowable) {
+        this(msg, Reason.INSUFFICIENT_PERMISSIONS, nestedThrowable);
+    }
+
+    public NotAllowedException(Reason reason) {
+        super();
+        this.reason = reason;
+    }
+
+    public NotAllowedException(String msg, Reason reason) {
         super(msg);
+        this.reason = reason;
+    }
+
+    public NotAllowedException(Reason reason, Throwable nestedThrowable) {
+        this.reason = reason;
         this.nestedThrowable = nestedThrowable;
+    }
+
+    public NotAllowedException(String msg, Reason reason, Throwable nestedThrowable) {
+        super(msg);
+        this.reason = reason;
+        this.nestedThrowable = nestedThrowable;
+    }
+
+    public Reason getReason() {
+        return reason;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
@@ -278,6 +278,12 @@ public class IQOwnerHandler {
             room.setPublicRoom( parseFirstValueAsBoolean( field, true ) );
         }
 
+        field = completedForm.getField("{http://igniterealtime.org}muc#roomconfig_tombstone");
+        if (field != null) {
+            final boolean newValue = parseFirstValueAsBoolean(field, true);
+            room.setTombstone(newValue);
+        }
+
         field = completedForm.getField("{http://igniterealtime.org}muc#roomconfig_preservehistondel");
         if (field != null) {
             final boolean newValue = parseFirstValueAsBoolean(field, true);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
@@ -278,10 +278,10 @@ public class IQOwnerHandler {
             room.setPublicRoom( parseFirstValueAsBoolean( field, true ) );
         }
 
-        field = completedForm.getField("{http://igniterealtime.org}muc#roomconfig_tombstone");
+        field = completedForm.getField("{http://igniterealtime.org}muc#roomconfig_retireondel");
         if (field != null) {
             final boolean newValue = parseFirstValueAsBoolean(field, true);
-            room.setTombstone(newValue);
+            room.setRetireOnDeletion(newValue);
         }
 
         field = completedForm.getField("{http://igniterealtime.org}muc#roomconfig_preservehistondel");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
@@ -536,6 +536,10 @@ public class IQOwnerHandler {
                 LocaleUtils.getLocalizedString("muc.form.conf.owner_persistentroom", preferredLocale),
                 Type.boolean_type);
 
+        configurationForm.addField("{http://igniterealtime.org}muc#roomconfig_retireondel",
+            LocaleUtils.getLocalizedString("muc.form.conf.owner_retireondel", preferredLocale),
+            Type.boolean_type);
+
         configurationForm.addField("muc#roomconfig_moderatedroom",
                 LocaleUtils.getLocalizedString("muc.form.conf.owner_moderatedroom", preferredLocale),
                 Type.boolean_type);
@@ -650,6 +654,10 @@ public class IQOwnerHandler {
             field = configurationForm.getField("muc#roomconfig_moderatedroom");
             field.clearValues();
             field.addValue((room.isModerated() ? "1" : "0"));
+
+            field = configurationForm.getField("{http://igniterealtime.org}muc#roomconfig_retireondel");
+            field.clearValues();
+            field.addValue((room.isRetireOnDeletion() ? "1" : "0"));
 
             field = configurationForm.getField("muc#roomconfig_membersonly");
             field.clearValues();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -65,7 +65,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.jivesoftware.openfire.muc.NotAllowedException.Reason.ROOM_TOMBSTONED;
+import static org.jivesoftware.openfire.muc.NotAllowedException.Reason.ROOM_RETIRED;
 
 /**
  * Implements the chat server as a cached memory resident chat server. The server is also
@@ -1271,7 +1271,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                 room = getChatRoom(roomName, packet.getFrom());
             } catch (NotAllowedException e) {
                 String errorMessage = switch (e.getReason()) {
-                    case ROOM_TOMBSTONED -> "This room name cannot be used as it has been retired.";
+                    case ROOM_RETIRED -> "This room name cannot be used as it has been retired.";
                     case INSUFFICIENT_PERMISSIONS -> "You do not have permission to create a new room.";
                 };
 
@@ -1916,9 +1916,9 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
             room = localMUCRoomManager.get(roomName);
             if (room == null) {
 
-                // Has the room been deleted and tomb-stoned?
-                if (MUCPersistenceManager.isRoomTombstoned(roomName, this)) {
-                    throw new NotAllowedException(ROOM_TOMBSTONED);
+                // Has the room been deleted and retired?
+                if (MUCPersistenceManager.isRoomRetired(roomName, this)) {
+                    throw new NotAllowedException(ROOM_RETIRED);
                 }
 
                 room = new MUCRoom(this, roomName);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
@@ -249,10 +249,15 @@ public class DefaultUserProvider implements UserProvider {
             con = DbConnectionManager.getConnection();
             if ((startIndex==0) && (numResults==Integer.MAX_VALUE))
             {
-                pstmt = con.prepareStatement(ALL_USERS);
+                // MSSQL differentiates between client-cursored and server-cursored result sets. For server-cursored result
+                // sets, the fetch buffer and scroll window are the same size (as opposed to fetch buffer containing all
+                // the rows). To hint that a server-cursored result set is desired, it should be configured to be 'forward
+                // only' as well as 'read only'.
+                pstmt = con.prepareStatement(ALL_USERS, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
                 // Set the fetch size. This will prevent some JDBC drivers from trying
                 // to load the entire result set into memory.
                 DbConnectionManager.setFetchSize(pstmt, 500);
+                pstmt.setFetchDirection(ResultSet.FETCH_FORWARD);
                 rs = pstmt.executeQuery();
                 while (rs.next()) {
                     usernames.add(rs.getString(1));

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/JDBCUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/JDBCUserProvider.java
@@ -235,10 +235,15 @@ public class JDBCUserProvider implements UserProvider {
             con = getConnection();
             if ((startIndex==0) && (numResults==Integer.MAX_VALUE))
             {
-                pstmt = con.prepareStatement(allUsersSQL);
+                // MSSQL differentiates between client-cursored and server-cursored result sets. For server-cursored result
+                // sets, the fetch buffer and scroll window are the same size (as opposed to fetch buffer containing all
+                // the rows). To hint that a server-cursored result set is desired, it should be configured to be 'forward
+                // only' as well as 'read only'.
+                pstmt = con.prepareStatement(allUsersSQL, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
                 // Set the fetch size. This will prevent some JDBC drivers from trying
                 // to load the entire result set into memory.
                 DbConnectionManager.setFetchSize(pstmt, 500);
+                pstmt.setFetchDirection(ResultSet.FETCH_FORWARD);
                 rs = pstmt.executeQuery();
                 while (rs.next()) {
                     // OF-1837: When the database does not hold escaped data, escape values before processing them further.

--- a/xmppserver/src/main/resources/admin-sidebar.xml
+++ b/xmppserver/src/main/resources/admin-sidebar.xml
@@ -512,6 +512,11 @@
                 </sidebar>
             </item>
 
+            <!-- MUC Room Name retirees (retired room names) -->
+            <item id="muc-room-retirees" name="${sidebar.muc-room-retirees}"
+                  url="muc-room-retirees.jsp"
+                  description="${sidebar.muc-room-retirees.descr}"/>
+
             <!-- Create New Room -->
             <item id="muc-room-create" name="${sidebar.muc-room-create}"
                   url="muc-room-create.jsp"

--- a/xmppserver/src/main/webapp/muc-default-settings.jsp
+++ b/xmppserver/src/main/webapp/muc-default-settings.jsp
@@ -38,6 +38,7 @@
 
     String publicRoom = ParamUtils.getParameter(request, "roomconfig_publicroom");
     String persistentRoom = ParamUtils.getParameter(request, "roomconfig_persistentroom");
+    String tombstone = ParamUtils.getParameter(request, "roomconfig_tombstone");
     String moderatedRoom = ParamUtils.getParameter(request, "roomconfig_moderatedroom");
     String membersOnly = ParamUtils.getParameter(request, "roomconfig_membersonly");
     String nonanonymous = ParamUtils.getParameter(request, "roomconfig_nonanonymous");
@@ -102,6 +103,12 @@
             }
             else {
                 MUCPersistenceManager.setProperty(mucname, "room.persistent", "false");
+            }
+            if (tombstone != null && tombstone.trim().length() > 0) {
+                MUCPersistenceManager.setProperty(mucname, "room.tombstone", "true");
+            }
+            else {
+                MUCPersistenceManager.setProperty(mucname, "room.tombstone", "false");
             }
             if (moderatedRoom != null && moderatedRoom.trim().length() > 0) {
                 MUCPersistenceManager.setProperty(mucname, "room.moderated", "true");
@@ -192,6 +199,7 @@
     pageContext.setAttribute("mucname", mucname);
     pageContext.setAttribute("publicRoom", MUCPersistenceManager.getBooleanProperty(mucname, "room.publicRoom", true));
     pageContext.setAttribute("persistent", MUCPersistenceManager.getBooleanProperty(mucname, "room.persistent", false));
+    pageContext.setAttribute("tombstone", MUCPersistenceManager.getBooleanProperty(mucname, "room.tombstone", false));
     pageContext.setAttribute("moderated", MUCPersistenceManager.getBooleanProperty(mucname, "room.moderated", false));
     pageContext.setAttribute("membersOnly", MUCPersistenceManager.getBooleanProperty(mucname, "room.membersOnly", false));
     pageContext.setAttribute("canAnyoneDiscoverJID", MUCPersistenceManager.getBooleanProperty(mucname, "room.canAnyoneDiscoverJID", true));
@@ -269,6 +277,10 @@
             <tr>
                 <td><input name="roomconfig_persistentroom" value="true" id="persistentRoom" type="checkbox" ${persistent ? 'checked' : ''}></td>
                 <td><label for="persistentRoom"><fmt:message key="muc.default.settings.persistent_room" /></label></td>
+            </tr>
+            <tr>
+                <td><input name="roomconfig_tombstone" value="true" id="tombstone" type="checkbox" ${tombstone ? 'checked' : ''}></td>
+                <td><label for="tombstone"><fmt:message key="muc.default.settings.tombstone" /></label></td>
             </tr>
             <tr>
                 <td><input name="roomconfig_moderatedroom" value="true" id="moderated" type="checkbox" ${moderated ? 'checked' : ''}></td>

--- a/xmppserver/src/main/webapp/muc-default-settings.jsp
+++ b/xmppserver/src/main/webapp/muc-default-settings.jsp
@@ -38,7 +38,7 @@
 
     String publicRoom = ParamUtils.getParameter(request, "roomconfig_publicroom");
     String persistentRoom = ParamUtils.getParameter(request, "roomconfig_persistentroom");
-    String tombstone = ParamUtils.getParameter(request, "roomconfig_tombstone");
+    String retireOnDeletion = ParamUtils.getParameter(request, "roomconfig_retireondel");
     String moderatedRoom = ParamUtils.getParameter(request, "roomconfig_moderatedroom");
     String membersOnly = ParamUtils.getParameter(request, "roomconfig_membersonly");
     String nonanonymous = ParamUtils.getParameter(request, "roomconfig_nonanonymous");
@@ -104,11 +104,11 @@
             else {
                 MUCPersistenceManager.setProperty(mucname, "room.persistent", "false");
             }
-            if (tombstone != null && tombstone.trim().length() > 0) {
-                MUCPersistenceManager.setProperty(mucname, "room.tombstone", "true");
+            if (retireOnDeletion != null && retireOnDeletion.trim().length() > 0) {
+                MUCPersistenceManager.setProperty(mucname, "room.retireOnDeletion", "true");
             }
             else {
-                MUCPersistenceManager.setProperty(mucname, "room.tombstone", "false");
+                MUCPersistenceManager.setProperty(mucname, "room.retireOnDeletion", "false");
             }
             if (moderatedRoom != null && moderatedRoom.trim().length() > 0) {
                 MUCPersistenceManager.setProperty(mucname, "room.moderated", "true");
@@ -199,7 +199,7 @@
     pageContext.setAttribute("mucname", mucname);
     pageContext.setAttribute("publicRoom", MUCPersistenceManager.getBooleanProperty(mucname, "room.publicRoom", true));
     pageContext.setAttribute("persistent", MUCPersistenceManager.getBooleanProperty(mucname, "room.persistent", false));
-    pageContext.setAttribute("tombstone", MUCPersistenceManager.getBooleanProperty(mucname, "room.tombstone", false));
+    pageContext.setAttribute("retireOnDeletion", MUCPersistenceManager.getBooleanProperty(mucname, "room.retireOnDeletion", false));
     pageContext.setAttribute("moderated", MUCPersistenceManager.getBooleanProperty(mucname, "room.moderated", false));
     pageContext.setAttribute("membersOnly", MUCPersistenceManager.getBooleanProperty(mucname, "room.membersOnly", false));
     pageContext.setAttribute("canAnyoneDiscoverJID", MUCPersistenceManager.getBooleanProperty(mucname, "room.canAnyoneDiscoverJID", true));
@@ -279,8 +279,8 @@
                 <td><label for="persistentRoom"><fmt:message key="muc.default.settings.persistent_room" /></label></td>
             </tr>
             <tr>
-                <td><input name="roomconfig_tombstone" value="true" id="tombstone" type="checkbox" ${tombstone ? 'checked' : ''}></td>
-                <td><label for="tombstone"><fmt:message key="muc.default.settings.tombstone" /></label></td>
+                <td><input name="roomconfig_retireondel" value="true" id="retireOnDeletion" type="checkbox" ${retireOnDeletion ? 'checked' : ''}></td>
+                <td><label for="retireOnDeletion"><fmt:message key="muc.default.settings.retire" /></label></td>
             </tr>
             <tr>
                 <td><input name="roomconfig_moderatedroom" value="true" id="moderated" type="checkbox" ${moderated ? 'checked' : ''}></td>

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -95,6 +95,7 @@
     String allowpm = ParamUtils.getParameter(request, "roomconfig_allowpm");
     boolean publicRoom = ParamUtils.getBooleanParameter(request, "roomconfig_publicroom");
     boolean persistentRoom = ParamUtils.getBooleanParameter(request, "roomconfig_persistentroom");
+    boolean tombstone = ParamUtils.getBooleanParameter(request, "roomconfig_tombstone");
     boolean moderatedRoom = ParamUtils.getBooleanParameter(request, "roomconfig_moderatedroom");
     boolean membersOnly = ParamUtils.getBooleanParameter(request, "roomconfig_membersonly");
     boolean allowInvites = ParamUtils.getBooleanParameter(request, "roomconfig_allowinvites");
@@ -210,8 +211,13 @@
                         }
                     }
                     catch (NotAllowedException e) {
-                        // This user is not allowed to create rooms
-                        errors.put("not_enough_permissions", "not_enough_permissions");
+                        // This user is not allowed to create rooms, or it has been tomb-stoned
+                        String cause = switch(e.getReason()) {
+                            case ROOM_TOMBSTONED -> "room_tombstoned";
+                            case INSUFFICIENT_PERMISSIONS -> "not_enough_permissions";
+                        };
+
+                        errors.put(cause, cause);
                     }
                 }
             }
@@ -239,6 +245,7 @@
 
             dataForm.addField("muc#roomconfig_publicroom", null, null).addValue(publicRoom ? "1": "0");
             dataForm.addField("muc#roomconfig_persistentroom", null, null).addValue(persistentRoom ? "1": "0");
+            dataForm.addField("{http://igniterealtime.org}muc#roomconfig_tombstone", null, null).addValue(tombstone ? "1": "0");
             dataForm.addField("muc#roomconfig_moderatedroom", null, null).addValue(moderatedRoom ? "1": "0");
             dataForm.addField("muc#roomconfig_membersonly", null, null).addValue(membersOnly ? "1": "0");
             dataForm.addField("muc#roomconfig_allowinvites", null, null).addValue(allowInvites ? "1": "0");
@@ -310,6 +317,7 @@
             allowpm = MUCPersistenceManager.getProperty(serviceName, "room.allowpm", "anyone");
             publicRoom = MUCPersistenceManager.getBooleanProperty(serviceName, "room.publicRoom", true);
             persistentRoom = true; // Rooms created from the admin console are always persistent
+            tombstone = MUCPersistenceManager.getBooleanProperty(serviceName, "room.tombstone", false);
             moderatedRoom = MUCPersistenceManager.getBooleanProperty(serviceName, "room.moderated", false);
             membersOnly = MUCPersistenceManager.getBooleanProperty(serviceName, "room.membersOnly", false);
             allowInvites = MUCPersistenceManager.getBooleanProperty(serviceName, "room.canOccupantsInvite", false);
@@ -334,6 +342,7 @@
             allowpm = room.canSendPrivateMessage();
             publicRoom = room.isPublicRoom();
             persistentRoom = room.isPersistent();
+            tombstone = room.isTombstone();
             moderatedRoom = room.isModerated();
             membersOnly = room.isMembersOnly();
             allowInvites = room.canOccupantsInvite();
@@ -369,6 +378,7 @@
     pageContext.setAttribute("whois", whois);
     pageContext.setAttribute("allowpm", allowpm);
     pageContext.setAttribute("publicRoom", publicRoom);
+    pageContext.setAttribute("tombstone", tombstone);
     pageContext.setAttribute("moderatedRoom", moderatedRoom);
     pageContext.setAttribute("membersonly", membersOnly);
     pageContext.setAttribute("allowInvites", allowInvites);
@@ -414,6 +424,7 @@
                         <c:when test="${err.key eq 'roomName'}"><fmt:message key="muc.room.edit.form.valid_hint" /></c:when>
                         <c:when test="${err.key eq 'room_already_exists'}"><fmt:message key="muc.room.edit.form.error_created_id" /></c:when>
                         <c:when test="${err.key eq 'not_enough_permissions'}"><fmt:message key="muc.room.edit.form.error_created_privileges" /></c:when>
+                        <c:when test="${err.key eq 'room_tombstoned'}"><fmt:message key="muc.room.edit.form.error_room_tombstoned" /></c:when>
                         <c:when test="${err.key eq 'room_topic'}"><fmt:message key="muc.room.edit.form.valid_hint_subject" /></c:when>
                         <c:when test="${err.key eq 'room_topic_longer'}"><fmt:message key="muc.room.edit.form.valid_hint_subject_too_long" /></c:when>
                         <c:otherwise>
@@ -623,6 +634,10 @@
                         <tr>
                             <td><input type="checkbox" name="roomconfig_publicroom" value="true" id="public" ${publicRoom ? 'checked' : ''}>
                                 <label for="public"><fmt:message key="muc.room.edit.form.list_room" /></label></td>
+                        </tr>
+                        <tr>
+                            <td><input name="roomconfig_tombstone" value="true" id="tombstone" type="checkbox" ${tombstone ? 'checked' : ''}>
+                            <label for="tombstone"><fmt:message key="muc.default.settings.tombstone" /></label></td>
                         </tr>
                         <tr>
                             <td><input type="checkbox" name="roomconfig_moderatedroom" value="true" id="moderated" ${moderatedRoom ? 'checked' : ''}>

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -95,7 +95,7 @@
     String allowpm = ParamUtils.getParameter(request, "roomconfig_allowpm");
     boolean publicRoom = ParamUtils.getBooleanParameter(request, "roomconfig_publicroom");
     boolean persistentRoom = ParamUtils.getBooleanParameter(request, "roomconfig_persistentroom");
-    boolean tombstone = ParamUtils.getBooleanParameter(request, "roomconfig_tombstone");
+    boolean retireOnDeletion = ParamUtils.getBooleanParameter(request, "roomconfig_retireondel");
     boolean moderatedRoom = ParamUtils.getBooleanParameter(request, "roomconfig_moderatedroom");
     boolean membersOnly = ParamUtils.getBooleanParameter(request, "roomconfig_membersonly");
     boolean allowInvites = ParamUtils.getBooleanParameter(request, "roomconfig_allowinvites");
@@ -211,9 +211,9 @@
                         }
                     }
                     catch (NotAllowedException e) {
-                        // This user is not allowed to create rooms, or it has been tomb-stoned
+                        // This user is not allowed to create rooms, or it has been retired
                         String cause = switch(e.getReason()) {
-                            case ROOM_TOMBSTONED -> "room_tombstoned";
+                            case ROOM_RETIRED -> "room_retired";
                             case INSUFFICIENT_PERMISSIONS -> "not_enough_permissions";
                         };
 
@@ -245,7 +245,7 @@
 
             dataForm.addField("muc#roomconfig_publicroom", null, null).addValue(publicRoom ? "1": "0");
             dataForm.addField("muc#roomconfig_persistentroom", null, null).addValue(persistentRoom ? "1": "0");
-            dataForm.addField("{http://igniterealtime.org}muc#roomconfig_tombstone", null, null).addValue(tombstone ? "1": "0");
+            dataForm.addField("{http://igniterealtime.org}muc#roomconfig_retireondel", null, null).addValue(retireOnDeletion ? "1": "0");
             dataForm.addField("muc#roomconfig_moderatedroom", null, null).addValue(moderatedRoom ? "1": "0");
             dataForm.addField("muc#roomconfig_membersonly", null, null).addValue(membersOnly ? "1": "0");
             dataForm.addField("muc#roomconfig_allowinvites", null, null).addValue(allowInvites ? "1": "0");
@@ -317,7 +317,7 @@
             allowpm = MUCPersistenceManager.getProperty(serviceName, "room.allowpm", "anyone");
             publicRoom = MUCPersistenceManager.getBooleanProperty(serviceName, "room.publicRoom", true);
             persistentRoom = true; // Rooms created from the admin console are always persistent
-            tombstone = MUCPersistenceManager.getBooleanProperty(serviceName, "room.tombstone", false);
+            retireOnDeletion = MUCPersistenceManager.getBooleanProperty(serviceName, "room.retireOnDeletion", false);
             moderatedRoom = MUCPersistenceManager.getBooleanProperty(serviceName, "room.moderated", false);
             membersOnly = MUCPersistenceManager.getBooleanProperty(serviceName, "room.membersOnly", false);
             allowInvites = MUCPersistenceManager.getBooleanProperty(serviceName, "room.canOccupantsInvite", false);
@@ -342,7 +342,7 @@
             allowpm = room.canSendPrivateMessage();
             publicRoom = room.isPublicRoom();
             persistentRoom = room.isPersistent();
-            tombstone = room.isTombstone();
+            retireOnDeletion = room.isRetireOnDeletion();
             moderatedRoom = room.isModerated();
             membersOnly = room.isMembersOnly();
             allowInvites = room.canOccupantsInvite();
@@ -378,7 +378,7 @@
     pageContext.setAttribute("whois", whois);
     pageContext.setAttribute("allowpm", allowpm);
     pageContext.setAttribute("publicRoom", publicRoom);
-    pageContext.setAttribute("tombstone", tombstone);
+    pageContext.setAttribute("retireOnDeletion", retireOnDeletion);
     pageContext.setAttribute("moderatedRoom", moderatedRoom);
     pageContext.setAttribute("membersonly", membersOnly);
     pageContext.setAttribute("allowInvites", allowInvites);
@@ -424,7 +424,7 @@
                         <c:when test="${err.key eq 'roomName'}"><fmt:message key="muc.room.edit.form.valid_hint" /></c:when>
                         <c:when test="${err.key eq 'room_already_exists'}"><fmt:message key="muc.room.edit.form.error_created_id" /></c:when>
                         <c:when test="${err.key eq 'not_enough_permissions'}"><fmt:message key="muc.room.edit.form.error_created_privileges" /></c:when>
-                        <c:when test="${err.key eq 'room_tombstoned'}"><fmt:message key="muc.room.edit.form.error_room_tombstoned" /></c:when>
+                        <c:when test="${err.key eq 'room_retired'}"><fmt:message key="muc.room.edit.form.error_room_retired" /></c:when>
                         <c:when test="${err.key eq 'room_topic'}"><fmt:message key="muc.room.edit.form.valid_hint_subject" /></c:when>
                         <c:when test="${err.key eq 'room_topic_longer'}"><fmt:message key="muc.room.edit.form.valid_hint_subject_too_long" /></c:when>
                         <c:otherwise>
@@ -636,8 +636,8 @@
                                 <label for="public"><fmt:message key="muc.room.edit.form.list_room" /></label></td>
                         </tr>
                         <tr>
-                            <td><input name="roomconfig_tombstone" value="true" id="tombstone" type="checkbox" ${tombstone ? 'checked' : ''}>
-                            <label for="tombstone"><fmt:message key="muc.default.settings.tombstone" /></label></td>
+                            <td><input name="roomconfig_retireondel" value="true" id="retireOnDeletion" type="checkbox" ${retireOnDeletion ? 'checked' : ''}>
+                            <label for="retireOnDeletion"><fmt:message key="muc.default.settings.retire" /></label></td>
                         </tr>
                         <tr>
                             <td><input type="checkbox" name="roomconfig_moderatedroom" value="true" id="moderated" ${moderatedRoom ? 'checked' : ''}>

--- a/xmppserver/src/main/webapp/muc-room-retirees.jsp
+++ b/xmppserver/src/main/webapp/muc-room-retirees.jsp
@@ -21,6 +21,7 @@
 <%@ page import="java.util.Collection" %>
 <%@ page import="org.jivesoftware.util.*" %>
 <%@ page import="java.util.ArrayList" %>
+<%@ page import="org.jivesoftware.openfire.muc.MUCRoomRetiree" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -116,7 +117,7 @@
     }
 
     // Get retirees for current page
-    Collection<String> retirees = webManager.getMultiUserChatManager().getRetirees(mucService.getServiceName(), start, range);
+    Collection<MUCRoomRetiree> retirees = webManager.getMultiUserChatManager().getRetirees(mucService.getServiceName(), start, range);
 
     // Set attributes for JSTL
     request.setAttribute("mucService", mucService);
@@ -223,6 +224,9 @@
         <tr>
             <th>&nbsp;</th>
             <th nowrap><fmt:message key="user.create.name" /></th>
+            <th nowrap><fmt:message key="muc.room.retirees.alternate_jid" /></th>
+            <th nowrap><fmt:message key="muc.room.retirees.reason" /></th>
+            <th nowrap><fmt:message key="muc.room.retirees.retired_at" /></th>
             <th nowrap><fmt:message key="global.delete" /></th>
         </tr>
         </thead>
@@ -230,7 +234,7 @@
         <c:choose>
             <c:when test="${empty retirees}">
                 <tr>
-                    <td style="text-align: center" colspan="7">
+                    <td style="text-align: center" colspan="6">
                         <fmt:message key="muc.room.retirees.no_retirees" />
                     </td>
                 </tr>
@@ -239,9 +243,28 @@
                 <c:forEach items="${retirees}" var="retiree" varStatus="status">
                     <tr>
                         <td style="width: 1%">${start + status.count}</td>
-                        <td style="width: 20%"><c:out value="${retiree}"/> &nbsp;</td>
+                        <td style="width: 20%"><c:out value="${retiree.name}"/></td>
+                        <td style="width: 20%">
+                            <c:if test="${not empty retiree.alternateJID}">
+                                <c:out value="${retiree.alternateJID}"/>
+                            </c:if>
+                            <c:if test="${empty retiree.alternateJID}">
+                                &nbsp;
+                            </c:if>
+                        </td>
+                        <td style="width: 30%">
+                            <c:if test="${not empty retiree.reason}">
+                                <c:out value="${retiree.reason}"/>
+                            </c:if>
+                            <c:if test="${empty retiree.reason}">
+                                &nbsp;
+                            </c:if>
+                        </td>
+                        <td style="width: 20%">
+                            <fmt:formatDate value="${retiree.retiredAt}" pattern="yyyy-MM-dd HH:mm:ss"/>
+                        </td>
                         <td style="width: 1%; text-align: center; border-right:1px #ccc solid;">
-                            <a href="muc-room-retirees.jsp?delete=true&service=${mucService.serviceName}&name=${retiree}&csrf=${csrf}"
+                            <a href="muc-room-retirees.jsp?delete=true&service=${mucService.serviceName}&name=${retiree.name}&csrf=${csrf}"
                                title="<fmt:message key="global.click_delete" />">
                                 <img src="images/delete-16x16.gif" alt="<fmt:message key="global.click_delete" />">
                             </a>

--- a/xmppserver/src/main/webapp/muc-room-retirees.jsp
+++ b/xmppserver/src/main/webapp/muc-room-retirees.jsp
@@ -1,0 +1,302 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%--
+  -
+  - Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
+
+<%@ page import="org.jivesoftware.openfire.muc.MultiUserChatService"
+%>
+<%@ page import="java.net.URLEncoder" %>
+<%@ page import="java.util.Collection" %>
+<%@ page import="org.jivesoftware.util.*" %>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib prefix="admin" uri="admin" %>
+
+<%!
+    final int DEFAULT_RANGE = 100;
+    final int[] RANGE_PRESETS = {25, 50, 75, 100, 500, 1000, -1};
+%>
+
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager"  />
+<% webManager.init(request, response, session, application, out ); %>
+
+<html>
+    <head>
+        <title><fmt:message key="muc.room.retirees.title"/></title>
+        <meta name="pageID" content="muc-room-retirees"/>
+    </head>
+    <body>
+
+<%  // Get parameters
+    String mucname = ParamUtils.getParameter(request,"mucname");
+
+    int start = ParamUtils.getIntParameter(request,"start",0);
+    int range = ParamUtils.getIntParameter(request,"range",webManager.getRowsPerPage("retirees-summary", DEFAULT_RANGE));
+    boolean delete = ParamUtils.getBooleanParameter(request,"delete");
+    Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+    String csrfParam = ParamUtils.getParameter(request, "csrf");
+
+    if (delete) {
+        if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
+            delete = false;
+        }
+    }
+
+    // Delete retiree if requested
+    if (delete) {
+        String service = ParamUtils.getParameter(request,"service");
+        String name = ParamUtils.getParameter(request,"name");
+
+        if (service != null && name != null) {
+            webManager.getMultiUserChatManager().deleteRetiree(service, name);
+            response.sendRedirect("muc-room-retirees.jsp?mucname=" + URLEncoder.encode(service, "UTF-8") + "&deletesuccess=true");
+            return;
+        }
+    }
+
+    csrfParam = StringUtils.randomString(15);
+    CookieUtils.setCookie(request, response, "csrf", csrfParam, -1);
+
+    if (request.getParameter("range") != null) {
+        webManager.setRowsPerPage("retirees-summary", range);
+    }
+
+    MultiUserChatService mucService = null;
+    if (mucname != null && webManager.getMultiUserChatManager().isServiceRegistered(mucname)) {
+        mucService = webManager.getMultiUserChatManager().getMultiUserChatService(mucname);
+    }
+    else {
+        for (MultiUserChatService muc : webManager.getMultiUserChatManager().getMultiUserChatServices()) {
+            if (muc.isHidden()) {
+                // Private and hidden, skip it.
+                continue;
+            }
+            mucService = muc;
+            break;
+        }
+    }
+
+    if (mucService == null) {
+        // No services exist, so redirect to where one can configure the services
+        response.sendRedirect("muc-service-summary.jsp");
+        return;
+    }
+
+    // Get the retirees manager
+    int retireeCount = webManager.getMultiUserChatManager().getRetireeCount(mucService.getServiceName());
+
+    // paginator vars
+    int numPages = (int)Math.ceil((double) retireeCount /(double)range);
+    int curPage = (start/range) + 1;
+
+%>
+
+<p>
+    <fmt:message key="muc.room.retirees.info" />
+    <a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucService.getServiceName(), "UTF-8")%>"><%= StringUtils.escapeHTMLTags(mucService.getServiceDomain()) %></a>
+    <fmt:message key="muc.room.retirees.info2" />
+</p>
+
+<%  if (request.getParameter("deletesuccess") != null) { %>
+
+    <admin:infoBox type="success">
+        <fmt:message key="muc.room.retirees.deleted" />
+    </admin:infoBox>
+
+<%  } %>
+
+<p>
+<fmt:message key="muc.room.retirees.total" />:
+<b><%= LocaleUtils.getLocalizedNumber(retireeCount) %></b>
+
+<%  if (numPages > 1) { %>
+    --
+    <fmt:message key="global.showing" />
+    <%= LocaleUtils.getLocalizedNumber(start+1) %>-<%= LocaleUtils.getLocalizedNumber(Math.min(start + range, retireeCount)) %>,
+
+<%  } %>
+
+<% if (retireeCount > 0) { %>
+<fmt:message key="muc.room.retirees.sorted" />
+<% } %>
+
+
+<% if (webManager.getMultiUserChatManager().getMultiUserChatServicesCount() > 1) { %>
+-- <fmt:message key="muc.room.summary.service" />:
+<select name="mucname" id="mucname" onchange="location.href='muc-room-retirees.jsp?mucname=' + this.options[this.selectedIndex].value;">
+    <% for (MultiUserChatService service : webManager.getMultiUserChatManager().getMultiUserChatServices()) {
+        if (service.isHidden()) {
+            // Private and hidden, skip it.
+            continue;
+        }
+    %>
+    <option value="<%= StringUtils.escapeForXML(service.getServiceName()) %>"<%= mucService.getServiceName().equals(service.getServiceName()) ? " selected='selected'" : "" %>><%= StringUtils.escapeHTMLTags(service.getServiceDomain()) %></option>
+    <% } %>
+</select>
+<% } %>
+
+<% if (retireeCount > 0) { %>
+-- <fmt:message key="muc.room.retirees.per_page" />:
+<select size="1" onchange="location.href='muc-room-retirees.jsp?start=0&range=' + this.options[this.selectedIndex].value;">
+
+    <% for (int aRANGE_PRESETS : RANGE_PRESETS) { %>
+
+    <option value="<%  if (aRANGE_PRESETS > 0) { %><%= aRANGE_PRESETS %><%  }else{ %><%= retireeCount %><%}%>"
+            <%= (aRANGE_PRESETS == range ? "selected" : "") %>><%  if (aRANGE_PRESETS > 0) { %><%= aRANGE_PRESETS %><%  }else{ %><%= retireeCount %><%}%>
+    </option>
+
+    <% } %>
+
+</select>
+<% } %>
+
+</p>
+
+<%  if (numPages > 1) { %>
+
+    <p>
+    <fmt:message key="global.pages" />:
+    [
+    <%  int num = 15 + curPage;
+        int s = curPage-1;
+        if (s > 5) {
+            s -= 5;
+        }
+        if (s < 5) {
+            s = 0;
+        }
+        if (s > 2) {
+    %>
+        <a href="muc-room-retirees.jsp?start=0&range=<%= range %>">1</a> ...
+
+    <%
+        }
+        int i;
+        for (i=s; i<numPages && i<num; i++) {
+            String sep = ((i+1)<numPages) ? " " : "";
+            boolean isCurrent = (i+1) == curPage;
+    %>
+        <a href="muc-room-retirees.jsp?start=<%= (i*range) %>&range=<%= range %>"
+         class="<%= ((isCurrent) ? "jive-current" : "") %>"
+         ><%= (i+1) %></a><%= sep %>
+
+    <%  } %>
+
+    <%  if (i < numPages) { %>
+
+        ... <a href="muc-room-retirees.jsp?start=<%= ((numPages-1)*range) %>&range=<%= range %>"><%= numPages %></a>
+
+    <%  } %>
+
+    ]
+
+    </p>
+
+<%  } %>
+
+<div class="jive-table">
+<table>
+<thead>
+    <tr>
+        <th>&nbsp;</th>
+        <th nowrap><fmt:message key="user.create.name" /></th>
+        <th nowrap><fmt:message key="global.delete" /></th>
+    </tr>
+</thead>
+<tbody>
+
+<%  // Print the list of retirees
+    Collection<String> retirees = webManager.getMultiUserChatManager().getRetirees(mucService.getServiceName(), start, range);
+    if (retirees.isEmpty()) {
+%>
+    <tr>
+        <td style="text-align: center" colspan="7">
+            <fmt:message key="muc.room.retirees.no_retirees" />
+        </td>
+    </tr>
+
+<%
+    }
+
+    int i = start;
+    for (String retiree : retirees) {
+        i++;
+%>
+    <tr>
+        <td style="width: 1%">
+            <%= i %>
+        </td>
+        <td style="width: 20%">
+            <%= StringUtils.escapeHTMLTags(retiree) %> &nbsp;
+        </td>
+        <td style="width: 1%; text-align: center; border-right:1px #ccc solid;">
+            <a href="muc-room-retirees.jsp?delete=true&service=<%= URLEncoder.encode(mucService.getServiceName(), "UTF-8") %>&name=<%= URLEncoder.encode(retiree, "UTF-8") %>&csrf=<%= csrfParam %>"
+             title="<fmt:message key="global.click_delete" />"
+             ><img src="images/delete-16x16.gif" alt="<fmt:message key="global.click_delete" />"></a>
+        </td>
+    </tr>
+
+<%
+    }
+%>
+</tbody>
+</table>
+</div>
+
+<%  if (numPages > 1) { %>
+
+    <p>
+    <fmt:message key="global.pages" />:
+    [
+    <%  int num = 15 + curPage;
+        int s = curPage-1;
+        if (s > 5) {
+            s -= 5;
+        }
+        if (s < 5) {
+            s = 0;
+        }
+        if (s > 2) {
+    %>
+        <a href="muc-room-retirees.jsp?start=0&range=<%= range %>">1</a> ...
+
+    <%
+        }
+        for (i=s; i<numPages && i<num; i++) {
+            String sep = ((i+1)<numPages) ? " " : "";
+            boolean isCurrent = (i+1) == curPage;
+    %>
+        <a href="muc-room-retirees.jsp?start=<%= (i*range) %>&range=<%= range %>"
+         class="<%= ((isCurrent) ? "jive-current" : "") %>"
+         ><%= (i+1) %></a><%= sep %>
+
+    <%  } %>
+
+    <%  if (i < numPages) { %>
+
+        ... <a href="muc-room-retirees.jsp?start=<%= ((numPages-1)*range) %>&range=<%= range %>"><%= numPages %></a>
+
+    <%  } %>
+
+    ]
+
+    </p>
+
+<%  } %>
+
+    </body>
+</html>


### PR DESCRIPTION
Retiring a room means that this room's name cannot be used again after the room is deleted. 

Where a MUC may have particular meaning to plugins or to other systems, assume that deletion is explicit and intentional. Do not allow the MUC name (and so JID) to be repurposed, preventing impersonation / corruption / access of MUC history, or other unforeseen side effects.