### PR TITLE
chore: replace empty string comparision with `isEmpty()`

### DIFF
--- a/xmppserver/src/main/java/org/dom4j/io/XMPPPacketReader.java
+++ b/xmppserver/src/main/java/org/dom4j/io/XMPPPacketReader.java
@@ -437,7 +437,7 @@ public class XMPPPacketReader {
                         dropNamespace = true;
                         for (Element el = parent; el != null; el = el.getParent()) {
                             final String defaultNS = el.getNamespaceForPrefix("").getURI();
-                            if (defaultNS.equals("")) {
+                            if (defaultNS.isEmpty()) {
                                 // We've cleared this one already, just bail.
                                 break;
                             }

--- a/xmppserver/src/main/java/org/jivesoftware/database/JNDIDataSourceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/JNDIDataSourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class JNDIDataSourceProvider implements ConnectionProvider {
 
     @Override
     public void start() {
-        if (dataSourceName == null || dataSourceName.equals("")) {
+        if (dataSourceName == null || dataSourceName.isEmpty()) {
             Log.error("No name specified for DataSource. JNDI lookup will fail", new Throwable());
             return;
         }

--- a/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
@@ -374,7 +374,7 @@ public class SchemaManager {
                     }
                 }
                 // Send command to database.
-                if (!done && !command.toString().equals("")) {
+                if (!done && !command.toString().isEmpty()) {
                     // Remove last semicolon when using Oracle or DB2 to prevent "invalid character error"
                     if (DbConnectionManager.getDatabaseType() == DbConnectionManager.DatabaseType.oracle ||
                             DbConnectionManager.getDatabaseType() == DbConnectionManager.DatabaseType.db2) {
@@ -421,7 +421,7 @@ public class SchemaManager {
      */
     private static boolean isSQLCommandPart(String line) {
         line = line.trim();
-        if (line.equals("")) {
+        if (line.isEmpty()) {
             return false;
         }
         // Check to see if the line is a comment. Valid comment types:

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/audit/spi/AuditManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/audit/spi/AuditManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -364,7 +364,7 @@ public class AuditManagerImpl extends BasicModule implements AuditManager, Prope
                 break;
             case "xmpp.audit.logdir":
                 File d = null;
-                if (!"".equals(value.trim())) {
+                if (!value.trim().isEmpty()) {
                     d = new File(value);
                 }
                 logDir = (d == null || !d.exists() || !d.canRead() || !d.canWrite() || !d

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2016-2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class CrowdAuthProvider implements AuthProvider {
             throw new ConnectionException("Unable to connect to Crowd");
         }
 
-        if (username == null || password == null || "".equals(password.trim())) {
+        if (username == null || password == null || password.trim().isEmpty()) {
             throw new UnauthorizedException();
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -315,7 +315,7 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
             // Local updates can simply run through the roster of the local user
             String name = update.getFrom().getNode();
             try {
-                if (name != null && !"".equals(name)) {
+                if (name != null && !name.isEmpty()) {
                     Roster roster = rosterManager.getRoster(name);
                     roster.broadcastPresence(update);
                 }
@@ -353,7 +353,7 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
         if (localServer.isLocal(update.getFrom())) {
             boolean keepTrack = false;
             String name = update.getFrom().getNode();
-            if (name != null && !"".equals(name)) {
+            if (name != null && !name.isEmpty()) {
                 // Keep track of all directed presences if roster service is disabled
                 if (!RosterManager.isRosterServiceEnabled()) {
                     keepTrack = true;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindBody.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ public class HttpBindBody
     {
         // Default language is English ("en").
         final String language = document.getRootElement().attributeValue( QName.get( "lang", XMLConstants.XML_NS_URI ) );
-        if ( language == null || "".equals( language ) )
+        if ( language == null || language.isEmpty())
         {
             return "en";
         }
@@ -156,7 +156,7 @@ public class HttpBindBody
     public String getVersion()
     {
         final String version = document.getRootElement().attributeValue( "ver" );
-        if ( version == null || "".equals( version ) )
+        if ( version == null || version.isEmpty())
         {
             return "1.5";
         }
@@ -207,7 +207,7 @@ public class HttpBindBody
     }
 
     protected static long getLongAttribute(String value, long defaultValue) {
-        if (value == null || "".equals(value)) {
+        if (value == null || value.isEmpty()) {
             return defaultValue;
         }
         try {
@@ -219,7 +219,7 @@ public class HttpBindBody
     }
 
     protected static int getIntAttribute(String value, int defaultValue) {
-        if (value == null || "".equals(value)) {
+        if (value == null || value.isEmpty()) {
             return defaultValue;
         }
         try {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ public class HttpBindServlet extends HttpServlet {
         }
 
         String queryString = request.getQueryString();
-        if (queryString == null || "".equals(queryString)) {
+        if (queryString == null || queryString.isEmpty()) {
             sendLegacyError(context, BoshBindingError.badRequest);
             return;
         } else if ("isBoshAvailable".equals(queryString)) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapGroupProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -440,7 +440,7 @@ public class LdapGroupProvider extends AbstractGroupProvider {
 
     @Override
     public Collection<String> search(String query, int startIndex, int numResults) {
-        if (query == null || "".equals(query)) {
+        if (query == null || query.isEmpty()) {
             return Collections.emptyList();
         }
         StringBuilder filter = new StringBuilder();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -423,7 +423,7 @@ public class LdapManager {
         }
 
         adminDN = properties.get("ldap.adminDN");
-        if (adminDN != null && adminDN.trim().equals("")) {
+        if (adminDN != null && adminDN.trim().isEmpty()) {
             adminDN = null;
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,12 +125,12 @@ public class LdapUserProvider implements UserProvider {
             }
             Date creationDate = null;
             Attribute creationDateField = attrs.get("createTimestamp");
-            if (creationDateField != null && "".equals(((String) creationDateField.get()).trim())) {
+            if (creationDateField != null && ((String) creationDateField.get()).trim().isEmpty()) {
                 creationDate = parseLDAPDate((String) creationDateField.get());
             }
             Date modificationDate = null;
             Attribute modificationDateField = attrs.get("modifyTimestamp");
-            if (modificationDateField != null && "".equals(((String) modificationDateField.get()).trim())) {
+            if (modificationDateField != null && ((String) modificationDateField.get()).trim().isEmpty()) {
                 modificationDate = parseLDAPDate((String)modificationDateField.get());
             }
             // Escape the username so that it can be used as a JID.
@@ -320,7 +320,7 @@ public class LdapUserProvider implements UserProvider {
     public Collection<User> findUsers(Set<String> fields, String query, int startIndex,
             int numResults) throws UnsupportedOperationException
     {
-        if (fields.isEmpty() || query == null || "".equals(query)) {
+        if (fields.isEmpty() || query == null || query.isEmpty()) {
             return Collections.emptyList();
         }
         

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -545,7 +545,7 @@ public class LdapVCardProvider implements VCardProvider, PropertyEventListener {
         private Element treeWalk(Element rootElement, Map<String, String> map) {
             for ( final Element element : rootElement.elements() ) {
                 String elementText = element.getTextTrim();
-                if (elementText != null && !"".equals(elementText)) {
+                if (elementText != null && !elementText.isEmpty()) {
                     String format = element.getStringValue();
 
                     // A map that will hold all replacements for placeholders

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/mediaproxy/MediaProxyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public class MediaProxyService extends BasicModule
 
         String defaultName = "rtpbridge";
         serviceName = JiveGlobals.getProperty("mediaproxy.serviceName", defaultName);
-        serviceName = serviceName.equals("") ? defaultName : serviceName;
+        serviceName = serviceName.isEmpty() ? defaultName : serviceName;
 
         echoPort = JiveGlobals.getIntProperty("mediaproxy.echoPort", echoPort);
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCSearchHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCSearchHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -183,7 +183,7 @@ public class IQMUCSearchHandler
             if (userAmountFF != null)
             {
                 String value = userAmountFF.getFirstValue();
-                if (value != null && !"".equals(value)) {
+                if (value != null && !value.isEmpty()) {
                     numUsers = Integer.parseInt(value);
                 }
             }
@@ -192,7 +192,7 @@ public class IQMUCSearchHandler
             if (maxUsersFF != null)
             {
                 String value = maxUsersFF.getFirstValue();
-                if (value != null && !"".equals(value)) {
+                if (value != null && !value.isEmpty()) {
                     numMaxUsers = Integer.parseInt(value);
                 }
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
@@ -74,7 +74,7 @@ public class ComponentStanzaHandler extends StanzaHandler {
             String initialDomain = component.getInitialSubdomain();
             String extraDomain = doc.attributeValue("name");
             String allowMultiple = doc.attributeValue("allowMultiple");
-            if (extraDomain == null || "".equals(extraDomain)) {
+            if (extraDomain == null || extraDomain.isEmpty()) {
                 // No new bind domain was specified so return a bad_request error
                 Element reply = doc.createCopy();
                 reply.add(new PacketError(PacketError.Condition.bad_request).getElement());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -400,7 +400,7 @@ public class DefaultUserProvider implements UserProvider {
         if (!getSearchFields().containsAll(fields)) {
             throw new IllegalArgumentException("Search fields " + fields + " are not valid.");
         }
-        if (query == null || "".equals(query)) {
+        if (query == null || query.isEmpty()) {
             return Collections.emptyList();
         }
         // SQL LIKE queries don't map directly into a keyword/wildcard search like we want.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/JDBCUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/JDBCUserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -344,7 +344,7 @@ public class JDBCUserProvider implements UserProvider {
         if (!getSearchFields().containsAll(fields)) {
             throw new IllegalArgumentException("Search fields " + fields + " are not valid.");
         }
-        if (query == null || "".equals(query)) {
+        if (query == null || query.isEmpty()) {
             return Collections.emptyList();
         }
         // SQL LIKE queries don't map directly into a keyword/wildcard search like we want.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/User.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,11 +110,11 @@ public class User implements Cacheable, Externalizable, Result {
             throw new NullPointerException("Username cannot be null");
         }
         this.username = username;
-        if (UserManager.getUserProvider().isNameRequired() && (name == null || "".equals(name.trim()))) {
+        if (UserManager.getUserProvider().isNameRequired() && (name == null || name.trim().isEmpty())) {
             throw new IllegalArgumentException("Invalid or empty name specified with provider that requires name");
         }
         this.name = name;
-        if (UserManager.getUserProvider().isEmailRequired() && (email == null || "".equals(email.trim()))) {
+        if (UserManager.getUserProvider().isEmailRequired() && (email == null || email.trim().isEmpty())) {
             throw new IllegalArgumentException("Empty email address specified with provider that requires email address. User: "
                                                 + username + " Email: " + email);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ public class JiveGlobals {
                     country = localeArray[1];
                 }
                 // If no locale info is specified, return the system default Locale.
-                if (language.equals("") && country.equals("")) {
+                if (language.isEmpty() && country.isEmpty()) {
                     locale = Locale.getDefault();
                 }
                 else {

--- a/xmppserver/src/main/java/org/jivesoftware/util/ParamUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ParamUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public class ParamUtils {
     {
         String temp = request.getParameter(name);
         if (temp != null) {
-            if (temp.equals("") && !emptyStringsOK) {
+            if (temp.isEmpty() && !emptyStringsOK) {
                 return null;
             }
             else {
@@ -165,7 +165,7 @@ public class ParamUtils {
     public static int getIntParameter(HttpServletRequest request,
                                       String name, int defaultNum) {
         String temp = request.getParameter(name);
-        if (temp != null && !temp.equals("")) {
+        if (temp != null && !temp.isEmpty()) {
             int num = defaultNum;
             try {
                 num = Integer.parseInt(temp);
@@ -220,7 +220,7 @@ public class ParamUtils {
      */
     public static double getDoubleParameter(HttpServletRequest request, String name, double defaultNum) {
         String temp = request.getParameter(name);
-        if (temp != null && !temp.equals("")) {
+        if (temp != null && !temp.isEmpty()) {
             double num = defaultNum;
             try {
                 num = Double.parseDouble(temp);
@@ -248,7 +248,7 @@ public class ParamUtils {
      */
     public static long getLongParameter(HttpServletRequest request, String name, long defaultNum) {
         String temp = request.getParameter(name);
-        if (temp != null && !temp.equals("")) {
+        if (temp != null && !temp.isEmpty()) {
             long num = defaultNum;
             try {
                 num = Long.parseLong(temp);
@@ -318,7 +318,7 @@ public class ParamUtils {
     {
         String temp = (String)request.getAttribute(name);
         if (temp != null) {
-            if (temp.equals("") && !emptyStringsOK) {
+            if (temp.isEmpty() && !emptyStringsOK) {
                 return null;
             }
             else {
@@ -358,7 +358,7 @@ public class ParamUtils {
      */
     public static int getIntAttribute(HttpServletRequest request, String name, int defaultNum) {
         String temp = (String)request.getAttribute(name);
-        if (temp != null && !temp.equals("")) {
+        if (temp != null && !temp.isEmpty()) {
             int num = defaultNum;
             try {
                 num = Integer.parseInt(temp);
@@ -384,7 +384,7 @@ public class ParamUtils {
      */
     public static long getLongAttribute(HttpServletRequest request, String name, long defaultNum) {
         String temp = (String)request.getAttribute(name);
-        if (temp != null && !temp.equals("")) {
+        if (temp != null && !temp.isEmpty()) {
             long num = defaultNum;
             try {
                 num = Long.parseLong(temp);

--- a/xmppserver/src/main/java/org/jivesoftware/util/XMLWriter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/XMLWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2006 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2006 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1165,13 +1165,13 @@ public class XMLWriter extends XMLFilterImpl implements LexicalHandler {
 
         writer.write("<!DOCTYPE ");
         writer.write(name);
-        if ((publicID != null) && (!publicID.equals(""))) {
+        if ((publicID != null) && (!publicID.isEmpty())) {
             writer.write(" PUBLIC \"");
             writer.write(publicID);
             writer.write("\"");
             hasPublic = true;
         }
-        if ((systemID != null) && (!systemID.equals(""))) {
+        if ((systemID != null) && (!systemID.isEmpty())) {
             if (!hasPublic) {
                 writer.write(" SYSTEM");
             }

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/SerializingCache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/SerializingCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ public class SerializingCache<K extends Serializable, V extends Serializable> im
     @Nullable
     private Object unmarshall(@Nullable final String object)
     {
-        if (object == null || "".equals(object)) {
+        if (object == null || object.isEmpty()) {
             return null;
         } else {
             final Reader reader = new StringReader(object);

--- a/xmppserver/src/main/webapp/import-truststore-certificate.jsp
+++ b/xmppserver/src/main/webapp/import-truststore-certificate.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2018-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2018-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@
     {
         final TrustStore trustStoreConfig = XMPPServer.getInstance().getCertificateStoreManager().getTrustStore( connectionType );
 
-        if (alias == null || "".equals(alias))
+        if (alias == null || alias.isEmpty())
         {
             errors.put("missingalias", "missingalias");
         }
@@ -78,7 +78,7 @@
             // Verify that the provided alias is not already available
             errors.put("existingalias", "existingalias");
         }
-        if (certificate == null || "".equals(certificate))
+        if (certificate == null || certificate.isEmpty())
         {
             errors.put("certificate", "certificate-missing");
         }

--- a/xmppserver/src/main/webapp/log.jsp
+++ b/xmppserver/src/main/webapp/log.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@
     static final SimpleDateFormat formatter = new SimpleDateFormat("yyyy.MM.dd kk:mm:ss");
 
     private static String parseDate(String input) {
-        if (input == null || "".equals(input)) {
+        if (input == null || input.isEmpty()) {
             return input;
         }
         if (input.length() < 19) {
@@ -77,7 +77,7 @@
     }
 
     private static String leadingWhitespaceNonBreaking(String input) {
-        if (input == null || "".equals(input)) {
+        if (input == null || input.isEmpty()) {
             return input;
         }
         int i = 0;
@@ -92,7 +92,7 @@
     }
 
     private static String hilite(String input) {
-        if (input == null || "".equals(input)) {
+        if (input == null || input.isEmpty()) {
             return input;
         }
         if (input.contains("org.jivesoftware.")) {

--- a/xmppserver/src/main/webapp/login.jsp
+++ b/xmppserver/src/main/webapp/login.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2004-2010 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2010 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@
             try {
                 URL u = new URL(url);
                 StringBuilder s = new StringBuilder();
-                if (u.getPath().equals("")) {
+                if (u.getPath().isEmpty()) {
                     s.append("/");
                 } else {
                     s.append(u.getPath());

--- a/xmppserver/src/main/webapp/loginToken.jsp
+++ b/xmppserver/src/main/webapp/loginToken.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2019-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@
             try {
                 URL u = new URL(url);
                 StringBuilder s = new StringBuilder();
-                if (u.getPath().equals("")) {
+                if (u.getPath().isEmpty()) {
                     s.append("/");
                 } else {
                     s.append(u.getPath());

--- a/xmppserver/src/main/webapp/setup/setup-admin-settings_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-admin-settings_test.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2006-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2006-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@
     Map<String, String> userSettings =
             (Map<String, String>) session.getAttribute("ldapUserSettings");
     // Run the test if password was provided and we have the ldap information
-    if (errorDetail.equals( "" ) && settings != null && password != null) {
+    if (errorDetail.isEmpty() && settings != null && password != null) {
         LdapManager manager = new LdapManager(settings);
         manager.setUsernameField(userSettings.get("ldap.usernameField"));
         manager.setSearchFilter(userSettings.get("ldap.searchFilter"));

--- a/xmppserver/src/main/webapp/user-create.jsp
+++ b/xmppserver/src/main/webapp/user-create.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@
         // Trim the password. This means we don't accept spaces as passwords. We don't
         // trim the passwordConfirm as well since not trimming will ensure the user doesn't
         // think space is an ok password character.
-        if (password == null || password.trim().equals("")) {
+        if (password == null || password.trim().isEmpty()) {
             errors.put("password","");
         }
         if (passwordConfirm == null) {
@@ -113,7 +113,7 @@
         }
         // If provider requires name, validate
         if (UserManager.getUserProvider().isNameRequired()) {
-            if (name == null || name.equals("")) {
+            if (name == null || name.isEmpty()) {
                 errors.put("name","");
             }
         }

--- a/xmppserver/src/main/webapp/user-edit-form.jsp
+++ b/xmppserver/src/main/webapp/user-edit-form.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@
         }
         // If provider requires name, validate
         if (UserManager.getUserProvider().isNameRequired()) {
-            if (name == null || name.equals("")) {
+            if (name == null || name.isEmpty()) {
                 errors.put("name","");
             }
         }

--- a/xmppserver/src/main/webapp/user-groups.jsp
+++ b/xmppserver/src/main/webapp/user-groups.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@
 
     String search = null;
     if (webManager.getGroupManager().isSearchSupported() && request.getParameter("search") != null
-            && !request.getParameter("search").trim().equals("")) {
+            && !request.getParameter("search").trim().isEmpty()) {
         search = request.getParameter("search");
         search = StringUtils.escapeHTMLTags(search);
         // Use the search terms to get the list of groups.


### PR DESCRIPTION
Various bits of automation keep insisting that using `isEmpty()` is generally more readable and efficient than comparing against an empty string (`""`). I don't particularly feel that this is a worthwhile change in itself, were it not for it being a good way to reduce the number of 'hints' that are generated from our code base. That in itself may help to reduce noise: it can make other (more important) hints stand out better.

This should not introduce any functional change.

Code changes have been applied using IDE-provided automation (rather than manual changes).