### PR TITLE
Fixes for typos

### DIFF
--- a/build/osx/openfirePrefPane/openfirePrefPane.m
+++ b/build/osx/openfirePrefPane/openfirePrefPane.m
@@ -48,7 +48,7 @@
         // There was an error opening the pipe. Alert the user.
         NSAlert *alert = [[NSAlert alloc] init];
         alert.alertStyle = NSAlertStyleWarning;
-        alert.messageText = @"An error occured while detecting a running Openfire process.";
+        alert.messageText = @"An error occurred while detecting a running Openfire process.";
         [alert runModal];
         
         return NO;

--- a/distribution/src/bin/extra/redhat/openfire-sysconfig
+++ b/distribution/src/bin/extra/redhat/openfire-sysconfig
@@ -11,7 +11,7 @@
 # change the following line.
 #OPENFIRE_PIDFILE="/var/run/openfire.pid"
 
-# If you wish to explictly specific the location of the log directory,
+# If you wish to explicitly specific the location of the log directory,
 # you can set it here.  Note that this applies to the logs generated outside
 # openfire itself.  If you want to change the location of openfire's own
 # logs, see the system property 'log.directory'.  If this is not set,

--- a/documentation/client-minimal-working-example-stropejs.html
+++ b/documentation/client-minimal-working-example-stropejs.html
@@ -118,7 +118,7 @@
             below.
         </p>
         <fieldset>
-            <legend>Stroph.js client example</legend>
+            <legend>Strophe.js client example</legend>
             <pre><code class="language-html">&lt;!DOCTYPE html&gt;
 &lt;html&gt;
   &lt;head&gt;

--- a/documentation/client-minimal-working-example-stropejs.html
+++ b/documentation/client-minimal-working-example-stropejs.html
@@ -114,7 +114,7 @@
         <p>
             Find (or create) the directory <code>examples</code> in the directory in which the Strophe.js release
             archive was extracted (it should be a sibling to the <code>dist</code> directory that was created). In the
-            <code>exmples</code> directory, create a file called <code>openfire.html</code> and copy the code shown
+            <code>examples</code> directory, create a file called <code>openfire.html</code> and copy the code shown
             below.
         </p>
         <fieldset>

--- a/documentation/database-guide.html
+++ b/documentation/database-guide.html
@@ -787,7 +787,7 @@
                 <td>summary</td>
                 <td>VARCHAR</td>
                 <td>255</td>
-                <td>Summary of what occured in event</td>
+                <td>Summary of what occurred in event</td>
             </tr>
             <tr>
                 <td>node</td>

--- a/documentation/db-integration-guide.html
+++ b/documentation/db-integration-guide.html
@@ -163,7 +163,7 @@
             admin console. By default, only the user with username "admin" is allowed to login. However,
             you may have different users in your LDAP directory that you'd like to be administrators. The
             list of authorized usernames is controlled via the <code>admin.authorizedUsernames</code>
-            property. For example, to let the usersnames "joe" and "jane" login to the admin console:</p>
+            property. For example, to let the usernames "joe" and "jane" login to the admin console:</p>
 
         <fieldset>
             <legend>Usage of 'authorizedUsernames' in openfire.xml</legend>

--- a/documentation/separating-admin-users-guide.html
+++ b/documentation/separating-admin-users-guide.html
@@ -148,7 +148,7 @@
             <h3>User Providers</h3>
 
             <p>
-                Similar to the authentiation providers above, Openfire must be configured to use the <code>MappedUserProvider</code>
+                Similar to the authentication providers above, Openfire must be configured to use the <code>MappedUserProvider</code>
                 instead of the default user provider. This is  achieved by configuring the following setting in the
                 <code>conf/openfire.xml</code> file:
             </p>

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1888,7 +1888,7 @@ setup.ldap.user.vcard.department=Department
 setup.ldap.user.vcard.personal=Personal
 setup.ldap.user.vcard.avatardb=Store avatar in database if not provided by LDAP
 
-setup.ldap.test.error-loading-sample=An error occured while loading sample from LDAP. Check openfire.log for more information.
+setup.ldap.test.error-loading-sample=An error occurred while loading sample from LDAP. Check openfire.log for more information.
 setup.ldap.test.internal-server-error=Test page is not able to find required information in HTTP session.
 
 setup.ldap.user.vcard.test.description=A random profile is selected for you to review. Bold fields with no value mean that an error may have been found. To view another profile click &#39;Next ramdom profile&#39;. When you are finished close this window.

--- a/i18n/src/main/resources/openfire_i18n_pl_PL.properties
+++ b/i18n/src/main/resources/openfire_i18n_pl_PL.properties
@@ -1312,7 +1312,7 @@ setup.ldap.user.vcard.title=Job Title
 setup.ldap.user.vcard.department=Department
 setup.ldap.user.vcard.personal=Personal
 
-setup.ldap.test.error-loading-sample=An error occured while loading sample from LDAP. Check openfire.log for more information.
+setup.ldap.test.error-loading-sample=An error occurred while loading sample from LDAP. Check openfire.log for more information.
 setup.ldap.test.internal-server-error=Test page is not able to find required information in HTTP session.
 
 setup.ldap.user.vcard.test.description=A random profile is selected for you to review. Bold fields with no value mean \

--- a/starter/src/main/java/org/jivesoftware/openfire/launcher/DroppableFrame.java
+++ b/starter/src/main/java/org/jivesoftware/openfire/launcher/DroppableFrame.java
@@ -38,7 +38,7 @@ public class DroppableFrame extends JFrame implements DropTargetListener, DragSo
     private DragSource dragSource = DragSource.getDefaultDragSource();
 
     /**
-     * Creates a droppable rame.
+     * Creates a droppable frame.
      */
     public DroppableFrame() {
         new DropTarget(this, this);

--- a/starter/src/main/java/org/jivesoftware/openfire/launcher/GraphicUtils.java
+++ b/starter/src/main/java/org/jivesoftware/openfire/launcher/GraphicUtils.java
@@ -394,7 +394,7 @@ public final class GraphicUtils {
     }
 
     /**
-     * Return the hexidecimal color from a java.awt.Color
+     * Return the hexadecimal color from a java.awt.Color
      *
      * @param c the colour
      * @return hexadecimal string

--- a/xmppserver/changelog.html
+++ b/xmppserver/changelog.html
@@ -5154,7 +5154,7 @@ adjusted vCard to be cached.
 <li>[<a href='http://www.igniterealtime.org/issues/browse/JM-890'>JM-890</a>] - Fixed error when IQ error packet failed to be handled.</li>
 <li>[<a href='http://www.igniterealtime.org/issues/browse/JM-895'>JM-895</a>] - TLS was being offered even when keystore was empty.</li>
 <li>[<a href='http://www.igniterealtime.org/issues/browse/JM-896'>JM-896</a>] - Fixed error that was closing a database statement twice.</li>
-<li>[<a href='http://www.igniterealtime.org/issues/browse/JM-902'>JM-902</a>] - Component domain was not being released if an error occured while registing a new component.</li>
+<li>[<a href='http://www.igniterealtime.org/issues/browse/JM-902'>JM-902</a>] - Component domain was not being released if an error occurred while registing a new component.</li>
 <li>[<a href='http://www.igniterealtime.org/issues/browse/JM-916'>JM-916</a>] - External components were able to connect to the server before the server has finished to start up.</li>
 <li>[<a href='http://www.igniterealtime.org/issues/browse/JM-903'>JM-903</a>] - Sending "subscribed" presence to a new user was updating roster of both users.</li>
 <li>[<a href='http://www.igniterealtime.org/issues/browse/JM-918'>JM-918</a>] - Fixed error when shared group had no display name.</li>

--- a/xmppserver/changelog.html
+++ b/xmppserver/changelog.html
@@ -242,7 +242,7 @@ hr {
 
 <h2>Improvement</h2>
 <ul>
-    <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2651">OF-2651</a>] - Give explict names to Netty's threads</li>
+    <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2651">OF-2651</a>] - Give explicit names to Netty's threads</li>
     <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2788">OF-2788</a>] - Have distinct thread pools for each type of connection</li>
     <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2791">OF-2791</a>] - Announce support for PubSub delete-item</li>
     <li>[<a href="https://igniterealtime.atlassian.net/browse/OF-2798">OF-2798</a>] - Admin Console should warn end-user if plugin installation failed</li>

--- a/xmppserver/changelog.html
+++ b/xmppserver/changelog.html
@@ -4885,7 +4885,7 @@ adjusted vCard to be cached.
 <h3>Openfire Enterprise</h3>
 <ul>
     <li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-135'>ENT-135</a>] - Added SparkWeb Flash Beta.</li>
-    <li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-129'>ENT-129</a>] - Round robin algorithm is no longer used when transfering/invitating a single user.</li>
+    <li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-129'>ENT-129</a>] - Round robin algorithm is no longer used when transferring/invitating a single user.</li>
     <li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-131'>ENT-131</a>] - Fixed "Agent never joined" issue with Webchat.</li>
     <li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-133'>ENT-133</a>] - Removing Demo workgroup and user was causing other workgroups to fail.</li>
     <li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-136'>ENT-136</a>] - Workgroup queues page was showing wrong number of agents logged in.</li>
@@ -5168,7 +5168,7 @@ adjusted vCard to be cached.
 <ul>
 <li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-50'>ENT-50</a>] - Added support for SIP integration.</li>
 <li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-35'>ENT-35</a>] - Archiving was only done one-way with gateways.</li>
-<li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-44'>ENT-44</a>] - Added support for transfering support session to another workgroup, queue, agent or user.</li>
+<li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-44'>ENT-44</a>] - Added support for transferring support session to another workgroup, queue, agent or user.</li>
 <li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-63'>ENT-63</a>] - Fixed security breach when viewing messages of ongoing support sessions.</li>
 <li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-56'>ENT-56</a>] - Warning message is now displayed when license is about to expire (30 days).</li>
 <li>[<a href='http://www.igniterealtime.org/issues/browse/ENT-54'>ENT-54</a>] - Added support for iq:version to components to discover Openfire version.</li>

--- a/xmppserver/src/main/java/org/jivesoftware/database/CachedPreparedStatement.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/CachedPreparedStatement.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * Allows PreparedStatement information to be cached. A prepared statement consists of
  * a SQL statement containing bind variables as well as variable values. For example,
  * the SQL statement {@code "SELECT * FROM person WHERE age &gt; ?"} would have the integer
- * variable {@code 18} (which replaces the "?" chracter) to find all adults. This class
+ * variable {@code 18} (which replaces the "?" character) to find all adults. This class
  * encapsulates both the SQL string and bind variable values so that actual
  * PreparedStatement can be created from that information later.
  *

--- a/xmppserver/src/main/java/org/jivesoftware/database/ConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/ConnectionProvider.java
@@ -50,7 +50,7 @@ public interface ConnectionProvider {
      * on the wrapper class will release the connection from the pool.
      *
      * @return a Connection object.
-     * @throws SQLException is an SQL error occured while retrieving the connection.
+     * @throws SQLException is an SQL error occurred while retrieving the connection.
      */
     Connection getConnection() throws SQLException;
 

--- a/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProvider.java
@@ -181,7 +181,7 @@ public class DefaultConnectionProvider implements ConnectionProvider {
      * Returns the username used to connect to the database. In some cases,
      * a username is not needed so this method will return null.
      *
-     * @return the username used to connect to the datbase.
+     * @return the username used to connect to the database.
      */
     public String getUsername() {
         return username;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Channel.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Channel.java
@@ -79,7 +79,7 @@ public class Channel<T extends Packet> {
     }
 
     /**
-     * Enqueus a message to be handled by this channel. After the ChannelHandler is done
+     * Enqueues a message to be handled by this channel. After the ChannelHandler is done
      * processing the message, it will be sent to the next channel. Messages with a higher
      * priority will be handled first.
      *

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
@@ -138,7 +138,7 @@ public interface Connection extends Closeable {
     /**
      * Keeps track if the other peer of this session presented a self-signed certificate. When
      * using self-signed certificate for server-2-server sessions then SASL EXTERNAL will not be
-     * used and instead server-dialback will be preferred for vcerifying the identify of the remote
+     * used and instead server-dialback will be preferred for verifying the identify of the remote
      * server.
      *
      * @param isSelfSigned true if the other peer presented a self-signed certificate.
@@ -148,7 +148,7 @@ public interface Connection extends Closeable {
     /**
      * Returns true if the other peer of this session presented a self-signed certificate. When
      * using self-signed certificate for server-2-server sessions then SASL EXTERNAL will not be
-     * used and instead server-dialback will be preferred for vcerifying the identify of the remote
+     * used and instead server-dialback will be preferred for verifying the identify of the remote
      * server.
      *
      * @return true if the other peer of this session presented a self-signed certificate.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/PresenceManager.java
@@ -66,7 +66,7 @@ public interface PresenceManager {
      * Returns all presences for the user, or {@code null} if the user is unavailable.
      *
      * @param username the name of the user.
-     * @return the Presence packets for all the users's connected sessions.
+     * @return the Presence packets for all the user's connected sessions.
      */
     Collection<Presence> getPresences( String username );
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RemotePacketRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RemotePacketRouter.java
@@ -29,14 +29,14 @@ import org.xmpp.packet.Packet;
 public interface RemotePacketRouter {
 
     /**
-     * Routes packet to specified receipient hosted in the specified node.
+     * Routes packet to specified recipient hosted in the specified node.
      *
-     * @param nodeID the ID of the node hosting the receipient.
-     * @param receipient the target entity that will get the packet.
+     * @param nodeID the ID of the node hosting the recipient.
+     * @param recipient the target entity that will get the packet.
      * @param packet the packet to send.
      * @return true if the remote node was found.
      */
-    boolean routePacket(byte[] nodeID, JID receipient, Packet packet);
+    boolean routePacket(byte[] nodeID, JID recipient, Packet packet);
 
     /**
      * Brodcasts the specified message to all local client sessions of each cluster node.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/admin/AdminManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/admin/AdminManager.java
@@ -122,7 +122,7 @@ public class AdminManager {
     }
 
     /**
-     * Refreshs the list of admin users from the provider.
+     * Refreshes the list of admin users from the provider.
      */
     public void refreshAdminAccounts() {
         loadAdminList();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/admin/AdminManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/admin/AdminManager.java
@@ -84,7 +84,7 @@ public class AdminManager {
     private static AdminProvider provider;
 
     /**
-     * Constructs a AdminManager, propery listener, and setting up the provider.
+     * Constructs a AdminManager, property listener, and setting up the provider.
      */
     private AdminManager() {
         // Load an admin provider.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/audit/AuditEvent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/audit/AuditEvent.java
@@ -45,8 +45,8 @@ public class AuditEvent {
      *
      * @param eventSession the session that triggered the event or null
      *      if no session is associated with this event.
-     * @param timestamp the date/time the event occured.
-     * @param eventCode a code indicating the type of event that occured.
+     * @param timestamp the date/time the event occurred.
+     * @param eventCode a code indicating the type of event that occurred.
      * @param eventReason a second code indicating more details about the event type.
      * @param eventData arbitrary string data associated with the event or null.
      */
@@ -133,18 +133,18 @@ public class AuditEvent {
     }
 
     /**
-     * Obtain the timestamp of when the event occured.
+     * Obtain the timestamp of when the event occurred.
      *
-     * @return the time the event occured.
+     * @return the time the event occurred.
      */
     public Date getTimestamp() {
         return time;
     }
 
     /**
-     * Set the timestamp of when the event occured.
+     * Set the timestamp of when the event occurred.
      *
-     * @param time the time the event occured.
+     * @param time the time the event occurred.
      */
     public void setTimestamp(Date time) {
         this.time = time;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/audit/spi/AuditorImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/audit/spi/AuditorImpl.java
@@ -70,7 +70,7 @@ public class AuditorImpl implements Auditor {
      */
     private boolean closed = false;
     /**
-     * Directoty (absolute path) where the audit files will be saved.
+     * Directory (absolute path) where the audit files will be saved.
      */
     private String logDir;
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthFactory.java
@@ -146,7 +146,7 @@ public class AuthFactory {
     }
 
     /**
-     * Sets the users's password. This method should throw an UnsupportedOperationException
+     * Sets the user's password. This method should throw an UnsupportedOperationException
      * if this operation is not supported by the backend user store.
      *
      * @param username the username of the user.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthToken.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthToken.java
@@ -43,7 +43,7 @@ public class AuthToken {
 
     /**
      * Constructs a new AuthToken that represents an authenticated, but anonymous user.
-     * @return an anonymouse auth token
+     * @return an anonymous auth token
      */
     public static AuthToken generateAnonymousToken()
     {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthorizationManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthorizationManager.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  *
  * If no classes authorize the authentication identity, false is returned, which traces all the way back to give the
  * client an unauthorized message. It's important to note that the message the client receives will give no indication
- * if the authentiation identity authenticated successfully. You will need to check the server logs for that information.
+ * if the authentication identity authenticated successfully. You will need to check the server logs for that information.
  *
  * @author Jay Kline
  */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterPacketRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/cluster/ClusterPacketRouter.java
@@ -37,10 +37,10 @@ public class ClusterPacketRouter implements RemotePacketRouter {
 
     private static Logger logger = LoggerFactory.getLogger(ClusterPacketRouter.class);
 
-    public boolean routePacket(byte[] nodeID, JID receipient, Packet packet) {
+    public boolean routePacket(byte[] nodeID, JID recipient, Packet packet) {
         // Send the packet to the specified node and let the remote node deliver the packet to the recipient
         try {
-            CacheFactory.doClusterTask(new RemotePacketExecution(receipient, packet), nodeID);
+            CacheFactory.doClusterTask(new RemotePacketExecution(recipient, packet), nodeID);
             return true;
         } catch (IllegalStateException  e) {
             logger.warn("Error while routing packet to remote node: " + e);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberAdded.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/event/GroupMemberAdded.java
@@ -34,7 +34,7 @@ import java.util.*;
 
 /**
  * Notifies the that a member was added to the group. It can be used by user providers to notify Openfire of the
- * aditon of a member to a group.
+ * addition of a member to a group.
  *
  * @author Gabriel Guarincerri
  */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/ComponentEventListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/ComponentEventListener.java
@@ -41,7 +41,7 @@ public interface ComponentEventListener {
 
     /**
      * A component was registered with the Component Manager. At this point the
-     * component has been intialized and started. XMPP entities can exchange packets
+     * component has been initialized and started. XMPP entities can exchange packets
      * with the component. However, the component is still not listed as a disco#items
      * of the server since the component has not answered the disco#info request sent
      * by the server.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/GetAdminConsoleInfoTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/GetAdminConsoleInfoTask.java
@@ -30,7 +30,7 @@ import java.util.Enumeration;
 /**
  * Task that will return the bind interface and ports being used by the admin
  * console of the node where the task will be executed. When the admin console
- * is binded to all network interfaces this task will try to find a valid IP
+ * is bound to all network interfaces this task will try to find a valid IP
  * address that will work for the remote node.<p>
  *
  * A {@code null} bindInterface in the result of this task means that the task

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdAuthProvider.java
@@ -50,7 +50,7 @@ public class CrowdAuthProvider implements AuthProvider {
      * @param password the password
      * @throws UnauthorizedException if the username and password do
      *      not match any existing user.
-     * @throws ConnectionException it there is a problem connecting to user and group sytem
+     * @throws ConnectionException it there is a problem connecting to user and group system
      * @throws InternalUnauthenticatedException if there is a problem authentication Openfire itself into the user and group system
      */
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdGroupProvider.java
@@ -262,7 +262,7 @@ public class CrowdGroupProvider extends AbstractGroupProvider {
     // TODO search on group attributes in Crowd
     @Override
     public Collection<String> search(String key, String value) {
-        LOG.info("Search groups on attibutes not implemented yet");
+        LOG.info("Search groups on attributes not implemented yet");
         return Collections.emptyList();
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdGroupProvider.java
@@ -299,7 +299,7 @@ public class CrowdGroupProvider extends AbstractGroupProvider {
                 }
             }
             
-            LOG.info("crowd synch done, returned " + (allGroups == null ? "no" : allGroups.size()) + " groups");
+            LOG.info("crowd sync done, returned " + (allGroups == null ? "no" : allGroups.size()) + " groups");
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdManager.java
@@ -453,7 +453,7 @@ public class CrowdManager {
     }
     
     private void handleError(Exception e) throws RemoteException {
-        LOG.error("Error occured while consuming Crowd REST service", e);
+        LOG.error("Error occurred while consuming Crowd REST service", e);
         throw new RemoteException(e.getMessage());
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdUserProvider.java
@@ -283,7 +283,7 @@ public class CrowdUserProvider implements UserProvider {
         
         @Override
         public void run() {
-            LOG.info("running synch with crowd...");
+            LOG.info("running sync with crowd...");
             CrowdManager manager;
             try {
                 manager = CrowdManager.getInstance();
@@ -316,7 +316,7 @@ public class CrowdUserProvider implements UserProvider {
                 }
             }
             
-            LOG.info("crowd synch done, returned " + (allUsers == null ? "no" : allUsers.size()) + " users");
+            LOG.info("crowd sync done, returned " + (allUsers == null ? "no" : allUsers.size()) + " users");
             
         }
         

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdVCardProvider.java
@@ -97,7 +97,7 @@ public class CrowdVCardProvider extends DefaultVCardProvider {
             return vcard;
 
         } catch (RuntimeException re) {
-            LOG.error("Failure occured when loading a vcard for user:" + username, re);
+            LOG.error("Failure occurred when loading a vcard for user:" + username, re);
             throw re;
         } finally {
             MUTEX.remove(username);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/DiscoInfoProvider.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * <p>
  * The information to provide has to include the entity's identity and the features offered and
  * protocols supported by the target entity. The identity will be provided as an Element that will
- * include the categoty, type and name attributes. Whilst the features will be just plain Strings.
+ * include the category, type and name attributes. Whilst the features will be just plain Strings.
  * </p>
  *
  * @author Gaston Dombiak
@@ -40,7 +40,7 @@ public interface DiscoInfoProvider {
 
     /**
      * Returns an Iterator (of Element) with the target entity's identities. Each Element must
-     * include the categoty, type and name attributes of the entity.
+     * include the category, type and name attributes of the entity.
      *
      * @param name the recipient JID's name.
      * @param node the requested disco node.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferProgress.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferProgress.java
@@ -66,7 +66,7 @@ public interface FileTransferProgress {
      * When the file transfer is being carried out by another thread this will set the Future
      * relating to the thread that is carrying out the transfer.
      *
-     * @param future the furute that is carrying out the transfer
+     * @param future the future that is carrying out the transfer
      */
     void setTransferFuture( Future<?> future );
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferProgress.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferProgress.java
@@ -63,7 +63,7 @@ public interface FileTransferProgress {
     void setSessionID( String streamID );
 
     /**
-     * When the file transfer is being caried out by another thread this will set the Future
+     * When the file transfer is being carried out by another thread this will set the Future
      * relating to the thread that is carrying out the transfer.
      *
      * @param future the furute that is carrying out the transfer

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferRejectedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferRejectedException.java
@@ -78,7 +78,7 @@ public class FileTransferRejectedException extends Exception {
     }
 
     /**
-     * Returns the text to include in a message that will be sent to the intitiator and target
+     * Returns the text to include in a message that will be sent to the initiator and target
      * of the file transfer that got rejected or {@code null} if none was defined. If no text was
      * specified then no message will be sent to the parties of the rejected file transfer.
      *

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferRejectedException.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/FileTransferRejectedException.java
@@ -90,7 +90,7 @@ public class FileTransferRejectedException extends Exception {
     }
 
     /**
-     * Sets the text to include in a message that will be sent to the intiator and target of the
+     * Sets the text to include in a message that will be sent to the initiator and target of the
      * file transfer that got rejected or {@code null} if no message will be sent to the parties
      * of the rejected file transfer. Bt default, no message will be sent.
      *

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
@@ -41,7 +41,7 @@ import java.net.UnknownHostException;
 import java.util.*;
 
 /**
- * Manages the transfering of files between two remote entities on the jabber network.
+ * Manages the transferring of files between two remote entities on the jabber network.
  * This class acts independently as a Jabber component from the rest of the server, according to
  * the Jabber <a href="http://www.jabber.org/jeps/jep-0065.html">SOCKS5 bytestreams protocol</a>.
  *

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/filetransfer/proxy/FileTransferProxy.java
@@ -54,7 +54,7 @@ public class FileTransferProxy extends BasicModule
     private static final Logger Log = LoggerFactory.getLogger( FileTransferProxy.class);
 
     /**
-     * The JiveProperty relating to whether or not the file treansfer proxy is enabled.
+     * The JiveProperty relating to whether or not the file transfer proxy is enabled.
      */
     public static final String JIVEPROPERTY_PROXY_ENABLED = "xmpp.proxy.enabled";
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
@@ -35,7 +35,7 @@ import org.xmpp.packet.StreamError;
 
 /**
  * Binds a resource to the stream so that the client's address becomes a full JID. Once a resource
- * has been binded to the session the entity (i.e. client) is considered a "connected resource".
+ * has been bound to the session the entity (i.e. client) is considered a "connected resource".
  * <p>
  * Clients may specify a desired resource but if none was specified then the server will create
  * a random resource for the session. The new resource should be in accordance with ResourcePrep.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQOfflineMessagesHandler.java
@@ -114,11 +114,11 @@ public class IQOfflineMessagesHandler extends IQHandler implements ServerFeature
         return reply;
     }
 
-    private void sendOfflineMessage(JID receipient, OfflineMessage offlineMessage) {
+    private void sendOfflineMessage(JID recipient, OfflineMessage offlineMessage) {
         Element offlineInfo = offlineMessage.addChildElement("offline", NAMESPACE);
         offlineInfo.addElement("item").addAttribute("node",
                 XMPPDateTimeFormat.format(offlineMessage.getCreationDate()));
-        routingTable.routePacket(receipient, offlineMessage);
+        routingTable.routePacket(recipient, offlineMessage);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -344,7 +344,7 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
      *
      * @param update  the directed Presence sent by the user to an entity.
      * @param handlerJID the JID of the handler that will receive/handle/process the sent packet.
-     * @param jid     the receipient specified in the packet to handle.
+     * @param jid     the recipient specified in the packet to handle.
      */
     public void directedPresenceSent(Presence update, JID handlerJID, String jid) {
         if (update.getFrom() == null) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreWatcher.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/keystore/CertificateStoreWatcher.java
@@ -160,7 +160,7 @@ public class CertificateStoreWatcher
         catch ( IOException e )
         {
             storeWatcher = null;
-            Log.warn( "An exception occured while trying to create a service that monitors the Openfire certificate stores for changes. Changes to Openfire certificate stores made outside of Openfire might not be detected. A restart of Openfire might be required for these to be applied.", e );
+            Log.warn( "An exception occurred while trying to create a service that monitors the Openfire certificate stores for changes. Changes to Openfire certificate stores made outside of Openfire might not be detected. A restart of Openfire might be required for these to be applied.", e );
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/lockout/LockOutManager.java
@@ -87,7 +87,7 @@ public class LockOutManager {
     private static LockOutProvider provider;
 
     /**
-     * Constructs a LockOutManager, setting up it's cache, propery listener, and setting up the provider.
+     * Constructs a LockOutManager, setting up it's cache, property listener, and setting up the provider.
      */
     private LockOutManager() {
         // Initialize the lockout cache.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/multiplex/ClientSessionConnection.java
@@ -67,7 +67,7 @@ public class ClientSessionConnection extends VirtualConnection {
      * special IQ packet. The wrapper IQ packet will be sent to the Connection Manager
      * and the stream ID of this Client Session will be used for identifying that the wrapped
      * packet must be sent to the connected user. Since some packets can be exchanged before
-     * the user has a binded JID we need to use the stream ID as the unique identifier.
+     * the user has a bound JID we need to use the stream ID as the unique identifier.
      *
      * @param packet the packet to send to the user.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
@@ -125,7 +125,7 @@ public class ComponentStanzaHandler extends StanzaHandler {
                 }
             }
             else {
-                // Return forbidden error since we only allow subdomains of the intial domain
+                // Return forbidden error since we only allow subdomains of the initial domain
                 // to be used by the same external component
                 Element reply = doc.createCopy();
                 reply.add(new PacketError(PacketError.Condition.forbidden).getElement());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -131,7 +131,7 @@ public class SASLAuthentication {
     /**
      * Java's SaslServer does not allow for null values. This makes it hard to distinguish between an empty (initial)
      * responses (represented in XMPP as a single equals sign character '=', as per RFC-6120 section 6.4.2), and a
-     * missing/absent response. This can be problematic when a SASL mechanism implemention is to act differently on each
+     * missing/absent response. This can be problematic when a SASL mechanism implementation is to act differently on each
      * scenario (like the EXTERNAL mechanism, that is to challenge for an authzid when no initial response is provided,
      * but which is to use the stream's 'from' attribute value when the initial response is empty). To work around this
      * shortcoming in Java's SASL implementation, this class will add a session attribute using a key that has the name

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReader.java
@@ -502,7 +502,7 @@ public abstract class SocketReader implements Runnable {
      * @return the created session or null.
      * @throws UnauthorizedException if the connection required encryption but was not encrypted.
      * @throws XmlPullParserException if there was an XML error while creating the session.
-     * @throws IOException if an IO error occured while creating the session.
+     * @throws IOException if an IO error occurred while creating the session.
      */
     abstract boolean createSession(String namespace) throws UnauthorizedException,
             XmlPullParserException, IOException;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/XMLLightweightParser.java
@@ -408,7 +408,7 @@ public class XMLLightweightParser {
 
     /**
      * This method verifies if the provided argument contains at least one numeric character reference (
-     * <code>CharRef	   ::=   	'&#' [0-9]+ ';' | '&#x' [0-9a-fA-F]+ ';</code>) for which the decimal or hexidecimal
+     * <code>CharRef	   ::=   	'&#' [0-9]+ ';' | '&#x' [0-9a-fA-F]+ ';</code>) for which the decimal or hexadecimal
      * character value refers to an invalid XML 1.0 character.
      * 
      * @param string

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyItem.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/privacy/PrivacyItem.java
@@ -184,7 +184,7 @@ public class PrivacyItem implements Cacheable, Comparable<PrivacyItem> {
         boolean matches = false;
         if (isPresence && !incoming && (filterEverything || filterPresence_out)) {
             // If this is an outgoing presence and we are filtering by outgoing presence
-            // notification then use the receipient of the packet in the analysis
+            // notification then use the recipient of the packet in the analysis
             matches = verifyJID(packet.getTo(), roster);
         }
         if (!matches && incoming &&

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CachingPubsubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CachingPubsubPersistenceProvider.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  * A persistence provider for Pub/Sub functionality that adds caching behavior. Instead of 'writing through' to the
  * persistence layer, the caching implementation will create batches of operations (optimizing away redundant actions).
  * Additionally, recently accessed published data items are cached. This improves performance when processing many
- * pub/sub operations (node modifiations, item publications, etc).
+ * pub/sub operations (node modifications, item publications, etc).
  *
  * This provider itself does not persist data. Instead, it uses a different persistence provider as a delegate to
  * perform these actions.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/CollectionNode.java
@@ -513,7 +513,7 @@ public class CollectionNode extends Node {
             return isAdmin(user);
         }
         else {
-            // Owners, sysadmins and a whitelist of usres are allowed to
+            // Owners, sysadmins and a whitelist of users are allowed to
             // associate leaf nodes with this node
             return isAdmin(user) || associationTrusted.contains(user);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
@@ -57,7 +57,7 @@ public class DefaultNodeConfiguration implements Cacheable {
     /**
      * Maximum number of published items to persist. Note that all nodes are going to persist
      * their published items. The only difference is the number of the last published items
-     * to be persisted. Even nodes that are configured to not use persitent items are going
+     * to be persisted. Even nodes that are configured to not use persistent items are going
      * to save the last published item.
      */
     private int maxPublishedItems;
@@ -157,7 +157,7 @@ public class DefaultNodeConfiguration implements Cacheable {
     /**
      * Returns the maximum number of published items to persist. Note that all nodes are going
      * to persist their published items. The only difference is the number of the last published
-     * items to be persisted. Even nodes that are configured to not use persitent items are going
+     * items to be persisted. Even nodes that are configured to not use persistent items are going
      * to save the last published item.
      *
      * @return the maximum number of published items to persist.
@@ -308,7 +308,7 @@ public class DefaultNodeConfiguration implements Cacheable {
     /**
      * Sets the maximum number of published items to persist. Note that all nodes are going
      * to persist their published items. The only difference is the number of the last published
-     * items to be persisted. Even nodes that are configured to not use persitent items are going
+     * items to be persisted. Even nodes that are configured to not use persistent items are going
      * to save the last published item.
      *
      * @param maxPublishedItems the maximum number of published items to persist.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
@@ -212,7 +212,7 @@ public class DefaultNodeConfiguration implements Cacheable {
     }
 
     /**
-     * Returnes the publisher model that specifies who is allowed to publish items to the node.
+     * Returns the publisher model that specifies who is allowed to publish items to the node.
      *
      * @return the publisher model that specifies who is allowed to publish items to the node.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultNodeConfiguration.java
@@ -37,7 +37,7 @@ import java.util.Locale;
 public class DefaultNodeConfiguration implements Cacheable {
 
     /**
-     * Flag indicating whether this default configutation belongs to a leaf node or not.
+     * Flag indicating whether this default configuration belongs to a leaf node or not.
      */
     private boolean leaf;
     /**
@@ -117,9 +117,9 @@ public class DefaultNodeConfiguration implements Cacheable {
     }
 
     /**
-     * Returns true if this default configutation belongs to a leaf node.
+     * Returns true if this default configuration belongs to a leaf node.
      *
-     * @return true if this default configutation belongs to a leaf node.
+     * @return true if this default configuration belongs to a leaf node.
      */
     public boolean isLeaf() {
         return leaf;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/LeafNode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/LeafNode.java
@@ -62,7 +62,7 @@ public class LeafNode extends Node {
     /**
      * Maximum number of published items to persist. Note that all nodes are going to persist
      * their published items. The only difference is the number of the last published items
-     * to be persisted. Even nodes that are configured to not use persitent items are going
+     * to be persisted. Even nodes that are configured to not use persistent items are going
      * to save the last published item.
      */
     private int maxPublishedItems;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/AccessModel.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/AccessModel.java
@@ -41,7 +41,7 @@ public abstract class AccessModel implements Serializable {
      * model name. If an unknown name is specified then an IllegalArgumentException
      * is going to be thrown.
      *
-     * @param name the name of the subsclass.
+     * @param name the name of the subclass.
      * @return the specific subclass of AccessModel as specified by the access
      *         model name.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/PublisherModel.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/PublisherModel.java
@@ -37,7 +37,7 @@ public abstract class PublisherModel implements Serializable {
      * model name. If an unknown name is specified then an IllegalArgumentException
      * is going to be thrown.
      *
-     * @param name the name of the subsclass.
+     * @param name the name of the subclass.
      * @return the specific subclass of PublisherModel as specified by the access
      *         model name.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
@@ -44,7 +44,7 @@ import java.util.concurrent.ExecutionException;
  * Rosters are another user resource accessed via the user or chatbot's long ID. A user/chatbot
  * may have zero or more roster items and each roster item may have zero or more groups. Each
  * roster item is additionally keyed on a XMPP jid. In most cases, the entire roster will be read
- * in from memory and manipulated or sent to the user. However some operations will need to retrive
+ * in from memory and manipulated or sent to the user. However some operations will need to retrieve
  * specific roster items rather than the entire roster.
  *
  * @author Iain Shigeoka

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ExecutionException;
  *
  * Rosters are another user resource accessed via the user or chatbot's long ID. A user/chatbot
  * may have zero or more roster items and each roster item may have zero or more groups. Each
- * roster item is additionaly keyed on a XMPP jid. In most cases, the entire roster will be read
+ * roster item is additionally keyed on a XMPP jid. In most cases, the entire roster will be read
  * in from memory and manipulated or sent to the user. However some operations will need to retrive
  * specific roster items rather than the entire roster.
  *

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/security/SecurityAuditEvent.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/security/SecurityAuditEvent.java
@@ -125,7 +125,7 @@ public class SecurityAuditEvent {
     }
 
     /**
-     * Sets the detailed information about what occured in the event.
+     * Sets the detailed information about what occurred in the event.
      * @param details The possibly long details of the event.  Can be null.
      */
     public void setDetails(String details) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -474,7 +474,7 @@ public class ServerDialback {
                 }
             }
             catch (Exception e) {
-                Log.error("An error occured while creating a server session", e);
+                Log.error("An error occurred while creating a server session", e);
                 // Close the underlying connection
                 connection.close();
                 return null;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSession.java
@@ -86,7 +86,7 @@ public interface ClientSession extends Session {
      * and presence statuses to the client. Initialization occurs only once
      * following the first available presence transition.
      *
-     * @return True if the session has already been initializsed
+     * @return True if the session has already been initialized
      */
     boolean isInitialized();
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSession.java
@@ -70,10 +70,10 @@ public interface ClientSession extends Session {
     String getUsername() throws UserNotFoundException;
 
     /**
-     * Returns true if the authetnicated user is an anonymous user or if
+     * Returns true if the authenticated user is an anonymous user or if
      * the use has not authenticated yet.
      *
-     * @return true if the authetnicated user is an anonymous user or if
+     * @return true if the authenticated user is an anonymous user or if
      * the use has not authenticated yet.
      */
     boolean isAnonymousUser();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -631,7 +631,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
      * and presence statuses to the client. Initialization occurs only once
      * following the first available presence transition.
      *
-     * @return True if the session has already been initializsed
+     * @return True if the session has already been initialized
      */
     @Override
     public boolean isInitialized() {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalClientSession.java
@@ -548,7 +548,7 @@ public class LocalClientSession extends LocalSession implements ClientSession {
 
     /**
      * Sets the new Authorization Token for this session. The session is not yet considered fully
-     * authenticated (i.e. active) since a resource has not been binded at this point. This
+     * authenticated (i.e. active) since a resource has not been bound at this point. This
      * message will be sent after SASL authentication was successful but yet resource binding
      * is required.
      *

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
@@ -63,7 +63,7 @@ public class LocalComponentSession extends LocalSession implements ComponentSess
      * Returns a newly created session between the server and a component. The session will be
      * created and returned only if all the checkings were correct.<p>
      *
-     * A domain will be binded for the new connecting component. This method is following
+     * A domain will be bound for the new connecting component. This method is following
      * the JEP-114 where the domain to bind is sent in the TO attribute of the stream header.
      *
      * @param serverName the name of the server where the session is connecting to.
@@ -279,7 +279,7 @@ public class LocalComponentSession extends LocalSession implements ComponentSess
         private String type = "";
         private String category = "";
         /**
-         * List of subdomains that were binded for this component. The list will include
+         * List of subdomains that were bound for this component. The list will include
          * the initial subdomain.
          */
         private List<String> subdomains = new ArrayList<>();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalComponentSession.java
@@ -53,7 +53,7 @@ public class LocalComponentSession extends LocalSession implements ComponentSess
     private LocalExternalComponent component;
     /**
      * When using XEP-114 (the old spec) components will include in the TO attribute
-     * of the intial stream header the domain they would like to have. The requested
+     * of the initial stream header the domain they would like to have. The requested
      * domain is used only after the authentication was successful so we need keep track
      * of this information until the handshake is done.  
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -99,7 +99,7 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
      * @param xpp XML parse that is providing data from the new established connection with the remote server.
      * @param connection the new established connection with the remote server.
      * @param directTLS true of connections are immediately encrypted (as opposed to plain text / startls).
-     * @return a new session that will receive packets or null if a problem occured while
+     * @return a new session that will receive packets or null if a problem occurred while
      *         authenticating the remote server or when acting as the Authoritative Server during
      *         a Server Dialback authentication process.
      * @throws org.xmlpull.v1.XmlPullParserException if an error occurs while parsing the XML.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -549,7 +549,7 @@ public abstract class LocalSession implements Session {
     /**
      * Returns true if the other peer of this session presented a self-signed certificate. When
      * using self-signed certificate for server-2-server sessions then SASL EXTERNAL will not be
-     * used and instead server-dialback will be preferred for vcerifying the identify of the remote
+     * used and instead server-dialback will be preferred for verifying the identify of the remote
      * server.
      *
      * @return true if the other peer of this session presented a self-signed certificate.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -486,7 +486,7 @@ public class ConnectionListener
     }
 
     /**
-     * Returns the applicable TLS policy, but only when it is hardcoded (and inconfigurable).
+     * Returns the applicable TLS policy, but only when it is hardcoded (and unconfigurable).
      * @return a policy or null.
      */
     private Connection.TLSPolicy getHardcodedTLSPolicy()

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -130,7 +130,7 @@ public class ConnectionListener
         this.bindAddress = bindAddress;
         this.identityStoreConfiguration = identityStoreConfiguration;
         this.trustStoreConfiguration = trustStoreConfiguration;
-        this.compressionPolicyPropertyName = compressionPolicyPropertyName;
+        this.compressionPolicyPropertyName = compressionPolicyPropertyName; 
 
         // A listener cannot be changed into or from Direct TLS mode. That fact is safe to use in the name of the logger..
         final String name = getType().toString().toLowerCase() + ( getTLSPolicy().equals( Connection.TLSPolicy.directTLS) ? "-directTLS" : "" );
@@ -738,7 +738,7 @@ public class ConnectionListener
     }
 
     /**
-     * Configuresif self-signed peer certificates can be used to establish an encrypted connection.
+     * Configures if self-signed peer certificates can be used to establish an encrypted connection.
      *
      * @param accept true when self-signed certificates are accepted, otherwise false.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -130,7 +130,7 @@ public class ConnectionListener
         this.bindAddress = bindAddress;
         this.identityStoreConfiguration = identityStoreConfiguration;
         this.trustStoreConfiguration = trustStoreConfiguration;
-        this.compressionPolicyPropertyName = compressionPolicyPropertyName; 
+        this.compressionPolicyPropertyName = compressionPolicyPropertyName;
 
         // A listener cannot be changed into or from Direct TLS mode. That fact is safe to use in the name of the logger..
         final String name = getType().toString().toLowerCase() + ( getTLSPolicy().equals( Connection.TLSPolicy.directTLS) ? "-directTLS" : "" );

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -111,7 +111,7 @@ public class ConnectionListener
      * @param maxPoolSizePropertyName Property name (of an int) that defines maximum IO processing threads. Null causes an unconfigurable default amount to be used.
      * @param maxReadBufferPropertyName Property name (of an int) that defines maximum amount (in bytes) of IO data can be cached, pending processing. Null to indicate boundless caches.
      * @param tlsPolicyPropertyName Property name (of a string) that defines the applicable TLS Policy. Or, the value {@link org.jivesoftware.openfire.Connection.TLSPolicy} to indicate unconfigurable TLS Policy. Cannot be null.
-     * @param clientAuthPolicyPropertyName Property name (of an string) that defines maximum IO processing threads. Null causes a unconfigurabel value of 'wanted' to be used.
+     * @param clientAuthPolicyPropertyName Property name (of an string) that defines maximum IO processing threads. Null causes a unconfigurable value of 'wanted' to be used.
      * @param bindAddress the address to bind to
      * @param identityStoreConfiguration the certificates the server identify as
      * @param trustStoreConfiguration the certificates the server trusts

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionManagerImpl.java
@@ -212,7 +212,7 @@ public class ConnectionManagerImpl extends BasicModule implements ConnectionMana
                 ConnectionSettings.Component.COMPRESSION_SETTINGS
         );
 
-        // Multiplexers (our propertietary connection manager implementation)
+        // Multiplexers (our proprietary connection manager implementation)
         connectionManagerListener = new ConnectionListener(
                 ConnectionType.CONNECTION_MANAGER,
                 ConnectionSettings.Multiplex.PORT,

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
@@ -372,8 +372,8 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
                             PrivacyList list = PrivacyListManager.getInstance()
                                     .getDefaultPrivacyList(probee.getNode());
                             // Send presence to all prober's resources
-                            for (JID receipient : proberFullJIDs) {
-                                presencePacket.setTo(receipient);
+                            for (JID recipient : proberFullJIDs) {
+                                presencePacket.setTo(recipient);
                                 if (list == null || !list.shouldBlockPacket(presencePacket)) {
                                     // Send the presence to the prober
                                     deliverer.deliver(presencePacket);
@@ -396,8 +396,8 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
                         PrivacyList list = session.getActiveList();
                         list = list == null ? session.getDefaultList() : list;
                         // Send presence to all prober's resources
-                        for (JID receipient : proberFullJIDs) {
-                            presencePacket.setTo(receipient);
+                        for (JID recipient : proberFullJIDs) {
+                            presencePacket.setTo(recipient);
                             if (list != null) {
                                 if (list.shouldBlockPacket(presencePacket)) {
                                     // Default list blocked outgoing presence so skip this session
@@ -462,7 +462,7 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
                 Presence presencePacket = new Presence();
                 presencePacket.setType(Presence.Type.unavailable);
                 presencePacket.setFrom(session.getAddress());
-                // Ensure that unavailable presence is sent to all receipient's resources
+                // Ensure that unavailable presence is sent to all recipient's resources
                 Collection<JID> recipientFullJIDs = new ArrayList<>();
                 if (server.isLocal(recipientJID)) {
                     for (ClientSession targetSession : sessionManager

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
@@ -179,7 +179,7 @@ public class DefaultUserProvider implements UserProvider {
         PreparedStatement pstmt = null;
         boolean abortTransaction = false;
         try {
-            // Delete all of the users's extended properties
+            // Delete all of the user's extended properties
             con = DbConnectionManager.getTransactionConnection();
             pstmt = con.prepareStatement(DELETE_USER_PROPS);
             pstmt.setString(1, username);

--- a/xmppserver/src/main/java/org/jivesoftware/util/BeanUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/BeanUtils.java
@@ -52,7 +52,7 @@ public class BeanUtils {
 
     /**
      * Sets the properties of a Java Bean based on the String name/value pairs in
-     * the specifieed Map. Because this method has to know how to convert a
+     * the specified Map. Because this method has to know how to convert a
      * String value into the correct type for the bean, only a few bean property
      * types are supported. They are: String, boolean, int, long, float, double,
      * Color, and Class.<p>

--- a/xmppserver/src/main/java/org/jivesoftware/util/BeanUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/BeanUtils.java
@@ -44,7 +44,7 @@ public class BeanUtils {
     private static final Logger Log = LoggerFactory.getLogger(BeanUtils.class);
 
     /**
-     * The date format recognized for parsing/formattig dates.
+     * The date format recognized for parsing/formatting dates.
      */
     public static final String DATE_FORMAT = "MM/dd/yyyy";
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/ElementUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ElementUtil.java
@@ -143,7 +143,7 @@ public class ElementUtil {
 
     /**
      * Return all values who's path matches the given property name as a String array,
-     * or an empty array if the if there are no children. You MAY NOT use the atttribute
+     * or an empty array if the if there are no children. You MAY NOT use the attribute
      * markup (using a ':' in the last element name) with this call.
      * <p>
      * getProperties() allows you to retrieve several values with the same property name.
@@ -189,7 +189,7 @@ public class ElementUtil {
     }
 
     /**
-     * Sets a property to an array of values.  You MAY NOT use the atttribute
+     * Sets a property to an array of values.  You MAY NOT use the attribute
      * markup (using a ':' in the last element name) with this call. Multiple values matching the
      * same property is mapped to an XML file as multiple elements containing each value.
      * For example, using the name "foo.bar.prop", and the value string array containing
@@ -237,7 +237,7 @@ public class ElementUtil {
 
     /**
      * Return all children property names of a parent property as a String array,
-     * or an empty array if the if there are no children. You MAY NOT use the atttribute
+     * or an empty array if the if there are no children. You MAY NOT use the attribute
      * markup (using a ':' in the last element name) with this call.
      * For example, given the properties {@code X.Y.A}, {@code X.Y.B}, and {@code X.Y.C}, then
      * the child properties of {@code X.Y} are {@code A}, {@code B}, and
@@ -345,7 +345,7 @@ public class ElementUtil {
 
     /**
      * <p>Deletes the specified property.</p>
-     * <p>You MAY NOT use the atttribute
+     * <p>You MAY NOT use the attribute
      * markup (using a ':' in the last element name) with this call.
      * deleteProperty() removes both the containing text, and the element itself along with
      * any attributes associated with that element.</p>

--- a/xmppserver/src/main/java/org/jivesoftware/util/ElementUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ElementUtil.java
@@ -24,7 +24,7 @@ import java.util.*;
 /**
  * <p>We use a simple
  * naming convention of meta-data key names: data is stored
- * heirarchically separated by dots. The last name may contain
+ * hierarchically separated by dots. The last name may contain
  * a colon ':' character that is read as name:attribute.
  * For example setting X.Y.Z to someValue, would map to an XML snippet of:</p>
  * <pre>

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactoryStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactoryStrategy.java
@@ -63,10 +63,10 @@ public interface CacheFactoryStrategy {
     void destroyCache(Cache cache);
 
     /**
-     * Returns true if this node is the maste node of the cluster. When not running
+     * Returns true if this node is the master node of the cluster. When not running
      * in cluster mode a value of true should be returned.
      *
-     * @return true if this node is the maste node of the cluster.
+     * @return true if this node is the master node of the cluster.
      */
     boolean isSeniorClusterMember();
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyChecks.java
@@ -483,7 +483,7 @@ public class ConsistencyChecks {
         }
 
         if (nonCachedRemoteIncomingServerSessions.isEmpty()) {
-            result.put("pass", String.format("All elements inincomingServerSessionsByClusterNode exist in %s.", incomingServerSessionsCache.getName()));
+            result.put("pass", String.format("All elements in incomingServerSessionsByClusterNode exist in %s.", incomingServerSessionsCache.getName()));
         } else {
             result.put("fail", String.format("Not all elements in incomingServerSessionsByClusterNode exist in %s. These %d entries do not: %s", incomingServerSessionsCache.getName(), nonCachedRemoteIncomingServerSessions.size(), nonCachedRemoteIncomingServerSessions.stream().map(StreamID::getID).collect(Collectors.joining(", "))));
         }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupJIDTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupJIDTest.java
@@ -47,7 +47,7 @@ public class GroupJIDTest {
         String test123 = "123";
         assertTrue(StringUtils.isBase32(test123));
 
-        // should be case insensitve
+        // should be case insensitive
         String testabc = "abc";
         assertTrue(StringUtils.isBase32(testabc));
 

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CertificateUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CertificateUtilsTest.java
@@ -191,7 +191,7 @@ public class CertificateUtilsTest
 
     /**
      * Test for {@link CertificateUtils#filterValid(Collection)}. Verifies that an input argument that
-     * contains one valid and one invalid valid certificatereturns an collection that contains one valid certificate.
+     * contains one valid and one invalid valid certificate returns an collection that contains one valid certificate.
      */
     @Test
     public void testFilterValidWithValidAndInvalidCerts() throws Exception

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CertificateUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CertificateUtilsTest.java
@@ -67,7 +67,7 @@ public class CertificateUtilsTest
 
     /**
      * Test for {@link CertificateUtils#filterValid(Collection)}. Verifies that an input argument that
-     * contains one valid certificate returns an collection that contains that certificate.
+     * contains one valid certificate returns a collection that contains that certificate.
      */
     @Test
     public void testFilterValidWithOneValidCert() throws Exception
@@ -87,7 +87,7 @@ public class CertificateUtilsTest
 
     /**
      * Test for {@link CertificateUtils#filterValid(Collection)}. Verifies that an input argument that
-     * contains one invalid certificate returns an collection that is empty.
+     * contains one invalid certificate returns a collection that is empty.
      */
     @Test
     public void testFilterValidWithOneInvalidCert() throws Exception
@@ -106,7 +106,7 @@ public class CertificateUtilsTest
 
     /**
      * Test for {@link CertificateUtils#filterValid(Collection)}. Verifies that an input argument that
-     * contains two duplicate, valid certificates returns an collection that contains that certificate once.
+     * contains two duplicate, valid certificates returns a collection that contains that certificate once.
      */
     @Test
     public void testFilterValidWithTwoDuplicateValidCerts() throws Exception
@@ -127,7 +127,7 @@ public class CertificateUtilsTest
 
     /**
      * Test for {@link CertificateUtils#filterValid(Collection)}. Verifies that an input argument that
-     * contains two distinct, valid certificates returns an collection that contains both certificates.
+     * contains two distinct, valid certificates returns a collection that contains both certificates.
      */
     @Test
     public void testFilterValidWithTwoDistinctValidCerts() throws Exception
@@ -150,7 +150,7 @@ public class CertificateUtilsTest
 
     /**
      * Test for {@link CertificateUtils#filterValid(Collection)}. Verifies that an input argument that
-     * contains two duplicate, invalid certificate returns an collection that is empty.
+     * contains two duplicate, invalid certificate returns a collection that is empty.
      */
     @Test
     public void testFilterValidWithTwoDuplicateInvalidCerts() throws Exception
@@ -170,7 +170,7 @@ public class CertificateUtilsTest
 
     /**
      * Test for {@link CertificateUtils#filterValid(Collection)}. Verifies that an input argument that
-     * contains two distinct, invalid certificate returns an collection that is empty.
+     * contains two distinct, invalid certificate returns a collection that is empty.
      */
     @Test
     public void testFilterValidWithTwoDistinctInvalidCerts() throws Exception
@@ -191,7 +191,7 @@ public class CertificateUtilsTest
 
     /**
      * Test for {@link CertificateUtils#filterValid(Collection)}. Verifies that an input argument that
-     * contains one valid and one invalid valid certificate returns an collection that contains one valid certificate.
+     * contains one valid and one invalid valid certificate returns a collection that contains one valid certificate.
      */
     @Test
     public void testFilterValidWithValidAndInvalidCerts() throws Exception
@@ -218,7 +218,7 @@ public class CertificateUtilsTest
      * - another valid (duplicated from the first)
      * - a third valid (no duplicate)
      * - and one invalid valid certificate
-     * returns an collection that contains the two distinct valid certificates.
+     * returns a collection that contains the two distinct valid certificates.
      */
     @Test
     public void testFilterValidWithMixOfValidityAndDuplicates() throws Exception

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CertificateUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CertificateUtilsTest.java
@@ -218,7 +218,7 @@ public class CertificateUtilsTest
      * - another valid (duplicated from the first)
      * - a third valid (no duplicate)
      * - and one invalid valid certificate
-     * returns an collection that contains the two distinc valid certificates.
+     * returns an collection that contains the two distinct valid certificates.
      */
     @Test
     public void testFilterValidWithMixOfValidityAndDuplicates() throws Exception

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CheckChainTrustedTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CheckChainTrustedTest.java
@@ -126,7 +126,7 @@ public class CheckChainTrustedTest
         // Add root certificate of a chain with an expired intermediate certificate to the trust store.
         trustStore.setCertificateEntry( getLast( expiredIntChain ).getSubjectDN().getName(), getLast( expiredIntChain ) );
 
-        // Add root certificate of a chain wwith an expired root certificate to the trust store.
+        // Add root certificate of a chain with an expired root certificate to the trust store.
         trustStore.setCertificateEntry( getLast( expiredRootChain ).getSubjectDN().getName(), getLast( expiredRootChain ) );
 
         // Reset the system under test before each test.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CheckChainTrustedTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/keystore/CheckChainTrustedTest.java
@@ -499,7 +499,7 @@ public class CheckChainTrustedTest
 
     /**
      * Verifies that self-signed certificates that expired are accepted only when both self-signed certificates are
-     * explicitly accepted, as well as validation is explictly skipped.
+     * explicitly accepted, as well as validation is explicitly skipped.
      */
     @Test
     public void testSelfSignedExpired() throws Exception

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/nio/XmlNumericCharacterReferenceTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/nio/XmlNumericCharacterReferenceTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <li>A set containing values that are no character references at all (but do resemble them)</li>
  * </ol>
  * 
- * The first and second set consist of lines in which each line contains both the decimal as well as the hexidecimal
+ * The first and second set consist of lines in which each line contains both the decimal as well as the hexadecimal
  * representation of the same numeric character reference. The remainder of the line is filled with zero-padded copies
  * of the same values. The various values (on each new line) are picked from the edges of each of the ranges that make
  * up the complete set of valid characters.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/pubsub/CachingPubsubPersistenceProviderItemOperationsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/pubsub/CachingPubsubPersistenceProviderItemOperationsTest.java
@@ -175,7 +175,7 @@ public class CachingPubsubPersistenceProviderItemOperationsTest
     /**
      * Asserts that an invocations {@link CachingPubsubPersistenceProvider#removePublishedItem(PublishedItem)} to
      * remove two items with the same identifier DOES NOT cause the provider to optimize: this is an erroneous invocation,
-     * and the delegate provider should (possibly) thrown an exception (or silently ignore the duplcate).
+     * and the delegate provider should (possibly) thrown an exception (or silently ignore the duplicate).
      */
     @Test
     public void testRemoveTwoPublishedItemsSameIdentifier() throws Exception

--- a/xmppserver/src/test/java/org/jivesoftware/util/cache/CacheFactoryTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/cache/CacheFactoryTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit tests that verify the implemention of {@link CacheFactory}
+ * Unit tests that verify the implementation of {@link CacheFactory}
  *
  * @author Guus der Kinderen, guus@goodbytes.nl
  */


### PR DESCRIPTION
This fixes many but certainly not all typos. Mostly applied by search/replace whole words, while keeping capitalization.