### PR TITLE
OF-3035: Propagate session 'detached' state through cluster

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -134,12 +134,7 @@ public abstract class LocalSession implements Session {
 
     }
 
-    /**
-     * Returns true if the session is detached (that is, if the underlying connection
-     * has been closed while the session instance itself has not been closed).
-     *
-     * @return true if session detached
-     */
+    @Override
     public boolean isDetached() {
         return this.sessionManager.isDetached(this);
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, 2021-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,6 +147,13 @@ public abstract class RemoteSession implements Session {
 
     public boolean isClosed() {
         ClusterTask<Object> task = getRemoteSessionTask(RemoteSessionTask.Operation.isClosed);
+        final Object clusterTaskResult = doSynchronousClusterTask(task);
+        return clusterTaskResult == null ? false : (Boolean) clusterTaskResult;
+    }
+
+    @Override
+    public boolean isDetached() {
+        ClusterTask<Object> task = getRemoteSessionTask(RemoteSessionTask.Operation.isDetached);
         final Object clusterTaskResult = doSynchronousClusterTask(task);
         return clusterTaskResult == null ? false : (Boolean) clusterTaskResult;
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, 2021-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,21 +114,32 @@ public abstract class RemoteSessionTask implements ClusterTask<Object> {
         else if (operation == Operation.isClosed) {
             result = getSession().isClosed();
         }
+        else if (operation == Operation.isDetached) {
+            result = getSession().isDetached();
+        }
         else if (operation == Operation.isEncrypted) {
             result = getSession().isEncrypted();
         }
         else if (operation == Operation.getHostAddress) {
             try {
-                result = getSession().getHostAddress();
+                if (getSession().isDetached()) {
+                    Log.debug("Unable to get host-address of detached session: {}", getSession());
+                } else {
+                    result = getSession().getHostAddress();
+                }
             } catch (UnknownHostException e) {
-                Log.error("Error getting address of session: " + getSession(), e);
+                Log.error("Error getting address of session: {}", getSession(), e);
             }
         }
         else if (operation == Operation.getHostName) {
             try {
-                result = getSession().getHostName();
+                if (getSession().isDetached()) {
+                    Log.debug("Unable to get hostname of detached session: {}", getSession());
+                } else {
+                    result = getSession().getHostName();
+                }
             } catch (UnknownHostException e) {
-                Log.error("Error getting address of session: " + getSession(), e);
+                Log.error("Error getting address of session: {}", getSession(), e);
             }
         }
         else if (operation == Operation.validate) {
@@ -186,6 +197,7 @@ public abstract class RemoteSessionTask implements ClusterTask<Object> {
         getSoftwareVersion,
         close,
         isClosed,
+        isDetached,
         isEncrypted,
         getHostAddress,
         getHostName,

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,6 +140,14 @@ public interface Session extends RoutableChannelHandler {
     default boolean isClosed() {
         return getStatus() == Status.CLOSED;
     };
+
+    /**
+     * Returns true if the session is detached (that is, if the underlying connection
+     * has been closed while the session instance itself has not been closed).
+     *
+     * @return true if session detached
+     */
+    boolean isDetached();
 
     /**
      * Returns true if this session uses encrypted communication paths when exchanging data with the remote XMPP entity.

--- a/xmppserver/src/main/webapp/session-details.jsp
+++ b/xmppserver/src/main/webapp/session-details.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@
                  java.util.Collection"
     errorPage="error.jsp"
 %>
+<%@ page import="org.jivesoftware.openfire.session.LocalSession" %>
 <%@ page import="org.jivesoftware.openfire.nio.NettyConnection" %>
 <%@ page import="org.jivesoftware.openfire.websocket.WebSocketConnection" %>
 <%@ page import="org.jivesoftware.openfire.http.HttpSession" %>
@@ -381,7 +382,7 @@
                     </td>
                     <td>
                         <%
-                            if (currentSess instanceof LocalClientSession && ((LocalClientSession) currentSess).isDetached()) { %>
+                            if (currentSess.isDetached()) { %>
                         <fmt:message key="session.details.sm-detached"/>
                         <% } else {
                             try { %>

--- a/xmppserver/src/main/webapp/session-row.jspf
+++ b/xmppserver/src/main/webapp/session-row.jspf
@@ -8,7 +8,6 @@
                  org.xmpp.packet.JID,
                  org.xmpp.packet.Presence"%>
  <%@ page import="java.net.URLEncoder"%>
- <%@ page import="org.jivesoftware.openfire.session.LocalSession" %>
  <%@ page import="java.text.NumberFormat" %>
 
  <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -23,7 +22,7 @@
  --%>
 
 <%  Session.Status _status = sess.getStatus();
-    boolean isDetached = sess instanceof LocalSession && ((LocalSession) sess).isDetached();
+    boolean isDetached = sess.isDetached();
 %>
 
  <%  if (current) { %>

--- a/xmppserver/src/main/webapp/session-summary.jsp
+++ b/xmppserver/src/main/webapp/session-summary.jsp
@@ -149,7 +149,7 @@
     if(!searchStatus.isEmpty()) {
         filter = filter.and(clientSession -> {
             if (searchStatus.equals("detached")) {
-                return clientSession instanceof LocalSession && ((LocalSession) clientSession).isDetached();
+                return clientSession.isDetached();
             }
             switch (clientSession.getStatus()) {
                 case CLOSED:


### PR DESCRIPTION
This commit ensures that all cluster nodes can see the 'detached' state of a session. Prior to this change, this was only visible at the local cluster node. Because of this, cluster tasks that cannot operate on detached sessions no longer are invoked.

Additionally, certain cluster tasks that cannot succeed on a detached session are now logged in a less verbose manner than on level 'error'.