### PR TITLE
OF-3028: Netty threads from 'child' EventLoop should use Netty-default settings

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyConnectionAcceptor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/NettyConnectionAcceptor.java
@@ -98,10 +98,11 @@ public class NettyConnectionAcceptor extends ConnectionAcceptor {
 
         final String name = configuration.getType().toString().toLowerCase() + (isDirectTLSConfigured() ? "_ssl" : "");
 
-        final ThreadFactory parentGroupthreadFactory = new NamedThreadFactory(name + "-acceptor-", null, false, 5);
+        // The configuration of threads is based on defaults used by io.netty.util.concurrent.DefaultThreadFactory (OF-3028)
+        final ThreadFactory parentGroupthreadFactory = new NamedThreadFactory(name + "-acceptor-", null, false, Thread.NORM_PRIORITY);
         parentGroup = new NioEventLoopGroup(parentGroupthreadFactory);
 
-        final ThreadFactory childGroupthreadFactory = new NamedThreadFactory( name + "-worker-", null, true, null );
+        final ThreadFactory childGroupthreadFactory = new NamedThreadFactory(name + "-worker-", null, false, Thread.NORM_PRIORITY);
         childGroup = new NioEventLoopGroup(configuration.getMaxThreadPoolSize(), childGroupthreadFactory);
 
         Log = LoggerFactory.getLogger( NettyConnectionAcceptor.class.getName() + "[" + name + "]" );


### PR DESCRIPTION
As we're overriding the thread factories used for Netty EventLoops to change the names of threads, we've also changed the default configuration of threads used by Netty.

Netty's default configuration can be expected to be optimized for performance. Openfire should use a similar configuration.

In this commit, the configuration is reverted back to the default configuration that's used by Netty (based on `io.netty.util.concurrent.DefaultThreadFactory`).