### PR TITLE
OF-2960: Replace Oracle database driver's BOM project with individual dependencies

### DIFF
--- a/build/ci/updater/pom.xml
+++ b/build/ci/updater/pom.xml
@@ -16,6 +16,7 @@
     <application.entrypoint>com.igniterealtime.openfire.updaterunner.Main</application.entrypoint>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
+    <ojdbc.version>23.7.0.25.01</ojdbc.version>
   </properties>
 
   <build>
@@ -90,18 +91,52 @@
       <artifactId>mssql-jdbc</artifactId>
       <version>9.4.1.jre11</version>
     </dependency>
-    <dependency>
+    <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
       <groupId>com.oracle.database.jdbc</groupId>
-      <artifactId>ojdbc11-production</artifactId>
-      <version>23.7.0.25.01</version>
-      <type>pom</type>
-        <exclusions>
-            <exclusion>
-                <!-- This dependency causes the JSPC compilation to fail.-->
-                <groupId>com.oracle.database.xml</groupId>
-                <artifactId>xmlparserv2</artifactId>
-            </exclusion>
-        </exclusions>
+      <artifactId>ojdbc11</artifactId>
+      <version>${ojdbc.version}</version>
+    </dependency>
+    <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ucp</artifactId>
+      <version>${ojdbc.version}</version>
+    </dependency>
+    <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>rsi</artifactId>
+      <version>${ojdbc.version}</version>
+    </dependency>
+    <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+      <groupId>com.oracle.database.security</groupId>
+      <artifactId>oraclepki</artifactId>
+      <version>${ojdbc.version}</version>
+    </dependency>
+    <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+      <groupId>com.oracle.database.ha</groupId>
+      <artifactId>simplefan</artifactId>
+      <version>${ojdbc.version}</version>
+    </dependency>
+    <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+      <groupId>com.oracle.database.ha</groupId>
+      <artifactId>ons</artifactId>
+      <version>${ojdbc.version}</version>
+    </dependency>
+    <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+      <groupId>com.oracle.database.nls</groupId>
+      <artifactId>orai18n</artifactId>
+      <version>${ojdbc.version}</version>
+    </dependency>
+    <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+      <groupId>com.oracle.database.xml</groupId>
+      <artifactId>xdb</artifactId>
+      <version>${ojdbc.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- This dependency causes the JSPC compilation to fail.-->
+          <groupId>com.oracle.database.xml</groupId>
+          <artifactId>xmlparserv2</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
         <bouncycastle.version>1.78.1</bouncycastle.version>
         <slf4j.version>2.0.9</slf4j.version>
         <log4j.version>2.20.0</log4j.version>
+        <ojdbc.version>23.7.0.25.01</ojdbc.version>
     </properties>
 
     <profiles>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -504,11 +504,45 @@
             <artifactId>mssql-jdbc</artifactId>
             <version>9.4.1.jre11</version>
         </dependency>
-        <dependency>
+        <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc11-production</artifactId>
-            <version>23.7.0.25.01</version>
-            <type>pom</type>
+            <artifactId>ojdbc11</artifactId>
+            <version>${ojdbc.version}</version>
+        </dependency>
+        <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ucp</artifactId>
+            <version>${ojdbc.version}</version>
+        </dependency>
+        <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>rsi</artifactId>
+            <version>${ojdbc.version}</version>
+        </dependency>
+        <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+            <groupId>com.oracle.database.security</groupId>
+            <artifactId>oraclepki</artifactId>
+            <version>${ojdbc.version}</version>
+        </dependency>
+        <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+            <groupId>com.oracle.database.ha</groupId>
+            <artifactId>simplefan</artifactId>
+            <version>${ojdbc.version}</version>
+        </dependency>
+        <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+            <groupId>com.oracle.database.ha</groupId>
+            <artifactId>ons</artifactId>
+            <version>${ojdbc.version}</version>
+        </dependency>
+        <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+            <groupId>com.oracle.database.nls</groupId>
+            <artifactId>orai18n</artifactId>
+            <version>${ojdbc.version}</version>
+        </dependency>
+        <dependency> <!-- OF-2960: Including dependencies of ojdbc11-production rather than ojdbc11-production itself. -->
+            <groupId>com.oracle.database.xml</groupId>
+            <artifactId>xdb</artifactId>
+            <version>${ojdbc.version}</version>
             <exclusions>
                 <exclusion>
                     <!-- This dependency causes the JSPC compilation to fail.-->


### PR DESCRIPTION
This works around an issue that creeps up when using the BOM project: it causes a POM file to be included in Openfire's distirbution. That file in turn causes the RPM build to fail.

As the distribution cannot be easily changed, this commit prevents usage of the project that introduces the POM file.

More context is provided in https://igniterealtime.atlassian.net/browse/OF-2960