### PR TITLE
OF-2786: Openfire to use system-defined preferences for IPv6 over IPv4

### DIFF
--- a/build/debian/openfire.init.d
+++ b/build/debian/openfire.init.d
@@ -47,6 +47,7 @@ test -x $JAVA || exit 1
 DAEMON_OPTS="$DAEMON_OPTS -server -DopenfireHome=${DAEMON_DIR} \
  -Dlog4j.configurationFile=${DAEMON_LIB}/log4j2.xml \
  -Dlog4j2.formatMsgNoLookups=true \
+ -Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Djava.net.preferIPv6Addresses=system \
  -Dopenfire.lib.dir=${DAEMON_LIB} -classpath ${DAEMON_LIB}/startup.jar\
  -jar ${DAEMON_LIB}/startup.jar"
 


### PR DESCRIPTION
Split from https://github.com/igniterealtime/Openfire/pull/2563 to simplify of review.

This change is the openfire.init.d is same as was made in 30b4a176 for openfire.sh

> When establishing an outbound connection, Openfire now prefers the IP family as defined by the order in which the operating system returns addresses.

The Debian init script makes almost the same as the `openfire.sh` so they should be synced until the SystemD migration.

CC @guusdk