### PR TITLE
OF-3045: SchemaManager explict check for success

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -346,6 +346,15 @@ jobs:
         with:
           name: mvn-repo
           path: ~/.m2/repository/org/igniterealtime/openfire/
+      - name: Download distribution artifact from build job.
+        uses: actions/download-artifact@v4
+        with:
+          name: distribution-java17
+          path: .
+      - name: untar distribution
+        run: |
+          mkdir dist
+          tar -xf distribution-artifact.tar -C ./dist
       - name: Set environment variables
         run: |
           echo "CONNECTION_STRING=jdbc:sqlserver://localhost:1433;databaseName=openfire;applicationName=Openfire" >> $GITHUB_ENV
@@ -364,7 +373,10 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package exec:java
+          ./mvnw -B clean package 
+          mkdir -p target/resources
+          cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
+          ./mvnw -B exec:java
 
 
   postgres-install:
@@ -426,6 +438,15 @@ jobs:
         with:
           name: mvn-repo
           path: ~/.m2/repository/org/igniterealtime/openfire/
+      - name: Download distribution artifact from build job.
+        uses: actions/download-artifact@v4
+        with:
+          name: distribution-java17
+          path: .
+      - name: untar distribution
+        run: |
+          mkdir dist
+          tar -xf distribution-artifact.tar -C ./dist
       - name: Set environment variables
         run: |
           echo "CONNECTION_STRING=jdbc:postgresql://localhost:5432/openfire" >> $GITHUB_ENV
@@ -444,7 +465,10 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package exec:java
+          ./mvnw -B clean package 
+          mkdir -p target/resources
+          cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
+          ./mvnw -B exec:java
 
 
   mysql-install:
@@ -507,6 +531,15 @@ jobs:
         with:
           name: mvn-repo
           path: ~/.m2/repository/org/igniterealtime/openfire/
+      - name: Download distribution artifact from build job.
+        uses: actions/download-artifact@v4
+        with:
+          name: distribution-java17
+          path: .
+      - name: untar distribution
+        run: |
+          mkdir dist
+          tar -xf distribution-artifact.tar -C ./dist
       - name: Set environment variables
         run: |
           echo "CONNECTION_STRING=jdbc:mysql://localhost:3306/openfire?rewriteBatchedStatements=true&characterEncoding=UTF-8&characterSetResults=UTF-8&serverTimezone=UTC" >> $GITHUB_ENV
@@ -526,7 +559,10 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package exec:java
+          ./mvnw -B clean package 
+          mkdir -p target/resources
+          cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
+          ./mvnw -B exec:java
 
   oracle-install:
     name: Test Oracle install scripts
@@ -589,6 +625,15 @@ jobs:
         with:
           name: mvn-repo
           path: ~/.m2/repository/org/igniterealtime/openfire/
+      - name: Download distribution artifact from build job.
+        uses: actions/download-artifact@v4
+        with:
+          name: distribution-java17
+          path: .
+      - name: untar distribution
+        run: |
+          mkdir dist
+          tar -xf distribution-artifact.tar -C ./dist
       - name: Set environment variables
         run: |
           echo "CONNECTION_STRING=jdbc:oracle:thin:@localhost:1521/FREEPDB1" >> $GITHUB_ENV
@@ -609,7 +654,10 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package exec:java
+          ./mvnw -B clean package 
+          mkdir -p target/resources
+          cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
+          ./mvnw -B exec:java
 
   publish-maven:
     name: Publish to Maven

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -285,6 +285,7 @@ jobs:
               - 'build/ci/**'
               - '.github/workflows/continuous-integration-workflow.yml'
               - 'xmppserver/pom.xml'
+              - 'xmppserver/src/main/java/org/jivesoftware/database/**'
 
   sqlserver-install:
     name: Test MS SQL Server install script


### PR DESCRIPTION
After SchemaManager runs database upgrade scripts, it should not assume success, but explicitly check for it.