### PR TITLE
OF-2945: Prevent stack traces when pre-compiling JSP pages

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -356,6 +356,19 @@
                             </configuration>
                         </execution>
                     </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.eclipse.jetty.ee8</groupId>
+                            <artifactId>jetty-ee8-glassfish-jstl</artifactId>
+                            <version>${jetty.version}</version>
+                            <exclusions>
+                                <exclusion> <!-- The exclusion of Xalan is no longer needed when Jetty bug https://github.com/jetty/jetty.project/issues/12674 is fixed. The fix is expected to be part of Jetty release 12.0.17. -->
+                                    <groupId>xalan</groupId>
+                                    <artifactId>xalan</artifactId>
+                                </exclusion>
+                            </exclusions>
+                        </dependency>
+                    </dependencies>
                 </plugin>
 
                 <plugin>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -175,6 +175,19 @@
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.eclipse.jetty.ee8</groupId>
+                        <artifactId>jetty-ee8-glassfish-jstl</artifactId>
+                        <version>${jetty.version}</version>
+                        <exclusions>
+                            <exclusion> <!-- The exclusion of Xalan is no longer needed when Jetty bug https://github.com/jetty/jetty.project/issues/12674 is fixed. The fix is expected to be part of Jetty release 12.0.17. -->
+                                <groupId>xalan</groupId>
+                                <artifactId>xalan</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
After upgrading to Jetty 12, we also updated the Jetty plugin that performs precompilation of the JPS pages that make up the admin console. We are now using jetty-ee8-jspc-maven

Since this update, the build process is spewing out rather long stack traces, related to missing JAR files. The stack traces can be seen in https://igniterealtime.atlassian.net/browse/OF-2945

We have not noticed any failing functional behavior because of this. Nonetheless, the stack traces are annoying, as they suggest that something is wrong.

The missing JAR files seem to relate to the Xalan project, which is not a dependency of Openfire. It is, however, a dependency of Jetty's JSPC plugin.

On a hunch, I've excluded that dependency from the plugin during our build. That makes the stack trace go away. JSP compilation appears to work just fine with this change.