### PR TITLE
Replace StringBuffer with StringBuilder

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapManager.java
@@ -1441,7 +1441,7 @@ public class LdapManager {
      */
     String getProviderURL(LdapName baseDN) throws NamingException
     {
-        StringBuffer ldapURL = new StringBuffer();
+        StringBuilder ldapURL = new StringBuilder();
 
         try
         {

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -834,7 +834,7 @@ public class CacheFactory {
         PluginClassLoader pluginLoader = pluginManager.getPluginClassloader(plugin);
         if (pluginLoader != null) {
             if (log.isDebugEnabled()) {
-                StringBuffer pluginLoaderDetails = new StringBuffer("Clustering plugin class loader: ");
+                StringBuilder pluginLoaderDetails = new StringBuilder("Clustering plugin class loader: ");
                 pluginLoaderDetails.append(pluginLoader.getClass().getName());
                 for (URL url : pluginLoader.getURLs()) {
                     pluginLoaderDetails.append("\n\t").append(url.toExternalForm());


### PR DESCRIPTION
StringBuilder is a non-thread-safe replacement for StringBuffer.