### PR TITLE
OF-2966: Fix race condition in BOSH (noticable during logout)

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/BoshBindingError.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/BoshBindingError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,8 +90,8 @@ public enum BoshBindingError {
      */
     undefinedCondition(Type.terminate, "undefined-condition");
 
-    private Type errorType;
-    private String condition;
+    private final Type errorType;
+    private final String condition;
     private int legacyErrorCode = HttpServletResponse.SC_BAD_REQUEST;
 
     BoshBindingError(Type errorType, String condition, int legacyErrorCode) {
@@ -143,7 +143,7 @@ public enum BoshBindingError {
          * due to a communication failure.
          */
         recoverable("error");
-        private String type;
+        private final String type;
 
         Type(String type) {
             this.type = type;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -557,7 +557,7 @@ public final class HttpBindManager implements CertificateEventListener {
         String interfaceName = JiveGlobals.getXMLProperty("network.interface");
         String bindInterface = null;
         if (interfaceName != null) {
-            if (interfaceName.trim().length() > 0) {
+            if (!interfaceName.trim().isEmpty()) {
                 bindInterface = interfaceName;
             }
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
@@ -141,14 +141,14 @@ public class HttpBindServlet extends HttpServlet {
         try {
             body = HttpBindBody.from( content );
         } catch (Exception ex) {
-            Log.warn("Error parsing request data from [" + remoteAddress + "]", ex);
+            Log.warn("Error parsing request data from [{}]", remoteAddress, ex);
             sendLegacyError(context, BoshBindingError.badRequest);
             return;
         }
 
         final Long rid = body.getRid();
         if (rid == null || rid <= 0) {
-            Log.info("Root element 'body' does not contain a valid RID attribute value in parsed request data from [" + remoteAddress + "]");
+            Log.info("Root element 'body' does not contain a valid RID attribute value in parsed request data from [{}]", remoteAddress);
             sendLegacyError(context, BoshBindingError.badRequest, "Body-element is missing a RID (Request ID) value, or the provided value is a non-positive integer.");
             return;
         }
@@ -159,7 +159,7 @@ public class HttpBindServlet extends HttpServlet {
             // something is wrong.
             if (!body.isEmpty()) {
                 // invalid session request; missing sid
-                Log.info("Root element 'body' does not contain a SID attribute value in parsed request data from [" + remoteAddress + "]");
+                Log.info("Root element 'body' does not contain a SID attribute value in parsed request data from [{}]", remoteAddress);
                 sendLegacyError(context, BoshBindingError.badRequest);
                 return;
             }
@@ -184,7 +184,7 @@ public class HttpBindServlet extends HttpServlet {
             connection.setSession(session);
 
             if (HttpBindManager.LOG_HTTPBIND_ENABLED.getValue()) {
-                Log.info("HTTP RECV(" + session.getStreamID().getID() + "): " + body.asXML());
+                Log.info("HTTP RECV({}): {}", session.getStreamID().getID(), body.asXML());
             }
 
             SessionEventDispatcher.dispatchEvent( connection.getSession(), SessionEventDispatcher.EventType.post_session_created, connection, context );
@@ -200,15 +200,12 @@ public class HttpBindServlet extends HttpServlet {
     {
         final String sid = body.getSid();
         if (HttpBindManager.LOG_HTTPBIND_ENABLED.getValue()) {
-            Log.info("HTTP RECV(" + sid + "): " + body.asXML());
+            Log.info("HTTP RECV({}): {}", sid, body.asXML());
         }
 
         HttpSession session = sessionManager.getSession(sid);
         if (session == null) {
-            if (Log.isDebugEnabled()) {
-                Log.debug("Client provided invalid session: " + sid + ". [" +
-                    context.getRequest().getRemoteAddr() + "]");
-            }
+            Log.debug("Client provided invalid session: {}. [{}]", sid, context.getRequest().getRemoteAddr());
             sendLegacyError(context, BoshBindingError.itemNotFound, "Invalid SID value.");
             return;
         }
@@ -247,7 +244,7 @@ public class HttpBindServlet extends HttpServlet {
         }
         
         if (HttpBindManager.LOG_HTTPBIND_ENABLED.getValue()) {
-            Log.info("HTTP SENT(" + session.getStreamID().getID() + "): " + content);
+            Log.info("HTTP SENT({}): {}", session.getStreamID().getID(), content);
         }
 
         final byte[] byteContent = content.getBytes(StandardCharsets.UTF_8);
@@ -339,9 +336,7 @@ public class HttpBindServlet extends HttpServlet {
 
         @Override
         public void onDataAvailable() throws IOException {
-            if( Log.isTraceEnabled() ) {
-                Log.trace("Data is available to be read from [" + remoteAddress + "]");
-            }
+            Log.trace("Data is available to be read from [{}]", remoteAddress);
 
             final ServletInputStream inputStream = context.getRequest().getInputStream();
 
@@ -354,21 +349,17 @@ public class HttpBindServlet extends HttpServlet {
 
         @Override
         public void onAllDataRead() throws IOException {
-            if( Log.isTraceEnabled() ) {
-                Log.trace("All data has been read from [" + remoteAddress + "]");
-            }
+            Log.trace("All data has been read from [{}]", remoteAddress);
             processContent(context, outStream.toString(StandardCharsets.UTF_8.name()));
         }
 
         @Override
         public void onError(Throwable throwable) {
-            if( Log.isWarnEnabled() ) {
-                Log.warn("Error reading request data from [" + remoteAddress + "]", throwable);
-            }
+            Log.warn("Error reading request data from [{}]", remoteAddress, throwable);
             try {
                 sendLegacyError(context, BoshBindingError.badRequest);
             } catch (IOException ex) {
-                Log.debug("Error while sending an error to ["+remoteAddress +"] in response to an earlier data-read failure.", ex);
+                Log.debug("Error while sending an error to [{}] in response to an earlier data-read failure.", remoteAddress, ex);
             }
         }
     }
@@ -390,9 +381,7 @@ public class HttpBindServlet extends HttpServlet {
             // This method may be invoked multiple times and by different threads, e.g. when writing large byte arrays.
             // Make sure a write/complete operation is only done, if no other write is pending, i.e. if isReady() == true
             // Otherwise WritePendingException is thrown.
-            if( Log.isTraceEnabled() ) {
-                Log.trace("Data can be written to [" + remoteAddress + "]");
-            }
+            Log.trace("Data can be written to [{}]", remoteAddress);
             synchronized ( context )
             {
                 final ServletOutputStream servletOutputStream = context.getResponse().getOutputStream();
@@ -419,9 +408,7 @@ public class HttpBindServlet extends HttpServlet {
 
         @Override
         public void onError(Throwable throwable) {
-            if( Log.isWarnEnabled() ) {
-                Log.warn("Error writing response data to [" + remoteAddress + "]", throwable);
-            }
+            Log.warn("Error writing response data to [{}]", remoteAddress, throwable);
             synchronized ( context )
             {
                 context.complete();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
@@ -78,7 +78,7 @@ public class HttpBindServlet extends HttpServlet {
                 response.setHeader("Access-Control-Allow-Origin", HttpBindManager.HTTP_BIND_CORS_ALLOW_ORIGIN_ALL);
             } else {
                 // Get the Origin header from the request and check if it is in the allowed Origin Map.
-                // If it is allowed write it back to the Access-Control-Allow-Origin header of the respond.
+                // If it is allowed write it back to the Access-Control-Allow-Origin header of the response.
                 final String origin = request.getHeader("Origin");
                 if (boshManager.isThisOriginAllowed(origin)) {
                     response.setHeader("Access-Control-Allow-Origin", origin);
@@ -114,7 +114,7 @@ public class HttpBindServlet extends HttpServlet {
             context.complete();
             return;
         }
-        queryString = URLDecoder.decode(queryString, "UTF-8");
+        queryString = URLDecoder.decode(queryString, StandardCharsets.UTF_8);
 
         processContent(context, queryString);
     }
@@ -288,7 +288,7 @@ public class HttpBindServlet extends HttpServlet {
             throws IOException
     {
         final HttpServletResponse response = (HttpServletResponse) context.getResponse();
-        if (message == null || message.trim().length() == 0) {
+        if (message == null || message.trim().isEmpty()) {
             response.sendError(error.getLegacyErrorCode());
         } else {
             response.sendError(error.getLegacyErrorCode(), message);
@@ -316,7 +316,7 @@ public class HttpBindServlet extends HttpServlet {
             remoteAddress = context.getRequest().getRemoteAddr();
         }
 
-        if (remoteAddress == null || remoteAddress.trim().length() == 0) {
+        if (remoteAddress == null || remoteAddress.trim().isEmpty()) {
             remoteAddress = "<UNKNOWN ADDRESS>";
         }
 
@@ -350,7 +350,7 @@ public class HttpBindServlet extends HttpServlet {
         @Override
         public void onAllDataRead() throws IOException {
             Log.trace("All data has been read from [{}]", remoteAddress);
-            processContent(context, outStream.toString(StandardCharsets.UTF_8.name()));
+            processContent(context, outStream.toString(StandardCharsets.UTF_8));
         }
 
         @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -554,7 +554,8 @@ public class HttpSession extends LocalClientSession {
 
         // Schedule in-order.
         synchronized (router) {
-            HttpBindManager.getInstance().getSessionManager().execute(() -> {
+            HttpBindManager.getInstance().getSessionManager().execute(this, () -> {
+                Log.trace("Stream {}: sending {} packet(s)", streamID, packetsToSend.size());
                 for (Element packet : packetsToSend) {
                     try {
                         router.route(packet);
@@ -973,8 +974,9 @@ public class HttpSession extends LocalClientSession {
         }
 
         // OF-2444: deliver asynchronously, to avoid deadlocking issues.
-        HttpBindManager.getInstance().getSessionManager().execute(() -> {
+        HttpBindManager.getInstance().getSessionManager().execute(this, () -> {
             try {
+                Log.trace("Stream {}: Immediate delivery of {} deliverable(s)", streamID, deliverables.size());
                 deliver(connection.get(), deliverables, true);
             } catch (HttpConnectionClosedException e) {
                 /* Connection was closed, try the next one. Indicates a (concurrency?) bug. */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -52,6 +52,7 @@ import java.io.StringReader;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.cert.X509Certificate;
+import java.text.MessageFormat;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -870,15 +871,8 @@ public class HttpSession extends LocalClientSession {
                 }
             }
             lastPoll = time;
-            Log.debug("Updated session " + getStreamID() +
-                    " lastPoll to " + lastPoll +
-                    " with rid " + connection.getRequestId() +
-                    " lastResponseEmpty = " + lastResponseEmpty  +
-                    " overactivity = " + overactivity +
-                    " deltaFromLastPoll = " + deltaFromLastPoll +
-                    " isPollingSession() = " + localIsPollingSession +
-                    " maxRequests = " + maxRequests +
-                    " pendingConnections = " + pendingConnections);
+            Log.debug("Updated session {} lastPoll to {} with rid {} lastResponseEmpty = {} overactivity = {} deltaFromLastPoll = {} isPollingSession() = {} maxRequests = {} pendingConnections = {}",
+                      getStreamID(), lastPoll, connection.getRequestId(), lastResponseEmpty, overactivity, deltaFromLastPoll, localIsPollingSession, maxRequests, pendingConnections);
         }
         setLastResponseEmpty(false);
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/ResourceServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/ResourceServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class ResourceServlet extends HttpServlet {
     private static final Logger Log = LoggerFactory.getLogger(ResourceServlet.class);
 
     //    private static String suffix = "";    // Set to "_src" to use source version
-    private static final Duration expiresOffset = Duration.ofDays(10);	// This long until client cache expires
+    private static final Duration expiresOffset = Duration.ofDays(10);	// How long until client cache expires
     private boolean debug = false;
     private boolean disableCompression = false;
     private static final Cache<String, byte[]> cache = CacheFactory.createCache("Javascript Cache");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/SessionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/SessionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public interface SessionListener {
     /**
      * A connection was closed.
      *
-     * @param context The servlet servlet context of the BOSH request that triggered this event.
+     * @param context The servlet context of the BOSH request that triggered this event.
      * @param session The session of which a connection was closed.
      * @param connection the connection that was closed.
      *
@@ -47,14 +47,14 @@ public interface SessionListener {
     /**
      * Called before an {@link HttpSession} is created for a given http-bind web request
      *
-     * @param context The servlet servlet context of the BOSH request that triggered this event.
+     * @param context The servlet context of the BOSH request that triggered this event.
      */
     default void preSessionCreated( AsyncContext context ) {};
 
     /**
      * Called when an {@link HttpSession} has been created for a given http-bind web request
      *
-     * @param context The servlet servlet context of the BOSH request that triggered this event.
+     * @param context The servlet context of the BOSH request that triggered this event.
      * @param session The newly created session.
      */
     default void postSessionCreated( AsyncContext context, HttpSession session) {};


### PR DESCRIPTION
The first three commits in this PR build towards a fix for a race condition, in which terminated BOSH clients can leave Openfire in an inconsistent state (and, in certain circumstances, lead to memory starvation). See https://igniterealtime.atlassian.net/browse/OF-2966 for details.