### PR TITLE
OF-2918: Expose numeric MUC room ID in events

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCEventDispatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,32 +102,32 @@ public class MUCEventDispatcher {
         }
     }
 
-    public static void roomCreated(JID roomJID) {
+    public static void roomCreated(long roomID, JID roomJID) {
         for (MUCEventListener listener : listeners) {
             try {
-                listener.roomCreated(roomJID);   
+                listener.roomCreated(roomID, roomJID);
             } catch (Exception e) {
-                Log.warn("An exception occurred while dispatching a 'roomCreated' event!", e);
+                Log.warn("An exception occurred while dispatching a 'roomCreated' event for room {} ({})!", roomJID, roomID, e);
             }
         }
     }
 
-    public static void roomDestroyed(JID roomJID) {
+    public static void roomDestroyed(long roomID, JID roomJID) {
         for (MUCEventListener listener : listeners) {
             try {
-                listener.roomDestroyed(roomJID);
+                listener.roomDestroyed(roomID, roomJID);
             } catch (Exception e) {
-                Log.warn("An exception occurred while dispatching a 'roomDestroyed' event!", e);
+                Log.warn("An exception occurred while dispatching a 'roomDestroyed' event for room {} ({})!", roomJID, roomID, e);
             }
         }
     }
 
-    public static void roomClearChatHistory(JID roomJID) {
+    public static void roomClearChatHistory(long roomID, JID roomJID) {
         for (MUCEventListener listener : listeners) {
             try {
-                listener.roomClearChatHistory(roomJID);
+                listener.roomClearChatHistory(roomID, roomJID);
             } catch (Exception e) {
-                Log.warn("An exception occurred while dispatching a 'roomClearChatHistory' event for room {}!", roomJID, e);
+                Log.warn("An exception occurred while dispatching a 'roomClearChatHistory' event for room {} ({})!",  roomJID, roomID, e);
             }
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.jivesoftware.openfire.muc;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
 
+import javax.annotation.Nonnull;
+
 /**
  * Interface to listen for MUC events. Use the {@link MUCEventDispatcher#addListener(MUCEventListener)}
  * method to register for events.
@@ -32,21 +34,21 @@ public interface MUCEventListener {
      *
      * @param roomJID JID of the room that was created.
      */
-    void roomCreated(JID roomJID);
+    void roomCreated(final long roomID, final @Nonnull JID roomJID);
 
     /**
      * Event triggered when a room was destroyed.
      *
      * @param roomJID JID of the room that was destroyed.
      */
-    void roomDestroyed(JID roomJID);
+    void roomDestroyed(final long roomID, final @Nonnull JID roomJID);
 
     /**
      * Event triggered when a clear chat history command was issued.
      *
      * @param roomJID JID of the room to clear chat history.
      */
-    void roomClearChatHistory(JID roomJID);
+    void roomClearChatHistory(final long roomID, final @Nonnull JID roomJID);
 
     /**
      * Event triggered when a new occupant joins a room.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1364,7 +1364,7 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
             // Remove the history of the room from memory (preventing it to pop up in a new room by the same name).
             roomHistory.purge();
             // Fire event to clear chat room history
-            MUCEventDispatcher.roomClearChatHistory(getJID());
+            MUCEventDispatcher.roomClearChatHistory(getID(), getJID());
         });
     }
 
@@ -1446,10 +1446,10 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
         roomHistory.purge();
         // If we are not preserving room history on deletion, fire event to clear chat room history
         if(!preserveHistOnRoomDeletion) {
-            MUCEventDispatcher.roomClearChatHistory(getJID());
+            MUCEventDispatcher.roomClearChatHistory(getID(), getJID());
         }
         // Fire event that the room has been destroyed
-        MUCEventDispatcher.roomDestroyed(getJID());
+        MUCEventDispatcher.roomDestroyed(getID(), getJID());
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -402,7 +402,8 @@ public class LocalMUCRoomManager
                 localRooms.remove(key);
                 final MultiUserChatService service = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(serviceName);
                 if (service != null) {
-                    service.getOccupantManager().roomDestroyed(new JID(key, service.getServiceDomain(), null));
+                    final long roomID = -1; // Unused by OccupantManager.
+                    service.getOccupantManager().roomDestroyed(roomID, new JID(key, service.getServiceDomain(), null));
                 }
             }
 
@@ -415,7 +416,8 @@ public class LocalMUCRoomManager
                 localRooms.remove(key);
                 final MultiUserChatService service = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(serviceName);
                 if (service != null) {
-                    service.getOccupantManager().roomDestroyed(new JID(key, service.getServiceDomain(), null));
+                    final long roomID = -1; // Unused by OccupantManager.
+                    service.getOccupantManager().roomDestroyed(roomID, new JID(key, service.getServiceDomain(), null));
                 }
             }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1963,7 +1963,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         }
         if (created) {
             // Fire event that a new room has been created
-            MUCEventDispatcher.roomCreated(room.getSelfRepresentation().getOccupantJID());
+            MUCEventDispatcher.roomCreated(room.getID(), room.getSelfRepresentation().getOccupantJID());
         }
         if (loaded || created) {
             // Initiate FMUC, when enabled.
@@ -3325,6 +3325,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                 Log.info("Room '{}' was lost from the data structure that's shared in the cluster (the cache). This room is now considered 'gone' for this cluster node. Occupants will be informed.", lostRoomName);
                 final Set<OccupantManager.Occupant> occupants = occupantManager.occupantsForRoomByNode(lostRoomName, XMPPServer.getInstance().getNodeID(), true);
                 final JID roomJID = new JID(lostRoomName, fullServiceName, null);
+                final long roomID = -1; // As this value is currently not used by OccupantManager, we can avoid the complexity in having it looked up.
                 for (final OccupantManager.Occupant occupant : occupants) {
                     try {
                         // Send a presence stanza of type "unavailable" to the occupant
@@ -3349,7 +3350,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                     }
                 }
                 // Clean up the locally maintained bookkeeping.
-                occupantManager.roomDestroyed(roomJID);
+                occupantManager.roomDestroyed(roomID, roomJID);
                 removeChatRoom(lostRoomName);
             } catch (Exception e) {
                 Log.warn("Unable to inform occupants on local cluster node that they are being removed from room '{}' because of a (cluster) error.", lostRoomName, e);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/OccupantManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/OccupantManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -937,12 +937,13 @@ public class OccupantManager implements MUCEventListener
     }
 
     @Override
-    public void roomCreated(JID roomJID) {
+    public void roomCreated(final long roomID, @Nonnull final JID roomJID) {
         // Not used.
     }
 
     @Override
-    public void roomDestroyed(@Nonnull final JID roomJID)
+    // Beware that the invocation does not properly initialize the first argument! Do not use it without fixing that!
+    public void roomDestroyed(final long unused, @Nonnull final JID roomJID)
     {
         // When a room is destroyed, remove all registered occupants for that room.
         mutex.writeLock().lock();
@@ -961,7 +962,7 @@ public class OccupantManager implements MUCEventListener
     }
 
     @Override
-    public void roomClearChatHistory(JID roomJID) {
+    public void roomClearChatHistory(final long roomID, final @Nonnull JID roomJID) {
         // Not used.
     }
 


### PR DESCRIPTION
A MUC room of the same name (JID) can be created, destroyed and recreated again. The two rooms should be seen as two different rooms.

When using the JID of the rooms, there's no way to distinghuish between them. For that, Openfire's numeric ID can be used.

In this commit, the numeric ID is added to selected MUC events.