### PR TITLE
OF-2811: Must not block on eventloop

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -350,6 +350,8 @@ public class StreamManager {
         // OF-2811: Cannot resume a session that's already closed. That session is likely busy firing its 'closeListeners'.
         if (route.isClosed()) {
             Log.debug("Not allowing a client of '{}' to resume a session, as the preexisting session is already in process of being closed.", fullJid);
+            sendError(new PacketError(PacketError.Condition.unexpected_request));
+            return;
         }
 
         // Previd identifies proper session. Now check SM status

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -346,6 +346,12 @@ public class StreamManager {
             return;
         }
         Log.debug("Found existing session for '{}', checking status", fullJid);
+
+        // OF-2811: Cannot resume a session that's already closed. That session is likely busy firing its 'closeListeners'.
+        if (route.isClosed()) {
+            Log.debug("Not allowing a client of '{}' to resume a session, as the preexisting session is already in process of being closed.", fullJid);
+        }
+
         // Previd identifies proper session. Now check SM status
         if (!otherSession.getStreamManager().resume) {
             Log.debug("Not allowing a client of '{}' to resume a session, the session to be resumed does not have the stream management resumption feature enabled.", fullJid);


### PR DESCRIPTION
OF-2808 describes an issue in which a session that is resumed gets closed. This is caused by the asynchronous 'close' operation to execute 'connection close' listeners on a session that, in another thread, has already been resumed.

The fix for OF-2808 introduces a Latch, that causes a thread to block. If that thread is one of a Netty EventLoop, all processing stops (possibly leading to the latch never be released, as the connection close listeners cannot operate).

This commit reverts the change for OF-2808, and applies a new fix for that issue: disallow a session that's already in the process of being closed from resumed.