### PR TITLE
OF-3034: Reduce log level for cluster task that can be expected to fail.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
@@ -61,7 +61,11 @@ public class ClientSessionTask extends RemoteSessionTask {
 
     public void run() {
         if (getSession() == null || getSession().isClosed()) {
-            logger.error("Unable to execute task for JID {}: {}", address, this, new IllegalStateException("Session not found for JID: " + address));
+            if (this.operation == Operation.removeDetached) {
+                logger.debug("Asked to remove detached sessions for JID {}, but no such sessions exist.", address); // This is a rather likely scenario. Don't log an error for this (OF-3034).
+            } else {
+                logger.error("Unable to execute task for JID {}: {}", address, this, new IllegalStateException("Session not found for JID: " + address));
+            }
             return;
         }
         super.run();


### PR DESCRIPTION
The 'removeDetached' cluster task is preemptively fired, and is likely to not find a session to be detached.

As not finding an applicable session is to be expected, this shouldn't be logged as an error.