### PR TITLE
OF-2939: Admin console landing page should show plugin warnings

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -676,6 +676,7 @@ index.available_users_sessions=Available Users Sessions
 index.update.alert=Update information
 index.update.info=Server version {0} is now available. Click {1}here{2} to download or read the \
         {3}change log{4} for more information.
+index.plugin.load-warning=One or more plugins failed to load. Please click {0}here{1} to review the status of all installed plugins.
 index.cs_blog=Ignite Realtime News
 index.cs_blog.unavailable=The Ignite Realtime feed is currently unavailable.
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -618,6 +618,7 @@ index.memory=Java geheugen
 index.memory_usage_description={0} MB van {1} MB ({2}%) in gebruik
 index.update.alert=Update information
 index.update.info=Openfire {0} is nu niet beschikbaar. Voor meer informatie, klik {1}hier{2} om de {3}change log{4} te downloaden of in te zien.
+index.plugin.load-warning=Een of meerdere plugins kunnen niet geladen worden. Klik {0}hier{1} om de status van de geïnstalleerde plugins te zien.
 index.cs_blog=Ignite Realtime Nieuws
 index.cs_blog.unavailable=De feed van Ignite Realtime is momenteel niet beschikbaar.
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -979,6 +979,15 @@ public class PluginManager
      */
     public String getLoadWarning(final String canonicalPluginName) {
         return lastLoadWarnings.get(canonicalPluginName);
+    }
+
+    /**
+     * Checks if there were any problems while loading plugins.
+     *
+     * @return true when at least one plugin has failed to load, otherwise false.
+     */
+    public boolean hasLoadWarnings() {
+        return !lastLoadWarnings.isEmpty();
     }
 
     /**

--- a/xmppserver/src/main/webapp/index.jsp
+++ b/xmppserver/src/main/webapp/index.jsp
@@ -42,6 +42,7 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="admin" prefix="admin" %>
 
 <%-- Define page bean for header and sidebar --%>
 <jsp:useBean id="pageinfo" scope="request" class="org.jivesoftware.admin.AdminPageBean" />
@@ -116,7 +117,10 @@
 <%
     UpdateManager updateManager = XMPPServer.getInstance().getUpdateManager();
     Update serverUpdate = updateManager.getServerUpdate();
-    pageContext.setAttribute( "serverUpdate", serverUpdate ); %>
+    pageContext.setAttribute( "serverUpdate", serverUpdate );
+
+    pageContext.setAttribute( "hasPluginWarnings", XMPPServer.getInstance().getPluginManager().hasLoadWarnings());
+%>
 
     <c:if test="${not empty serverUpdate}">
         <div class="warning">
@@ -144,6 +148,14 @@
         <br>
     </c:if>
 
+    <c:if test="${hasPluginWarnings}">
+        <admin:infoBox type="warning">
+            <fmt:message key="index.plugin.load-warning">
+                <fmt:param value="<a href=\"./plugin-admin.jsp\">" />
+                <fmt:param value="</a>"/>
+            </fmt:message>
+        </admin:infoBox>
+    </c:if>
 <style>
 .bar TD {
     padding : 0;


### PR DESCRIPTION
When plugins fail to load, add a warning on the landing page. This should make the problem more visible.

![image](https://github.com/user-attachments/assets/23c570f6-c9db-4677-8985-6f5238a945d1)
