### PR TITLE
CI: Introduce checks for the database install scripts

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -320,6 +320,11 @@ jobs:
           cp $GITHUB_WORKSPACE/distribution/src/database/openfire_sqlserver.sql $GITHUB_WORKSPACE/olddb/openfire_sqlserver.sql
       - name: Start database server and install database
         run: docker compose -f ./build/ci/compose/mssql.yml up --detach
+      - name: Build & run database tester
+        run: |
+          pushd ./build/ci/updater
+          ./mvnw package
+          java -jar ./target/updaterunner-1.0.0-jar-with-dependencies.jar
 
 
   sqlserver-upgrade:
@@ -356,7 +361,7 @@ jobs:
           curl https://raw.githubusercontent.com/igniterealtime/Openfire/v3.9.3/src/database/openfire_sqlserver.sql > $GITHUB_WORKSPACE/olddb/openfire_sqlserver.sql
       - name: Start database server and install database
         run: docker compose -f ./build/ci/compose/mssql.yml up --detach
-      - name: Build & run update tester
+      - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
           ./mvnw package
@@ -397,6 +402,11 @@ jobs:
           cp $GITHUB_WORKSPACE/distribution/src/database/openfire_postgresql.sql $GITHUB_WORKSPACE/olddb/openfire_postgresql.sql
       - name: Start database server and install database
         run: docker compose -f ./build/ci/compose/postgresql.yml up --detach
+      - name: Build & run database tester
+        run: |
+          pushd ./build/ci/updater
+          ./mvnw package
+          java -jar ./target/updaterunner-1.0.0-jar-with-dependencies.jar
 
 
   postgres-upgrade:
@@ -433,7 +443,7 @@ jobs:
           curl https://raw.githubusercontent.com/igniterealtime/Openfire/v3.9.3/src/database/openfire_postgresql.sql > $GITHUB_WORKSPACE/olddb/openfire_postgresql.sql
       - name: Start database server and install database
         run: docker compose -f ./build/ci/compose/postgresql.yml up --detach
-      - name: Build & run update tester
+      - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
           ./mvnw package
@@ -474,6 +484,11 @@ jobs:
           cp $GITHUB_WORKSPACE/distribution/src/database/openfire_mysql.sql $GITHUB_WORKSPACE/olddb/openfire_mysql.sql
       - name: Start database server and install database
         run: docker compose -f ./build/ci/compose/mysql.yml up --detach
+      - name: Build & run database tester
+        run: |
+          pushd ./build/ci/updater
+          ./mvnw package
+          java -jar ./target/updaterunner-1.0.0-jar-with-dependencies.jar
 
 
   mysql-upgrade:
@@ -510,7 +525,7 @@ jobs:
           curl https://raw.githubusercontent.com/igniterealtime/Openfire/v3.9.3/src/database/openfire_mysql.sql > $GITHUB_WORKSPACE/olddb/openfire_mysql.sql
       - name: Start database server and install database
         run: docker compose -f ./build/ci/compose/mysql.yml up --detach
-      - name: Build & run update tester
+      - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
           ./mvnw package

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -265,8 +265,8 @@ jobs:
         if: ${{ always() && steps.startCIServer.conclusion == 'success' }} # TODO figure out if this is correct. The intent is to have the server stopped if it was successfully started, even if the tests fail. Failing tests should still cause the job to fail.
         uses: ./.github/actions/stopserver-action
 
-  should-do-database-upgrade-tests:
-    name: Check if database upgrade tests should be run
+  should-do-database-tests:
+    name: Check if database install/upgrade tests should be run
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -286,11 +286,47 @@ jobs:
               - '.github/workflows/continuous-integration-workflow.yml'
               - 'xmppserver/pom.xml'
 
-  sqlserver:
-    name: Test SQL Server Upgrades
-    needs: [build, should-do-database-upgrade-tests, check_branch]
+  sqlserver-install:
+    name: Test MS SQL Server install script
+    needs: [build, should-do-database-tests, check_branch]
     runs-on: ubuntu-latest
-    if: ${{ needs.should-do-database-upgrade-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
+    if: ${{ needs.should-do-database-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
+    steps:
+      - name: Checkout Openfire
+        uses: actions/checkout@v4
+      - name: Set up JDK 17 Zulu
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: zulu
+          cache: maven
+      - name: Restore mvn repo artifacts from build job
+        uses: actions/download-artifact@v4
+        with:
+          name: mvn-repo
+          path: ~/.m2/repository/org/igniterealtime/openfire/
+      - name: Set environment variables
+        run: |
+          echo "CONNECTION_STRING=jdbc:sqlserver://localhost:1433;databaseName=openfire;applicationName=Openfire" >> $GITHUB_ENV
+          echo "CONNECTION_DRIVER=com.microsoft.sqlserver.jdbc.SQLServerDriver" >> $GITHUB_ENV
+          echo "CONNECTION_USERNAME=sa" >> $GITHUB_ENV
+          echo "CONNECTION_PASSWORD=SecurePa55w0rd" >> $GITHUB_ENV
+          OPENFIREVSN=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "OPENFIREVSN=$OPENFIREVSN" >> $GITHUB_ENV
+          echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
+      - name: Copy the Openfire database installation script
+        run: |
+          mkdir olddb
+          cp $GITHUB_WORKSPACE/distribution/src/database/openfire_sqlserver.sql $GITHUB_WORKSPACE/olddb/openfire_sqlserver.sql
+      - name: Start database server and install database
+        run: docker compose -f ./build/ci/compose/mssql.yml up --detach
+
+
+  sqlserver-upgrade:
+    name: Test MS SQL Server upgrade scripts
+    needs: [build, should-do-database-tests, check_branch]
+    runs-on: ubuntu-latest
+    if: ${{ needs.should-do-database-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
     steps:
       - name: Checkout Openfire
         uses: actions/checkout@v4
@@ -327,11 +363,47 @@ jobs:
           java -jar ./target/updaterunner-1.0.0-jar-with-dependencies.jar
 
 
-  postgres:
-    name: Test Postgres Upgrades
-    needs: [build, should-do-database-upgrade-tests, check_branch]
+  postgres-install:
+    name: Test Postgres install script
+    needs: [build, should-do-database-tests, check_branch]
     runs-on: ubuntu-latest
-    if: ${{ needs.should-do-database-upgrade-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
+    if: ${{ needs.should-do-database-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
+    steps:
+      - name: Checkout Openfire
+        uses: actions/checkout@v4
+      - name: Set up JDK 17 Zulu
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: zulu
+          cache: maven
+      - name: Restore mvn repo artifacts from build job
+        uses: actions/download-artifact@v4
+        with:
+          name: mvn-repo
+          path: ~/.m2/repository/org/igniterealtime/openfire/
+      - name: Set environment variables
+        run: |
+          echo "CONNECTION_STRING=jdbc:postgresql://localhost:5432/openfire" >> $GITHUB_ENV
+          echo "CONNECTION_DRIVER=org.postgresql.Driver" >> $GITHUB_ENV
+          echo "CONNECTION_USERNAME=openfire" >> $GITHUB_ENV
+          echo "CONNECTION_PASSWORD=SecurePa55w0rd" >> $GITHUB_ENV
+          OPENFIREVSN=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "OPENFIREVSN=$OPENFIREVSN" >> $GITHUB_ENV
+          echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
+      - name: Copy the Openfire database installation script
+        run: |
+          mkdir olddb
+          cp $GITHUB_WORKSPACE/distribution/src/database/openfire_postgresql.sql $GITHUB_WORKSPACE/olddb/openfire_postgresql.sql
+      - name: Start database server and install database
+        run: docker compose -f ./build/ci/compose/postgresql.yml up --detach
+
+
+  postgres-upgrade:
+    name: Test Postgres upgrade scripts
+    needs: [build, should-do-database-tests, check_branch]
+    runs-on: ubuntu-latest
+    if: ${{ needs.should-do-database-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
     steps:
       - name: Checkout Openfire
         uses: actions/checkout@v4
@@ -368,11 +440,47 @@ jobs:
           java -jar ./target/updaterunner-1.0.0-jar-with-dependencies.jar
 
 
-  mysql:
-    name: Test MySQL Upgrades
-    needs: [build, should-do-database-upgrade-tests, check_branch]
+  mysql-install:
+    name: Test MySQL install script
+    needs: [build, should-do-database-tests, check_branch]
     runs-on: ubuntu-latest
-    if: ${{ needs.should-do-database-upgrade-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
+    if: ${{ needs.should-do-database-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
+    steps:
+      - name: Checkout Openfire
+        uses: actions/checkout@v4
+      - name: Set up JDK 17 Zulu
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: zulu
+          cache: maven
+      - name: Restore mvn repo artifacts from build job
+        uses: actions/download-artifact@v4
+        with:
+          name: mvn-repo
+          path: ~/.m2/repository/org/igniterealtime/openfire/
+      - name: Set environment variables
+        run: |
+          echo "CONNECTION_STRING=jdbc:mysql://localhost:3306/openfire?rewriteBatchedStatements=true&characterEncoding=UTF-8&characterSetResults=UTF-8&serverTimezone=UTC" >> $GITHUB_ENV
+          echo "CONNECTION_DRIVER=com.mysql.cj.jdbc.Driver" >> $GITHUB_ENV
+          echo "CONNECTION_USERNAME=root" >> $GITHUB_ENV
+          echo "CONNECTION_PASSWORD=SecurePa55w0rd" >> $GITHUB_ENV
+          OPENFIREVSN=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "OPENFIREVSN=$OPENFIREVSN" >> $GITHUB_ENV
+          echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
+      - name: Copy the Openfire database installation script
+        run: |
+          mkdir olddb
+          cp $GITHUB_WORKSPACE/distribution/src/database/openfire_mysql.sql $GITHUB_WORKSPACE/olddb/openfire_mysql.sql
+      - name: Start database server and install database
+        run: docker compose -f ./build/ci/compose/mysql.yml up --detach
+
+
+  mysql-upgrade:
+    name: Test MySQL upgrade scripts
+    needs: [build, should-do-database-tests, check_branch]
+    runs-on: ubuntu-latest
+    if: ${{ needs.should-do-database-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
     steps:
       - name: Checkout Openfire
         uses: actions/checkout@v4
@@ -411,7 +519,7 @@ jobs:
   publish-maven:
     name: Publish to Maven
     runs-on: ubuntu-latest
-    needs: [aioxmpp, connectivity, smack, check_branch, sqlserver, postgres, mysql]
+    needs: [aioxmpp, connectivity, smack, check_branch, sqlserver-install, sqlserver-upgrade, postgres-install, postgres-upgrade, mysql-install, mysql-upgrade]
     if: ${{github.repository == 'igniterealtime/Openfire' && github.event_name == 'push' && needs.check_branch.outputs.is_publishable_branch == 'true'}}
 
     steps:
@@ -438,7 +546,7 @@ jobs:
   build-and-push-docker:
     name: Publish to GitHub's Docker registry
     runs-on: ubuntu-latest
-    needs: [aioxmpp, connectivity, smack, check_branch, sqlserver, postgres, mysql]
+    needs: [aioxmpp, connectivity, smack, check_branch, sqlserver-install, sqlserver-upgrade, postgres-install, postgres-upgrade, mysql-install, mysql-upgrade]
     if: |
       github.event_name == 'push' && 
       (contains(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')

--- a/build/ci/updater/src/main/java/com/igniterealtime/openfire/updaterunner/Main.java
+++ b/build/ci/updater/src/main/java/com/igniterealtime/openfire/updaterunner/Main.java
@@ -65,7 +65,7 @@ public class Main {
             SchemaManager sm = new SchemaManager();
             boolean fixed = sm.checkOpenfireSchema(conn);
             if(!fixed){
-                throw new Exception("Failed to upgrade database");
+                throw new Exception("Failed to install or upgrade the database! It is likely that the installation or upgrade SQL scripts contain a bug.");
             }
         } catch (Exception e) {
             System.out.println(e.getClass() + "\n" + e.getMessage());

--- a/distribution/src/database/openfire_db2.sql
+++ b/distribution/src/database/openfire_db2.sql
@@ -395,11 +395,12 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
-
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)
     VALUES ('admin', 'admin', 'Administrator', 'admin@example.com', '0', '0');
 
 -- Entry for default conference service
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
+
+-- Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);

--- a/distribution/src/database/openfire_hsqldb.sql
+++ b/distribution/src/database/openfire_hsqldb.sql
@@ -383,14 +383,15 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
-
 // Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)
     VALUES ('admin', 'admin', 'Administrator', 'admin@example.com', '0', '0');
 
 // Entry for default conference service
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
+
+// Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
 
 // The value is the size in megabytes that the .log file can reach before an automatic
 // checkpoint occurs. A checkpoint rewrites the .script file and clears the .log file

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -380,7 +380,5 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 # Entry for default conference service
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
-INSERT INTO doesNotExist (foo) VALUES ('bar');
-
-// Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
+# Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
 INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -373,8 +373,6 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
-
 # Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)
     VALUES ('admin', 'admin', 'Administrator', 'admin@example.com', '0', '0');
@@ -383,3 +381,6 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
 INSERT INTO doesNotExist (foo) VALUES ('bar');
+
+// Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -381,3 +381,5 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 
 # Entry for default conference service
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
+
+INSERT INTO doesNotExist (foo) VALUES ('bar');

--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -381,13 +381,14 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
-
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)
     VALUES ('admin', 'admin', 'Administrator', 'admin@example.com', '0', '0');
 
 -- Entry for default conference service
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
+
+-- Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
 
 commit;

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -396,7 +396,5 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 -- Entry for default conference service
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
-INSERT INTO doesNotExist (foo) VALUES ('bar');
-
 -- Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
 INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -389,8 +389,6 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
-
 -- Entry for admin user
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)
     VALUES ('admin', 'admin', 'Administrator', 'admin@example.com', '0', '0');
@@ -399,3 +397,6 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
 INSERT INTO doesNotExist (foo) VALUES ('bar');
+
+-- Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -397,3 +397,5 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 
 -- Entry for default conference service
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
+
+INSERT INTO doesNotExist (foo) VALUES ('bar');

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -386,8 +386,6 @@ INSERT INTO ofID (idType, id) VALUES (23, 1);
 INSERT INTO ofID (idType, id) VALUES (26, 2);
 INSERT INTO ofID (idType, id) VALUES (27, 1);
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);
-
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)
     VALUES ('admin', 'admin', 'Administrator', 'admin@example.com', '0', '0');
@@ -396,3 +394,6 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
 INSERT INTO doesNotExist (foo) VALUES ('bar');
+
+/* Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully. */
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -394,3 +394,5 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 
 /* Entry for default conference service */
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
+
+INSERT INTO doesNotExist (foo) VALUES ('bar');

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -393,7 +393,5 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 /* Entry for default conference service */
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
-INSERT INTO doesNotExist (foo) VALUES ('bar');
-
 /* Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully. */
 INSERT INTO ofVersion (name, version) VALUES ('openfire', 37);

--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -386,11 +386,12 @@ INSERT INTO ofID (idType, id) VALUES (23, 1)
 INSERT INTO ofID (idType, id) VALUES (26, 2)
 INSERT INTO ofID (idType, id) VALUES (27, 1)
 
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 37)
-
 /* Entry for admin user */
 INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)
     VALUES ('admin', 'admin', 'Administrator', 'admin@example.com', '0', '0')
 
 /* Entry for default conference service */
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0)
+
+/* Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully. */
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 37)


### PR DESCRIPTION
Prior to this commit, Openfire's continuous integration already had some scripts that verify the scripts used to update the database managed by Openfire from some base version to a newer version. These checks do not verify the installation script - only the update scripts, which provide a 'delta'.

In this commit, the mechanism used to test the update scripts is repurposed to also test the install scripts:
- instead of provisioning the database with a known-good (but old) database installation script, the latest version of the script is used (which is the system under test)
- the 'update runner' is not executed at all - instead, it is assumed that a bug in the install script will cause the docker build to fail.