### PR TITLE
OF-2760: Fix MSSQL date/time column

### DIFF
--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -232,7 +232,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                NVARCHAR(50)  NOT NULL,
   alternateJID        NVARCHAR(2000),
   reason              NVARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           DATETIME DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 

--- a/distribution/src/database/upgrade/36/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/36/openfire_sqlserver.sql
@@ -5,7 +5,7 @@ CREATE TABLE ofMucRoomRetiree (
   name                NVARCHAR(50)  NOT NULL,
   alternateJID        NVARCHAR(2000),
   reason              NVARCHAR(1024),
-  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  retiredAt           DATETIME DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT ofMucRoomRetiree_pk PRIMARY KEY (serviceID, name)
 );
 


### PR DESCRIPTION
The Transact-SQL timestamp data type is different from the timestamp data type defined in the ISO standard. In MSSQL, `timestamp` is a synonym for the `rowversion` data type.