### PR TITLE
OF-2956: Drop database table ofSASLAuthorized

### DIFF
--- a/distribution/src/database/openfire_db2.sql
+++ b/distribution/src/database/openfire_db2.sql
@@ -154,13 +154,6 @@ CREATE TABLE ofPrivacyList (
 );
 CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
 
-
-CREATE TABLE ofSASLAuthorized (
-  username            VARCHAR(64)   NOT NULL,
-  principal           VARCHAR(190)  NOT NULL,
-  CONSTRAINT ofSASLAuthrizd_pk PRIMARY KEY (username, principal)
-);
-
 CREATE TABLE ofSecurityAuditLog (
   msgID                 INTEGER         NOT NULL,
   username              VARCHAR(64)     NOT NULL,
@@ -402,7 +395,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_hsqldb.sql
+++ b/distribution/src/database/openfire_hsqldb.sql
@@ -151,12 +151,6 @@ CREATE TABLE ofPrivacyList (
 );
 CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
 
-CREATE TABLE ofSASLAuthorized (
-  username        VARCHAR(64)      NOT NULL,
-  principal       VARCHAR(4000)    NOT NULL,
-  CONSTRAINT ofSASLAuthorized_pk PRIMARY KEY (username, principal)
-);
-
 CREATE TABLE ofSecurityAuditLog (
   msgID                 BIGINT          NOT NULL,
   username              VARCHAR(64)     NOT NULL,
@@ -389,7 +383,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
 
 // Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -141,12 +141,6 @@ CREATE TABLE ofPrivacyList (
   INDEX ofPrivacyList_default_idx (username, isDefault)
 );
 
-CREATE TABLE ofSASLAuthorized (
-  username            VARCHAR(64)   NOT NULL,
-  principal           TEXT          NOT NULL,
-  PRIMARY KEY (username, principal(200))
-);
-
 CREATE TABLE ofSecurityAuditLog (
   msgID                 BIGINT          NOT NULL,
   username              VARCHAR(64)     NOT NULL,
@@ -379,7 +373,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
 
 # Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -148,12 +148,6 @@ CREATE TABLE ofPrivacyList (
 );
 CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
 
-CREATE TABLE ofSASLAuthorized (
-  username            VARCHAR(64)   NOT NULL,
-  principal           VARCHAR(4000) NOT NULL,
-  CONSTRAINT ofSASLAuthorized_pk PRIMARY KEY (username, principal)
-);
-
 CREATE TABLE ofSecurityAuditLog (
   msgID                 INTEGER         NOT NULL,
   username              VARCHAR2(64)    NOT NULL,
@@ -387,7 +381,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -156,12 +156,6 @@ CREATE TABLE ofPrivacyList (
 );
 CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
 
-CREATE TABLE ofSASLAuthorized (
-  username          VARCHAR(64)   NOT NULL,
-  principal         VARCHAR(4000) NOT NULL,
-  CONSTRAINT ofSASLAuthorized_pk PRIMARY KEY (username, principal)
-);
-
 CREATE TABLE ofSecurityAuditLog (
   msgID                 INTEGER         NOT NULL,
   username              VARCHAR(64)     NOT NULL,
@@ -395,7 +389,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
 
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -154,12 +154,6 @@ CREATE TABLE ofPrivacyList (
 );
 CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
 
-CREATE TABLE ofSASLAuthorized (
-  username        NVARCHAR(64)     NOT NULL,
-  principal       NVARCHAR(2000)   NOT NULL,
-  CONSTRAINT ofSASLAuthorized_pk PRIMARY KEY (username, principal)
-);
-
 CREATE TABLE ofSecurityAuditLog (
   msgID                 INTEGER         NOT NULL,
   username              NVARCHAR(64)    NOT NULL,
@@ -392,7 +386,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 36);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -153,12 +153,6 @@ CREATE TABLE ofPrivacyList (
 )
 CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault)
 
-CREATE TABLE ofSASLAuthorized (
-  username            NVARCHAR(64)   NOT NULL,
-  principal           NVARCHAR(4000) NOT NULL,
-  CONSTRAINT ofSASLAuthorized_pk PRIMARY KEY (username, principal)
-)
-
 CREATE TABLE ofSecurityAuditLog (
   msgID                 INTEGER         NOT NULL,
   username              NVARCHAR(64)    NOT NULL,
@@ -392,7 +386,7 @@ INSERT INTO ofID (idType, id) VALUES (23, 1)
 INSERT INTO ofID (idType, id) VALUES (26, 2)
 INSERT INTO ofID (idType, id) VALUES (27, 1)
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 36)
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37)
 
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)

--- a/distribution/src/database/upgrade/10/openfire_db2.sql
+++ b/distribution/src/database/upgrade/10/openfire_db2.sql
@@ -1,7 +1,7 @@
 
 CREATE TABLE jiveSASLAuthorized (
   username            VARCHAR(64)   NOT NULL,
-  principal           VARCHAR(4000) NOT NULL,
+  principal           VARCHAR(3000) NOT NULL,
   CONSTRAINT jiveSASLAuthorized_pk PRIMARY KEY (username, principal)
 );
 

--- a/distribution/src/database/upgrade/10/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/10/openfire_hsqldb.sql
@@ -1,7 +1,7 @@
 
 CREATE TABLE jiveSASLAuthorized (
   username        VARCHAR(64)      NOT NULL,
-  principal       VARCHAR(4000)    NOT NULL,
+  principal       VARCHAR(3000)    NOT NULL,
   CONSTRAINT jiveSASLAuthorized_pk PRIMARY KEY (username, principal)
 );
 

--- a/distribution/src/database/upgrade/10/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/10/openfire_oracle.sql
@@ -1,7 +1,7 @@
 
 CREATE TABLE jiveSASLAuthorized (
   username            VARCHAR(64)   NOT NULL,
-  principal           VARCHAR(4000) NOT NULL,
+  principal           VARCHAR(3000) NOT NULL,
   CONSTRAINT jiveSASLAuthoirzed_pk PRIMARY KEY (username, principal)
 );
 

--- a/distribution/src/database/upgrade/10/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/10/openfire_postgresql.sql
@@ -1,7 +1,7 @@
 
 CREATE TABLE jiveSASLAuthorized (
   username          VARCHAR(64)   NOT NULL,
-  principal         VARCHAR(4000) NOT NULL,
+  principal         VARCHAR(3000) NOT NULL,
   CONSTRAINT jiveSASLAuthoirzed_pk PRIMARY KEY (username, principal)
 );
 

--- a/distribution/src/database/upgrade/10/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/10/openfire_sqlserver.sql
@@ -1,7 +1,7 @@
 
 CREATE TABLE jiveSASLAuthorized (
   username        NVARCHAR(64)     NOT NULL,
-  principal       NVARCHAR(2000)   NOT NULL,
+  principal       NVARCHAR(1500)   NOT NULL,
   CONSTRAINT jiveSASLAuthoirzed_pk PRIMARY KEY (username, principal)
 );
 

--- a/distribution/src/database/upgrade/10/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/10/openfire_sybase.sql
@@ -1,7 +1,7 @@
 
 CREATE TABLE jiveSASLAuthorized (
   username            NVARCHAR(64)   NOT NULL,
-  principal           NVARCHAR(4000) NOT NULL,
+  principal           NVARCHAR(3000) NOT NULL,
   CONSTRAINT jiveSASLAuthoirzed_pk PRIMARY KEY (username, principal)
 );
 

--- a/distribution/src/database/upgrade/19/openfire_db2.sql
+++ b/distribution/src/database/upgrade/19/openfire_db2.sql
@@ -104,6 +104,7 @@ CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
 
 -- Rename jiveSASLAuthorized to ofSASLAuthorized
 ALTER TABLE jiveSASLAuthorized DROP CONSTRAINT jSASLAuthrizd_pk;
+ALTER TABLE jiveSASLAuthorized ALTER COLUMN principal SET DATA TYPE VARCHAR(3000);
 RENAME jiveSASLAuthorized TO ofSASLAuthorized;
 ALTER TABLE ofSASLAuthorized ADD CONSTRAINT ofSASLAuthrizd_pk PRIMARY KEY (username, principal);
 

--- a/distribution/src/database/upgrade/19/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/19/openfire_hsqldb.sql
@@ -104,6 +104,7 @@ CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
 
 // Rename jiveSASLAuthorized to ofSASLAuthorized
 ALTER TABLE jiveSASLAuthorized DROP CONSTRAINT jiveSASLAuthorized_pk;
+ALTER TABLE jiveSASLAuthorized ALTER COLUMN principal VARCHAR(3000) NOT NULL;
 ALTER TABLE jiveSASLAuthorized RENAME TO ofSASLAuthorized;
 ALTER TABLE ofSASLAuthorized ADD CONSTRAINT ofSASLAuthorized_pk PRIMARY KEY (username, principal);
 

--- a/distribution/src/database/upgrade/19/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/19/openfire_oracle.sql
@@ -110,6 +110,7 @@ CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
 
 -- Rename jiveSASLAuthorized to ofSASLAuthorized
 ALTER TABLE jiveSASLAuthorized DROP CONSTRAINT jiveSASLAuthoirzed_pk;
+ALTER TABLE jiveSASLAuthorized MODIFY principal VARCHAR(3000) NOT NULL;
 ALTER TABLE jiveSASLAuthorized RENAME TO ofSASLAuthorized;
 ALTER TABLE ofSASLAuthorized ADD CONSTRAINT ofSASLAuthorized_pk PRIMARY KEY (username, principal);
 

--- a/distribution/src/database/upgrade/19/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/19/openfire_postgresql.sql
@@ -110,6 +110,7 @@ CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
 
 -- Rename jiveSASLAuthorized to ofSASLAuthorized
 ALTER TABLE jiveSASLAuthorized DROP CONSTRAINT jiveSASLAuthoirzed_pk;
+ALTER TABLE jiveSASLAuthorized ALTER COLUMN principal TYPE VARCHAR(3000) NOT NULL;
 ALTER TABLE jiveSASLAuthorized RENAME TO ofSASLAuthorized;
 ALTER TABLE ofSASLAuthorized ADD CONSTRAINT ofSASLAuthorized_pk PRIMARY KEY (username, principal);
 

--- a/distribution/src/database/upgrade/19/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/19/openfire_sqlserver.sql
@@ -110,6 +110,7 @@ CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
 
 /* Rename jiveSASLAuthorized to ofSASLAuthorized */
 ALTER TABLE jiveSASLAuthorized DROP CONSTRAINT jiveSASLAuthoirzed_pk;
+ALTER TABLE jiveSASLAuthorized ALTER COLUMN principal NVARCHAR(1500) NOT NULL;
 sp_rename 'jiveSASLAuthorized', 'ofSASLAuthorized';
 ALTER TABLE ofSASLAuthorized ADD CONSTRAINT ofSASLAuthorized_pk PRIMARY KEY (username, principal);
 

--- a/distribution/src/database/upgrade/19/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/19/openfire_sybase.sql
@@ -109,6 +109,7 @@ CREATE INDEX ofPrivacyList_default_idx ON ofPrivacyList (username, isDefault);
 
 /* Rename jiveSASLAuthorized to ofSASLAuthorized */
 ALTER TABLE jiveSASLAuthorized DROP CONSTRAINT jiveSASLAuthoirzed_pk;
+ALTER TABLE jiveSASLAuthorized MODIFY principal NVARCHAR(3000) NOT NULL;
 sp_rename 'jiveSASLAuthorized', 'ofSASLAuthorized';
 ALTER TABLE ofSASLAuthorized ADD CONSTRAINT ofSASLAuthorized_pk PRIMARY KEY (username, principal);
 

--- a/distribution/src/database/upgrade/37/openfire_db2.sql
+++ b/distribution/src/database/upgrade/37/openfire_db2.sql
@@ -1,0 +1,3 @@
+DROP TABLE ofSASLAuthorized;
+
+UPDATE ofVersion SET version = 37 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/37/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/37/openfire_hsqldb.sql
@@ -1,0 +1,3 @@
+DROP TABLE ofSASLAuthorized;
+
+UPDATE ofVersion SET version = 37 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/37/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/37/openfire_mysql.sql
@@ -1,0 +1,3 @@
+DROP TABLE ofSASLAuthorized;
+
+UPDATE ofVersion SET version = 37 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/37/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/37/openfire_oracle.sql
@@ -1,0 +1,5 @@
+DROP TABLE ofSASLAuthorized;
+
+UPDATE ofVersion SET version = 37 WHERE name = 'openfire';
+
+COMMIT;

--- a/distribution/src/database/upgrade/37/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/37/openfire_postgresql.sql
@@ -1,0 +1,3 @@
+DROP TABLE ofSASLAuthorized;
+
+UPDATE ofVersion SET version = 37 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/37/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/37/openfire_sqlserver.sql
@@ -1,0 +1,3 @@
+DROP TABLE ofSASLAuthorized;
+
+UPDATE ofVersion SET version = 37 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/37/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/37/openfire_sybase.sql
@@ -1,0 +1,3 @@
+DROP TABLE ofSASLAuthorized;
+
+UPDATE ofVersion SET version = 37 WHERE name = 'openfire';

--- a/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
@@ -68,7 +68,7 @@ public class SchemaManager {
     /**
      * Current Openfire database schema version.
      */
-    private static final int DATABASE_VERSION = 36;
+    private static final int DATABASE_VERSION = 37;
 
     /**
      * Checks the Openfire database schema to ensure that it's installed and up to date.


### PR DESCRIPTION
The database table ofSASLAuthorized is unused, while its definition causes database installation/upgrade errors for some users.

This commit removes the database table completely, both for fresh installs of Openfire, as for updates.