### PR TITLE
 openfire.sh

### DIFF
--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -127,6 +127,7 @@ fi
 # Note: you can combine options, eg: -devboot -debug
 for arguments in "$@"
 do
+  echo "Option: $arguments"
   case $arguments in
     -debug)
       echo "Starting debug mode"

--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # tries to determine arguments to launch openfire
 
+# shellcheck disable=SC2166
+
 # OS specific support
 cygwin=false
 darwin=false
@@ -44,7 +46,7 @@ if [ -z "$OPENFIRE_HOME" -o ! -d "$OPENFIRE_HOME" ]; then
     OPENFIRE_HOME="/usr/local/openfire"
   fi
 
-  if [ -d ${HOME}/opt/openfire ] ; then
+  if [ -d "${HOME}/opt/openfire" ] ; then
     OPENFIRE_HOME="${HOME}/opt/openfire"
   fi
 
@@ -125,11 +127,11 @@ do
       ;;
     -demoboot)
       echo "Starting demoboot"
-      cp $OPENFIRE_HOME/conf/openfire-demoboot.xml $OPENFIRE_HOME/conf/openfire.xml
+      cp "$OPENFIRE_HOME/conf/openfire-demoboot.xml" "$OPENFIRE_HOME/conf/openfire.xml"
       ;;
     -devboot)
       HOSTNAME=$(hostname)
-      sed "s/example.org/$HOSTNAME/g" $OPENFIRE_HOME/conf/openfire-demoboot.xml > $OPENFIRE_HOME/conf/openfire.xml
+      sed "s/example.org/$HOSTNAME/g" "$OPENFIRE_HOME/conf/openfire-demoboot.xml" > "$OPENFIRE_HOME/conf/openfire.xml"
       ;;
     *)
       # unknown option, pass through the Java command
@@ -195,4 +197,5 @@ if $cygwin; then
 fi
 
 openfire_exec_command="exec $JAVACMD -server $OPENFIRE_OPTS -classpath \"$LOCALCLASSPATH\" -jar \"$OPENFIRE_LIB/startup.jar\""
+# shellcheck disable=SC2086
 eval $openfire_exec_command

--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -2,33 +2,37 @@
 # tries to determine arguments to launch openfire
 
 # OS specific support
-cygwin=false;
-darwin=false;
-linux=false;
+cygwin=false
+darwin=false
+linux=false
 case "`uname`" in
   CYGWIN*)
     cygwin=true
     ;;
   Darwin*)
     darwin=true
-    if [ -z "$JAVA_HOME" ] ; then
-      JAVA_HOME=/usr/libexec/java_home
-    fi
     ;;
   Linux*)
     linux=true
-    if [ -z "$JAVA_HOME" ]; then
-      shopt -s nullglob
-      jdks=`ls -r1d /usr/java/j* /usr/lib/jvm/* 2>/dev/null`
-      for jdk in $jdks; do
-        if [ -f "$jdk/bin/java" ]; then
-          JAVA_HOME="$jdk"
-          break
-        fi
-      done
-    fi
     ;;
 esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if $darwin ; then
+    JAVA_HOME=/usr/libexec/java_home
+  fi
+  if $linux; then
+    # shellcheck disable=SC2039
+    shopt -s nullglob
+    jdks=$(ls -r1d /usr/java/j* /usr/lib/jvm/* 2>/dev/null)
+    for jdk in $jdks; do
+      if [ -f "$jdk/bin/java" ]; then
+        JAVA_HOME="$jdk"
+        break
+      fi
+    done
+  fi
+fi
 
 #if openfire home is not set or is not a directory
 if [ -z "$OPENFIRE_HOME" -o ! -d "$OPENFIRE_HOME" ]; then

--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -5,7 +5,7 @@
 cygwin=false
 darwin=false
 linux=false
-case "`uname`" in
+case "$(uname)" in
   CYGWIN*)
     cygwin=true
     ;;
@@ -50,24 +50,23 @@ if [ -z "$OPENFIRE_HOME" -o ! -d "$OPENFIRE_HOME" ]; then
 
   #resolve links - $0 may be a link in openfire's home
   PRG="$0"
-  progname=`basename "$0$"`
 
   # need this for relative symlinks
   while [ -h "$PRG" ] ; do
-    ls=`ls -ld "$PRG"`
-    link=`expr "$ls" : '.*-> \(.*\)$'`
+    ls=$(ls -ld "$PRG")
+    link=$(expr "$ls" : '.*-> \(.*\)$')
     if expr "$link" : '/.*' > /dev/null; then
       PRG="$link"
     else
-      PRG=`dirname "$PRG"`"/$link"
+      PRG=$(dirname "$PRG")"/$link"
     fi
   done
 
   #assumes we are in the bin directory
-  OPENFIRE_HOME=`dirname "$PRG"`/..
+  OPENFIRE_HOME=$(dirname "$PRG")/..
 
   #make it fully qualified
-  OPENFIRE_HOME=`cd "$OPENFIRE_HOME" && pwd`
+  OPENFIRE_HOME=$(cd "$OPENFIRE_HOME" && pwd)
 fi
 OPENFIRE_OPTS="${OPENFIRE_OPTS} -DopenfireHome=\"${OPENFIRE_HOME}\""
 
@@ -75,9 +74,9 @@ OPENFIRE_OPTS="${OPENFIRE_OPTS} -DopenfireHome=\"${OPENFIRE_HOME}\""
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
   [ -n "$OPENFIRE_HOME" ] &&
-    OPENFIRE_HOME=`cygpath --unix "$OPENFIRE_HOME"`
+    OPENFIRE_HOME=$(cygpath --unix "$OPENFIRE_HOME")
   [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+    JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
 fi
 
 #set the OPENFIRE_LIB location
@@ -99,7 +98,7 @@ if [ -z "$JAVACMD" ] ; then
       JAVACMD="$JAVA_HOME/bin/java"
     fi
   else
-    JAVACMD=`which java 2> /dev/null `
+    JAVACMD=$(which java 2> /dev/null )
     if [ -z "$JAVACMD" ] ; then
       JAVACMD=java
     fi
@@ -163,14 +162,14 @@ if $cygwin; then
     else
       format=windows
     fi
-    OPENFIRE_HOME=`cygpath --$format "$OPENFIRE_HOME"`
-    OPENFIRE_LIB=`cygpath --$format "$OPENFIRE_LIB"`
-    JAVA_HOME=`cygpath --$format "$JAVA_HOME"`
-    LOCALCLASSPATH=`cygpath --path --$format "$LOCALCLASSPATH"`
+    OPENFIRE_HOME=$(cygpath --$format "$OPENFIRE_HOME")
+    OPENFIRE_LIB=$(cygpath --$format "$OPENFIRE_LIB")
+    JAVA_HOME=$(cygpath --$format "$JAVA_HOME")
+    LOCALCLASSPATH=$(cygpath --path --$format "$LOCALCLASSPATH")
     if [ -n "$CLASSPATH" ] ; then
-      CLASSPATH=`cygpath --path --$format "$CLASSPATH"`
+      CLASSPATH=$(cygpath --path --$format "$CLASSPATH")
     fi
-    CYGHOME=`cygpath --$format "$HOME"`
+    CYGHOME=$(cygpath --$format "$HOME")
 fi
 
 # add a second backslash to variables terminated by a backslash under cygwin

--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -157,23 +157,21 @@ fi
 
 # For Cygwin, switch paths to appropriate format before running java
 if $cygwin; then
-    if [ "$OS" = "Windows_NT" ] && cygpath -m .>/dev/null 2>/dev/null ; then
-      format=mixed
-    else
-      format=windows
-    fi
-    OPENFIRE_HOME=$(cygpath --$format "$OPENFIRE_HOME")
-    OPENFIRE_LIB=$(cygpath --$format "$OPENFIRE_LIB")
-    JAVA_HOME=$(cygpath --$format "$JAVA_HOME")
-    LOCALCLASSPATH=$(cygpath --path --$format "$LOCALCLASSPATH")
-    if [ -n "$CLASSPATH" ] ; then
-      CLASSPATH=$(cygpath --path --$format "$CLASSPATH")
-    fi
-    CYGHOME=$(cygpath --$format "$HOME")
-fi
+  if [ "$OS" = "Windows_NT" ] && cygpath -m .>/dev/null 2>/dev/null ; then
+    format=mixed
+  else
+    format=windows
+  fi
+  OPENFIRE_HOME=$(cygpath --$format "$OPENFIRE_HOME")
+  OPENFIRE_LIB=$(cygpath --$format "$OPENFIRE_LIB")
+  JAVA_HOME=$(cygpath --$format "$JAVA_HOME")
+  LOCALCLASSPATH=$(cygpath --path --$format "$LOCALCLASSPATH")
+  if [ -n "$CLASSPATH" ] ; then
+    CLASSPATH=$(cygpath --path --$format "$CLASSPATH")
+  fi
+  CYGHOME=$(cygpath --$format "$HOME")
 
-# add a second backslash to variables terminated by a backslash under cygwin
-if $cygwin; then
+  # add a second backslash to variables terminated by a backslash under cygwin
   case "$OPENFIRE_HOME" in
     *\\ )
     OPENFIRE_HOME="$OPENFIRE_HOME\\"

--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -1,82 +1,79 @@
 #!/bin/sh
-
-#
-#
-
 # tries to determine arguments to launch openfire
 
-# OS specific support.  $var _must_ be set to either true or false.
+# OS specific support
 cygwin=false;
 darwin=false;
 linux=false;
 case "`uname`" in
-  CYGWIN*) cygwin=true ;;
-  Darwin*) darwin=true
-           if [ -z "$JAVA_HOME" ] ; then
-             JAVA_HOME=/usr/libexec/java_home
-           fi
-           ;;
-  Linux*) linux=true
-          if [ -z "$JAVA_HOME" ]; then
-              shopt -s nullglob
-              jdks=`ls -r1d /usr/java/j* /usr/lib/jvm/* 2>/dev/null`
-              for jdk in $jdks; do
-                if [ -f "$jdk/bin/java" ]; then
-                  JAVA_HOME="$jdk"
-                  break
-                fi
-              done
-          fi
-          ;;
+  CYGWIN*)
+    cygwin=true
+    ;;
+  Darwin*)
+    darwin=true
+    if [ -z "$JAVA_HOME" ] ; then
+      JAVA_HOME=/usr/libexec/java_home
+    fi
+    ;;
+  Linux*)
+    linux=true
+    if [ -z "$JAVA_HOME" ]; then
+      shopt -s nullglob
+      jdks=`ls -r1d /usr/java/j* /usr/lib/jvm/* 2>/dev/null`
+      for jdk in $jdks; do
+        if [ -f "$jdk/bin/java" ]; then
+          JAVA_HOME="$jdk"
+          break
+        fi
+      done
+    fi
+    ;;
 esac
 
 #if openfire home is not set or is not a directory
 if [ -z "$OPENFIRE_HOME" -o ! -d "$OPENFIRE_HOME" ]; then
+  if [ -d /opt/openfire ] ; then
+    OPENFIRE_HOME="/opt/openfire"
+  fi
 
-	if [ -d /opt/openfire ] ; then
-		OPENFIRE_HOME="/opt/openfire"
-	fi
+  if [ -d /usr/local/openfire ] ; then
+    OPENFIRE_HOME="/usr/local/openfire"
+  fi
 
-	if [ -d /usr/local/openfire ] ; then
-		OPENFIRE_HOME="/usr/local/openfire"
-	fi
+  if [ -d ${HOME}/opt/openfire ] ; then
+    OPENFIRE_HOME="${HOME}/opt/openfire"
+  fi
 
-	if [ -d ${HOME}/opt/openfire ] ; then
-		OPENFIRE_HOME="${HOME}/opt/openfire"
-	fi
+  #resolve links - $0 may be a link in openfire's home
+  PRG="$0"
+  progname=`basename "$0$"`
 
-	#resolve links - $0 may be a link in openfire's home
-	PRG="$0"
-	progname=`basename "$0$"`
+  # need this for relative symlinks
+  while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+      PRG="$link"
+    else
+      PRG=`dirname "$PRG"`"/$link"
+    fi
+  done
 
-	# need this for relative symlinks
+  #assumes we are in the bin directory
+  OPENFIRE_HOME=`dirname "$PRG"`/..
 
-	# need this for relative symlinks
-  	while [ -h "$PRG" ] ; do
-    		ls=`ls -ld "$PRG"`
-    		link=`expr "$ls" : '.*-> \(.*\)$'`
-    		if expr "$link" : '/.*' > /dev/null; then
-    			PRG="$link"
-    		else
-    			PRG=`dirname "$PRG"`"/$link"
-    		fi
-  	done
-
-	#assumes we are in the bin directory
-	OPENFIRE_HOME=`dirname "$PRG"`/..
-
-	#make it fully qualified
-	OPENFIRE_HOME=`cd "$OPENFIRE_HOME" && pwd`
+  #make it fully qualified
+  OPENFIRE_HOME=`cd "$OPENFIRE_HOME" && pwd`
 fi
 OPENFIRE_OPTS="${OPENFIRE_OPTS} -DopenfireHome=\"${OPENFIRE_HOME}\""
 
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-	[ -n "$OPENFIRE_HOME" ] &&
-    		OPENFIRE_HOME=`cygpath --unix "$OPENFIRE_HOME"`
-  	[ -n "$JAVA_HOME" ] &&
-    		JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$OPENFIRE_HOME" ] &&
+    OPENFIRE_HOME=`cygpath --unix "$OPENFIRE_HOME"`
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
 fi
 
 #set the OPENFIRE_LIB location
@@ -85,57 +82,57 @@ OPENFIRE_OPTS="${OPENFIRE_OPTS} -Dopenfire.lib.dir=\"${OPENFIRE_LIB}\""
 
 # Override with bundled jre if it exists.
 if [ -f "$OPENFIRE_HOME/jre/bin/java" ]; then
-	JAVA_HOME="$OPENFIRE_HOME/jre"
-	JAVACMD="$OPENFIRE_HOME/jre/bin/java"
+  JAVA_HOME="$OPENFIRE_HOME/jre"
+  JAVACMD="$OPENFIRE_HOME/jre/bin/java"
 fi
 
 if [ -z "$JAVACMD" ] ; then
-  	if [ -n "$JAVA_HOME"  ] ; then
-    		if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
-      			# IBM's JDK on AIX uses strange locations for the executables
-      			JAVACMD="$JAVA_HOME/jre/sh/java"
-    		else
-      			JAVACMD="$JAVA_HOME/bin/java"
-    		fi
-  	else
-    		JAVACMD=`which java 2> /dev/null `
-    		if [ -z "$JAVACMD" ] ; then
-        		JAVACMD=java
-    		fi
-  	fi
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=`which java 2> /dev/null `
+    if [ -z "$JAVACMD" ] ; then
+      JAVACMD=java
+    fi
+  fi
 fi
 
 if [ ! -x "$JAVACMD" ] ; then
-  	echo "Error: JAVA_HOME is not defined correctly."
-  	echo "  We cannot execute $JAVACMD"
-  	exit 1
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo "  We cannot execute $JAVACMD"
+  exit 1
 fi
 
 # Note: you can combine options, eg: -devboot -debug
 for arguments in "$@"
 do
-case $arguments in
+  case $arguments in
     -debug)
-    echo "Starting debug mode"
-    JAVACMD="$JAVACMD -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
-    ;;
+      echo "Starting debug mode"
+      JAVACMD="$JAVACMD -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+      ;;
     -remotedebug)
-    echo "Starting remote debug mode"
-    JAVACMD="$JAVACMD -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=\*:5005"
-    ;;
+      echo "Starting remote debug mode"
+      JAVACMD="$JAVACMD -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=\*:5005"
+      ;;
     -demoboot)
-    echo "Starting demoboot"
-    cp $OPENFIRE_HOME/conf/openfire-demoboot.xml $OPENFIRE_HOME/conf/openfire.xml
-    ;;
+      echo "Starting demoboot"
+      cp $OPENFIRE_HOME/conf/openfire-demoboot.xml $OPENFIRE_HOME/conf/openfire.xml
+      ;;
     -devboot)
-    HOSTNAME=$(hostname)
-    sed "s/example.org/$HOSTNAME/g" $OPENFIRE_HOME/conf/openfire-demoboot.xml > $OPENFIRE_HOME/conf/openfire.xml
-    ;;
+      HOSTNAME=$(hostname)
+      sed "s/example.org/$HOSTNAME/g" $OPENFIRE_HOME/conf/openfire-demoboot.xml > $OPENFIRE_HOME/conf/openfire.xml
+      ;;
     *)
-	# unknown option, pass through the Java command
-	JAVACMD="$JAVACMD $arguments"
-    ;;
-esac
+      # unknown option, pass through the Java command
+      JAVACMD="$JAVACMD $arguments"
+      ;;
+  esac
 done
 
 # Java security config
@@ -150,26 +147,26 @@ OPENFIRE_OPTS="${OPENFIRE_OPTS} -Dcom.sun.security.enableCRLDP=true"
 JAVACMD="${JAVACMD} -Dlog4j.configurationFile=${OPENFIRE_LIB}/log4j2.xml -Dlog4j2.formatMsgNoLookups=true -Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Djava.net.preferIPv6Addresses=system"
 
 if [ -z "$LOCALCLASSPATH" ] ; then
-	LOCALCLASSPATH=$OPENFIRE_LIB/startup.jar
+  LOCALCLASSPATH=$OPENFIRE_LIB/startup.jar
 else
-      	LOCALCLASSPATH=$OPENFIRE_LIB/startup.jar:$LOCALCLASSPATH
+  LOCALCLASSPATH=$OPENFIRE_LIB/startup.jar:$LOCALCLASSPATH
 fi
 
 # For Cygwin, switch paths to appropriate format before running java
 if $cygwin; then
-  	if [ "$OS" = "Windows_NT" ] && cygpath -m .>/dev/null 2>/dev/null ; then
-    		format=mixed
-  	else
-    		format=windows
-  	fi
-  	OPENFIRE_HOME=`cygpath --$format "$OPENFIRE_HOME"`
-  	OPENFIRE_LIB=`cygpath --$format "$OPENFIRE_LIB"`
-  	JAVA_HOME=`cygpath --$format "$JAVA_HOME"`
-  	LOCALCLASSPATH=`cygpath --path --$format "$LOCALCLASSPATH"`
-  	if [ -n "$CLASSPATH" ] ; then
-    		CLASSPATH=`cygpath --path --$format "$CLASSPATH"`
-  	fi
-  	CYGHOME=`cygpath --$format "$HOME"`
+    if [ "$OS" = "Windows_NT" ] && cygpath -m .>/dev/null 2>/dev/null ; then
+      format=mixed
+    else
+      format=windows
+    fi
+    OPENFIRE_HOME=`cygpath --$format "$OPENFIRE_HOME"`
+    OPENFIRE_LIB=`cygpath --$format "$OPENFIRE_LIB"`
+    JAVA_HOME=`cygpath --$format "$JAVA_HOME"`
+    LOCALCLASSPATH=`cygpath --path --$format "$LOCALCLASSPATH"`
+    if [ -n "$CLASSPATH" ] ; then
+      CLASSPATH=`cygpath --path --$format "$CLASSPATH"`
+    fi
+    CYGHOME=`cygpath --$format "$HOME"`
 fi
 
 # add a second backslash to variables terminated by a backslash under cygwin


### PR DESCRIPTION
Split from #2563 to simplify of review.

The `openfire.sh` is used to start the service with a detected JRE.
It's included into the tarball distribution so it must be used by those who installed the Openfire manually.
However, the Debian and RPM packages doesn't use the script but instead their init scripts are doing almost the same themselves.
When migrating to SystemD service I decided to reuse the `openfire.sh` to avoid code duplication and use the same wrapper with expected behavior.
But before I made the refactoring and improvements.

The script itself is has a problem with detection of OPENFIRE_HOME when the value of the var is overwritten few times. I didn't fixed that.