### PR TITLE
OF-2961: Upgrade Netty from 4.1.115 to 4.1.118

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
         <jetty.version>12.0.14</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
-        <netty.version>4.1.115.Final</netty.version>
+        <netty.version>4.1.118.Final</netty.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
         <slf4j.version>2.0.9</slf4j.version>
         <log4j.version>2.20.0</log4j.version>


### PR DESCRIPTION
This release from Netty's 4.1 branch fixes a couple of CVEs: https://netty.io/news/2025/02/10/4-1-118-Final.html