### PR TITLE
OF-2935: Fix retire MUC Room feature in cluster

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -3727,6 +3727,7 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
         ExternalizableUtil.getInstance().writeStringList(out, rolesToBroadcastPresence.stream().map(Enum::name).collect(Collectors.toList())); // This uses stringlist for compatibility with Openfire 4.6.0. Can be replaced the next major release.
         ExternalizableUtil.getInstance().writeBoolean(out, publicRoom);
         ExternalizableUtil.getInstance().writeBoolean(out, persistent);
+        ExternalizableUtil.getInstance().writeBoolean(out, retireOnDeletion);
         ExternalizableUtil.getInstance().writeBoolean(out, moderated);
         ExternalizableUtil.getInstance().writeBoolean(out, membersOnly);
         ExternalizableUtil.getInstance().writeBoolean(out, canOccupantsInvite);
@@ -3786,6 +3787,7 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
         rolesToBroadcastPresence.addAll(ExternalizableUtil.getInstance().readStringList(in).stream().map(Role::valueOf).collect(Collectors.toSet())); // This uses stringlist for compatibility with Openfire 4.6.0. Can be replaced the next major release.
         publicRoom = ExternalizableUtil.getInstance().readBoolean(in);
         persistent = ExternalizableUtil.getInstance().readBoolean(in);
+        retireOnDeletion = ExternalizableUtil.getInstance().readBoolean(in);
         moderated = ExternalizableUtil.getInstance().readBoolean(in);
         membersOnly = ExternalizableUtil.getInstance().readBoolean(in);
         canOccupantsInvite = ExternalizableUtil.getInstance().readBoolean(in);
@@ -3852,6 +3854,7 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
         rolesToBroadcastPresence = otherRoom.rolesToBroadcastPresence;
         publicRoom = otherRoom.publicRoom;
         persistent = otherRoom.persistent;
+        retireOnDeletion = otherRoom.retireOnDeletion;
         moderated = otherRoom.moderated;
         membersOnly = otherRoom.membersOnly;
         canOccupantsInvite = otherRoom.canOccupantsInvite;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -3680,6 +3680,7 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
         size += CacheSizes.sizeOfCollection(rolesToBroadcastPresence);
         size += CacheSizes.sizeOfBoolean();     // publicRoom
         size += CacheSizes.sizeOfBoolean();     // persistent
+        size += CacheSizes.sizeOfBoolean();     // retireOnDeletion
         size += CacheSizes.sizeOfBoolean();     // moderated
         size += CacheSizes.sizeOfBoolean();     // membersOnly
         size += CacheSizes.sizeOfBoolean();     // canOccupantsInvite

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQOwnerHandler.java
@@ -280,7 +280,7 @@ public class IQOwnerHandler {
 
         field = completedForm.getField("{http://igniterealtime.org}muc#roomconfig_retireondel");
         if (field != null) {
-            final boolean newValue = parseFirstValueAsBoolean(field, true);
+            final boolean newValue = parseFirstValueAsBoolean(field, false);
             room.setRetireOnDeletion(newValue);
         }
 


### PR DESCRIPTION
Prior to this change the `retireOnDeletion` value was not correctly retained during serialization in a clustered environment, e.g. when editing a MUC room properties.

If you were in a clustered environment and attempted to set the “Retire room names on deletion to prevent reuse“ option, when you saved changes to the room, the check box was not persisted and so you were unable to retire a room.

Also fixes:
- MUC Room cache size calculation
- Default `retireOnDeletion` value should be false if unable to parse data form value