### PR TITLE
OF-3047: Fix parsing of LDAP 'authPassword' attribute.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
@@ -148,7 +148,7 @@ public class LdapUserProvider implements UserProvider {
                 NamingEnumeration values = authPassword.getAll();
                 while (values.hasMore()) {
                     Attribute authPasswordValue = (Attribute) values.next();
-                    String[] parts = ((String) authPasswordValue.get()).split("$");
+                    String[] parts = ((String) authPasswordValue.get()).split("\\$");
                     String[] authInfo = parts[1].split(":");
                     String[] authValue = parts[2].split(":");
     


### PR DESCRIPTION
Openfire’s implementation splits values based on the $ character. The method used, however, interpret that character as a regular expression. Instead, it should be used literally (per RFC 3112).