### PR TITLE
OF-3039: Avoid resource conflict resolution on closed session

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ public class IQBindHandler extends IQHandler {
             // If a session already exists with the requested JID, then check to see
             // if we should kick it off or refuse the new connection
             ClientSession oldSession = routingTable.getClientRoute(new JID(username, serverName, resource, true));
-            if (oldSession != null) {
+            if (oldSession != null && !oldSession.isClosed()) {
                 try {
                     int conflictLimit = sessionManager.getConflictKickLimit();
                     if (conflictLimit == SessionManager.NEVER_KICK) {


### PR DESCRIPTION
When a session is closed, there is no need to apply resource-part conflict resolution anymore (as that session isn't going to be used anyway).

This can also prevent a cluster task exception: the cluster task to increase a conflict count will throw an exception when the session being operated on is non-existing, or existing-but-closed.