### PR TITLE
OF-2831: Modify tests to cover offending data

### DIFF
--- a/xmppserver/src/test/java/org/jivesoftware/openfire/muc/MUCOccupantTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/muc/MUCOccupantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class MUCOccupantTest
     public void testExternalizedEquals() throws Exception
     {
         // Setup test fixture.
-        final JID userAddress = new JID("unittest@example.org");
+        final JID userAddress = new JID("unittest@example.org/Ψ+");
         final String nickname = "nickname for test";
         final Role role = Role.participant;
         final Affiliation affiliation = Affiliation.admin;

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/muc/MUCRoomTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/muc/MUCRoomTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ public class MUCRoomTest {
 
         final List<MUCOccupant> occupants = new ArrayList<>();
         final MUCOccupant occupantA = new MUCOccupant();
-        populateField(occupantA, "roomJid", new JID("occupantA@example.org"));
+        populateField(occupantA, "roomJid", new JID("occupantA@example.org/Ψ+"));
         populateField(occupantA, "role", Role.participant);
         populateField(occupantA, "affiliation", Affiliation.member);
         populateField(occupantA, "occupantJID", new JID("room-test-jid@conference.example.org/occupantA"));


### PR DESCRIPTION
This modifies existing unit tests to explicitly use data that appears to have triggered OF-2831. The resulting tests do not fail.