### PR TITLE
OF-2793: Bundle an Oracle database driver

### DIFF
--- a/build/ci/updater/pom.xml
+++ b/build/ci/updater/pom.xml
@@ -90,6 +90,19 @@
       <artifactId>mssql-jdbc</artifactId>
       <version>9.4.1.jre11</version>
     </dependency>
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc11-production</artifactId>
+      <version>23.7.0.25.01</version>
+      <type>pom</type>
+        <exclusions>
+            <exclusion>
+                <!-- This dependency causes the JSPC compilation to fail.-->
+                <groupId>com.oracle.database.xml</groupId>
+                <artifactId>xmlparserv2</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/documentation/database.html
+++ b/documentation/database.html
@@ -27,8 +27,8 @@
         </p>
         <p>
             JDBC drivers are required for Openfire to communicate with your database. Suggested drivers for particular
-            databases are noted below where applicable. Openfire bundles JDBC drivers for MySQL, Postgres, Microsoft
-            SQL Server, and HSQLDB.
+            databases are noted below where applicable. Openfire bundles JDBC drivers for MySQL, Oracle, PostgreSQL,
+            Microsoft SQL Server, and HSQLDB.
         </p>
         <p>
             All supported database schemas can be found in the <code>resources/database</code> directory of the
@@ -159,11 +159,8 @@
             <h3>JDBC Drivers</h3>
 
             <p>
-                The Oracle JDBC drivers cannot readily be distributed with Openfire, so must be manually downloaded
-                from <a href="https://www.oracle.com/technetwork/database/application-development/jdbc/downloads/index.html">Oracle's website</a>.
-                Various versions of the drivers are available, but the most recent driver compatible with your version
-                of Oracle is recommended for use with Openfire. Copy the JDBC driver to the <code>lib/</code> directory
-                of your Openfire installation.
+                Openfire bundles Oracle 'production' JDBC drivers, as described on
+                <a href="https://www.oracle.com/database/technologies/maven-central-guide.html">Oracle's website</a>.
             </p>
 
             <p>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -466,6 +466,16 @@
             <artifactId>json</artifactId>
             <version>20231013</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>32.0.1-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jgonian</groupId>
+            <artifactId>commons-ip-math</artifactId>
+            <version>1.32</version>
+        </dependency>
 
         <!-- Database Drivers -->
         <dependency>
@@ -500,15 +510,19 @@
             <version>9.4.1.jre11</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>32.0.1-jre</version>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11-production</artifactId>
+            <version>23.7.0.25.01</version>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <!-- This dependency causes the JSPC compilation to fail.-->
+                    <groupId>com.oracle.database.xml</groupId>
+                    <artifactId>xmlparserv2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.github.jgonian</groupId>
-            <artifactId>commons-ip-math</artifactId>
-            <version>1.32</version>
-        </dependency>
+
         <!-- Test Scope -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Given changes in the Oracle license, we can now bundle their database drivers with Openfire. The changes in this commit do just that.

I've opted to use ojdbc11-production rather than ojdbc17-production as the latter is documented to be compatible with Jakarta. We do not use Jakarta. ojdbc11 has been documented to be compatible with Java 17 and 21, which should be good enough for us for now.

Jetty's JSP compiler plugin is not happy with the standard Oracle dependencies. It fails on expecting but not finding oracle.i18n.util.LocaleMapper. The internet suggests that this is caused by Oracle's xmlparserv2 dependency. Excluding that 'fixes' the problem. I'm not sure what functionality this affects.

As a side-effect, the `lib` folder of a distribution now contains an unneeded POM file. I can't find an easy way to exclude that.