### PR TITLE
OF-3026: State changes of LocalRoutingTable should happen under guard of a lock

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1037,7 +1037,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         }
 
         Log.debug("Removing client route {}", route);
-        final DomainPair domainPair = new DomainPair("", route.toString());
+        final DomainPair domainPair = new DomainPair("", route.toFullJID());
 
         boolean sessionRemoved;
         final Lock lock = usersSessionsCache.getLock(route.toBareJID());


### PR DESCRIPTION
This builds on the change in https://github.com/igniterealtime/Openfire/pull/2687 and introduces guards, when modifying state of LocalRoutingTable instances. The first commit in this PR is equal to that in #2687. The second commit in this PR is the relevant bit.

When modifications to a LocalRoutingTable is made, this should always happen under guard of a lock that also guards related changes to the corresponding cache.
    
This commit should reduce the possibility of state inconsistencies. It does so by re-using the Cache-sourced locks that were originally introduced by the changes for issue ENT-425.
    
In the past, we introduced deadlock potential by putting more operations under guard of a lock. From history, I don't think we ever attempted this change. Additionally, as the code that's now moved under guard of the pre-existing lock is not (intended to be) used by code outside of this package (the class has a corresponding access modified), this change should have minimal risks of introducing such a deadlock.

