### PR TITLE
OF-2821: Admin Console Client Sessions page with configurable columns

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1831,6 +1831,11 @@ session.summary.filtered_session_count=Filtered sessions
 session.summary.not_session=No Client Sessions
 session.summary.last_update=List last updated
 session.summary.sessions_per_page=Sessions per page
+session.summary.column-config=Configure columns...
+
+# Session summary config page
+session.summary.config.intro=The form below can be used to configure the columns that are visible on the Session Summary page.
+session.summary.config.title=Select columns to show
 
 # Server Session summary Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SessionSummaryConfigServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/SessionSummaryConfigServlet.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.admin.servlet;
+
+import org.jivesoftware.openfire.cluster.ClusterManager;
+import org.jivesoftware.util.*;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.*;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Servlet for the admin console page that configures what columns are visible on the 'client sessions' page.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+@WebServlet(value = "/session-summary-config.jsp")
+public class SessionSummaryConfigServlet extends HttpServlet
+{
+    protected void setStandardAttributes(final HttpServletRequest request, final HttpServletResponse response, final WebManager webManager)
+    {
+        final String csrf = StringUtils.randomString(16);
+        CookieUtils.setCookie(request, response, "csrf", csrf, -1);
+        request.setAttribute("csrf", csrf);
+
+        request.setAttribute("clusteringEnabled", ClusterManager.isClusteringStarted() || ClusterManager.isClusteringStarting() );
+
+        request.setAttribute("showName", webManager.getPageProperty("session-summary", "console.showNameColumn", 1) == 1);
+        request.setAttribute("showResource", webManager.getPageProperty("session-summary", "console.showResourceColumn", 0) == 1);
+        request.setAttribute("showVersion", webManager.getPageProperty("session-summary", "console.showVersionColumn", 1) == 1);
+        request.setAttribute("showClusterNode", webManager.getPageProperty("session-summary", "console.showClusterNodeColumn", 1) == 1);
+        request.setAttribute("showStatus", webManager.getPageProperty("session-summary", "console.showStatusColumn", 1) == 1);
+        request.setAttribute("showPresence", webManager.getPageProperty("session-summary", "console.showPresenceColumn", 1) == 1);
+        request.setAttribute("showRxTx", webManager.getPageProperty("session-summary", "console.showRxTxColumn", 1) == 1);
+        request.setAttribute("showIp", webManager.getPageProperty("session-summary", "console.ShowIpColumn", 1) == 1);
+    }
+
+    @Override
+    protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException
+    {
+        final HttpSession session = request.getSession();
+        final WebManager webManager = new WebManager();
+        webManager.init(request, response, session, session.getServletContext());
+
+        setStandardAttributes(request, response, webManager);
+
+        request.getRequestDispatcher("session-summary-config-page.jsp").forward(request, response);
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException
+    {
+        final HttpSession session = request.getSession();
+        final WebManager webManager = new WebManager();
+        webManager.init(request, response, session, session.getServletContext());
+
+        final Map<String, Object> errors = new HashMap<>();
+
+        final Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+        if (csrfCookie == null || !csrfCookie.getValue().equals(request.getParameter("csrf"))) {
+            errors.put("csrf", null);
+        } else {
+            // Checkboxes that are unchecked do not register as a parameter. Thus, if the parameter is absent, then the user unchecked the checkbox!
+            final boolean showName = ParamUtils.getBooleanParameter(request, "showName", false);
+            final boolean showResource = ParamUtils.getBooleanParameter(request, "showResource", false);
+            final boolean showVersion = ParamUtils.getBooleanParameter(request, "showVersion", false);
+            final boolean showClusterNode = ParamUtils.getBooleanParameter(request, "showClusterNode", false);
+            final boolean showStatus = ParamUtils.getBooleanParameter(request, "showStatus", false);
+            final boolean showPresence = ParamUtils.getBooleanParameter(request, "showPresence", false);
+            final boolean showRxTx = ParamUtils.getBooleanParameter(request, "showRxTx", false);
+            final boolean showIp = ParamUtils.getBooleanParameter(request, "showIp", false);
+
+            webManager.setPageProperty("session-summary", "console.showNameColumn", showName ? 1 : 0);
+            webManager.setPageProperty("session-summary", "console.showResourceColumn", showResource ? 1 : 0);
+            webManager.setPageProperty("session-summary", "console.showVersionColumn", showVersion ? 1 : 0);
+            webManager.setPageProperty("session-summary", "console.showClusterNodeColumn", showClusterNode ? 1 : 0);
+            webManager.setPageProperty("session-summary", "console.showStatusColumn", showStatus ? 1 : 0);
+            webManager.setPageProperty("session-summary", "console.showPresenceColumn", showPresence ? 1 : 0);
+            webManager.setPageProperty("session-summary", "console.showRxTxColumn", showRxTx ? 1 : 0);
+            webManager.setPageProperty("session-summary", "console.showIpColumn", showIp ? 1 : 0);
+        }
+
+        request.setAttribute("errors", errors);
+        setStandardAttributes(request, response, webManager);
+        request.getRequestDispatcher("session-summary.jsp").forward(request, response);
+    }
+}

--- a/xmppserver/src/main/webapp/session-row.jspf
+++ b/xmppserver/src/main/webapp/session-row.jspf
@@ -22,7 +22,11 @@
    -     * 'linkURL', a String representing the JSP page to link to
  --%>
 
-<%  if (current) { %>
+<%  Session.Status _status = sess.getStatus();
+    boolean isDetached = sess instanceof LocalSession && ((LocalSession) sess).isDetached();
+%>
+
+ <%  if (current) { %>
 
     <tr class="jive-current">
 
@@ -33,67 +37,74 @@
 <%  } %>
 
     <td style="width: 1%; white-space: nowrap"><%= count %></td>
-    <td style="width: 10%; white-space: nowrap">
-        <%  String name = sess.getAddress().getNode(); %>
+    <c:if test="${showName}">
+        <td style="width: 10%; white-space: nowrap">
+            <%  String name = sess.getAddress().getNode(); %>
             <a href="session-details.jsp?jid=<%= URLEncoder.encode(sess.getAddress().toString(), "UTF-8") %>" title="<fmt:message key='session.row.click' />"
             ><%= ((!sessionManager.isAnonymousRoute(sess.getUsername())) ? JID.unescapeNode(name): "<i>"+LocaleUtils.getLocalizedString("session.details.anonymous")+"</i>") %></a>
-    </td>
-    <td style="width: 15%; white-space: nowrap">
-        <% if (sess.getSoftwareVersion() != null) {
-            final String softwareName = sess.getSoftwareVersion().get("name");
-            final String softwareVersion = sess.getSoftwareVersion().get("version");
+        </td>
+    </c:if>
+    <c:if test="${showResource}">
+        <td style="width: 15%; white-space: nowrap">
+            <%= StringUtils.escapeHTMLTags(sess.getAddress().getResource()) %>
+        </td>
+    </c:if>
+    <c:if test="${showVersion}">
+        <td style="width: 15%; white-space: nowrap">
+            <% if (sess.getSoftwareVersion() != null) {
+                final String softwareName = sess.getSoftwareVersion().get("name");
+                final String softwareVersion = sess.getSoftwareVersion().get("version");
 
-            String softwareString = "";
-            if(softwareName != null && !softwareName.isBlank()){
-                softwareString += softwareName;
-            }
-            if(softwareVersion != null && !softwareVersion.isBlank()) {
-                if (!softwareString.isBlank()) {
-                    softwareString += " - ";
+                String softwareString = "";
+                if(softwareName != null && !softwareName.isBlank()){
+                    softwareString += softwareName;
                 }
-                softwareString += softwareVersion;
-            };
+                if(softwareVersion != null && !softwareVersion.isBlank()) {
+                    if (!softwareString.isBlank()) {
+                        softwareString += " - ";
+                    }
+                    softwareString += softwareVersion;
+                };
 
-            if (!softwareString.isBlank()) { %>
-                <%= StringUtils.escapeHTMLTags(softwareString) %>
-            <% }
-        } %>
-    </td>
-    <% if (ClusterManager.isClusteringStarted() || ClusterManager.isClusteringStarting()) { %>
-    <td nowrap>
+                if (!softwareString.isBlank()) { %>
+                    <%= StringUtils.escapeHTMLTags(softwareString) %>
+                <% }
+            } %>
+        </td>
+    </c:if>
+    <c:if test="${clusteringEnabled and showClusterNode}">
+        <td nowrap>
             <% if (sess instanceof LocalClientSession) { %>
              <fmt:message key="session.details.local" />
             <% } else { %>
              <fmt:message key="session.details.remote" />
             <% } %>
-    </td>
-    <% } %>
-    <td>
-        <%  Session.Status _status = sess.getStatus();
-            boolean isDetached = sess instanceof LocalSession && ((LocalSession) sess).isDetached();
-            if (isDetached) { %>
+        </td>
+    </c:if>
+    <c:if test="${showStatus}">
+        <td>
+            <%  if (isDetached) { %>
+                <fmt:message key="session.details.sm-detached" />
+            <%
+                } else if (_status == Session.Status.CLOSED) {
+            %>
+                <fmt:message key="session.details.close" />
 
-            <fmt:message key="session.details.sm-detached" />
-        <%
-            } else if (_status == Session.Status.CLOSED) {
-        %>
-            <fmt:message key="session.details.close" />
+            <%  } else if (_status == Session.Status.CONNECTED) { %>
 
-        <%  } else if (_status == Session.Status.CONNECTED) { %>
+                <fmt:message key="session.details.connect" />
 
-            <fmt:message key="session.details.connect" />
+            <% } else if (_status == Session.Status.AUTHENTICATED) { %>
 
-        <% } else if (_status == Session.Status.AUTHENTICATED) { %>
+                <fmt:message key="session.details.authenticated" />
 
-            <fmt:message key="session.details.authenticated" />
+            <%  } else { %>
 
-        <%  } else { %>
+                <fmt:message key="session.details.unknown" />
 
-            <fmt:message key="session.details.unknown" />
-
-        <%  } %>
-    </td>
-    <td style="width: 1%">
+            <%  } %>
+        </td>
+        <td style="width: 1%">
         <%  if (isDetached) { %>
                     <img src="images/working-16x16.gif" width="1" height="1" alt="">
         <%  } else if (sess.isEncrypted()) {
@@ -105,8 +116,10 @@
             } else { %>
                     <img src="images/blank.gif" width="1" height="1" alt="">
      <%     } %>
-    </td>
-    <%  Presence.Show _show = sess.getPresence().getShow();
+       </td>
+    </c:if>
+    <c:if test="${showPresence}">
+     <%  Presence.Show _show = sess.getPresence().getShow();
         String _stat = sess.getPresence().getStatus();
         if (!sess.getPresence().isAvailable()) {
      %>
@@ -191,15 +204,17 @@
         </td>
 
     <%  } %>
-
-    <td style="width: 1%; white-space: nowrap">
-        <%= NumberFormat.getNumberInstance().format(sess.getNumClientPackets()) %>
-    </td>
-    <td style="width: 1%; white-space: nowrap">
-        <%= NumberFormat.getNumberInstance().format(sess.getNumServerPackets()) %>
-    </td>
-
-    <td style="width: 1%; white-space: nowrap">
+    </c:if>
+    <c:if test="${showRxTx}">
+        <td style="width: 1%; white-space: nowrap">
+            <%= NumberFormat.getNumberInstance().format(sess.getNumClientPackets()) %>
+        </td>
+        <td style="width: 1%; white-space: nowrap">
+            <%= NumberFormat.getNumberInstance().format(sess.getNumServerPackets()) %>
+        </td>
+    </c:if>
+    <c:if test="${showIp}">
+        <td style="width: 1%; white-space: nowrap">
         <%
             if (isDetached) { %>
                 <fmt:message key="session.details.sm-detached"/>
@@ -211,7 +226,8 @@
             <% }
             } %>
 
-    </td>
+        </td>
+    </c:if>
 
     <td style="width: 1%; white-space: nowrap; text-align: center;">
         <a href="session-summary.jsp?jid=<%= URLEncoder.encode(sess.getAddress().toString(), "UTF-8") %>&close=true&csrf=${csrf}"

--- a/xmppserver/src/main/webapp/session-summary-config-page.jsp
+++ b/xmppserver/src/main/webapp/session-summary-config-page.jsp
@@ -1,0 +1,105 @@
+<%--
+  -
+  - Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+--%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib uri="admin" prefix="admin" %>
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
+<% webManager.init(request, response, session, application, out ); %>
+<head>
+    <title><fmt:message key="session.summary.title"/></title>
+    <meta name="pageID" content="session-summary"/>
+</head>
+<body>
+
+<c:forEach var="err" items="${errors}">
+    <admin:infobox type="error">
+        <c:choose>
+            <c:when test="${err.key eq 'csrf'}"><fmt:message key="global.csrf.failed" /></c:when>
+            <c:otherwise>
+                <c:if test="${not empty err.value}">
+                    <fmt:message key="admin.error"/>: <c:out value="${err.value}"/>
+                </c:if>
+                (<c:out value="${err.key}"/>)
+            </c:otherwise>
+        </c:choose>
+    </admin:infobox>
+</c:forEach>
+
+<p>
+    <fmt:message key="session.summary.config.intro" />
+</p>
+
+<br>
+
+<form action="session-summary-config.jsp" method="post">
+    <input type="hidden" name="csrf" value="${csrf}">
+
+    <fmt:message key="session.summary.config.title" var="settingsTitle"/>
+    <admin:contentBox title="${settingsTitle}">
+        <table>
+            <colgroup>
+                <col style="width: 1%"/>
+                <col style="width: 99%"/>
+            </colgroup>
+            <tbody>
+            <tr>
+                <td><input name="showName" id="showName" type="checkbox" value="true" ${showName ? 'checked' : ''}></td>
+                <td><label for="showName"><fmt:message key="session.details.name" /></label></td>
+            </tr>
+            <tr>
+                <td><input name="showVersion" id="showVersion" type="checkbox" value="true" ${showVersion ? 'checked' : ''}></td>
+                <td><label for="showVersion"><fmt:message key="session.details.version" /></label></td>
+            </tr>
+            <tr>
+                <td><input name="showResource" id="showResource" type="checkbox" value="true" ${showResource ? 'checked' : ''}></td>
+                <td><label for="showResource"><fmt:message key="session.details.resource" /></label></td>
+            </tr>
+            <c:if test="${clusteringEnabled}">
+                <tr>
+                    <td><input name="showClusterNode" id="showClusterNode" type="checkbox" value="true" ${showClusterNode ? 'checked' : ''}></td>
+                    <td><label for="showClusterNode"><fmt:message key="session.details.node" /></label></td>
+                </tr>
+
+            </c:if>
+            <tr>
+                <td><input name="showStatus" id="showStatus" type="checkbox" value="true" ${showStatus ? 'checked' : ''}></td>
+                <td><label for="showStatus"><fmt:message key="session.details.status" /></label></td>
+            </tr>
+            <tr>
+                <td><input name="showPresence" id="showPresence" type="checkbox" value="true" ${showPresence ? 'checked' : ''}></td>
+                <td><label for="showPresence"><fmt:message key="session.details.presence" /></label></td>
+            </tr>
+            <tr>
+                <td><input name="showRxTx" id="showRxTx" type="checkbox" value="true" ${showRxTx ? 'checked' : ''}></td>
+                <td><label for="showRxTx"><fmt:message key="session.details.received" /> <fmt:message key="session.details.transmitted" /></label></td>
+            </tr>
+            <tr>
+                <td><input name="showIp" id="showIp" type="checkbox" value="true" ${showIp ? 'checked' : ''}></td>
+                <td><label for="showIp"><fmt:message key="session.details.clientip" /></label></td>
+            </tr>
+            </tbody>
+        </table>
+    </admin:contentBox>
+
+    <br/>
+
+    <input type="submit" value="<fmt:message key="global.save_settings" />">
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
In OF-2706, the 'resource' column disappeared from the admin console page that showed the overview of client sessions. This proved to be problematic for some users.

In this commit, the columns that are shown on that page can be configured by each admin user. To do so, a new configuration page is added (accessible through a small link in the top-right corner of the session summary page). Settings are saved per-user, to allow for personal preferences.

![image](https://github.com/user-attachments/assets/4f77fa2d-fa88-41de-ba33-6828b79c2732)

![image](https://github.com/user-attachments/assets/554a6d01-7c0d-4a36-95b4-fac2d6aae9a1)
