### PR TITLE
CI: Database tests shouldn't use hardcoded file paths

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -243,7 +243,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
-           .github
+            .github
       - name: Download distribution artifact from build job.
         uses: actions/download-artifact@v4
         with:
@@ -324,7 +324,7 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package exec:java
+          ./mvnw -B clean package exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
 
   sqlserver-upgrade:
@@ -376,7 +376,7 @@ jobs:
           ./mvnw -B clean package 
           mkdir -p target/resources
           cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
-          ./mvnw -B exec:java
+          ./mvnw -B exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
 
   postgres-install:
@@ -416,7 +416,7 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package exec:java
+          ./mvnw -B clean package exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
 
   postgres-upgrade:
@@ -468,7 +468,7 @@ jobs:
           ./mvnw -B clean package 
           mkdir -p target/resources
           cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
-          ./mvnw -B exec:java
+          ./mvnw -B exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
 
   mysql-install:
@@ -509,7 +509,7 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package exec:java
+          ./mvnw -B clean package exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
 
   mysql-upgrade:
@@ -562,7 +562,7 @@ jobs:
           ./mvnw -B clean package 
           mkdir -p target/resources
           cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
-          ./mvnw -B exec:java
+          ./mvnw -B exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
   oracle-install:
     name: Test Oracle install scripts
@@ -603,7 +603,7 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package exec:java
+          ./mvnw -B clean package exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
 
   oracle-upgrade:
@@ -657,7 +657,7 @@ jobs:
           ./mvnw -B clean package 
           mkdir -p target/resources
           cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
-          ./mvnw -B exec:java
+          ./mvnw -B exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
   publish-maven:
     name: Publish to Maven

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -346,15 +346,6 @@ jobs:
         with:
           name: mvn-repo
           path: ~/.m2/repository/org/igniterealtime/openfire/
-      - name: Download distribution artifact from build job.
-        uses: actions/download-artifact@v4
-        with:
-          name: distribution-java17
-          path: .
-      - name: untar distribution
-        run: |
-          mkdir dist
-          tar -xf distribution-artifact.tar -C ./dist
       - name: Set environment variables
         run: |
           echo "CONNECTION_STRING=jdbc:sqlserver://localhost:1433;databaseName=openfire;applicationName=Openfire" >> $GITHUB_ENV
@@ -373,10 +364,7 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package 
-          mkdir -p target/resources
-          cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
-          ./mvnw -B exec:java -Dexec.args="$GITHUB_WORKSPACE"
+          ./mvnw -B clean package exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
 
   postgres-install:
@@ -438,15 +426,6 @@ jobs:
         with:
           name: mvn-repo
           path: ~/.m2/repository/org/igniterealtime/openfire/
-      - name: Download distribution artifact from build job.
-        uses: actions/download-artifact@v4
-        with:
-          name: distribution-java17
-          path: .
-      - name: untar distribution
-        run: |
-          mkdir dist
-          tar -xf distribution-artifact.tar -C ./dist
       - name: Set environment variables
         run: |
           echo "CONNECTION_STRING=jdbc:postgresql://localhost:5432/openfire" >> $GITHUB_ENV
@@ -465,10 +444,7 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package 
-          mkdir -p target/resources
-          cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
-          ./mvnw -B exec:java -Dexec.args="$GITHUB_WORKSPACE"
+          ./mvnw -B clean package exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
 
   mysql-install:
@@ -531,15 +507,6 @@ jobs:
         with:
           name: mvn-repo
           path: ~/.m2/repository/org/igniterealtime/openfire/
-      - name: Download distribution artifact from build job.
-        uses: actions/download-artifact@v4
-        with:
-          name: distribution-java17
-          path: .
-      - name: untar distribution
-        run: |
-          mkdir dist
-          tar -xf distribution-artifact.tar -C ./dist
       - name: Set environment variables
         run: |
           echo "CONNECTION_STRING=jdbc:mysql://localhost:3306/openfire?rewriteBatchedStatements=true&characterEncoding=UTF-8&characterSetResults=UTF-8&serverTimezone=UTC" >> $GITHUB_ENV
@@ -559,10 +526,7 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package 
-          mkdir -p target/resources
-          cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
-          ./mvnw -B exec:java -Dexec.args="$GITHUB_WORKSPACE"
+          ./mvnw -B clean package exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
   oracle-install:
     name: Test Oracle install scripts
@@ -625,15 +589,6 @@ jobs:
         with:
           name: mvn-repo
           path: ~/.m2/repository/org/igniterealtime/openfire/
-      - name: Download distribution artifact from build job.
-        uses: actions/download-artifact@v4
-        with:
-          name: distribution-java17
-          path: .
-      - name: untar distribution
-        run: |
-          mkdir dist
-          tar -xf distribution-artifact.tar -C ./dist
       - name: Set environment variables
         run: |
           echo "CONNECTION_STRING=jdbc:oracle:thin:@localhost:1521/FREEPDB1" >> $GITHUB_ENV
@@ -654,10 +609,7 @@ jobs:
       - name: Build & run database tester
         run: |
           pushd ./build/ci/updater
-          ./mvnw -B clean package 
-          mkdir -p target/resources
-          cp -R ../../../dist/distribution/target/distribution-base/resources/database ./target/resources
-          ./mvnw -B exec:java -Dexec.args="$GITHUB_WORKSPACE"
+          ./mvnw -B clean package exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
   publish-maven:
     name: Publish to Maven

--- a/build/ci/updater/pom.xml
+++ b/build/ci/updater/pom.xml
@@ -39,6 +39,11 @@
       <version>${env.OPENFIREVSN}</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.18.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <version>2.7.1</version>

--- a/build/ci/updater/src/main/java/com/igniterealtime/openfire/updaterunner/Main.java
+++ b/build/ci/updater/src/main/java/com/igniterealtime/openfire/updaterunner/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,25 @@
  */
 package com.igniterealtime.openfire.updaterunner;
 
+import org.apache.commons.io.FileUtils;
 import org.jivesoftware.database.*;
 import org.jivesoftware.util.JiveGlobals;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
 
 public class Main {
-    
-    public static void main(String[] args) {
 
+    public static void main(String[] args) throws Exception
+    {
+        if (args.length == 0) {
+            throw new IllegalArgumentException("Invoke with one argument: the path to the compiled distribution (eg: 'distribution/target/distribution-base/'");
+        }
+        for (String arg : args) {
+            System.out.println("Passed argument: " + arg);
+        }
         String connectionString = System.getenv("CONNECTION_STRING");
         String connectionDriver = System.getenv("CONNECTION_DRIVER");
         String connectionUsername = System.getenv("CONNECTION_USERNAME");
@@ -46,36 +52,52 @@ public class Main {
         "IBM DB2","com.ibm.db2.jcc.DB2Driver","jdbc:db2://HOSTNAME:50000/DATABASENAME"
         "Microsoft SQL Server","com.microsoft.sqlserver.jdbc.SQLServerDriver","jdbc:sqlserver://HOSTNAME:1433;databaseName=DATABASENAME;applicationName=Openfire"
         */
-        
+
+        final Path distributionDir = Paths.get(args[0]);
+        if (!distributionDir.toFile().exists()) {
+            throw new IllegalArgumentException("Distribution directory does not exist: " + distributionDir);
+        }
+
+        // The Home path (OPENFIRE_HOME) is used for two things:
+        // - this application needs openfire.xml and security.xml in OPENFIRE_HOME/conf
+        // - Openfire will attempt to load the database scripts from OPENFIRE_HOME/resources/database
+        // Note that when CI is executing this application, the workspace is _uncompiled_. This application attempts to
+        // create a mock OPENFIRE_HOME that holds just enough information for the application to be able to execute.
+        final Path openfireHome = Files.createDirectory(distributionDir.resolve("mockOpenfireHome"));
+
+        // Create the 'conf' directory.
+        final Path confDir = Files.createDirectory(openfireHome.resolve("conf"));
+        final Path propertyFile = Files.createFile(confDir.resolve("openfire.xml"));
+        Files.writeString(propertyFile, "<jive/>");
+        final Path securityFile = Files.createFile(confDir.resolve("security.xml"));
+        Files.writeString(securityFile, "<security/>");
+
+        // Create the 'resources/database' directory (which is a direct copy from source)
+        final Path sourceDir = distributionDir.resolve("distribution/src/database");
+        final Path destinationDir = Files.createDirectories(openfireHome.resolve("resources/database"));
+        FileUtils.copyDirectory(sourceDir.toFile(), destinationDir.toFile());
+
+        JiveGlobals.setHomePath(openfireHome);
+
+        JiveGlobals.setXMLProperty("connectionProvider.className", "org.jivesoftware.database.DefaultConnectionProvider");
+        JiveGlobals.setXMLProperty("database.defaultProvider.driver", connectionDriver);
+        JiveGlobals.setXMLProperty("database.defaultProvider.serverURL", connectionString);
+        JiveGlobals.setXMLProperty("database.defaultProvider.username", connectionUsername);
+        JiveGlobals.setXMLProperty("database.defaultProvider.password", connectionPassword);
+        JiveGlobals.setXMLProperty("database.defaultProvider.testSQL", DbConnectionManager.getTestSQL(connectionDriver));
+
+        Connection conn = null;
         try {
-            Path parent = Paths.get(Main.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParent();
-            PropertiesReader reader = new PropertiesReader(parent.resolve("maven-archiver/pom.properties")); // TODO determine why we read properties but not use them. Is this an existence check only?
-
-            // Create a dummy OPENFIRE_HOME, in which the config files are created where XML properties will be stored.
-            final Path confDir = Files.createDirectory(parent.resolve("conf"));
-            final Path propertyFile = Files.createFile(confDir.resolve("openfire.xml"));
-            Files.writeString(propertyFile, "<jive/>");
-            final Path securityFile = Files.createFile(confDir.resolve("security.xml"));
-            Files.writeString(securityFile, "<security/>");
-            JiveGlobals.setHomePath(parent);
-
-            JiveGlobals.setXMLProperty("connectionProvider.className", "org.jivesoftware.database.DefaultConnectionProvider");
-            JiveGlobals.setXMLProperty("database.defaultProvider.driver", connectionDriver);
-            JiveGlobals.setXMLProperty("database.defaultProvider.serverURL", connectionString);
-            JiveGlobals.setXMLProperty("database.defaultProvider.username", connectionUsername);
-            JiveGlobals.setXMLProperty("database.defaultProvider.password", connectionPassword);
-            JiveGlobals.setXMLProperty("database.defaultProvider.testSQL", DbConnectionManager.getTestSQL(connectionDriver));
-
             //Try connecting
             DefaultConnectionProvider cp = new DefaultConnectionProvider();
             cp.start();
             DbConnectionManager.setConnectionProvider(cp);
-            Connection conn = DbConnectionManager.getConnection();
+            conn = DbConnectionManager.getConnection();
 
             //Try updating explicitly. It'll already have happened once as a byproduct of the above, but we need to trap the result
             SchemaManager sm = new SchemaManager();
             boolean fixed = sm.checkOpenfireSchema(conn);
-            if(!fixed){
+            if (!fixed) {
                 throw new Exception("Failed to install or upgrade the database! It is likely that the installation or upgrade SQL scripts contain a bug.");
             }
             System.out.println("Database schema check complete.");
@@ -83,7 +105,8 @@ public class Main {
             System.out.println(e.getClass() + "\n" + e.getMessage());
             e.printStackTrace();
             System.exit(1);
+        } finally {
+            DbConnectionManager.closeConnection(conn);
         }
     }
-    
 }


### PR DESCRIPTION
Instead of hard-coding the location of Openfire's source code, this location should be provided to the application.

Additionally:
- Use the location to generate a mock 'OPENFIRE_HOME' directory, that can be used to both: 
-- Read and write property files used by the update runner
-- Retrieve the database scripts that are being tested by the update runner.
- Close the database connection after use