### PR TITLE
Make close event handling asynchronous and remote session locator improvement

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ConnectionCloseListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ConnectionCloseListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,47 @@
 
 package org.jivesoftware.openfire;
 
+import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Implement and register with a connection to receive notification
  * of the connection closing.
  *
  * @author Iain Shigeoka
+ * @author Guus der Kinderen, guus@goodbytes.nl
  */
-public interface ConnectionCloseListener {
+public interface ConnectionCloseListener
+{
     /**
-     * Called when a connection is closed.
+     * Called when a connection is being closed.
      *
      * @param handback The handback object associated with the connection listener during Connection.registerCloseListener()
+     * @deprecated replaced by {@link #onConnectionClosing(Object)}
      */
-    void onConnectionClose( Object handback );
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.1.0
+    default void onConnectionClose( Object handback ) {};
+
+    /**
+     * Called when a connection is being closed.
+     *
+     * This method is intended to be used to start asynchronous processes. The Future that is returned is to be used
+     * to status of such an asynchronous process.
+     *
+     * @param handback The handback object associated with the connection listener during Connection.registerCloseListener()
+     * @return a Future representing pending completion of the event listener invocation.
+     */
+    default CompletableFuture<Void> onConnectionClosing(@Nullable final Object handback)
+    {
+        // The default implementation is a blocking invocation of the method that is being replaced: onConnectionClose()
+        // This is designed to facilitate a graceful migration, where pre-existing implementations of this interface
+        // will continue to work without change. When the deprecated method is deleted, this default implementation
+        // should also be removed.
+        try {
+            onConnectionClose(handback);
+        } catch (Throwable t) {
+            return CompletableFuture.failedFuture(t);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -423,8 +423,13 @@ public class SocketConnection extends AbstractConnection {
             }
                 
             closeConnection();
-            notifyCloseListeners();
-            closeListeners.clear();
+
+            notifyCloseListeners().whenComplete((v,t) -> {
+                closeListeners.clear();
+                if (t != null) {
+                    Log.warn("Exception while invoking close listeners for {}", this, t);
+                }
+            });
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,14 +141,18 @@ public abstract class VirtualConnection extends AbstractConnection
             // This fixes a very visible bug where MUC users would remain in the MUC room long after
             // their session was closed. Effectively, the bug prevents the MUC room from getting a
             // presence update to notify it that the user logged off.
-            notifyCloseListeners();
-            closeListeners.clear();
+            notifyCloseListeners().whenComplete((v,t) -> {
+                closeListeners.clear();
+                if (t != null) {
+                    Log.warn("Exception while invoking close listeners for {}", this, t);
+                }
 
-            try {
-                closeVirtualConnection(error);
-            } catch (Exception e) {
-                Log.error(LocaleUtils.getLocalizedString("admin.error.close") + "\n" + toString(), e);
-            }
+                try {
+                    closeVirtualConnection(error);
+                } catch (Exception e) {
+                    Log.error(LocaleUtils.getLocalizedString("admin.error.close") + "\n" + toString(), e);
+                }
+            });
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionLocator.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionLocator.java
@@ -37,7 +37,7 @@ public interface RemoteSessionLocator {
      *
      * @param nodeID the ID of the node hosting the session.
      * @param address the address that uniquely identifies the session.
-     * @return a session surrogate of a client session hosted by a remote cluster node.
+     * @return a session surrogate of a client session hosted by a remote cluster node, or null if no such session was found.
      */
     ClientSession getClientSession(byte[] nodeID, JID address);
 
@@ -49,7 +49,7 @@ public interface RemoteSessionLocator {
      *
      * @param nodeID the ID of the node hosting the session.
      * @param address the address that uniquely identifies the session.
-     * @return a session surrogate of a component session hosted by a remote cluster node.
+     * @return a session surrogate of a component session hosted by a remote cluster node, or null if no such session was found.
      */
     ComponentSession getComponentSession(byte[] nodeID, JID address);
 
@@ -61,7 +61,7 @@ public interface RemoteSessionLocator {
      *
      * @param nodeID the ID of the node hosting the session.
      * @param address the address that uniquely identifies the session.
-     * @return a session surrogate of a ConnectionMultiplexer session hosted by a remote cluster node.
+     * @return a session surrogate of a ConnectionMultiplexer session hosted by a remote cluster node, or null if no such session was found.
      */
     ConnectionMultiplexerSession getConnectionMultiplexerSession(byte[] nodeID, JID address);
 
@@ -73,7 +73,7 @@ public interface RemoteSessionLocator {
      *
      * @param nodeID the ID of the node hosting the session.
      * @param streamID the stream ID that uniquely identifies the session.
-     * @return a session surrogate of an incoming server session hosted by a remote cluster node.
+     * @return a session surrogate of an incoming server session hosted by a remote cluster node, or null if no such session was found.
      */
     IncomingServerSession getIncomingServerSession(byte[] nodeID, StreamID streamID);
 
@@ -85,7 +85,7 @@ public interface RemoteSessionLocator {
      *
      * @param nodeID the ID of the node hosting the session.
      * @param address the address that uniquely identifies the session.
-     * @return a session surrogate of an incoming server session hosted by a remote cluster node.
+     * @return a session surrogate of an incoming server session hosted by a remote cluster node, or null if no such session was found.
      */
     OutgoingServerSession getOutgoingServerSession(byte[] nodeID, DomainPair address);
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionLocatorImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionLocatorImpl.java
@@ -18,6 +18,8 @@ package org.jivesoftware.openfire.session;
 
 import org.jivesoftware.openfire.StreamID;
 import org.jivesoftware.openfire.XMPPServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
 import java.nio.charset.StandardCharsets;
@@ -29,39 +31,46 @@ import java.nio.charset.StandardCharsets;
  */
 public class RemoteSessionLocatorImpl implements RemoteSessionLocator {
 
+    private static final Logger Log = LoggerFactory.getLogger(RemoteSessionLocatorImpl.class);
+
     // TODO Keep a cache for a brief moment so we can reuse same instances (that use their own cache)
 
     public ClientSession getClientSession(byte[] nodeID, JID address) {
         if (XMPPServer.getInstance().getNodeID().equals(nodeID)) {
-            throw new IllegalStateException("Asked to return a RemoteClientSession for '" + address + " on node " + new String(nodeID, StandardCharsets.UTF_8) + ". That node, however, is the local node (not a remote one).");
+            Log.warn("Illegal State: Asked to return a RemoteClientSession for '{} on node {}. That node, however, is the local node (not a remote one). This is likely a bug in Openfire or one of its plugins.", address, new String(nodeID, StandardCharsets.UTF_8));
+            return null;
         }
         return new RemoteClientSession(nodeID, address);
     }
 
     public ComponentSession getComponentSession(byte[] nodeID, JID address) {
         if (XMPPServer.getInstance().getNodeID().equals(nodeID)) {
-            throw new IllegalStateException("Asked to return a RemoteComponentSession for '" + address + " on node " + new String(nodeID, StandardCharsets.UTF_8) + ". That node, however, is the local node (not a remote one).");
+            Log.warn("Illegal State: Asked to return a RemoteComponentSession for '{} on node {}. That node, however, is the local node (not a remote one). This is likely a bug in Openfire or one of its plugins.", address, new String(nodeID, StandardCharsets.UTF_8));
+            return null;
         }
         return new RemoteComponentSession(nodeID, address);
     }
 
     public ConnectionMultiplexerSession getConnectionMultiplexerSession(byte[] nodeID, JID address) {
         if (XMPPServer.getInstance().getNodeID().equals(nodeID)) {
-            throw new IllegalStateException("Asked to return a RemoteConnectionMultiplexerSession for '" + address + " on node " + new String(nodeID, StandardCharsets.UTF_8) + ". That node, however, is the local node (not a remote one).");
+            Log.warn("Illegal State: Asked to return a RemoteConnectionMultiplexerSession for '{} on node {}. That node, however, is the local node (not a remote one). This is likely a bug in Openfire or one of its plugins.", address, new String(nodeID, StandardCharsets.UTF_8));
+            return null;
         }
         return new RemoteConnectionMultiplexerSession(nodeID, address);
     }
 
     public IncomingServerSession getIncomingServerSession(byte[] nodeID, StreamID streamID) {
         if (XMPPServer.getInstance().getNodeID().equals(nodeID)) {
-            throw new IllegalStateException("Asked to return a RemoteIncomingServerSession for '" + streamID + " on node " + new String(nodeID, StandardCharsets.UTF_8) + ". That node, however, is the local node (not a remote one).");
+            Log.warn("Illegal State: Asked to return a RemoteIncomingServerSession for '{} on node {}. That node, however, is the local node (not a remote one). This is likely a bug in Openfire or one of its plugins.", streamID, new String(nodeID, StandardCharsets.UTF_8));
+            return null;
         }
         return new RemoteIncomingServerSession(nodeID, streamID);
     }
 
     public OutgoingServerSession getOutgoingServerSession(byte[] nodeID, DomainPair address) {
         if (XMPPServer.getInstance().getNodeID().equals(nodeID)) {
-            throw new IllegalStateException("Asked to return a RemoteIncomingServerSession for '" + address + " on node " + new String(nodeID, StandardCharsets.UTF_8) + ". That node, however, is the local node (not a remote one).");
+            Log.warn("Illegal State: Asked to return a RemoteOutgoingServerSession for '{} on node {}. That node, however, is the local node (not a remote one). This is likely a bug in Openfire or one of its plugins.", address, new String(nodeID, StandardCharsets.UTF_8));
+            return null;
         }
         return new RemoteOutgoingServerSession(nodeID, address);
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionLocatorImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionLocatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,10 @@
 package org.jivesoftware.openfire.session;
 
 import org.jivesoftware.openfire.StreamID;
+import org.jivesoftware.openfire.XMPPServer;
 import org.xmpp.packet.JID;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * Locator of sessions that know how to talk to Hazelcast cluster nodes.
@@ -29,22 +32,37 @@ public class RemoteSessionLocatorImpl implements RemoteSessionLocator {
     // TODO Keep a cache for a brief moment so we can reuse same instances (that use their own cache)
 
     public ClientSession getClientSession(byte[] nodeID, JID address) {
+        if (XMPPServer.getInstance().getNodeID().equals(nodeID)) {
+            throw new IllegalStateException("Asked to return a RemoteClientSession for '" + address + " on node " + new String(nodeID, StandardCharsets.UTF_8) + ". That node, however, is the local node (not a remote one).");
+        }
         return new RemoteClientSession(nodeID, address);
     }
 
     public ComponentSession getComponentSession(byte[] nodeID, JID address) {
+        if (XMPPServer.getInstance().getNodeID().equals(nodeID)) {
+            throw new IllegalStateException("Asked to return a RemoteComponentSession for '" + address + " on node " + new String(nodeID, StandardCharsets.UTF_8) + ". That node, however, is the local node (not a remote one).");
+        }
         return new RemoteComponentSession(nodeID, address);
     }
 
     public ConnectionMultiplexerSession getConnectionMultiplexerSession(byte[] nodeID, JID address) {
+        if (XMPPServer.getInstance().getNodeID().equals(nodeID)) {
+            throw new IllegalStateException("Asked to return a RemoteConnectionMultiplexerSession for '" + address + " on node " + new String(nodeID, StandardCharsets.UTF_8) + ". That node, however, is the local node (not a remote one).");
+        }
         return new RemoteConnectionMultiplexerSession(nodeID, address);
     }
 
     public IncomingServerSession getIncomingServerSession(byte[] nodeID, StreamID streamID) {
+        if (XMPPServer.getInstance().getNodeID().equals(nodeID)) {
+            throw new IllegalStateException("Asked to return a RemoteIncomingServerSession for '" + streamID + " on node " + new String(nodeID, StandardCharsets.UTF_8) + ". That node, however, is the local node (not a remote one).");
+        }
         return new RemoteIncomingServerSession(nodeID, streamID);
     }
 
     public OutgoingServerSession getOutgoingServerSession(byte[] nodeID, DomainPair address) {
+        if (XMPPServer.getInstance().getNodeID().equals(nodeID)) {
+            throw new IllegalStateException("Asked to return a RemoteIncomingServerSession for '" + address + " on node " + new String(nodeID, StandardCharsets.UTF_8) + ". That node, however, is the local node (not a remote one).");
+        }
         return new RemoteOutgoingServerSession(nodeID, address);
     }
 }


### PR DESCRIPTION
This revisits the fix for OF-2921, which introduces a problem in which a broadcast of presence occurs while the session is removed from the session manager. This causes issues, as the broadcast needs data associated to the session (such as its roster, privacy lists, etc). 

This PR holds two changes that improve on the previous solution. Please refer to individual commit messages for details. 