### PR TITLE
OF-2952: Warn admins of certificate expiry

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1482,6 +1482,11 @@ system_property.xmpp.server.resolution-delay=The time to wait for a response for
 system_property.xmpp.server.resolution-timeout=The maximum amount of time to wait for successful resolution of a host of a target domain.
 system_property.xmpp.server.connection-max-workers=The maximum amount of worker threads attempting to set up a socket connection to a target remote XMPP domain. A value of '1' will effectively make 'Happy Eyeballs' impossible (as that requires concurrent connection attempts).
 
+system_property.ssl.certificates.expirycheck.service-enabled=Enables or disabled the period check for expiry of Openfire's TLS certificates.
+system_property.ssl.certificates.expirycheck.notify-admins=Determines if the administrators receive a message when an (almost) expired TLS certificate is detected.
+system_property.ssl.certificates.expirycheck.frequency=How often to check for (nearly) expired TLS certificates.
+system_property.ssl.certificates.expirycheck.warning-period=How long before a TLS certificate will expire a warning is to be sent out to admins.
+
 # Server properties Page
 
 server.properties.title=System Properties
@@ -2375,6 +2380,34 @@ ssl.certificates.identity-store=Identity store
 ssl.certificates.trust-store=Trust store
 ssl.certificates.trust-store.s2s=Trust store used for connections from other servers
 ssl.certificates.trust-store.c2s=Trust store used for connections from clients
+
+# Expiry check
+sidebar.ssl.certificate.expirycheck=Expiry Check
+sidebar.ssl.certificate.expirycheck.descr=Configure automated checking of the validity of TLS certificates.
+ssl.certificate.expirycheck.title=Certificate Expiry Check
+ssl.certificate.expirycheck.info=The server can periodically check for the validity of the certificates that are installed in Openfire's "identity" certificate stores. When a certificate is expired, or is about to expire, administrators can be sent a chat notification. Use the form below to configure this service.
+ssl.certificate.expirycheck.settings-header=Settings
+ssl.certificate.expirycheck.enabled.legend=Service Enabled
+ssl.certificate.expirycheck.label_enable=Enabled
+ssl.certificate.expirycheck.label_enable_info=The server will periodically check if installed TLS certificates are still valid (have not expired)
+ssl.certificate.expirycheck.label_disable=Disabled
+ssl.certificate.expirycheck.label_disable_info=No automatic validity checks are performed.
+ssl.certificate.expirycheck.notification.legend=Administrator Notifications
+ssl.certificate.expirycheck.notification.label_enable=Enabled
+ssl.certificate.expirycheck.notification.label_enable_info=Administrators will receive notifications when certificates are expired or about to expire.
+ssl.certificate.expirycheck.notification.label_disable=Disabled
+ssl.certificate.expirycheck.notification.label_disable_info=Administrators will not be sent notifications.
+ssl.certificate.expirycheck.frequency.legend=Frequency
+ssl.certificate.expirycheck.frequency.info=This defines how often the server checks the certificate. The provided value is the interval (in hours) between each check.
+ssl.certificate.expirycheck.frequency-label=Interval
+ssl.certificate.expirycheck.warning-period.legend=Warning Period
+ssl.certificate.expirycheck.warning-period.info=The server will issue warnings <em>before</em> a certificate has expired. The value below controls how long before expiry of a certificate the server should start generating notifications.
+ssl.certificate.expirycheck.warning-period-label=Warning Period
+ssl.certificate.expirycheck.error.frequency=The value provided for 'frequency' was invalid. Please provide a numeric value higher than zero.
+ssl.certificate.expirycheck.error.warning-period=The value provided for 'warning period' was invalid. Please provide a different value. Please provide a numeric value higher than zero.
+ssl.certificate.expirycheck.save-success=Settings have successfully been saved.
+ssl.certificates.expirycheck.notification-message.expired=One or more TLS certificates used by Openfire have expired. This can cause connectivity issues. Please use the Openfire Admin Console to review the state of all certificates in each of Openfire's "identity" certificate stores. Replace certificates where need.
+ssl.certificates.expirycheck.notification-message.nearly-expired=One or more TLS certificates used by Openfire will expire soon. This can cause connectivity issues. Please use the Openfire Admin Console to review the state of all certificates in each of Openfire's "identity" certificate stores. Replace certificates where need.
 
 # Store Management page
 

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1485,7 +1485,7 @@ system_property.xmpp.server.connection-max-workers=The maximum amount of worker 
 system_property.ssl.certificates.expirycheck.service-enabled=Enables or disabled the period check for expiry of Openfire's TLS certificates.
 system_property.ssl.certificates.expirycheck.notify-admins=Determines if the administrators receive a message when an (almost) expired TLS certificate is detected.
 system_property.ssl.certificates.expirycheck.frequency=How often to check for (nearly) expired TLS certificates.
-system_property.ssl.certificates.expirycheck.warning-period=How long before a TLS certificate will expire a warning is to be sent out to admins.
+system_property.ssl.certificates.expirycheck.warning-period=How long (in hours) before a TLS certificate will expire for a warning is to be sent out to admins.
 
 # Server properties Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/CertificateExpirtyCheckerServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/CertificateExpirtyCheckerServlet.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.admin.servlet;
+
+import org.jivesoftware.util.*;
+import org.jivesoftware.util.cert.CertificateExpiryChecker;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.*;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Servlet for the admin console page that configures the automated, continuous checks of TLS certificate expiry.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+@WebServlet(value = "/security-certificate-expiry-check.jsp")
+public class CertificateExpirtyCheckerServlet extends HttpServlet
+{
+    protected void setStandardAttributes(final HttpServletRequest request, final HttpServletResponse response, final WebManager webManager)
+    {
+        final String csrf = StringUtils.randomString(16);
+        CookieUtils.setCookie(request, response, "csrf", csrf, -1);
+        request.setAttribute("csrf", csrf);
+
+        request.setAttribute("isEnabled", CertificateExpiryChecker.ENABLED.getValue());
+        request.setAttribute("isNotifyAdmins", CertificateExpiryChecker.NOTIFY_ADMINS.getValue());
+        request.setAttribute("frequencyHours", CertificateExpiryChecker.FREQUENCY.getValue().toHours());
+        request.setAttribute("warningPeriodHours", CertificateExpiryChecker.WARNING_PERIOD.getValue().toHours());
+    }
+
+    @Override
+    protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException
+    {
+        final HttpSession session = request.getSession();
+        final WebManager webManager = new WebManager();
+        webManager.init(request, response, session, session.getServletContext());
+
+        setStandardAttributes(request, response, webManager);
+
+        request.getRequestDispatcher("security-certificate-expiry-check-page.jsp").forward(request, response);
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException
+    {
+        final HttpSession session = request.getSession();
+        final WebManager webManager = new WebManager();
+        webManager.init(request, response, session, session.getServletContext());
+
+        final Map<String, Object> errors = new HashMap<>();
+
+        final Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+        if (csrfCookie == null || !csrfCookie.getValue().equals(request.getParameter("csrf"))) {
+            errors.put("csrf", null);
+        } else {
+            final long frequencyHours = ParamUtils.getLongParameter(request, "frequencyHours", -1);
+            final long warningPeriodHours = ParamUtils.getLongParameter(request, "warningPeriodHours", -1);
+
+            // Checkboxes that are unchecked do not register as a parameter. Thus, if the parameter is absent, then the user unchecked the checkbox!
+            final boolean isEnabled = ParamUtils.getBooleanParameter(request, "isEnabled", false);
+            final boolean isNotifyAdmins = ParamUtils.getBooleanParameter(request, "isNotifyAdmins", false);
+
+            if (frequencyHours <= 0) {
+                errors.put("frequency", null);
+            }
+            final Duration frequency = Duration.ofHours(frequencyHours);
+
+            if (warningPeriodHours <= 0) {
+                errors.put("warningPeriod", null);
+            }
+            final Duration warningPeriod = Duration.ofHours(warningPeriodHours);
+
+            setStandardAttributes(request, response, webManager);
+
+            if (errors.isEmpty())
+            {
+                // Place back the user-provided values (even if they're incorrect) so that they can be modified.
+                request.setAttribute("isEnabled", isEnabled);
+                request.setAttribute("isNotifyAdmins", isNotifyAdmins);
+                if (ParamUtils.getParameter(request, "frequencyHours") != null) request.setAttribute("frequencyHours", ParamUtils.getParameter(request, "frequencyHours"));
+                if (ParamUtils.getParameter(request, "warningPeriodHours") != null) request.setAttribute("warningPeriodHours", ParamUtils.getParameter(request, "warningPeriodHours"));
+
+                CertificateExpiryChecker.ENABLED.setValue(isEnabled);
+                CertificateExpiryChecker.NOTIFY_ADMINS.setValue(isNotifyAdmins);
+                CertificateExpiryChecker.FREQUENCY.setValue(frequency);
+                CertificateExpiryChecker.WARNING_PERIOD.setValue(warningPeriod);
+
+                webManager.logEvent("Edited TLS certificate expiry check settings", "enabled = "+isEnabled+", notificationsEnabled = "+isNotifyAdmins+", frequency = "+frequency+", warningPeriod = "+warningPeriod);
+            }
+        }
+
+        request.setAttribute("errors", errors);
+        request.getRequestDispatcher("security-certificate-expiry-check-page.jsp?success=" + (errors.isEmpty() ? "true" : "false")).forward(request, response);
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -70,6 +70,7 @@ import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.openfire.vcard.VCardManager;
 import org.jivesoftware.util.*;
 import org.jivesoftware.util.cache.CacheFactory;
+import org.jivesoftware.util.cert.CertificateExpiryChecker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
@@ -801,6 +802,7 @@ public class XMPPServer {
         loadModule(EntityCapabilitiesManager.class.getName());
         loadModule(SoftwareVersionManager.class.getName());
         loadModule(SoftwareServerVersionManager.class.getName());
+        loadModule(CertificateExpiryChecker.class.getName());
 
         // Load this module always last since we don't want to start listening for clients
         // before the rest of the modules have been started
@@ -1728,6 +1730,18 @@ public class XMPPServer {
     public CertificateStoreManager getCertificateStoreManager() {
         return (CertificateStoreManager) modules.get( CertificateStoreManager.class );
     }
+
+    /**
+     * Returns the <code>CertificateExpiryChecker</code> registered with this server. The
+     * <code>CertificateExpiryChecker</code> was registered with the server as a module while starting up
+     * the server.
+     *
+     * @return the <code>CertificateExpiryChecker</code> registered with this server.
+     */
+    public CertificateExpiryChecker getCertificateExpiryChecker() {
+        return (CertificateExpiryChecker) modules.get(CertificateExpiryChecker.class);
+    }
+
     /**
      * Returns the locator to use to find sessions hosted in other cluster nodes. When not running
      * in a cluster a {@code null} value is returned.

--- a/xmppserver/src/main/java/org/jivesoftware/util/cert/CertificateExpiryChecker.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cert/CertificateExpiryChecker.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.util.cert;
+
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.container.BasicModule;
+import org.jivesoftware.openfire.keystore.CertificateStoreManager;
+import org.jivesoftware.openfire.keystore.IdentityStore;
+import org.jivesoftware.openfire.spi.ConnectionType;
+import org.jivesoftware.util.LocaleUtils;
+import org.jivesoftware.util.SystemProperty;
+import org.jivesoftware.util.TaskEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+/**
+ * Periodically evaluates the TLS certificates in all identity stores of Openfire. Sends out a warning (in the form of
+ * an XMPP message) to all server administrators when a certificate is detected that is expired, or is about to expire.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class CertificateExpiryChecker extends BasicModule
+{
+    private static final Logger Log = LoggerFactory.getLogger(CertificateExpiryChecker.class);
+
+    /**
+     * Enables or disabled the period check for expiry of Openfire's TLS certificates.
+     */
+    public static final SystemProperty<Boolean> ENABLED = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("ssl.certificates.expirycheck.service-enabled")
+        .setDynamic(true)
+        .setDefaultValue(true)
+        .build();
+
+    /**
+     * Determines if the administrators receive a message when an (almost) expired TLS certificate is detected.
+     */
+    public static final SystemProperty<Boolean> NOTIFY_ADMINS = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("ssl.certificates.expirycheck.notify-admins")
+        .setDynamic(true)
+        .setDefaultValue(true)
+        .build();
+
+    /**
+     * How often to check for (nearly) expired TLS certificates.
+     */
+    public static final SystemProperty<Duration> FREQUENCY = SystemProperty.Builder.ofType(Duration.class)
+        .setKey("ssl.certificates.expirycheck.frequency")
+        .setDynamic(true)
+        .setChronoUnit(ChronoUnit.HOURS)
+        .setDefaultValue(Duration.ofHours(6))
+        .setMinValue(Duration.ofHours(1))
+        .addListener((duration) -> {
+            XMPPServer.getInstance().getCertificateExpiryChecker().stop();
+            XMPPServer.getInstance().getCertificateExpiryChecker().start();
+        })
+        .build();
+
+    /**
+     * How long before a TLS certificate will expire a warning is to be sent out to admins.
+     */
+    public static final SystemProperty<Duration> WARNING_PERIOD = SystemProperty.Builder.ofType(Duration.class)
+        .setKey("ssl.certificates.expirycheck.warning-period")
+        .setDynamic(true)
+        .setChronoUnit(ChronoUnit.HOURS)
+        .setMinValue(Duration.ofHours(1))
+        .setDefaultValue(Duration.ofDays(7))
+        .build();
+
+    private ExpiryCheckerTask expiryCheckerTask;
+
+    public CertificateExpiryChecker()
+    {
+        super("Certificate Expiry Checker");
+    }
+
+    @Override
+    public void start() throws IllegalStateException
+    {
+        expiryCheckerTask = new ExpiryCheckerTask();
+        TaskEngine.getInstance().schedule(expiryCheckerTask, Duration.ofSeconds(20), FREQUENCY.getValue());
+    }
+
+    @Override
+    public void stop()
+    {
+        if (expiryCheckerTask != null) {
+            TaskEngine.getInstance().cancelScheduledTask(expiryCheckerTask);
+            expiryCheckerTask = null;
+        }
+    }
+
+    public static class ExpiryCheckerTask extends TimerTask
+    {
+        @Override
+        public void run()
+        {
+            if (!ENABLED.getValue()) {
+                Log.debug("Skipping TLS certificate expiry check, as it has been disabled by configuration.");
+                return;
+            }
+            Log.debug("Starting TLS certificate expiry check.");
+
+            try {
+                final CertificateStoreManager certificateStoreManager = XMPPServer.getInstance().getCertificateStoreManager();
+
+                // Openfire can use different identity stores for different types of connection. We'll iterate over all of them.
+                final Set<IdentityStore> identityStores = new HashSet<>();
+                for (final ConnectionType connectionType : ConnectionType.values()) {
+                    identityStores.add(certificateStoreManager.getIdentityStore(connectionType));
+                }
+
+                // Time until expiry of the certificate with the lowest 'notAfter' value.
+                Instant lowestNotAfter = Instant.MAX;
+
+                for (final IdentityStore identityStore : identityStores) {
+                    final Optional<Instant> oldest;
+                        oldest = identityStore.getAllCertificates().values().stream()
+                            .map(X509Certificate::getNotAfter)
+                            .filter(Objects::nonNull)
+                            .map(Date::toInstant)
+                            .sorted()
+                            .findFirst();
+
+                    if (oldest.isPresent()) {
+                        final Instant oldestDate = oldest.get();
+                        if (oldestDate.isBefore(lowestNotAfter)) {
+                            lowestNotAfter = oldestDate;
+                        }
+                    }
+                }
+
+                // Check if there's expired or nearly expired certificates.
+                final boolean hasExpired = lowestNotAfter.isBefore(Instant.now());
+                final boolean hasNearlyExpired = lowestNotAfter.minus(WARNING_PERIOD.getValue()).isBefore(Instant.now());
+                if (hasExpired) {
+                    Log.warn("One or more TLS certificates used by Openfire have expired. This can cause connectivity issues. Please use the Openfire Admin Console to review the state of all certificates in each of Openfire's \"identity\" certificate stores. Replace certificates where need.");
+                    if (NOTIFY_ADMINS.getValue()) {
+                        XMPPServer.getInstance().sendMessageToAdmins(LocaleUtils.getLocalizedString("ssl.certificates.expirycheck.notification-message.expired"));
+                    }
+                } else if (hasNearlyExpired) {
+                    Log.info("One or more TLS certificates used by Openfire will expire soon. This can cause connectivity issues. Please use the Openfire Admin Console to review the state of all certificates in each of Openfire's \"identity\" certificate stores. Replace certificates where need.");
+                    if (NOTIFY_ADMINS.getValue()) {
+                        XMPPServer.getInstance().sendMessageToAdmins(LocaleUtils.getLocalizedString("ssl.certificates.expirycheck.notification-message.nearly-expired"));
+                    }
+                } else {
+                    Log.debug("None of the TLS certificates used by Openfire have expired or will expire soon.");
+                }
+            } catch (Throwable e) {
+                Log.warn("An unexpected exception prevented the period check for expired TLS certificates from executing successfully.", e);
+            }
+        }
+    }
+}

--- a/xmppserver/src/main/resources/admin-sidebar.xml
+++ b/xmppserver/src/main/resources/admin-sidebar.xml
@@ -280,6 +280,10 @@
                   url="security-certificate-store-backup.jsp"
                   description="${sidebar.certificate-stores-backup.descr}"/>
 
+            <item id="security-certificate-expiry-check" name="${sidebar.ssl.certificate.expirycheck}"
+                  url="security-certificate-expiry-check.jsp"
+                  description="${sidebar.ssl.certificate.expirycheck.descr}"/>
+
         </sidebar>
 
         <!-- Server Settings -->

--- a/xmppserver/src/main/webapp/security-certificate-expiry-check-page.jsp
+++ b/xmppserver/src/main/webapp/security-certificate-expiry-check-page.jsp
@@ -1,0 +1,173 @@
+<%--@elvariable id="errors" type="java.util.Map<java.lang.String, java.lang.Object>"--%>
+<%--@elvariable id="csrf" type="java.lang.String"--%>
+<%--@elvariable id="isEnabled" type="java.lang.Boolean"--%>
+<%--@elvariable id="isNotifyAdmins" type="java.lang.Boolean"--%>
+<%--@elvariable id="frequencyHours" type="java.lang.Long"--%>
+<%--@elvariable id="warningPeriodHours" type="java.lang.Long"--%>
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%--
+  - Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+
+--%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="admin" prefix="admin" %>
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager"/>
+<%  webManager.init(request, response, session, application, out ); %>
+
+<html>
+<head>
+<title><fmt:message key="ssl.certificate.expirycheck.title"/></title>
+<meta name="pageID" content="security-certificate-expiry-check"/>
+</head>
+<body>
+<p>
+<fmt:message key="ssl.certificate.expirycheck.info"/>
+</p>
+
+<c:choose>
+    <c:when test="${not empty errors}">
+        <c:forEach var="err" items="${errors}">
+            <admin:infobox type="error">
+                <c:choose>
+                    <c:when test="${err.key eq 'csrf'}"><fmt:message key="global.csrf.failed" /></c:when>
+                    <c:when test="${err.key eq 'frequency'}"><fmt:message key="ssl.certificate.expirycheck.error.frequency" /></c:when>
+                    <c:when test="${err.key eq 'warningPeriod'}"><fmt:message key="ssl.certificate.expirycheck.error.warning-period" /></c:when>
+                    <c:otherwise>
+                        <c:if test="${not empty err.value}">
+                            <fmt:message key="admin.error"/>: <c:out value="${err.value}"/>
+                        </c:if>
+                        (<c:out value="${err.key}"/>)
+                    </c:otherwise>
+                </c:choose>
+            </admin:infobox>
+        </c:forEach>
+    </c:when>
+    <c:when test="${param.success}">
+        <admin:infobox type="success">
+            <fmt:message key="ssl.certificate.expirycheck.save-success"/>
+        </admin:infobox>
+    </c:when>
+</c:choose>
+
+<form action="security-certificate-expiry-check.jsp" method="post">
+    <input type="hidden" name="csrf" value="${csrf}"/>
+
+    <c:set var="configHeader"><fmt:message key="ssl.certificate.expirycheck.settings-header" /></c:set>
+    <admin:contentBox title="${configHeader}">
+
+        <h4><fmt:message key="ssl.certificate.expirycheck.enabled.legend"/></h4>
+        <table>
+        <tbody>
+            <tr>
+                <td style="width: 1%; white-space: nowrap">
+                    <input type="radio" name="isEnabled" value="true" id="rb02" ${isEnabled ? 'checked' : ''}>
+                </td>
+                <td>
+                    <label for="rb02">
+                    <b><fmt:message key="ssl.certificate.expirycheck.label_enable"/></b> - <fmt:message key="ssl.certificate.expirycheck.label_enable_info"/>
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 1%; white-space: nowrap">
+                    <input type="radio" name="isEnabled" value="false" id="rb01" ${isEnabled ? '' : 'checked'}>
+                </td>
+                <td>
+                    <label for="rb01">
+                    <b><fmt:message key="ssl.certificate.expirycheck.label_disable"/></b> - <fmt:message key="ssl.certificate.expirycheck.label_disable_info"/>
+                    </label>
+                </td>
+            </tr>
+        </tbody>
+        </table>
+
+        <br/>
+
+        <h4><fmt:message key="ssl.certificate.expirycheck.notification.legend"/></h4>
+        <table>
+        <tbody>
+            <tr>
+                <td style="width: 1%; white-space: nowrap">
+                    <input type="radio" name="isNotifyAdmins" value="true" id="rb04" ${isNotifyAdmins ? 'checked' : ''}>
+                </td>
+                <td>
+                    <label for="rb04">
+                    <b><fmt:message key="ssl.certificate.expirycheck.notification.label_enable"/></b> - <fmt:message key="ssl.certificate.expirycheck.notification.label_enable_info"/>
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 1%; white-space: nowrap">
+                    <input type="radio" name="isNotifyAdmins" value="false" id="rb03" ${isNotifyAdmins ? '' : 'checked'}>
+                </td>
+                <td>
+                    <label for="rb03">
+                        <b><fmt:message key="ssl.certificate.expirycheck.notification.label_disable"/></b> - <fmt:message key="ssl.certificate.expirycheck.notification.label_disable_info"/>
+                    </label>
+                </td>
+            </tr>
+        </tbody>
+        </table>
+
+        <br/>
+
+        <h4><fmt:message key="ssl.certificate.expirycheck.frequency.legend"/></h4>
+        <table>
+            <tbody>
+            <tr>
+                <td colspan="2">
+                    <fmt:message key="ssl.certificate.expirycheck.frequency.info" />
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 1%; white-space: nowrap; text-align: right" class="c1">
+                    <label for="frequencyHours"><b><fmt:message key="ssl.certificate.expirycheck.frequency-label" /></b></label>
+                </td>
+                <td>
+                    <input type="number" min="1" id="frequencyHours" name="frequencyHours" value="${not empty frequencyHours ? admin:escapeHTMLTags(frequencyHours) : ''}"> <fmt:message key="global.hours" />
+                </td>
+            </tr>
+
+        </table>
+
+        <br/>
+
+        <h4><fmt:message key="ssl.certificate.expirycheck.warning-period.legend"/></h4>
+        <table>
+            <tbody>
+            <tr>
+                <td colspan="2">
+                    <fmt:message key="ssl.certificate.expirycheck.warning-period.info" />
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 1%; white-space: nowrap; text-align: right" class="c1">
+                    <label for="warningPeriodHours"><b><fmt:message key="ssl.certificate.expirycheck.warning-period-label" /></b></label>
+                </td>
+                <td>
+                    <input type="number" min="1" id="warningPeriodHours" name="warningPeriodHours" value="${not empty warningPeriodHours ? admin:escapeHTMLTags(warningPeriodHours) : ''}"> <fmt:message key="global.hours" />
+                </td>
+            </tr>
+
+        </table>
+
+    </admin:contentBox>
+
+<input type="submit" name="update" value="<fmt:message key="global.save_settings" />">
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
This commit adds a new feature that periodically checks if TLS certificates are expired, or are about to expire.

When such an expired is detected, an XMPP message is sent out to all admins (similar to the notifications sent out on available plugin updates).

A new admin console page has been added that can be used to configure this functionality.

![image](https://github.com/user-attachments/assets/8a64419f-50ad-4387-834c-9e9ca763ecf0)
