### PR TITLE
OF-2938: Fix missing warnings for incompatible plugins

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -450,9 +450,6 @@ public class PluginManager
      */
     synchronized boolean loadPlugin( String canonicalName, Path pluginDir )
     {
-        // Clean up any warnings that were recorded during a previous attempt to load the plugin.
-        lastLoadWarnings.remove(canonicalName);
-
         final PluginMetadata metadata = PluginMetadata.getInstance( pluginDir );
         pluginMetadata.put( canonicalName, metadata );
 
@@ -468,6 +465,9 @@ public class PluginManager
             Log.debug("The unloaded file for plugin '{}' is silently ignored, as it has failed to load repeatedly.", canonicalName);
             return false;
         }
+
+        // Clean up any warnings that were recorded during a previous attempt to load the plugin.
+        lastLoadWarnings.remove(canonicalName);
 
         Log.debug( "Loading plugin '{}'...", canonicalName );
         try


### PR DESCRIPTION
When a plugin fails to load, a warning should be displayed on the admin console plugin page.

This commit fixes a bug where this warning would be removed when an automatic reload of the plugin was attempted.

![image](https://github.com/user-attachments/assets/39950a1a-6995-4d46-a7df-a7b6b5aa4042)
