### PR TITLE
OF-3026: Splitting up LocalRoutingTable

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/LocalRoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/LocalRoutingTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,31 +17,27 @@
 package org.jivesoftware.openfire.spi;
 
 import org.jivesoftware.openfire.RoutableChannelHandler;
-import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.session.*;
-import org.jivesoftware.util.LocaleUtils;
-import org.jivesoftware.util.TaskEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
-import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Internal component used by the RoutingTable to keep references to routes hosted by this JVM. When
  * running in a cluster each cluster member will have its own RoutingTable containing an instance of
- * this class. Each LocalRoutingTable is responsible for storing routes to components, client sessions
- * and outgoing server sessions hosted by local cluster node.
+ * this class. Each LocalRoutingTable is responsible for storing routes to entities of a particular type
+ * (such as components, client sessions or outgoing server sessions) hosted by local cluster node.
  *
  * @author Gaston Dombiak
  */
-class LocalRoutingTable {
+class LocalRoutingTable<R extends RoutableChannelHandler> {
     
     private static final Logger Log = LoggerFactory.getLogger(LocalRoutingTable.class);
 
-    Map<DomainPair, RoutableChannelHandler> routes = new ConcurrentHashMap<>();
+    Map<DomainPair, R> routes = new ConcurrentHashMap<>();
 
     /**
      * Adds a route of a local {@link RoutableChannelHandler}
@@ -50,7 +46,7 @@ class LocalRoutingTable {
      * @param route the route hosted by this node.
      * @return true if the element was added or false if was already present.
      */
-    boolean addRoute(DomainPair pair, RoutableChannelHandler route) {
+    boolean addRoute(DomainPair pair, R route) {
         final boolean result = routes.put(pair, route) != route;
         Log.trace( "Route '{}' (for pair: '{}') {}", route.getAddress(), pair, result ? "added" : "not added (was already present)." );
         return result;
@@ -62,56 +58,29 @@ class LocalRoutingTable {
      * @param pair DomainPair associated to the route.
      * @return the route hosted by this node that is associated to the specified address.
      */
-    RoutableChannelHandler getRoute(DomainPair pair) {
+    R getRoute(DomainPair pair) {
         return routes.get(pair);
     }
-    RoutableChannelHandler getRoute(JID jid) {
+    R getRoute(JID jid) {
         return routes.get(new DomainPair("", jid.toString()));
     }
 
     /**
-     * Returns the client sessions that are connected to this JVM.
+     * Returns the sessions that are connected to this JVM.
      *
-     * @return the client sessions that are connected to this JVM.
+     * @return the sessions that are connected to this JVM.
      */
-    Collection<LocalClientSession> getClientRoutes() {
-        List<LocalClientSession> sessions = new ArrayList<>();
-        for (RoutableChannelHandler route : routes.values()) {
-            if (route instanceof LocalClientSession) {
-                sessions.add((LocalClientSession) route);
-            }
-        }
-        return sessions;
+    Collection<R> getRoutes() {
+        return new LinkedList<>(routes.values());
     }
 
     /**
-     * Returns the outgoing server sessions that are connected to this JVM.
+     * Returns the amount routes that are connected to this JVM.
      *
-     * @return the outgoing server sessions that are connected to this JVM.
+     * @return a route count.
      */
-    Collection<LocalOutgoingServerSession> getServerRoutes() {
-        List<LocalOutgoingServerSession> sessions = new ArrayList<>();
-        for (RoutableChannelHandler route : routes.values()) {
-            if (route instanceof LocalOutgoingServerSession) {
-                sessions.add((LocalOutgoingServerSession) route);
-            }
-        }
-        return sessions;
-    }
-
-    /**
-     * Returns the external component sessions that are connected to this JVM.
-     *
-     * @return the external component sessions that are connected to this JVM.
-     */
-    Collection<RoutableChannelHandler> getComponentRoute() {
-        List<RoutableChannelHandler> sessions = new ArrayList<>();
-        for (RoutableChannelHandler route : routes.values()) {
-            if (!(route instanceof LocalOutgoingServerSession || route instanceof LocalClientSession)) {
-                sessions.add(route);
-            }
-        }
-        return sessions;
+    int size() {
+        return routes.size();
     }
 
     /**
@@ -125,9 +94,6 @@ class LocalRoutingTable {
     }
 
     public void start() {
-        // Run through the server sessions every 3 minutes after a 3 minutes server startup delay (default values)
-        Duration period = Duration.ofMinutes(3);
-        TaskEngine.getInstance().scheduleAtFixedRate(new ServerCleanupTask(), period, period);
     }
 
     public void stop() {
@@ -158,38 +124,5 @@ class LocalRoutingTable {
     }
     public boolean isLocalRoute(JID jid) {
         return routes.containsKey(new DomainPair("", jid.toString()));
-    }
-
-    /**
-     * Task that closes idle server sessions.
-     */
-    private class ServerCleanupTask extends TimerTask {
-        /**
-         * Close outgoing server sessions that have been idle for a long time.
-         */
-        @Override
-        public void run() {
-            // Do nothing if this feature is disabled
-            int idleTime = SessionManager.getInstance().getServerSessionIdleTime();
-            if (idleTime == -1) {
-                return;
-            }
-            final long deadline = System.currentTimeMillis() - idleTime;
-            for (RoutableChannelHandler route : routes.values()) {
-                // Check outgoing server sessions
-                if (route instanceof OutgoingServerSession) {
-                    Session session = (Session) route;
-                    try {
-                        if (session.getLastActiveDate().getTime() < deadline) {
-                            Log.debug( "ServerCleanupTask is closing an outgoing server session that has been idle for a long time. Last active: {}. Session to be closed: {}", session.getLastActiveDate(), session );
-                            session.close();
-                        }
-                    }
-                    catch (Throwable e) {
-                        Log.error(LocaleUtils.getLocalizedString("admin.error"), e);
-                    }
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Instead of having one 'local' routing table to track routes from all types of connections (component, server, client) a distinct table for each of these types should be used.

This allows for more granular control of data access. It will become easier to move invocations under a guard of a lock form a corresponding cache.

In this commit, only minor functional changes are applied. This affects some exception handling (a more generic `Throwable` is caught when processing of a stanza fails) and the registration of a task that cleans up server sessions (this task is now cancelled when the RoutingTable is stopped).

Changes are applied to classes and methods that all have limited visibility outside of the RoutingTableImpl class (or its package). It's therefor unlikely that this change introduces compilation issues in other projects (such as Openfire plugins). The code changed here isn't expected to be re-used directly by other projects.