### PR TITLE
OF-3027: Give Netty threads a recognizable name

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyConnectionAcceptor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyConnectionAcceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public class NettyConnectionAcceptor extends ConnectionAcceptor {
      * <p>
      * The parent 'boss' accepts an incoming connection.
      */
-    private final EventLoopGroup parentGroup = new NioEventLoopGroup();
+    private final EventLoopGroup parentGroup;
 
     /**
      * A multithreaded event loop that handles I/O operation
@@ -96,10 +96,13 @@ public class NettyConnectionAcceptor extends ConnectionAcceptor {
     public NettyConnectionAcceptor(ConnectionConfiguration configuration) {
         super(configuration);
 
-        String name = configuration.getType().toString().toLowerCase() + (isDirectTLSConfigured() ? "_ssl" : "");
+        final String name = configuration.getType().toString().toLowerCase() + (isDirectTLSConfigured() ? "_ssl" : "");
 
-        final ThreadFactory threadFactory = new NamedThreadFactory( name + "-thread-", null, true, null );
-        childGroup = new NioEventLoopGroup(configuration.getMaxThreadPoolSize(), threadFactory);
+        final ThreadFactory parentGroupthreadFactory = new NamedThreadFactory(name + "-acceptor-", null, false, 5);
+        parentGroup = new NioEventLoopGroup(parentGroupthreadFactory);
+
+        final ThreadFactory childGroupthreadFactory = new NamedThreadFactory( name + "-worker-", null, true, null );
+        childGroup = new NioEventLoopGroup(configuration.getMaxThreadPoolSize(), childGroupthreadFactory);
 
         Log = LoggerFactory.getLogger( NettyConnectionAcceptor.class.getName() + "[" + name + "]" );
     }


### PR DESCRIPTION
To facilitate debugging, the various threads used by Netty EventLoops should have names that at least contain the type of connection that they're operating for.

This commit changes the name of threads of the
- 'parent' eventloop from `nioEventLoopGroup-7-1` (a Netty default) to `socket_s2s_ssl-acceptor-7`
- 'child' eventloop from `socket_s2s_ssl-thread-3` (a Netty default) to `socket_s2s_ssl-worker-3`

To do this, a new theadpool factory is introduces for the 'parent' eventloop. The new factory is configured to use the same priorty and daemon settings as the default Netty threadpool factory.