### PR TITLE
update native2ascii-maven-plugin

### DIFF
--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -29,7 +29,7 @@
                   -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>native2ascii-maven-plugin</artifactId>
-                <version>2.0.1</version>
+                <version>2.1.1</version>
                 <executions>
                     <execution>
                         <id>utf8-to-latin1</id>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -218,7 +218,7 @@
                   -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>native2ascii-maven-plugin</artifactId>
-                <version>2.0.1</version>
+                <version>2.1.1</version>
                 <executions>
                     <execution>
                         <id>utf8-to-latin1</id>


### PR DESCRIPTION
The maven plugin `native2ascii-maven-plugin` has wrong  encoding in two of its xml files. This causes **vscode** and **eclipse** to report `pom.xml` errors.
Bellow is the error reported by eclipse for each maven project which has **openfire-plugins** as parent:
`Cannot read lifecycle mapping metadata for artifact org.codehaus.mojo:native2ascii-maven-plugin:maven-plugin:2.0.1:runtime Cause: UTF-8 BOM plus xml decl of ISO-8859-1 is incompatible (position: START_DOCUMENT seen <?xml version="1.0" encoding="ISO-8859-1"... @1:42) `

This was fixed in July 2023 and was included in version 2.1.1
https://github.com/mojohaus/native2ascii-maven-plugin/commit/f92ab618f1a894fd1ba09222c6f19f0b45b8615a
https://github.com/mojohaus/native2ascii-maven-plugin/commit/a71e02fabcf78754505f3a2ad0a27eb235871a94