### PR TITLE
OF-2754: Deprecate FastDateFormat

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/FastDateFormat.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/FastDateFormat.java
@@ -50,8 +50,6 @@
  * For more information about Tea, please see http://opensource.go.com/.
  */
 
-//TODO: https://igniterealtime.atlassian.net/browse/OF-2754
-
 package org.jivesoftware.util;
 
 import java.util.Date;
@@ -75,7 +73,9 @@ import java.text.SimpleDateFormat;
  * <p>Note, this class is from the open source Tea project (http://sourceforge.net/projects/teatrove/).</p>
  *
  * @author Brian S O'Neill
+ * @deprecated Use instead thread-safe implementations provided by Java, such as {@link java.time.format.DateTimeFormatter}
  */
+@Deprecated(forRemoval = true) // Remove in or after Openfire 5.1.0
 public class FastDateFormat {
     /** Style pattern */
     public static final Object

--- a/xmppserver/src/main/java/org/jivesoftware/util/XMPPDateTimeFormat.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/XMPPDateTimeFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Florian Schmaus, 2017-2024 Ignite Realtime Foundation. All rights reserved
+ * Copyright (C) 2013 Florian Schmaus, 2017-2025 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package org.jivesoftware.util;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
@@ -61,8 +64,7 @@ public class XMPPDateTimeFormat {
     @SuppressWarnings("unused")
     private static final Pattern xep91Pattern = Pattern.compile("^\\d+T\\d+:\\d+:\\d+$");
 
-    private static final FastDateFormat FAST_FORMAT = FastDateFormat.getInstance(
-            XMPP_DATETIME_FORMAT, TimeZone.getTimeZone("UTC"));
+    private static final DateTimeFormatter FAST_FORMAT = DateTimeFormatter.ofPattern(XMPP_DATETIME_FORMAT).withZone(ZoneOffset.UTC);
 
     private final DateFormat dateTimeFormat = new SimpleDateFormat(XMPP_DATETIME_FORMAT_WO_TIMEZONE + 'Z');
     private final DateFormat dateTimeFormatWoMillies = new SimpleDateFormat(XMPP_DATETIME_FORMAT_WO_MILLIS_WO_TIMEZONE + 'Z');
@@ -137,6 +139,19 @@ public class XMPPDateTimeFormat {
      * @return the formatted date
      */
     public static String format(Date date) {
-        return FAST_FORMAT.format(date);
+        return FAST_FORMAT.format(date.toInstant());
+    }
+
+    /**
+     * Formats a Date object to String as defined in XEP-0082.
+     *
+     * The resulting String will have the timezone set to UTC ('Z') and includes milliseconds:
+     * CCYY-MM-DDThh:mm:ss.sssZ
+     *
+     * @param instant the date to format
+     * @return the formatted date
+     */
+    public static String format(Instant instant) {
+        return FAST_FORMAT.format(instant);
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/util/XMPPDateTimeFormatTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/XMPPDateTimeFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -124,7 +125,53 @@ public class XMPPDateTimeFormatTest {
         final Date result = xmppDateTimeFormat.parseString(testValue);
 
         // Verify results
-        long expected = 1426805655841L; // Epoch value of Thu, 19 Mar 2015 22:54:15 GMT
+        long expected = 1426805655841L; // Epoch value of Thu, 19 Mar 2015 22:54:15:841 GMT
         assertEquals( expected, result.getTime() );
+    }
+
+    @Test
+    public void testFormatDate() throws Exception
+    {
+        // Setup fixture
+        final Date testValue = new Date(1426805655841L); // Epoch value of Thu, 19 Mar 2015 22:54:15:841 GMT
+
+        // Execute system under test
+        final String result = XMPPDateTimeFormat.format(testValue);
+
+        // Verify results
+        assertEquals("2015-03-19T22:54:15.841Z", result);
+    }
+
+    @Test
+    public void testFormatDateNull() throws Exception
+    {
+        // Setup fixture
+        final Date testValue = null;
+
+        // Execute system under test & verify results
+        assertThrows(NullPointerException.class, () -> XMPPDateTimeFormat.format(testValue));
+    }
+
+    @Test
+    public void testFormatInstant() throws Exception
+    {
+        // Setup fixture
+        final Instant testValue = Instant.ofEpochMilli(1426805655841L); // Epoch value of Thu, 19 Mar 2015 22:54:15:841 GMT
+
+        // Execute system under test
+        final String result = XMPPDateTimeFormat.format(testValue);
+
+        // Verify results
+        assertEquals("2015-03-19T22:54:15.841Z", result);
+    }
+
+    @Test
+    public void testFormatInstantNull() throws Exception
+    {
+        // Setup fixture
+        final Instant testValue = null;
+
+        // Execute system under test & verify results
+        assertThrows(NullPointerException.class, () -> XMPPDateTimeFormat.format(testValue));
     }
 }


### PR DESCRIPTION
This marks the third-party FastDateFormat class as deprecated, and replaces its usage with Java-native APIs.