### PR TITLE
update xpp3 from xpp3/xpp3/1.1.4c to org.codelibs/xpp3/1.1.4c.0

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -262,9 +262,9 @@
         </dependency>
 
         <dependency>
-            <groupId>xpp3</groupId>
+            <groupId>org.codelibs</groupId>
             <artifactId>xpp3</artifactId>
-            <version>1.1.4c</version>
+            <version>1.1.4c.0</version>
         </dependency>
 
         <!-- Jetty -->


### PR DESCRIPTION
The issue was described here:
https://discourse.igniterealtime.org/t/java-11-module-issue-xpp3-dependency-in-xmppserver-provides-duplicate-qname-class/95185

In short, xpp3/xpp3/1.1.4c contains javax.xml.namespace.QName class, which it should't
This started to cause issues since java11