### PR TITLE
Fixed: modify column retiredAt from TIMESTAMP to CHAR, to be compatible with various databases

### DIFF
--- a/distribution/src/database/openfire_db2.sql
+++ b/distribution/src/database/openfire_db2.sql
@@ -233,7 +233,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                VARCHAR(50)   NOT NULL,
   alternateJID        VARCHAR(2000),
   reason              VARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/openfire_hsqldb.sql
+++ b/distribution/src/database/openfire_hsqldb.sql
@@ -229,7 +229,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                VARCHAR(50)   NOT NULL,
   alternateJID        VARCHAR(2000),
   reason              VARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -219,7 +219,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                VARCHAR(50)   NOT NULL,
   alternateJID        VARCHAR(2000),
   reason              VARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   PRIMARY KEY (serviceID,name)
 );
 

--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -226,7 +226,7 @@ CREATE TABLE ofMucRoomRetiree(
   name                VARCHAR2(50)  NOT NULL,
   alternateJID        VARCHAR2(2000),
   reason              VARCHAR2(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -234,7 +234,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                VARCHAR(50)   NOT NULL,
   alternateJID        VARCHAR(2000),
   reason              VARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -232,7 +232,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                NVARCHAR(50)  NOT NULL,
   alternateJID        NVARCHAR(2000),
   reason              NVARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)       NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -231,7 +231,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                NVARCHAR(50)  NOT NULL,
   alternateJID        NVARCHAR(2000),
   reason              NVARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 )
 

--- a/distribution/src/database/upgrade/36/openfire_db2.sql
+++ b/distribution/src/database/upgrade/36/openfire_db2.sql
@@ -5,7 +5,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                VARCHAR(50)   NOT NULL,
   alternateJID        VARCHAR(2000),
   reason              VARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/36/openfire_hsqldb.sql
@@ -5,7 +5,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                VARCHAR(50)   NOT NULL,
   alternateJID        VARCHAR(2000),
   reason              VARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/36/openfire_mysql.sql
@@ -5,7 +5,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                VARCHAR(50)   NOT NULL,
   alternateJID        VARCHAR(2000),
   reason              VARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   PRIMARY KEY (serviceID,name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/36/openfire_oracle.sql
@@ -5,7 +5,7 @@ CREATE TABLE ofMucRoomRetiree(
   name                VARCHAR2(50)  NOT NULL,
   alternateJID        VARCHAR2(2000),
   reason              VARCHAR2(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/36/openfire_postgresql.sql
@@ -5,7 +5,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                VARCHAR(50)   NOT NULL,
   alternateJID        VARCHAR(2000),
   reason              VARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/36/openfire_sqlserver.sql
@@ -5,7 +5,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                NVARCHAR(50)  NOT NULL,
   alternateJID        NVARCHAR(2000),
   reason              NVARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/36/openfire_sybase.sql
@@ -5,7 +5,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                NVARCHAR(50)  NOT NULL,
   alternateJID        NVARCHAR(2000),
   reason              NVARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           CHAR(15)      NOT NULL,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 )
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
@@ -48,6 +48,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.sql.*;
 import java.util.*;
+import java.util.Date;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -1056,7 +1057,7 @@ public class MultiUserChatManager extends BasicModule implements MUCServicePrope
                         rs.getString("name"),
                         rs.getString("alternateJID"),
                         rs.getString("reason"),
-                        rs.getTimestamp("retiredAt")
+                        new Date(Long.parseLong(rs.getString("retiredAt").trim()))
                     ));
                 }
             } else {
@@ -1073,7 +1074,7 @@ public class MultiUserChatManager extends BasicModule implements MUCServicePrope
                         rs.getString("name"),
                         rs.getString("alternateJID"),
                         rs.getString("reason"),
-                        rs.getTimestamp("retiredAt")
+                        new Date(Long.parseLong(rs.getString("retiredAt").trim()))
                     ));
                     count++;
                 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MUCPersistenceManager.java
@@ -117,7 +117,7 @@ public class MUCPersistenceManager {
         "fmucOutboundMode, fmucInboundNodes) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
     private static final String CHECK_RETIREES = "SELECT 1 FROM ofMucRoomRetiree WHERE serviceID=? AND name=?";
     private static final String ADD_RETIREE =
-        "INSERT INTO ofMucRoomRetiree (serviceID, name, alternateJID, reason) VALUES (?,?,?,?)";
+        "INSERT INTO ofMucRoomRetiree (serviceID, name, alternateJID, reason, retiredAt) VALUES (?,?,?,?,?)";
     private static final String UPDATE_SUBJECT =
         "UPDATE ofMucRoom SET subject=? WHERE roomID=?";
     private static final String UPDATE_LOCK =
@@ -595,6 +595,7 @@ public class MUCPersistenceManager {
                 } else {
                     pstmt.setString(4, reason.trim());
                 }
+                pstmt.setString(5, StringUtils.dateToMillis(new Date()));
 
                 pstmt.executeUpdate();
                 DbConnectionManager.fastcloseStmt(pstmt);


### PR DESCRIPTION
When I try to use 5.0.0 alpha version on my local box, found the upgrade SQL run out error on  my SQL-Server db.
```
2025.03.04 16:12:07.008 [1;31mERROR[m [main]: org.jivesoftware.database.SchemaManager - SchemaManager: Failed to execute SQL:
 CREATE TABLE ofMucRoomRetiree (   serviceID           INT           NOT NULL,   name                NVARCHAR(50)  NOT NULL,   alternateJID        NVARCHAR(2000),   reason              NVARCHAR(1024),   retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name) );
2025.03.04 16:12:07.008 [1;31mERROR[m [main]: org.jivesoftware.database.SchemaManager - Defaults cannot be created on columns of data type timestamp. Table 'ofMucRoomRetiree', column 'retiredAt'.
com.microsoft.sqlserver.jdbc.SQLServerException: Defaults cannot be created on columns of data type timestamp. Table 'ofMucRoomRetiree', column 'retiredAt'.
	at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDatabaseError(SQLServerException.java:265) ~[mssql-jdbc-9.4.1.jre11.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.getNextResult(SQLServerStatement.java:1662) ~[mssql-jdbc-9.4.1.jre11.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.doExecuteStatement(SQLServerStatement.java:898) ~[mssql-jdbc-9.4.1.jre11.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerStatement$StmtExecCmd.doExecute(SQLServerStatement.java:793) ~[mssql-jdbc-9.4.1.jre11.jar:?]
	at com.microsoft.sqlserver.jdbc.TDSCommand.execute(IOBuffer.java:7417) ~[mssql-jdbc-9.4.1.jre11.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.executeCommand(SQLServerConnection.java:3488) ~[mssql-jdbc-9.4.1.jre11.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.executeCommand(SQLServerStatement.java:262) ~[mssql-jdbc-9.4.1.jre11.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.executeStatement(SQLServerStatement.java:237) ~[mssql-jdbc-9.4.1.jre11.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.execute(SQLServerStatement.java:766) ~[mssql-jdbc-9.4.1.jre11.jar:?]
	at org.apache.commons.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:193) ~[commons-dbcp2-2.9.0.jar:2.9.0]
	at org.apache.commons.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:193) ~[commons-dbcp2-2.9.0.jar:2.9.0]
	at org.jivesoftware.database.SchemaManager.executeSQLScript(SchemaManager.java:395) ~[xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.database.SchemaManager.checkSchema(SchemaManager.java:292) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.database.SchemaManager.checkOpenfireSchema(SchemaManager.java:85) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.database.DbConnectionManager.setConnectionProvider(DbConnectionManager.java:660) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.database.DbConnectionManager.ensureConnectionProvider(DbConnectionManager.java:101) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.database.DbConnectionManager.getConnection(DbConnectionManager.java:162) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.util.JiveProperties.loadProperties(JiveProperties.java:472) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.util.JiveProperties.init(JiveProperties.java:108) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.util.JiveProperties.getInstance(JiveProperties.java:84) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.util.JiveGlobals.getProperty(JiveGlobals.java:547) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.util.cache.CacheFactory.<clinit>(CacheFactory.java:102) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.openfire.XMPPServer.initialize(XMPPServer.java:381) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.openfire.XMPPServer.start(XMPPServer.java:661) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.jivesoftware.openfire.XMPPServer.<init>(XMPPServer.java:221) [xmppserver-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) [?:?]
	at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) [?:?]
	at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) [?:?]
	at java.lang.reflect.ReflectAccess.newInstance(ReflectAccess.java:128) [?:?]
	at jdk.internal.reflect.ReflectionFactory.newInstance(ReflectionFactory.java:347) [?:?]
	at java.lang.Class.newInstance(Class.java:645) [?:?]
	at org.jivesoftware.openfire.starter.ServerStarter.start(ServerStarter.java:92) [classes/:?]
	at org.jivesoftware.openfire.starter.ServerStarter.main(ServerStarter.java:56) [classes/:?]
```