### PR TITLE
OF-3041: Prevent Deadlock by reworking `LocalSession#canDeliver()`

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -433,7 +433,7 @@ public class IQRouter extends BasicModule {
                     IQ dummyIQ = packet.createCopy();
                     dummyIQ.setFrom(packet.getTo());
                     dummyIQ.setTo(packet.getFrom());
-                    if (!((LocalClientSession) session).canProcess(dummyIQ)) {
+                    if (!((LocalClientSession) session).canDeliver(dummyIQ)) {
                         packet.setTo(session.getAddress());
                         packet.setFrom((JID) null);
                         packet.setError(PacketError.Condition.not_acceptable);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/MessageRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ public class MessageRouter extends BasicModule {
                     Message dummyMessage = packet.createCopy();
                     dummyMessage.setFrom(packet.getTo());
                     dummyMessage.setTo(packet.getFrom());
-                    if (!((LocalClientSession) session).canProcess(dummyMessage)) {
+                    if (!((LocalClientSession) session).canDeliver(dummyMessage)) {
                         packet.setTo(session.getAddress());
                         packet.setFrom((JID)null);
                         packet.setError(PacketError.Condition.not_acceptable);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
@@ -194,7 +194,7 @@ public class LocalComponentSession extends LocalSession implements ComponentSess
     }
 
     @Override
-    boolean canProcess(Packet packet) {
+    boolean canDeliver(@Nonnull final Packet stanza) {
         return true;
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalConnectionMultiplexerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2009 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2009 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -283,7 +283,7 @@ public class LocalConnectionMultiplexerSession extends LocalSession implements C
     }
 
     @Override
-    boolean canProcess(Packet packet) {
+    boolean canDeliver(@Nonnull final Packet stanza) {
         return true;
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.xmpp.packet.JID;
 import org.xmpp.packet.Packet;
 import org.xmpp.packet.StreamError;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
@@ -239,7 +240,7 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
     }
 
     @Override
-    boolean canProcess(Packet packet) {
+    boolean canDeliver(@Nonnull final Packet stanza) {
         return true;
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalOutgoingServerSession.java
@@ -291,8 +291,8 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
     }
 
     @Override
-    boolean canProcess(Packet packet) {
-        final DomainPair domainPair = new DomainPair(packet.getFrom().getDomain(), packet.getTo().getDomain());
+    boolean canDeliver(@Nonnull final Packet stanza) {
+        final DomainPair domainPair = new DomainPair(stanza.getFrom().getDomain(), stanza.getTo().getDomain());
         boolean processed = true;
         synchronized (remoteAuthMutex.intern(new JID(null, domainPair.getRemote(), null))) {
             if (!checkOutgoingDomainPair(domainPair) && !authenticateSubdomain(domainPair)) {
@@ -301,7 +301,7 @@ public class LocalOutgoingServerSession extends LocalServerSession implements Ou
             }
         }
         if (!processed) {
-            returnErrorToSenderAsync(packet);
+            returnErrorToSenderAsync(stanza);
         }
         return processed;
     }


### PR DESCRIPTION
Introduces an alternative to `LocalSession#canProcess`: `#canDeliver`, to fix:
- no longer generate two error stanzas if `LocalOutgoingServerSession#canProcess` returns `false`
- have implemenations be responsible for generating any error stanzas, making it possible for each implemenation to choose the best type of error. No longer assume that every error must be related to XEP-0016.
- prevent synchronous error processing in `LocalOutgoingServerSession` that can introduce a deadlock (similar to OF-2341 and OF-2342).

This commit replaces `#canProcess` but marks it as being deprecated. The replacement method, `#canDeliver` has temporarily received a default implementation that is backwards compatible with the preexisting code. This should allow any third-party implementations to be able to gracefully migrate. In future versions of Openfire `#canProcess` will be removed, and the definition of `#canDeliver` will be changed: instead of a default implementation, it will only be an interface definition of a method (`public boolean canDeliver(@Nonnull final Packet stanza);`)

(see https://igniterealtime.atlassian.net/browse/OF-3041 for more details)