### PR TITLE
OF-3036: Improve log message when remote domain is unreachable

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettySessionInitializer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettySessionInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public class NettySessionInitializer {
         final Map.Entry<Socket, Boolean> socketToXmppDomain = SocketUtil.createSocketToXmppDomain(domainPair.getRemote(), port );
 
         if ( socketToXmppDomain == null ) {
-            throw new RuntimeException("Unable to create new session: Cannot create a plain socket connection with any applicable remote host.");
+            throw new NetworkEntityUnreachableException("Cannot establish connection to any host in the XMPP domain '" + domainPair.getRemote() + "'.");
         }
         Socket socket = socketToXmppDomain.getKey();
         this.directTLS = socketToXmppDomain.getValue();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NetworkEntityUnreachableException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NetworkEntityUnreachableException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.nio;
+
+/**
+ * Represents a generic issue with connecting to a remote network entity.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class NetworkEntityUnreachableException extends RuntimeException
+{
+    public NetworkEntityUnreachableException(String message)
+    {
+        super(message);
+    }
+
+    public NetworkEntityUnreachableException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.jivesoftware.openfire.*;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.event.ServerSessionEventDispatcher;
 import org.jivesoftware.openfire.nio.NettySessionInitializer;
+import org.jivesoftware.openfire.nio.NetworkEntityUnreachableException;
 import org.jivesoftware.openfire.server.OutgoingServerSocketReader;
 import org.jivesoftware.openfire.server.RemoteServerManager;
 import org.jivesoftware.openfire.server.ServerDialback;
@@ -261,6 +262,11 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
             // Wait for the future to give us a session...
             // Set a read timeout so that we don't keep waiting forever
             return (LocalOutgoingServerSession) sessionInitialiser.init(listener).get(INITIALISE_TIMEOUT_SECONDS.getValue().getSeconds(), TimeUnit.SECONDS);
+        } catch (NetworkEntityUnreachableException e) {
+            Log.warn("Cannot connect to XMPP domain '{}' (from '{}'): Unable to create a socket connection to a host that associated " +
+                "to the domain. This is typically caused by an outage (the remote server may be turned off) or a network configuration " +
+                "issue (eg: missing or invalid DNS records, restrictive firewalls, etc.).", domainPair.getRemote(), domainPair.getLocal());
+            sessionInitialiser.stop();
         } catch (Exception e) {
             // This might be RFC6120, section 5.4.2.2 "Failure Case" or even an unrelated problem. Handle 'normally'.
             log.warn("An exception occurred while creating a session. Closing connection.", e);


### PR DESCRIPTION
This drops the stack trace, and changes the log message in such a way that it's more descriptive to an admin.