### PR TITLE
OF-2921: Do not acquire mutex on unused StreamManager

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -944,14 +944,25 @@ public class LocalClientSession extends LocalSession implements ClientSession {
         if (stanzasToPush.isEmpty()) {
             return;
         }
-        synchronized (streamManager)
-        {
+
+        // When stream management is enabled, deliver and record stanzas under a mutex. If it's not enabled, don't
+        // acquire the lock to reduce lock contention (OF-2921).
+        if (!streamManager.isEnabled()) {
             // Push stanzas to the client.
             for (final Packet stanzaToPush : stanzasToPush) {
                 if (conn != null) {
                     conn.deliver(stanzaToPush);
                 }
-                streamManager.sentStanza(stanzaToPush);
+            }
+        } else {
+            synchronized (streamManager) {
+                // Push stanzas to the client.
+                for (final Packet stanzaToPush : stanzasToPush) {
+                    if (conn != null) {
+                        conn.deliver(stanzaToPush);
+                    }
+                    streamManager.sentStanza(stanzaToPush);
+                }
             }
         }
     }


### PR DESCRIPTION
Historically, disabling the Stream Management functionality has been a work-around for various issues.

To be able to work around a deadlock issue as described in OF-2921, this commit prevents a Stream Management-related mutex to be acquired when the Stream Management feature is disabled.