### PR TITLE
OF-3046: UserMultiProvider should only use supported search fields

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserMultiProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserMultiProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 IgniteRealtime.org, 2018-2024 Ignite Realtime Foundation. All rights reserved
+ * Copyright (C) 2016 IgniteRealtime.org, 2018-2025 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.jivesoftware.openfire.user;
 
-import org.jivesoftware.openfire.group.GroupProvider;
 import org.jivesoftware.util.ClassUtils;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.SystemProperty;
@@ -287,7 +286,7 @@ public abstract class UserMultiProvider implements UserProvider
                 supportedFields.retainAll( provider.getSearchFields() );
 
                 // Query the provider for sub-results.
-                final Collection<User> providerResults = provider.findUsers( fields, query );
+                final Collection<User> providerResults = provider.findUsers( supportedFields, query );
 
                 // Keep track of how many hits we have had so far.
                 totalMatchedUserCount += providerResults.size();


### PR DESCRIPTION
Fixes a bug where a list of supported search fields was created, but never used.