### PR TITLE
OF-2951: Async stanza delivery

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/OfflinePacketDeliverer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/OfflinePacketDeliverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2015 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2015 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import org.xmpp.packet.Message;
 import org.xmpp.packet.Packet;
 import org.xmpp.packet.Presence;
 
+import javax.annotation.Nonnull;
+
 /**
  * Fallback method used by {@link org.jivesoftware.openfire.nio.NettyConnection} when a
  * connection fails to send a {@link Packet} (likely because it was closed). Message packets
@@ -39,25 +41,24 @@ public class OfflinePacketDeliverer implements PacketDeliverer {
 
     private static final Logger Log = LoggerFactory.getLogger(OfflinePacketDeliverer.class);
 
-    private OfflineMessageStrategy messageStrategy;
+    private final OfflineMessageStrategy messageStrategy;
 
     public OfflinePacketDeliverer() {
         this.messageStrategy = XMPPServer.getInstance().getOfflineMessageStrategy();
     }
 
     @Override
-    public void deliver(Packet packet) throws UnauthorizedException, PacketException {
-        
-        if (packet instanceof Message) {
-            messageStrategy.storeOffline((Message) packet);
+    public void deliver(final @Nonnull Packet stanza) throws UnauthorizedException, PacketException
+    {
+        if (stanza instanceof Message) {
+            messageStrategy.storeOffline((Message) stanza);
         }
-        else if (packet instanceof Presence) {
-            // presence packets are dropped silently
+        else if (stanza instanceof Presence) {
+            Log.trace("Silently dropping a presence stanza.");
         }
-        else if (packet instanceof IQ) {
+        else if (stanza instanceof IQ) {
             // IQ packets are logged before being dropped
-            Log.warn(LocaleUtils.getLocalizedString("admin.error.routing") + "\n" + packet.toString());
+            Log.warn(LocaleUtils.getLocalizedString("admin.error.routing") + "\n" + stanza);
         }
     }
-
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PacketDelivererImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PacketDelivererImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import org.jivesoftware.openfire.container.BasicModule;
 import org.jivesoftware.openfire.net.SocketPacketWriteHandler;
 import org.xmpp.packet.Packet;
 
+import javax.annotation.Nonnull;
+
 /**
  * In-memory implementation of the packet deliverer service
  *
@@ -41,12 +43,12 @@ public class PacketDelivererImpl extends BasicModule implements PacketDeliverer 
     }
 
     @Override
-    public void deliver(Packet packet) throws UnauthorizedException, PacketException {
+    public void deliver(@Nonnull final Packet packet) throws UnauthorizedException, PacketException {
         if (packet == null) {
             throw new PacketException("Packet was null");
         }
         if (deliverHandler == null) {
-            throw new PacketException("Could not send packet - no route" + packet.toString());
+            throw new PacketException("Could not send packet - no route: " + packet.toString());
         }
         // Let the SocketPacketWriteHandler process the packet. SocketPacketWriteHandler may send
         // it over the socket or store it when user is offline or drop it.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -435,7 +435,7 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
                         probePresence.setFrom(prober);
                         probePresence.setTo(probee.toBareJID());
                         // Send the probe presence
-                        deliverer.deliver(probePresence);
+                        deliverer.deliverAsync(probePresence).whenComplete((v, t) -> { if (t != null) { Log.warn("Unable to probe presence from {} to {}", prober, probee, t); }});
                     }
                     else {
                         // The probee may be related to a component that has not yet been connected so


### PR DESCRIPTION
Adds a facility to allow for non-blocking stanza delivery.

The new facility is used when probing presence of entities on remote domains (as that can slow down a client that's connecting to Openfire).

Potentially this could/should be used in other places too (as the act of delivery doesn't return a result, and thus isn't expected to be needing a blocking operation), but I thought it best to take baby steps here. 