### PR TITLE
OF-2921: Async closure partial revert

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -292,9 +292,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
                     Presence presence = new Presence();
                     presence.setType(Presence.Type.unavailable);
                     presence.setFrom(session.getAddress());
-
-                    // Broadcast asynchronously, to reduce the likelihood of the broadcast introducing a deadlock (OF-2921).
-                    TaskEngine.getInstance().submit(() -> router.route(presence));
+                    router.route(presence);
                 }
 
                 session.getStreamManager().onClose(router, serverAddress);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import java.io.ObjectOutput;
  */
 public class ClientSessionTask extends RemoteSessionTask {
 
-    private static Logger logger = LoggerFactory.getLogger(ClientSessionTask.class);
+    private static final Logger logger = LoggerFactory.getLogger(ClientSessionTask.class);
 
     private JID address;
     private transient Session session;
@@ -61,7 +61,7 @@ public class ClientSessionTask extends RemoteSessionTask {
 
     public void run() {
         if (getSession() == null || getSession().isClosed()) {
-            logger.error("Session not found for JID: " + address);
+            logger.error("Unable to execute task for JID {}: {}", address, this, new IllegalStateException("Session not found for JID: " + address));
             return;
         }
         super.run();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -414,7 +414,8 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
                         routed = remotePacketRouter
                                 .routePacket(clientRoute.getNodeID().toByteArray(), jid, packet);
                         if (!routed) {
-                            removeClientRoute(jid); // drop invalid client route
+                            Log.warn("Dropping invalid client route for {}", jid);
+                            removeClientRoute(jid);
                         }
                     }
                 }


### PR DESCRIPTION
Reverts some of the changes introduced to prevent a deadlock (OF-2921).

Routing the unavailable presence that's sent out when a session closes cannot be made asynchronous. If the 'next step' is done prior to the routing of unavailable presence having completed, the session seems to be (partially) re-added. This causes an invalid state: the routing table no longer has the session, but caches such as the Routing Users Cache does.

This incorrect behavior was introduced by a fix for OF-2921: https://github.com/igniterealtime/Openfire/commit/b98a83d3470e06b66fbe718a304cfcf39bfba8c5

It was already partially reverted by https://github.com/igniterealtime/Openfire/commit/7aca93f16826c00215e0e7909ec8519a375a4701

The first commit in this PR reverts the remainder.