### PR TITLE
OF-2967: Remove newlines in toString implementations

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/RemotePacketExecution.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/RemotePacketExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2009 Jive Software, 2021-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 1999-2009 Jive Software, 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,6 @@ public class RemotePacketExecution implements ClusterTask<Void> {
     }
 
     public String toString() {
-        return super.toString() + " recipient: " + recipient + "packet: " + packet;
+        return super.toString() + " recipient: " + recipient + "packet: " + (packet == null ? "(null)" : packet.toXML());
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1471,7 +1471,7 @@ public class HttpSession extends LocalClientSession {
             ", isInitialized=" + isInitialized() +
             ", hasAuthToken=" + (getAuthToken() != null) +
             ", peer address='" + peerAddress +'\'' +
-            ", presence='" + getPresence().toString() + '\'' +
+            ", presence='" + getPresence().toXML() + '\'' +
             ", hold='" + getHold() + '\'' +
             ", wait='" + getWait() + '\'' +
             ", maxRequests='" + getMaxRequests() + '\'' +

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -988,7 +988,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
             ", isInitialized=" + initialized +
             ", hasAuthToken=" + (authToken != null) +
             ", peer address='" + peerAddress +'\'' +
-            ", presence='" + presence.toString() + '\'' +
+            ", presence='" + presence.toXML() + '\'' +
             '}';
     }
 }


### PR DESCRIPTION
Where a stanza is used in a toString(), use to `toXML` rather than `toString` of the stanza, as the latter uses 'pretty print' (which introduces newlines).