### PR TITLE
Remove redundant 'sync' when closing Netty connection

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -237,8 +237,7 @@ public class NettyConnection extends AbstractConnection
                             latch.countDown();
                         }
                     })
-                    .addListener(e -> Log.trace("Finished closing connection."))
-                    .sync(); // TODO: OF-2811 Remove this blocking operation (which may have been made redundant by the fix for OF-2808 anyway).
+                    .addListener(e -> Log.trace("Finished closing connection."));
             } catch (Throwable t) {
                 Log.error("Problem during connection close or cleanup", t);
                 latch.countDown(); // Ensure we're not kept waiting! OF-2845


### PR DESCRIPTION
To prevent a stream management issue described in OF-2808, two fixes were applied.

One of them, invoking close listeners synchronously, is suspected to have undesirable side-effects. This commit removes that fix, which is expected to be redundant anyway.