### PR TITLE
OF-2542 fix: admin console setup page: check JRE version

### DIFF
--- a/xmppserver/src/main/webapp/setup/index.jsp
+++ b/xmppserver/src/main/webapp/setup/index.jsp
@@ -43,12 +43,13 @@
     boolean openfireHomeExists = false;
     Path openfireHome = null;
 
-    // Check for JRE 1.8
+    // Check for min JRE requirement
+    int MIN_JAVA_VERSION = 11;
     try {
         String version = System.getProperty("java.version");
-        jreVersionCompatible = Integer.parseInt(version.split("\\.")[0]) >= 11;
+        jreVersionCompatible = Integer.parseInt(version.split("[-.]+")[0]) >= MIN_JAVA_VERSION;
     }
-    catch (Throwable t) {}
+    catch (Exception ignored) {}
     // Check for Servlet 2.3:
     try {
         Class c = ClassUtils.forName("javax.servlet.http.HttpSession");


### PR DESCRIPTION
Split from #2563 to simplify of review.

Fixed a bug that I had on `23-ea` OpenJDK version.
Use [Runtime.version()](https://docs.oracle.com/javase/9/docs/api/java/lang/Runtime.Version.html) to compare JRE version. It works correctly now.