### PR TITLE
code cleanup: Use standard 'Charset' object instead of String literal

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
@@ -198,7 +199,7 @@ public class AuthCheckFilter implements Filter {
 
         String decodedUrl = null;
         try {
-            decodedUrl = URLDecoder.decode(url, "UTF-8");
+            decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8);
         } catch (Exception e) {
             return false;
         }
@@ -334,7 +335,7 @@ public class AuthCheckFilter implements Filter {
             Log.error(e.getMessage(), e);
         }
         try {
-            return loginPage + "?url=" + URLEncoder.encode(buf.toString(), "ISO-8859-1")
+            return loginPage + "?url=" + URLEncoder.encode(buf.toString(), StandardCharsets.ISO_8859_1)
                     + (optionalParams != null ? "&"+optionalParams : "");
         }
         catch (Exception e) {

--- a/xmppserver/src/main/java/org/jivesoftware/admin/JSTLFunctions.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/JSTLFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.jivesoftware.util.StringUtils;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Utility functions that are exposed through a taglib.
@@ -80,15 +81,7 @@ public class JSTLFunctions
      */
     public static String urlEncode( String string )
     {
-        try
-        {
-            return URLEncoder.encode( string, "UTF-8" );
-        }
-        catch ( UnsupportedEncodingException e )
-        {
-            // Should never occur, as UTF-8 encoding is mantdatory to implement for any JRE.
-            throw new IllegalStateException( "Unable to URL-encode string: " + string, e );
-        }
+        return URLEncoder.encode( string, StandardCharsets.UTF_8);
     }
 
     /**
@@ -100,15 +93,7 @@ public class JSTLFunctions
      */
     public static String urlDecode( String string )
     {
-        try
-        {
-            return URLDecoder.decode( string, "UTF-8" );
-        }
-        catch ( UnsupportedEncodingException e )
-        {
-            // Should never occur, as UTF-8 encoding is mandatory to implement for any JRE.
-            throw new IllegalStateException( "Unable to URL-decode string: " + string, e );
-        }
+        return URLDecoder.decode( string, StandardCharsets.UTF_8);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/crowd/CrowdManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2012 Issa Gorissen <issa-gorissen@usa.net>, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -427,12 +427,7 @@ public class CrowdManager {
     }
     
     private String urlEncode(String str) {
-        try {
-            return URLEncoder.encode(str, "UTF-8");
-        } catch (UnsupportedEncodingException uee) {
-            LOG.error("UTF-8 not supported ?", uee);
-            return str;
-        }
+        return URLEncoder.encode(str, StandardCharsets.UTF_8);
     }
     
     

--- a/xmppserver/src/main/java/org/jivesoftware/util/Base64.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/Base64.java
@@ -15,6 +15,8 @@
  */
 package org.jivesoftware.util;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * <p>Encodes and decodes to and from Base64 notation.</p>
  * <p>Homepage: <a href="http://iharder.net/base64">http://iharder.net/base64</a>.</p>
@@ -1222,7 +1224,7 @@ public class Base64
     {
         String encoded = Base64.encodeFromFile( infile );
         try (java.io.OutputStream out = new java.io.BufferedOutputStream(new java.io.FileOutputStream(outfile))) {
-            out.write(encoded.getBytes("US-ASCII")); // Strict, 7-bit output.
+            out.write(encoded.getBytes(StandardCharsets.US_ASCII)); // Strict, 7-bit output.
         } catch (java.io.IOException ex) {
             ex.printStackTrace();
         }

--- a/xmppserver/src/main/java/org/jivesoftware/util/ListPager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/ListPager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -332,11 +332,7 @@ public class ListPager<T> {
             final String formFieldValue = ParamUtils.getStringParameter(request, additionalFormField, "").trim();
             if(!formFieldValue.isEmpty()) {
                 String encodedValue;
-                try {
-                    encodedValue = URLEncoder.encode(formFieldValue, StandardCharsets.UTF_8.name());
-                } catch (final UnsupportedEncodingException e) {
-                   encodedValue = formFieldValue;
-                }
+                encodedValue = URLEncoder.encode(formFieldValue, StandardCharsets.UTF_8);
                 sb.append(conjunction)
                     .append(String.format("%s=%s", additionalFormField, encodedValue));
                 conjunction = '&';

--- a/xmppserver/src/main/webapp/component-session-summary.jsp
+++ b/xmppserver/src/main/webapp/component-session-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 <%@ page import="java.util.Date"%>
 <%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
 <%@ page import="org.jivesoftware.openfire.session.LocalSession" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -191,7 +192,7 @@
     <tr>
         <td style="width: 1%; white-space: nowrap"><%= count %></td>
         <td style="width: 43%; white-space: nowrap" nowrap>
-            <a href="component-session-details.jsp?jid=<%= URLEncoder.encode(componentSession.getAddress().toString(), "UTF-8") %>" title="<fmt:message key="session.row.click" />"><%= componentSession.getAddress() %></a>
+            <a href="component-session-details.jsp?jid=<%= URLEncoder.encode(componentSession.getAddress().toString(), StandardCharsets.UTF_8) %>" title="<fmt:message key="session.row.click" />"><%= componentSession.getAddress() %></a>
         </td>
         <td style="width: 1%">
             <%  if (componentSession.isEncrypted()) {
@@ -264,7 +265,7 @@
         </td>
 
         <td style="width: 1%; white-space: nowrap; text-align: center">
-            <a href="component-session-summary.jsp?jid=<%= URLEncoder.encode(componentSession.getAddress().toString(), "UTF-8") %>&close=true"
+            <a href="component-session-summary.jsp?jid=<%= URLEncoder.encode(componentSession.getAddress().toString(), StandardCharsets.UTF_8) %>&close=true"
              title="<fmt:message key="session.row.click_kill_session" />"
              onclick="return confirm('<fmt:message key="session.row.confirm_close" />');"
              ><img src="images/delete-16x16.gif" alt=""></a>

--- a/xmppserver/src/main/webapp/group-create.jsp
+++ b/xmppserver/src/main/webapp/group-create.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 <%@ page import="java.util.HashMap"%>
 <%@ page import="java.util.Map" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -66,7 +67,7 @@
             response.sendRedirect("group-summary.jsp");
         }
         else {
-            response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, "UTF-8"));    
+            response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, StandardCharsets.UTF_8));
         }
         return;
     }
@@ -90,7 +91,7 @@
                 }
 
                 // Successful, so redirect
-                response.sendRedirect("group-edit.jsp?creategroupsuccess=true&group=" + URLEncoder.encode(newGroup.getName(), "UTF-8"));
+                response.sendRedirect("group-edit.jsp?creategroupsuccess=true&group=" + URLEncoder.encode(newGroup.getName(), StandardCharsets.UTF_8));
                 return;
             }
             catch (GroupAlreadyExistsException e) {
@@ -123,7 +124,7 @@
                 }
 
                 // Successful, so redirect
-                response.sendRedirect("group-edit.jsp?groupChanged=true&group=" + URLEncoder.encode(group.getName(), "UTF-8"));
+                response.sendRedirect("group-edit.jsp?groupChanged=true&group=" + URLEncoder.encode(group.getName(), StandardCharsets.UTF_8));
                 return;
             }
             catch (Exception e) {

--- a/xmppserver/src/main/webapp/group-delete.jsp
+++ b/xmppserver/src/main/webapp/group-delete.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
     errorPage="error.jsp"
 %>
 <%@ page import="org.jivesoftware.openfire.security.SecurityAuditManager" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -48,7 +49,7 @@
 
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, "UTF-8"));
+        response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, StandardCharsets.UTF_8));
         return;
     }
 

--- a/xmppserver/src/main/webapp/group-edit.jsp
+++ b/xmppserver/src/main/webapp/group-edit.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@
 <%@ page import="java.util.function.Predicate" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
 <%@ page import="org.jivesoftware.openfire.group.SharedGroupVisibility" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="admin" prefix="admin" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
@@ -131,7 +132,7 @@
                 }
 
                 // Successful, so redirect
-                response.sendRedirect( "group-edit.jsp?groupChanged=true&group=" + URLEncoder.encode( group.getName(), "UTF-8" )
+                response.sendRedirect( "group-edit.jsp?groupChanged=true&group=" + URLEncoder.encode( group.getName(), StandardCharsets.UTF_8)
                     + ListPager.getQueryString(request, '&', "searchName") );
                 return;
             }
@@ -187,7 +188,7 @@
             }
 
             // Get admin list and compare it the admin posted list.
-            response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, "UTF-8") + "&groupChanged=true"
+            response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, StandardCharsets.UTF_8) + "&groupChanged=true"
                 + ListPager.getQueryString(request, '&', "searchName") );
             return;
         }
@@ -227,7 +228,7 @@
         }
 
         // Get admin list and compare it the admin posted list.
-        response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, "UTF-8") + "&updatesuccess=true"
+        response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, StandardCharsets.UTF_8) + "&updatesuccess=true"
             + ListPager.getQueryString(request, '&', "searchName") );
         return;
     }
@@ -288,7 +289,7 @@
 
             if ( memberAdded )
             {
-                response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, "UTF-8") + "&success=true"
+                response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, StandardCharsets.UTF_8) + "&success=true"
                     + ListPager.getQueryString(request, '&', "searchName") );
                 return;
             }
@@ -302,7 +303,7 @@
             group.getMembers().remove(member);
             group.getAdmins().remove(member);
         }
-        response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, "UTF-8") + "&deletesuccess=true"
+        response.sendRedirect("group-edit.jsp?group=" + URLEncoder.encode(groupName, StandardCharsets.UTF_8) + "&deletesuccess=true"
             + ListPager.getQueryString(request, '&', "searchName") );
         return;
     }
@@ -774,12 +775,7 @@
         }
         for (String anArray : array) {
             String item;
-            try {
-                item = URLDecoder.decode( anArray, "UTF-8" );
-            }
-            catch (UnsupportedEncodingException e) {
-                item = anArray;
-            }
+            item = URLDecoder.decode( anArray, StandardCharsets.UTF_8);
             result.add(item);
         }
         return result;

--- a/xmppserver/src/main/webapp/logviewer.jsp
+++ b/xmppserver/src/main/webapp/logviewer.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2016-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 %>
 <%@ page import="org.apache.logging.log4j.Level" %>
 <%@ page import="java.util.stream.Collectors" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -406,7 +407,7 @@ IFRAME {
 
 <br><br>
 
-<iframe src="log.jsp?log=<%= URLEncoder.encode(log, "UTF-8") %>&mode=<%= URLEncoder.encode(mode, "UTF-8") %>&lines=<%= ("All".equals(numLinesParam) ? "All" : String.valueOf(numLines)) %>"
+<iframe src="log.jsp?log=<%= URLEncoder.encode(log, StandardCharsets.UTF_8) %>&mode=<%= URLEncoder.encode(mode, StandardCharsets.UTF_8) %>&lines=<%= ("All".equals(numLinesParam) ? "All" : String.valueOf(numLines)) %>"
     frameborder="0" height="600" style="width: 100%" marginheight="0" marginwidth="0" scrolling="auto"></iframe>
 
 </form>

--- a/xmppserver/src/main/webapp/muc-create-permission.jsp
+++ b/xmppserver/src/main/webapp/muc-create-permission.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 %>
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="java.net.URLDecoder" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -80,14 +81,14 @@
             mucService.setRoomCreationRestricted(false);
             // Log the event
             webManager.logEvent("set MUC room creation to restricted for service "+mucname, null);
-            response.sendRedirect("muc-create-permission.jsp?success=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+            response.sendRedirect("muc-create-permission.jsp?success=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
         else {
             mucService.setRoomCreationRestricted(true);
             // Log the event
             webManager.logEvent("set MUC room creation to not restricted for service "+mucname, null);
-            response.sendRedirect("muc-create-permission.jsp?success=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+            response.sendRedirect("muc-create-permission.jsp?success=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
     }
@@ -112,7 +113,7 @@
         if (groupNames != null) {
             // create a group JID for each group
             for (String groupName : groupNames) {
-                GroupJID groupJID = new GroupJID(URLDecoder.decode(groupName, "UTF-8"));
+                GroupJID groupJID = new GroupJID(URLDecoder.decode(groupName, StandardCharsets.UTF_8));
                 allowedJIDs.add(groupJID);
             }
         }
@@ -127,7 +128,7 @@
             mucService.setAllRegisteredUsersAllowedToCreate(allowAllRegisteredUsers);
             // Log the event
             webManager.logEvent("updated MUC room creation permissions for service "+mucname, null);
-            response.sendRedirect("muc-create-permission.jsp?addsuccess=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+            response.sendRedirect("muc-create-permission.jsp?addsuccess=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
 
@@ -138,7 +139,7 @@
             // Log the event
             webManager.logEvent("removed MUC room creation permission from "+userJID+" for service "+mucname, null);
             // done, return
-            response.sendRedirect("muc-create-permission.jsp?deletesuccess=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+            response.sendRedirect("muc-create-permission.jsp?deletesuccess=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
     }
@@ -148,14 +149,14 @@
 <head>
 <title><fmt:message key="muc.create.permission.title"/></title>
 <meta name="subPageID" content="muc-perms"/>
-<meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, "UTF-8") %>"/>
+<meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"/>
 <meta name="helpPage" content="set_group_chat_room_creation_permissions.html"/>
 </head>
 <body>
 
 <p>
 <fmt:message key="muc.create.permission.info" />
-<fmt:message key="groupchat.service.settings_affect" /> <b><a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucname, "UTF-8") %>"><%= StringUtils.escapeHTMLTags(mucname) %></a></b>
+<fmt:message key="groupchat.service.settings_affect" /> <b><a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"><%= StringUtils.escapeHTMLTags(mucname) %></a></b>
 </p>
 
 <%  if (errors.size() > 0) { 
@@ -245,7 +246,7 @@
         <select name="groupNames" size="6" multiple style="width:400px;font-family:verdana,arial,helvetica,sans-serif;font-size:8pt;" 
          onclick="this.form.openPerms[1].checked=true;" id="groupJIDs">
         <%  for (Group g : webManager.getGroupManager().getGroups()) {	%>
-            <option value="<%= URLEncoder.encode(g.getName(), "UTF-8") %>"
+            <option value="<%= URLEncoder.encode(g.getName(), StandardCharsets.UTF_8) %>"
              <%= (StringUtils.contains(groupNames, g.getName()) ? "selected" : "") %>
              ><%= StringUtils.escapeHTMLTags(g.getName()) %></option>
         <%  } %>
@@ -288,11 +289,11 @@
                           <% } else { %>
                             <img src="images/user.gif" title="<fmt:message key="muc.create.permission.user" />" alt="<fmt:message key="muc.create.permission.user" />"/>
                           <% } %>
-                          <a href="<%= isGroup ? "group-edit.jsp?group=" + URLEncoder.encode(jidDisplay) : "user-properties.jsp?username=" + URLEncoder.encode(jid.getNode(), "UTF-8") %>">
+                          <a href="<%= isGroup ? "group-edit.jsp?group=" + URLEncoder.encode(jidDisplay) : "user-properties.jsp?username=" + URLEncoder.encode(jid.getNode(), StandardCharsets.UTF_8) %>">
                           <%= jidDisplay %></a>
                         </td>
                         <td style="width: 1%; text-align: center">
-                            <a href="muc-create-permission.jsp?userJID=<%= jid.toString() %>&delete=true&csrf=${csrf}&mucname=<%= URLEncoder.encode(mucname, "UTF-8") %>"
+                            <a href="muc-create-permission.jsp?userJID=<%= jid.toString() %>&delete=true&csrf=${csrf}&mucname=<%= URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"
                              title="<fmt:message key="muc.create.permission.click_title" />"
                              onclick="return confirm('<fmt:message key="muc.create.permission.confirm_remove" />');"
                              ><img src="images/delete-16x16.gif" alt=""></a>

--- a/xmppserver/src/main/webapp/muc-default-settings.jsp
+++ b/xmppserver/src/main/webapp/muc-default-settings.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2010 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2010 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
     errorPage="error.jsp"
 %>
 <%@ page import="java.net.URLEncoder" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -190,7 +191,7 @@
             }
         }
 
-        response.sendRedirect("muc-default-settings.jsp?success=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+        response.sendRedirect("muc-default-settings.jsp?success=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
         return;
     }
 
@@ -224,7 +225,7 @@
     <head>
         <title><fmt:message key="muc.default.settings.title"/></title>
         <meta name="subPageID" content="muc-defaultsettings"/>
-        <meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, "UTF-8") %>"/>
+        <meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"/>
         <meta name="helpPage" content="set_group_chat_room_creation_permissions.html"/>
     </head>
 

--- a/xmppserver/src/main/webapp/muc-history-settings.jsp
+++ b/xmppserver/src/main/webapp/muc-history-settings.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
     errorPage="error.jsp"
 %>
 <%@ page import="java.net.URLEncoder" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
@@ -96,7 +97,7 @@
             // Log the event
             webManager.logEvent("set MUC history settings for service "+mucname, "type = "+policy+"\nmax messages = "+numMessages);
             // All done, redirect
-            response.sendRedirect("muc-history-settings.jsp?success=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+            response.sendRedirect("muc-history-settings.jsp?success=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
     }
@@ -120,14 +121,14 @@
 <head>
 <title><fmt:message key="groupchat.history.settings.title"/></title>
 <meta name="subPageID" content="muc-history"/>
-<meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, "UTF-8") %>"/>
+<meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"/>
 <meta name="helpPage" content="edit_group_chat_history_settings.html"/>
 </head>
 <body>
 
 <p>
 <fmt:message key="groupchat.history.settings.introduction" />
-<fmt:message key="groupchat.service.settings_affect" /> <b><a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucname, "UTF-8") %>"><%= StringUtils.escapeHTMLTags(mucname) %></a></b>
+<fmt:message key="groupchat.service.settings_affect" /> <b><a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"><%= StringUtils.escapeHTMLTags(mucname) %></a></b>
 </p>
 
 <%  if ("true".equals(request.getParameter("success"))) { %>

--- a/xmppserver/src/main/webapp/muc-room-affiliations.jsp
+++ b/xmppserver/src/main/webapp/muc-room-affiliations.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@
 <%@ page import="org.jivesoftware.openfire.muc.CannotBeInvitedException" %>
 <%@ page import="java.util.*" %>
 <%@ page import="java.util.stream.Collectors" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -60,7 +61,7 @@
 
     if (room == null) {
         // The requested room name does not exist so return to the list of the existing rooms
-        response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8"));
+        response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8));
         return;
     }
 
@@ -107,7 +108,7 @@
                 if (groupNames != null) {
                     // create a group JID for each group
                     for (String groupName : groupNames) {
-                        GroupJID groupJID = new GroupJID(URLDecoder.decode(groupName, "UTF-8"));
+                        GroupJID groupJID = new GroupJID(URLDecoder.decode(groupName, StandardCharsets.UTF_8));
                         memberJIDs.add(groupJID);
                     }
                 }
@@ -133,7 +134,7 @@
                     }
                 }
                 // done, return
-                response.sendRedirect("muc-room-affiliations.jsp?addsuccess=true&roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8"));
+                response.sendRedirect("muc-room-affiliations.jsp?addsuccess=true&roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8));
                 return;
             }
             catch (ConflictException e) {
@@ -161,7 +162,7 @@
         webManager.getMultiUserChatManager().getMultiUserChatService(roomJID).syncChatRoom(room);
 
         // done, return
-        response.sendRedirect("muc-room-affiliations.jsp?deletesuccess=true&roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8"));
+        response.sendRedirect("muc-room-affiliations.jsp?deletesuccess=true&roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8));
         return;
         }
         catch (ConflictException e) {
@@ -182,14 +183,14 @@
     <head>
         <title><fmt:message key="muc.room.affiliations.title"/></title>
         <meta name="subPageID" content="muc-room-affiliations"/>
-        <meta name="extraParams" content="<%= "roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8") %>"/>
+        <meta name="extraParams" content="<%= "roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8) %>"/>
         <meta name="helpPage" content="edit_group_chat_room_user_permissions.html"/>
     </head>
     <body>
 
 <p>
 <fmt:message key="muc.room.affiliations.info" />
-<b><a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), "UTF-8") %>"><%= room.getJID().toBareJID() %></a></b>.
+<b><a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), StandardCharsets.UTF_8) %>"><%= room.getJID().toBareJID() %></a></b>.
 <fmt:message key="muc.room.affiliations.info_detail" />
 </p>
 
@@ -232,7 +233,7 @@
             .sorted(Comparator.comparing(g->g.getName().toLowerCase()))
             .collect(Collectors.toList());
         for (Group g : groups) {	%>
-        <option value="<%= URLEncoder.encode(g.getName(), "UTF-8") %>"
+        <option value="<%= URLEncoder.encode(g.getName(), StandardCharsets.UTF_8) %>"
          <%= (StringUtils.contains(groupNames, g.getName()) ? "selected" : "") %>
          ><%= StringUtils.escapeHTMLTags(g.getName()) %></option>
     <%  } %>
@@ -295,11 +296,11 @@
                   <% } else { %>
                     <img src="images/user.gif" title="<fmt:message key="muc.room.affiliations.user" />" alt="<fmt:message key="muc.room.affiliations.user" />"/>
                   <% } %>
-                    <a href="<%= isGroup ? "group-edit.jsp?group=" + URLEncoder.encode(userDisplay, "UTF-8") : "user-properties.jsp?username=" + URLEncoder.encode(user.getNode(), "UTF-8") %>">
+                    <a href="<%= isGroup ? "group-edit.jsp?group=" + URLEncoder.encode(userDisplay, StandardCharsets.UTF_8) : "user-properties.jsp?username=" + URLEncoder.encode(user.getNode(), StandardCharsets.UTF_8) %>">
                     <%= StringUtils.escapeHTMLTags(userDisplay) %></a>
                 </td>
                 <td style="width: 1%; text-align: center">
-                    <a href="muc-room-affiliations.jsp?roomJID=<%= URLEncoder.encode(roomJID.toBareJID(), "UTF-8") %>&userJID=<%= URLEncoder.encode(user.toString(), "UTF-8") %>&delete=true&affiliation=owner&csrf=${csrf}"
+                    <a href="muc-room-affiliations.jsp?roomJID=<%= URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8) %>&userJID=<%= URLEncoder.encode(user.toString(), StandardCharsets.UTF_8) %>&delete=true&affiliation=owner&csrf=${csrf}"
                      title="<fmt:message key="global.click_delete" />"
                      onclick="return confirm('<fmt:message key="muc.room.affiliations.confirm_removed" />');"
                      ><img src="images/delete-16x16.gif" alt=""></a>
@@ -334,11 +335,11 @@
                   <% } else { %>
                     <img src="images/user.gif" title="<fmt:message key="muc.room.affiliations.user" />" alt="<fmt:message key="muc.room.affiliations.user" />"/>
                   <% } %>
-                    <a href="<%= isGroup ? "group-edit.jsp?group=" + URLEncoder.encode(userDisplay, "UTF-8") : "user-properties.jsp?username=" + URLEncoder.encode(user.getNode(), "UTF-8") %>">
+                    <a href="<%= isGroup ? "group-edit.jsp?group=" + URLEncoder.encode(userDisplay, StandardCharsets.UTF_8) : "user-properties.jsp?username=" + URLEncoder.encode(user.getNode(), StandardCharsets.UTF_8) %>">
                     <%= StringUtils.escapeHTMLTags(userDisplay) %></a>
                 </td>
                 <td style="width: 1%; text-align: center">
-                    <a href="muc-room-affiliations.jsp?roomJID=<%= URLEncoder.encode(roomJID.toBareJID(), "UTF-8") %>&userJID=<%= URLEncoder.encode(user.toString(), "UTF-8") %>&delete=true&affiliation=admin&csrf=${csrf}"
+                    <a href="muc-room-affiliations.jsp?roomJID=<%= URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8) %>&userJID=<%= URLEncoder.encode(user.toString(), StandardCharsets.UTF_8) %>&delete=true&affiliation=admin&csrf=${csrf}"
                      title="<fmt:message key="global.click_delete" />"
                      onclick="return confirm('<fmt:message key="muc.room.affiliations.confirm_removed" />');"
                      ><img src="images/delete-16x16.gif" alt=""></a>
@@ -375,11 +376,11 @@
                   <% } else { %>
                     <img src="images/user.gif" title="<fmt:message key="muc.room.affiliations.user" />" alt="<fmt:message key="muc.room.affiliations.user" />"/>
                   <% } %>
-                    <a href="<%= isGroup ? "group-edit.jsp?group=" + URLEncoder.encode(userDisplay, "UTF-8") : "user-properties.jsp?username=" + URLEncoder.encode(user.getNode(), "UTF-8") %>">
+                    <a href="<%= isGroup ? "group-edit.jsp?group=" + URLEncoder.encode(userDisplay, StandardCharsets.UTF_8) : "user-properties.jsp?username=" + URLEncoder.encode(user.getNode(), StandardCharsets.UTF_8) %>">
                     <%= StringUtils.escapeHTMLTags(userDisplay) %></a><%= StringUtils.escapeHTMLTags(nickname) %>
                 </td>
                 <td style="width: 1%; text-align: center">
-                    <a href="muc-room-affiliations.jsp?roomJID=<%= URLEncoder.encode(roomJID.toBareJID(), "UTF-8") %>&userJID=<%= URLEncoder.encode(user.toString(), "UTF-8") %>&delete=true&affiliation=member&csrf=${csrf}"
+                    <a href="muc-room-affiliations.jsp?roomJID=<%= URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8) %>&userJID=<%= URLEncoder.encode(user.toString(), StandardCharsets.UTF_8) %>&delete=true&affiliation=member&csrf=${csrf}"
                      title="<fmt:message key="global.click_delete" />"
                      onclick="return confirm('<fmt:message key="muc.room.affiliations.confirm_removed" />');"
                      ><img src="images/delete-16x16.gif" alt=""></a>
@@ -414,11 +415,11 @@
                   <% } else { %>
                     <img src="images/user.gif" title="<fmt:message key="muc.room.affiliations.user" />" alt="<fmt:message key="muc.room.affiliations.user" />"/>
                   <% } %>
-                    <a href="<%= isGroup ? "group-edit.jsp?group=" + URLEncoder.encode(userDisplay, "UTF-8") : "user-properties.jsp?username=" + URLEncoder.encode(user.getNode(), "UTF-8") %>">
+                    <a href="<%= isGroup ? "group-edit.jsp?group=" + URLEncoder.encode(userDisplay, StandardCharsets.UTF_8) : "user-properties.jsp?username=" + URLEncoder.encode(user.getNode(), StandardCharsets.UTF_8) %>">
                     <%= StringUtils.escapeHTMLTags(userDisplay) %></a>
                 </td>
                 <td style="width: 1%; text-align: center">
-                    <a href="muc-room-affiliations.jsp?roomJID=<%= URLEncoder.encode(roomJID.toBareJID(), "UTF-8") %>&userJID=<%= URLEncoder.encode(user.toString(), "UTF-8") %>&delete=true&affiliation=outcast&csrf=${csrf}"
+                    <a href="muc-room-affiliations.jsp?roomJID=<%= URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8) %>&userJID=<%= URLEncoder.encode(user.toString(), StandardCharsets.UTF_8) %>&delete=true&affiliation=outcast&csrf=${csrf}"
                      title="<fmt:message key="global.click_delete" />"
                      onclick="return confirm('<fmt:message key="muc.room.affiliations.confirm_removed" />');"
                      ><img src="images/delete-16x16.gif" alt=""></a>

--- a/xmppserver/src/main/webapp/muc-room-cache.jsp
+++ b/xmppserver/src/main/webapp/muc-room-cache.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2021-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2021-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="java.util.concurrent.ConcurrentHashMap" %>
 <%@ page import="java.util.concurrent.ConcurrentMap" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -113,7 +114,7 @@
 <head>
 <title><fmt:message key="muc.room_cache.title"/></title>
 <meta name="subPageID" content="muc-room-cache"/>
-<meta name="extraParams" content="<%= "mucName=" + URLEncoder.encode(mucName, "UTF-8") %>"/>
+<meta name="extraParams" content="<%= "mucName=" + URLEncoder.encode(mucName, StandardCharsets.UTF_8) %>"/>
 <meta name="helpPage" content="edit_idle_user_settings.html"/>
 </head>
 <body>

--- a/xmppserver/src/main/webapp/muc-room-clear-chat.jsp
+++ b/xmppserver/src/main/webapp/muc-room-clear-chat.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2024-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
     errorPage="error.jsp"
 %>
 <%@ page import="org.xmpp.packet.JID" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -50,7 +51,7 @@
 
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("muc-room-edit-form.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8"));
+        response.sendRedirect("muc-room-edit-form.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8));
         return;
     }
 
@@ -69,7 +70,7 @@
             });
         }
         // Done, so redirect to the room edit form
-        response.sendRedirect("muc-room-edit-form.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8")+"&clearchatsuccess=true");
+        response.sendRedirect("muc-room-edit-form.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8)+"&clearchatsuccess=true");
         return;
     }
 

--- a/xmppserver/src/main/webapp/muc-room-delete.jsp
+++ b/xmppserver/src/main/webapp/muc-room-delete.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
     errorPage="error.jsp"
 %>
 <%@ page import="org.xmpp.packet.JID" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -66,7 +67,7 @@
 
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8"));
+        response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8));
         return;
     }
 
@@ -85,7 +86,7 @@
             webManager.logEvent("destroyed MUC room "+roomName, "reason = "+reason+"\nalt jid = "+alternateJID);
         }
         // Done, so redirect
-        response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8")+"&deletesuccess=true");
+        response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8)+"&deletesuccess=true");
         return;
     }
 %>
@@ -94,14 +95,14 @@
     <head>
         <title><fmt:message key="muc.room.delete.title"/></title>
         <meta name="subPageID" content="muc-room-delete"/>
-        <meta name="extraParams" content="<%= "roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8") %>"/>
+        <meta name="extraParams" content="<%= "roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8) %>"/>
         <meta name="helpPage" content="delete_a_group_chat_room.html"/>
     </head>
     <body>
 
 <p>
 <fmt:message key="muc.room.delete.info" />
-<b><a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), "UTF-8") %>"><%= StringUtils.escapeHTMLTags(room.getJID().toBareJID()) %></a></b>
+<b><a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), StandardCharsets.UTF_8) %>"><%= StringUtils.escapeHTMLTags(room.getJID().toBareJID()) %></a></b>
 <fmt:message key="muc.room.delete.detail" />
 </p>
 

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@
 <%@ page import="org.jivesoftware.openfire.muc.NotAllowedException"%>
 <%@ page import="org.jivesoftware.openfire.muc.spi.MUCPersistenceManager" %>
 <%@ page import="org.jivesoftware.openfire.muc.Role" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -120,7 +121,7 @@
             response.sendRedirect("muc-room-summary.jsp");
         } else {
             // case when canceling a room edit, used on summary to set service
-            response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8"));
+            response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8));
         }
         return;
     }
@@ -132,7 +133,7 @@
 
         if (room == null) {
             // The requested room name does not exist so return to the list of the existing rooms
-            response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8"));
+            response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8));
             return;
         }
     }
@@ -289,12 +290,12 @@
             // Changes good, so redirect
             String params;
             if (create) {
-                params = "addsuccess=true&roomJID=" + URLEncoder.encode(roomJID.toBareJID(), "UTF-8");
+                params = "addsuccess=true&roomJID=" + URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8);
                 // Log the event
                 webManager.logEvent("created new MUC room "+roomName, "subject = "+roomSubject+"\nroomdesc = "+description+"\nroomname = "+naturalName+"\nmaxusers = "+maxUsers);
             }
             else {
-                params = "success=true&roomJID=" + URLEncoder.encode(roomJID.toBareJID(), "UTF-8");
+                params = "success=true&roomJID=" + URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8);
                 // Log the event
                 webManager.logEvent("updated MUC room "+roomName, "subject = "+roomSubject+"\nroomdesc = "+description+"\nroomname = "+naturalName+"\nmaxusers = "+maxUsers);
             }
@@ -405,7 +406,7 @@
             </c:otherwise>
         </c:choose>
 
-        <meta name="extraParams" content="<%= "roomJID="+(roomJID != null ? URLEncoder.encode(roomJID.toBareJID(), "UTF-8") : "")+"&create="+create %>"/>
+        <meta name="extraParams" content="<%= "roomJID="+(roomJID != null ? URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8) : "")+"&create="+create %>"/>
         <meta name="helpPage" content="view_group_chat_room_summary.html"/>
     </head>
     <body>

--- a/xmppserver/src/main/webapp/muc-room-federation.jsp
+++ b/xmppserver/src/main/webapp/muc-room-federation.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2020-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2020-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -66,7 +67,7 @@
     MUCRoom room = webManager.getMultiUserChatManager().getMultiUserChatService(roomJID).getChatRoom(roomName);
     if (room == null) {
         // The requested room name does not exist so return to the list of the existing rooms
-        response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8"));
+        response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8));
         return;
     }
     final FMUCHandler fmucHandler = room.getFmucHandler();
@@ -95,9 +96,9 @@
         webManager.getMultiUserChatManager().getMultiUserChatService(roomJID).syncChatRoom(room);
 
         if (stoppedSomething) {
-            response.sendRedirect("muc-room-federation.jsp?closeSuccess=true&roomJID=" + URLEncoder.encode(room.getJID().toBareJID(), "UTF-8"));
+            response.sendRedirect("muc-room-federation.jsp?closeSuccess=true&roomJID=" + URLEncoder.encode(room.getJID().toBareJID(), StandardCharsets.UTF_8));
         } else {
-            response.sendRedirect("muc-room-federation.jsp?closeError=true&roomJID=" + URLEncoder.encode(room.getJID().toBareJID(), "UTF-8"));
+            response.sendRedirect("muc-room-federation.jsp?closeError=true&roomJID=" + URLEncoder.encode(room.getJID().toBareJID(), StandardCharsets.UTF_8));
         }
         return;
     }
@@ -137,7 +138,7 @@
 
             // Log the event
             webManager.logEvent("Updated FMUC settings for MUC room "+roomName, "FMUC enabled = " + room.isFmucEnabled() + ",\noutbound peer = "+(room.getFmucOutboundNode() == null ? "(none)" :room.getFmucOutboundNode())+",\noutbound mode = "+(room.getFmucOutboundMode() == null ? "(none)" :room.getFmucOutboundMode()));
-            response.sendRedirect("muc-room-federation.jsp?success=true&roomJID="+URLEncoder.encode(room.getJID().toBareJID(), "UTF-8"));
+            response.sendRedirect("muc-room-federation.jsp?success=true&roomJID="+URLEncoder.encode(room.getJID().toBareJID(), StandardCharsets.UTF_8));
             return;
         }
     }
@@ -153,7 +154,7 @@
 <head>
     <title><fmt:message key="muc.room.federation.title"/></title>
     <meta name="subPageID" content="muc-room-federation"/>
-    <meta name="extraParams" content="<%= "roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8") %>"/>
+    <meta name="extraParams" content="<%= "roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8) %>"/>
 </head>
 <body>
 

--- a/xmppserver/src/main/webapp/muc-room-occupants.jsp
+++ b/xmppserver/src/main/webapp/muc-room-occupants.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 <%@ page import="org.xmpp.packet.JID" %>
 <%@ page import="java.util.List" %>
 <%@ page import="org.jivesoftware.openfire.muc.MUCOccupant" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -59,7 +60,7 @@
     MUCRoom room = webManager.getMultiUserChatManager().getMultiUserChatService(roomJID).getChatRoom(roomName);
     if (room == null) {
         // The requested room name does not exist so return to the list of the existing rooms
-        response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8"));
+        response.sendRedirect("muc-room-summary.jsp?roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8));
         return;
     }
 
@@ -76,7 +77,7 @@
             // Log the event
             webManager.logEvent("kicked MUC occupant "+nickName+" from "+roomName, null);
             // Done, so redirect
-            response.sendRedirect("muc-room-occupants.jsp?roomJID="+URLEncoder.encode(room.getJID().toBareJID(), "UTF-8")+"&nickName="+URLEncoder.encode(nickName, "UTF-8")+"&deletesuccess=true");
+            response.sendRedirect("muc-room-occupants.jsp?roomJID="+URLEncoder.encode(room.getJID().toBareJID(), StandardCharsets.UTF_8)+"&nickName="+URLEncoder.encode(nickName, StandardCharsets.UTF_8)+"&deletesuccess=true");
             return;
         }
     }
@@ -91,7 +92,7 @@
 <head>
 <title><fmt:message key="muc.room.occupants.title"/></title>
 <meta name="subPageID" content="muc-room-occupants"/>
-<meta name="extraParams" content="<%= "roomJID="+URLEncoder.encode(roomJID.toBareJID(), "UTF-8")+"&create=false" %>"/>
+<meta name="extraParams" content="<%= "roomJID="+URLEncoder.encode(roomJID.toBareJID(), StandardCharsets.UTF_8)+"&create=false" %>"/>
 </head>
 <body>
 
@@ -163,7 +164,7 @@
             <td><%= StringUtils.escapeHTMLTags(occupant.getNickname()) %></td>
             <td><%= StringUtils.escapeHTMLTags(occupant.getRole().toString()) %></td>
             <td><%= StringUtils.escapeHTMLTags(occupant.getAffiliation().toString()) %></td>
-            <td><a href="muc-room-occupants.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), "UTF-8") %>&nickName=<%= URLEncoder.encode(occupant.getNickname(), "UTF-8") %>&kick=1&csrf=${csrf}" title="<fmt:message key="muc.room.occupants.kick"/>"><img src="images/delete-16x16.gif" alt="<fmt:message key="muc.room.occupants.kick"/>" /></a></td>
+            <td><a href="muc-room-occupants.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), StandardCharsets.UTF_8) %>&nickName=<%= URLEncoder.encode(occupant.getNickname(), StandardCharsets.UTF_8) %>&kick=1&csrf=${csrf}" title="<fmt:message key="muc.room.occupants.kick"/>"><img src="images/delete-16x16.gif" alt="<fmt:message key="muc.room.occupants.kick"/>" /></a></td>
         </tr>
         <% } %>
     </tbody>

--- a/xmppserver/src/main/webapp/muc-room-retirees.jsp
+++ b/xmppserver/src/main/webapp/muc-room-retirees.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2024-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 <%@ page import="org.jivesoftware.util.*" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="org.jivesoftware.openfire.muc.MUCRoomRetiree" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -70,7 +71,7 @@
 
         if (service != null && name != null) {
             webManager.getMultiUserChatManager().deleteRetiree(service, name);
-            response.sendRedirect("muc-room-retirees.jsp?mucname=" + URLEncoder.encode(service, "UTF-8") + "&deletesuccess=true");
+            response.sendRedirect("muc-room-retirees.jsp?mucname=" + URLEncoder.encode(service, StandardCharsets.UTF_8) + "&deletesuccess=true");
             return;
         }
     }

--- a/xmppserver/src/main/webapp/muc-room-summary.jsp
+++ b/xmppserver/src/main/webapp/muc-room-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 <%@ page import="org.jivesoftware.openfire.muc.MultiUserChatService" %>
 <%@ page import="org.xmpp.packet.JID" %>
 <%@ page import="java.util.stream.Collectors" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -80,7 +81,7 @@
 
 <p>
 <fmt:message key="muc.room.summary.info" />
-<a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucService.getServiceName(), "UTF-8")%>"><%= StringUtils.escapeHTMLTags(mucService.getServiceDomain()) %></a>
+<a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucService.getServiceName(), StandardCharsets.UTF_8)%>"><%= StringUtils.escapeHTMLTags(mucService.getServiceDomain()) %></a>
 <fmt:message key="muc.room.summary.info2" />
 </p>
 
@@ -161,12 +162,12 @@
         </td>
         <td style="width: 45%; vertical-align: middle">
             <% if (room.getName().equals(room.getNaturalLanguageName())) { %>
-                 <a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), "UTF-8") %>" title="<fmt:message key="global.click_edit" />">
+                 <a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), StandardCharsets.UTF_8) %>" title="<fmt:message key="global.click_edit" />">
                      <%=  StringUtils.escapeHTMLTags(room.getName()) %>
                  </a>
             <% }
                else { %>
-                <a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), "UTF-8") %>"title="<fmt:message key="global.click_edit" />">
+                <a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), StandardCharsets.UTF_8) %>" title="<fmt:message key="global.click_edit" />">
                 <%= StringUtils.escapeHTMLTags(room.getNaturalLanguageName()) %> (<%=  StringUtils.escapeHTMLTags(room.getName()) %>)
                 </a>
             <% } %>
@@ -197,12 +198,12 @@
             <% } %>
         </td>
         <td style="width: 1%; text-align: center">
-            <a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), "UTF-8") %>"
+            <a href="muc-room-edit-form.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), StandardCharsets.UTF_8) %>"
              title="<fmt:message key="global.click_edit" />"
              ><img src="images/edit-16x16.gif" alt="Edit"></a>
         </td>
         <td style="width: 1%; text-align: center; border-right:1px #ccc solid;">
-            <a href="muc-room-delete.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), "UTF-8") %>"
+            <a href="muc-room-delete.jsp?roomJID=<%= URLEncoder.encode(room.getJID().toBareJID(), StandardCharsets.UTF_8) %>"
              title="<fmt:message key="global.click_delete" />"
              ><img src="images/delete-16x16.gif" alt="Delete"></a>
         </td>

--- a/xmppserver/src/main/webapp/muc-service-delete.jsp
+++ b/xmppserver/src/main/webapp/muc-service-delete.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
     errorPage="error.jsp"
 %>
 <%@ page import="org.jivesoftware.openfire.muc.MultiUserChatService" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -84,13 +85,13 @@
     <head>
         <title><fmt:message key="muc.service.delete.title"/></title>
         <meta name="subPageID" content="muc-service-delete"/>
-        <meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, "UTF-8") %>"/>
+        <meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"/>
     </head>
     <body>
 
 <p>
 <fmt:message key="muc.service.delete.info" />
-<b><a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucname, "UTF-8") %>"><%= StringUtils.escapeHTMLTags(mucname) %></a></b>
+<b><a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"><%= StringUtils.escapeHTMLTags(mucname) %></a></b>
 <fmt:message key="muc.service.delete.detail" />
 </p>
 

--- a/xmppserver/src/main/webapp/muc-service-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-service-edit-form.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 %>
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="org.xmpp.packet.JID" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib prefix="admin" uri="admin" %>
@@ -166,7 +167,7 @@
 <meta name="pageID" content="muc-service-create"/>
 <% } else { %>
 <meta name="subPageID" content="muc-service-edit-form"/>
-<meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, "UTF-8") %>"/>
+<meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"/>
 <% } %>
 <meta name="helpPage" content="edit_group_chat_service_properties.html"/>    
 <script>

--- a/xmppserver/src/main/webapp/muc-service-summary.jsp
+++ b/xmppserver/src/main/webapp/muc-service-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="org.jivesoftware.openfire.muc.MultiUserChatService" %>
 <%@ page import="java.util.List" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -189,24 +190,24 @@
             <%= i %>
         </td>
         <td style="width: 23%">
-            <a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(service.getServiceName(), "UTF-8") %>"><%= StringUtils.escapeHTMLTags(JID.unescapeNode(service.getServiceName())) %></a>
+            <a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(service.getServiceName(), StandardCharsets.UTF_8) %>"><%= StringUtils.escapeHTMLTags(JID.unescapeNode(service.getServiceName())) %></a>
         </td>
         <td style="width: 20%">
             <%= StringUtils.escapeHTMLTags(service.getDescription()) %> &nbsp;
         </td>
         <td style="width: 5%">
-            <a href="muc-room-summary.jsp?mucname=<%= URLEncoder.encode(service.getServiceName(), "UTF-8") %>"><%= service.getNumberChatRooms() %></a>
+            <a href="muc-room-summary.jsp?mucname=<%= URLEncoder.encode(service.getServiceName(), StandardCharsets.UTF_8) %>"><%= service.getNumberChatRooms() %></a>
         </td>
         <td style="width: 5%">
             <%= service.getNumberConnectedUsers() %>
         </td>
         <td style="width: 1%; text-align: center">
-            <a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(service.getServiceName(), "UTF-8") %>"
+            <a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(service.getServiceName(), StandardCharsets.UTF_8) %>"
              title="<fmt:message key="global.click_edit" />"
              ><img src="images/edit-16x16.gif" alt="<fmt:message key="global.click_edit" />"></a>
         </td>
         <td style="width: 1%; text-align: center; border-right:1px #ccc solid;">
-            <a href="muc-service-delete.jsp?mucname=<%= URLEncoder.encode(service.getServiceName(), "UTF-8") %>"
+            <a href="muc-service-delete.jsp?mucname=<%= URLEncoder.encode(service.getServiceName(), StandardCharsets.UTF_8) %>"
              title="<fmt:message key="global.click_delete" />"
              ><img src="images/delete-16x16.gif" alt="<fmt:message key="global.click_delete" />"></a>
         </td>

--- a/xmppserver/src/main/webapp/muc-sysadmins.jsp
+++ b/xmppserver/src/main/webapp/muc-sysadmins.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 %>
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="java.net.URLDecoder" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
@@ -88,7 +89,7 @@
         if (groupNames != null) {
             // create a group JID for each group
             for (String groupName : groupNames) {
-                GroupJID groupJID = new GroupJID(URLDecoder.decode(groupName, "UTF-8"));
+                GroupJID groupJID = new GroupJID(URLDecoder.decode(groupName, StandardCharsets.UTF_8));
                 allowedJIDs.add(groupJID);
             }
         }
@@ -101,7 +102,7 @@
             mucService.addSysadmins(allowedJIDs);
             // Log the event
             webManager.logEvent("added muc sysadmin permissions for service "+mucname, null);
-            response.sendRedirect("muc-sysadmins.jsp?addsuccess=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+            response.sendRedirect("muc-sysadmins.jsp?addsuccess=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
 
@@ -111,7 +112,7 @@
             // Log the event
             webManager.logEvent("removed muc sysadmin "+userJID+" for service "+mucname, null);
             // done, return
-            response.sendRedirect("muc-sysadmins.jsp?deletesuccess=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+            response.sendRedirect("muc-sysadmins.jsp?deletesuccess=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
 
@@ -120,7 +121,7 @@
             // Log the event
             webManager.logEvent("muc sysadmins for service "+mucname + "now " + (requirePassword ? "cannot" : "can") + " join a password-protected room, without supplying the password.", null);
             // done, return
-            response.sendRedirect("muc-sysadmins.jsp?success=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+            response.sendRedirect("muc-sysadmins.jsp?success=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
     }
@@ -130,14 +131,14 @@
 <head>
 <title><fmt:message key="groupchat.admins.title"/></title>
 <meta name="subPageID" content="muc-sysadmin"/>
-<meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, "UTF-8") %>"/>
+<meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"/>
 <meta name="helpPage" content="edit_group_chat_service_administrators.html"/>
 </head>
 <body>
 
 <p>
 <fmt:message key="groupchat.admins.introduction" />
-<fmt:message key="groupchat.service.settings_affect" /> <b><a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucname, "UTF-8") %>"><%= StringUtils.escapeHTMLTags(mucname) %></a></b>
+<fmt:message key="groupchat.service.settings_affect" /> <b><a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"><%= StringUtils.escapeHTMLTags(mucname) %></a></b>
 </p>
 
 <%  if ("true".equals(request.getParameter("deletesuccess"))) { %>
@@ -183,7 +184,7 @@
         <label for="groupJIDs"><fmt:message key="groupchat.admins.add_group" /></label><br/>
         <select name="groupNames" size="6" multiple style="width:400px;font-family:verdana,arial,helvetica,sans-serif;font-size:8pt;" id="groupJIDs">
         <%  for (Group g : webManager.getGroupManager().getGroups()) {	%>
-            <option value="<%= URLEncoder.encode(g.getName(), "UTF-8") %>"
+            <option value="<%= URLEncoder.encode(g.getName(), StandardCharsets.UTF_8) %>"
              <%= (StringUtils.contains(groupNames, g.getName()) ? "selected" : "") %>
              ><%= StringUtils.escapeHTMLTags(g.getName()) %></option>
         <%  } %>
@@ -230,7 +231,7 @@
                           </a>
                         </td>
                         <td style="width: 1%; text-align: center">
-                            <a href="muc-sysadmins.jsp?userJID=<%= URLEncoder.encode(jid.toString()) %>&delete=true&mucname=<%= URLEncoder.encode(mucname, "UTF-8") %>&amp;csrf=<%= URLEncoder.encode(csrfParam) %>"
+                            <a href="muc-sysadmins.jsp?userJID=<%= URLEncoder.encode(jid.toString()) %>&delete=true&mucname=<%= URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>&amp;csrf=<%= URLEncoder.encode(csrfParam) %>"
                              title="<fmt:message key="groupchat.admins.dialog.title" />"
                              onclick="return confirm('<fmt:message key="groupchat.admins.dialog.text" />');"
                              ><img src="images/delete-16x16.gif" alt=""></a>

--- a/xmppserver/src/main/webapp/muc-tasks.jsp
+++ b/xmppserver/src/main/webapp/muc-tasks.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="java.time.Duration" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -136,7 +137,7 @@
         }
 
         if (errors.isEmpty()) {
-            response.sendRedirect("muc-tasks.jsp?idleSettingSuccess=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+            response.sendRedirect("muc-tasks.jsp?idleSettingSuccess=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
     }
@@ -188,7 +189,7 @@
             mucService.setLogBatchGracePeriod( batchGracePeriod );
             // Log the event
             webManager.logEvent("edited muc conversation log settings for service "+mucname, "maxBatchSize = "+maxBatchSize+"\nmaxBatchInterval = "+maxBatchInterval+"\nbatchGrace = "+batchGrace);
-            response.sendRedirect("muc-tasks.jsp?logSettingSuccess=true&mucname="+URLEncoder.encode(mucname, "UTF-8"));
+            response.sendRedirect("muc-tasks.jsp?logSettingSuccess=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
     }
@@ -209,7 +210,7 @@
 <head>
 <title><fmt:message key="muc.tasks.title"/></title>
 <meta name="subPageID" content="muc-tasks"/>
-<meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, "UTF-8") %>"/>
+<meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"/>
 <meta name="helpPage" content="edit_idle_user_settings.html"/>
 </head>
 <body>
@@ -262,7 +263,7 @@
 
 <p>
     <fmt:message key="muc.tasks.info" />
-    <fmt:message key="groupchat.service.settings_affect" /> <b><a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucname, "UTF-8") %>"><%= StringUtils.escapeHTMLTags(mucname) %></a></b>
+    <fmt:message key="groupchat.service.settings_affect" /> <b><a href="muc-service-edit-form.jsp?mucname=<%= URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"><%= StringUtils.escapeHTMLTags(mucname) %></a></b>
 </p>
 
 <!-- BEGIN 'Idle User Settings' -->

--- a/xmppserver/src/main/webapp/plugin-showfile.jsp
+++ b/xmppserver/src/main/webapp/plugin-showfile.jsp
@@ -1,5 +1,5 @@
 <%--
-  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 <%@ page import="org.jivesoftware.openfire.container.PluginManager" %>
 <%@ page import="java.nio.file.Path" %>
 <%@ page import="java.io.*" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager"  />
 <%
@@ -48,7 +49,7 @@
 
             if ( filePath.toFile().exists() )
             {
-                try ( final BufferedReader in = new BufferedReader( new InputStreamReader( new FileInputStream( filePath.toFile() ), "UTF8") ) )
+                try ( final BufferedReader in = new BufferedReader( new InputStreamReader( new FileInputStream( filePath.toFile() ), StandardCharsets.UTF_8) ) )
                 {
                     String line;
                     while ((line = in.readLine()) != null)

--- a/xmppserver/src/main/webapp/pubsub-node-affiliates-delete.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-affiliates-delete.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@
 %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -77,7 +78,7 @@
 
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+URLEncoder.encode(nodeID, "UTF-8") + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : ""));
+        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+URLEncoder.encode(nodeID, StandardCharsets.UTF_8) + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), StandardCharsets.UTF_8) : ""));
         return;
     }
 
@@ -123,9 +124,9 @@
             webManager.logEvent("Deleted Affiliation for : " + affiliate + ", from Node " + nodeID, null);
         }
         // Done, so redirect
-        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+URLEncoder.encode( nodeID, "UTF-8" )
-                + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : "")
-                +"&deleteSuccess=true&affiliateJID="+URLEncoder.encode( affiliateJID, "UTF-8" ));
+        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+URLEncoder.encode( nodeID, StandardCharsets.UTF_8)
+                + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), StandardCharsets.UTF_8) : "")
+                +"&deleteSuccess=true&affiliateJID="+URLEncoder.encode( affiliateJID, StandardCharsets.UTF_8));
         return;
     }
 

--- a/xmppserver/src/main/webapp/pubsub-node-affiliates-edit.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-affiliates-edit.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@
                 java.util.Map"
     errorPage="error.jsp"
 %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -77,8 +78,8 @@
 
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+ URLEncoder.encode( nodeID, "UTF-8" )
-                + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : ""));
+        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+ URLEncoder.encode( nodeID, StandardCharsets.UTF_8)
+                + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), StandardCharsets.UTF_8) : ""));
         return;
     }
 
@@ -133,7 +134,7 @@
             webManager.logEvent("Changed affiliation between Node: " + nodeID + ", and JID: " + affiliateJID, "Changed from " + oldAffiliation +" to " + affiliation);
         }
         // Done, so redirect
-        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+URLEncoder.encode( nodeID, "UTF-8" )+"&updateSuccess=true&affiliateJID="+URLEncoder.encode( affiliateJID, "UTF-8" ));
+        response.sendRedirect("pubsub-node-affiliates.jsp?nodeID="+URLEncoder.encode( nodeID, StandardCharsets.UTF_8)+"&updateSuccess=true&affiliateJID="+URLEncoder.encode( affiliateJID, StandardCharsets.UTF_8));
         return;
     }
 

--- a/xmppserver/src/main/webapp/pubsub-node-affiliates.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-affiliates.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
                  java.util.List"
     errorPage="error.jsp"
 %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>
@@ -72,7 +73,7 @@
     Node node = pubSubServiceInfo.getNode(nodeID);
     if (node == null) {
         // The requested node does not exist so return to the list of the existing node
-        response.sendRedirect("pubsub-node-summary.jsp" + (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : ""));
+        response.sendRedirect("pubsub-node-summary.jsp" + (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), StandardCharsets.UTF_8) : ""));
         return;
     }
 

--- a/xmppserver/src/main/webapp/pubsub-node-configuration.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-configuration.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2020-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2020-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
     errorPage="error.jsp"
 %>
 <%@ page import="org.jivesoftware.util.JiveGlobals" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -69,7 +70,7 @@
     Node node = pubSubServiceInfo.getNode( nodeID );
     if (node == null) {
         // The requested node does not exist so return to the list of the existing node
-        response.sendRedirect("pubsub-node-summary.jsp" + (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : ""));
+        response.sendRedirect("pubsub-node-summary.jsp" + (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), StandardCharsets.UTF_8) : ""));
         return;
     }
 

--- a/xmppserver/src/main/webapp/pubsub-node-delete.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-delete.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
                 java.util.Map"
     errorPage="error.jsp"
 %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -79,7 +80,7 @@
 
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("pubsub-node-summary.jsp"+ (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : ""));
+        response.sendRedirect("pubsub-node-summary.jsp"+ (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), StandardCharsets.UTF_8) : ""));
         return;
     }
 
@@ -106,7 +107,7 @@
         }
         // Done, so redirect
         response.sendRedirect("pubsub-node-summary.jsp?deleteSuccess=true"
-            + (owner != null ? "&owner=" + URLEncoder.encode( owner.toBareJID(), "UTF-8") : "") );
+            + (owner != null ? "&owner=" + URLEncoder.encode( owner.toBareJID(), StandardCharsets.UTF_8) : "") );
         return;
     }
 

--- a/xmppserver/src/main/webapp/pubsub-node-edit.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-edit.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
                  java.net.URLEncoder"
     errorPage="error.jsp"
 %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -108,7 +109,7 @@
             webManager.logEvent("Configuration updated for " + nodeID, null);
         }
         // Done, so redirect
-        response.sendRedirect( "pubsub-node-edit.jsp?nodeID=" + URLEncoder.encode( nodeID, "UTF-8" ) + "&updateSuccess=true");
+        response.sendRedirect( "pubsub-node-edit.jsp?nodeID=" + URLEncoder.encode( nodeID, StandardCharsets.UTF_8) + "&updateSuccess=true");
         return;
     }
 

--- a/xmppserver/src/main/webapp/pubsub-node-items.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-items.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
                  java.util.Map"
     errorPage="error.jsp"
 %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -87,7 +88,7 @@
     Node node = pubSubServiceInfo.getNode( nodeID );
     if (node == null) {
         // The requested node does not exist so return to the list of the existing node
-        response.sendRedirect("pubsub-node-summary.jsp"+ (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : ""));
+        response.sendRedirect("pubsub-node-summary.jsp"+ (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), StandardCharsets.UTF_8) : ""));
         return;
     }
 
@@ -102,10 +103,10 @@
             // Log the event
             webManager.logEvent("Delete item ID: " + deleteID +  ", from node ID: " + nodeID, "Publisher: " + pi.getPublisher().toBareJID());
             // Done, so redirect
-            response.sendRedirect("pubsub-node-items.jsp?nodeID=" + URLEncoder.encode(nodeID, "UTF-8")
+            response.sendRedirect("pubsub-node-items.jsp?nodeID=" + URLEncoder.encode(nodeID, StandardCharsets.UTF_8)
                 + "&deleteSuccess=true"
-                + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : "")
-                + "&ownerOfDeleted=" + URLEncoder.encode(pi.getPublisher().toBareJID(), "UTF-8"));
+                + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), StandardCharsets.UTF_8) : "")
+                + "&ownerOfDeleted=" + URLEncoder.encode(pi.getPublisher().toBareJID(), StandardCharsets.UTF_8));
             return;
         }
     }

--- a/xmppserver/src/main/webapp/pubsub-node-subscribers.jsp
+++ b/xmppserver/src/main/webapp/pubsub-node-subscribers.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@
                  java.util.Map"
     errorPage="error.jsp"
 %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -86,7 +87,7 @@
     Node node = pubSubServiceInfo.getNode( nodeID );
     if (node == null) {
         // The requested node does not exist so return to the list of the existing node
-        response.sendRedirect("pubsub-node-summary.jsp" + (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : ""));
+        response.sendRedirect("pubsub-node-summary.jsp" + (owner != null ? "?owner=" + URLEncoder.encode(owner.toBareJID(), StandardCharsets.UTF_8) : ""));
         return;
     }
 
@@ -99,10 +100,10 @@
             // Log the event
             webManager.logEvent("Cancelled subscription ID: " + deleteID +  ", from node ID: " + nodeID, "Owner: " + subscription.getOwner().toBareJID());
             // Done, so redirect
-            response.sendRedirect("pubsub-node-subscribers.jsp?nodeID=" + URLEncoder.encode(nodeID, "UTF-8")
+            response.sendRedirect("pubsub-node-subscribers.jsp?nodeID=" + URLEncoder.encode(nodeID, StandardCharsets.UTF_8)
                 + "&deleteSuccess=true"
-                + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), "UTF-8") : "")
-                + "&ownerOfDeleted=" + URLEncoder.encode(subscription.getOwner().toBareJID(), "UTF-8"));
+                + (owner != null ? "&owner=" + URLEncoder.encode(owner.toBareJID(), StandardCharsets.UTF_8) : "")
+                + "&ownerOfDeleted=" + URLEncoder.encode(subscription.getOwner().toBareJID(), StandardCharsets.UTF_8));
             return;
         }
     }

--- a/xmppserver/src/main/webapp/server-session-row.jspf
+++ b/xmppserver/src/main/webapp/server-session-row.jspf
@@ -7,6 +7,7 @@
                  java.util.Calendar,
                  java.util.Date"%>
  <%@ page import="java.net.*" %>
+ <%@ page import="java.nio.charset.StandardCharsets" %>
 
  <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -49,8 +50,8 @@
     <td style="width: 47%; white-space: nowrap">
         <table>
             <tr>
-            <td style="width: 1%; padding-right: 0.5em" ><img src="getFavicon?host=<%=URLEncoder.encode(host, "UTF-8")%>" width="16" height="16" alt=""></td>
-            <td><a href="server-session-details.jsp?hostname=<%= URLEncoder.encode(host, "UTF-8") %>" title="<fmt:message key='session.row.click' />"><%= StringUtils.escapeHTMLTags(host) %></a></td>
+            <td style="width: 1%; padding-right: 0.5em" ><img src="getFavicon?host=<%=URLEncoder.encode(host, StandardCharsets.UTF_8)%>" width="16" height="16" alt=""></td>
+            <td><a href="server-session-details.jsp?hostname=<%= URLEncoder.encode(host, StandardCharsets.UTF_8) %>" title="<fmt:message key='session.row.click' />"><%= StringUtils.escapeHTMLTags(host) %></a></td>
             </tr>
         </table>
     </td>
@@ -178,7 +179,7 @@
     </td>
 
     <td style="width: 1%; white-space: nowrap; text-align: center;">
-        <a href="server-session-summary.jsp?hostname=<%= URLEncoder.encode(host, "UTF-8") %>&close=true&csrf=${csrf}"
+        <a href="server-session-summary.jsp?hostname=<%= URLEncoder.encode(host, StandardCharsets.UTF_8) %>&close=true&csrf=${csrf}"
          title="<fmt:message key="session.row.click_kill_session" />"
          onclick="return confirm('<fmt:message key="session.row.confirm_close" />');"
          ><img src="images/delete-16x16.gif" alt="Delete"></a>

--- a/xmppserver/src/main/webapp/session-details.jsp
+++ b/xmppserver/src/main/webapp/session-details.jsp
@@ -41,6 +41,7 @@
 <%@ page import="java.util.TreeSet" %>
 <%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -122,7 +123,7 @@
     // Handle a "message" click:
     if (request.getParameter("message") != null) {
         if (csrfCookie != null && csrfParam != null && csrfCookie.getValue().equals(csrfParam)) {
-            response.sendRedirect("user-message.jsp?username=" + URLEncoder.encode(user.getUsername(), "UTF-8"));
+            response.sendRedirect("user-message.jsp?username=" + URLEncoder.encode(user.getUsername(), StandardCharsets.UTF_8));
             return;
         }
     }
@@ -188,7 +189,7 @@
 
             <%  } else { %>
 
-                <a href="user-properties.jsp?username=<%= URLEncoder.encode(n, "UTF-8") %>"><%= StringUtils.escapeHTMLTags(JID.unescapeNode(n)) %></a>
+                <a href="user-properties.jsp?username=<%= URLEncoder.encode(n, StandardCharsets.UTF_8) %>"><%= StringUtils.escapeHTMLTags(JID.unescapeNode(n)) %></a>
                 - <%= address.getResource()==null?"":StringUtils.escapeForXML(address.getResource()) %>
 
             <%  } %>

--- a/xmppserver/src/main/webapp/session-row.jspf
+++ b/xmppserver/src/main/webapp/session-row.jspf
@@ -9,6 +9,7 @@
                  org.xmpp.packet.Presence"%>
  <%@ page import="java.net.URLEncoder"%>
  <%@ page import="java.text.NumberFormat" %>
+ <%@ page import="java.nio.charset.StandardCharsets" %>
 
  <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -39,7 +40,7 @@
     <c:if test="${showName}">
         <td style="width: 10%; white-space: nowrap">
             <%  String name = sess.getAddress().getNode(); %>
-            <a href="session-details.jsp?jid=<%= URLEncoder.encode(sess.getAddress().toString(), "UTF-8") %>" title="<fmt:message key='session.row.click' />"
+            <a href="session-details.jsp?jid=<%= URLEncoder.encode(sess.getAddress().toString(), StandardCharsets.UTF_8) %>" title="<fmt:message key='session.row.click' />"
             ><%= ((!sessionManager.isAnonymousRoute(sess.getUsername())) ? JID.unescapeNode(name): "<i>"+LocaleUtils.getLocalizedString("session.details.anonymous")+"</i>") %></a>
         </td>
     </c:if>
@@ -229,7 +230,7 @@
     </c:if>
 
     <td style="width: 1%; white-space: nowrap; text-align: center;">
-        <a href="session-summary.jsp?jid=<%= URLEncoder.encode(sess.getAddress().toString(), "UTF-8") %>&close=true&csrf=${csrf}"
+        <a href="session-summary.jsp?jid=<%= URLEncoder.encode(sess.getAddress().toString(), StandardCharsets.UTF_8) %>&close=true&csrf=${csrf}"
          title="<fmt:message key="session.row.click_kill_session" />"
          onclick="return confirm('<fmt:message key="session.row.confirm_close" />');"
          ><img src="images/delete-16x16.gif" alt=""></a>

--- a/xmppserver/src/main/webapp/setup/setup-admin-settings_test.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-admin-settings_test.jsp
@@ -21,13 +21,14 @@
 <%@ page import="java.net.URLDecoder" %>
 <%@ page import="javax.naming.ldap.Rdn" %>
 <%@ page import="org.jivesoftware.util.StringUtils" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="admin" prefix="admin"%>
 
 <%
-    String username = URLDecoder.decode( ParamUtils.getParameter( request, "username"), "UTF-8" );
+    String username = URLDecoder.decode( ParamUtils.getParameter( request, "username"), StandardCharsets.UTF_8);
     String password = ParamUtils.getParameter(request, "password");
     boolean ldap = "true".equals(request.getParameter("ldap"));
 

--- a/xmppserver/src/main/webapp/system-clustering.jsp
+++ b/xmppserver/src/main/webapp/system-clustering.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -360,12 +360,12 @@
             %>
               <tr class="<%= (isLocalMember ? "local" : "") %>" style="vertical-align: middle">
                   <td style="width: 1%; text-align: center">
-                      <a href="plugins/<%= CacheFactory.getPluginName() %>/system-clustering-node.jsp?UID=<%= URLEncoder.encode(nodeID, StandardCharsets.UTF_8.name()) %>"
+                      <a href="plugins/<%= CacheFactory.getPluginName() %>/system-clustering-node.jsp?UID=<%= URLEncoder.encode(nodeID, StandardCharsets.UTF_8) %>"
                        title="Click for more details"
                        ><img src="images/server-network-24x24.gif" width="24" height="24" alt=""></a>
                   </td>
                   <td class="jive-description" style="width: 1%; white-space: nowrap; vertical-align: middle">
-                      <a href="plugins/<%= CacheFactory.getPluginName() %>/system-clustering-node.jsp?UID=<%= URLEncoder.encode(nodeID, StandardCharsets.UTF_8.name()) %>">
+                      <a href="plugins/<%= CacheFactory.getPluginName() %>/system-clustering-node.jsp?UID=<%= URLEncoder.encode(nodeID, StandardCharsets.UTF_8) %>">
                       <%  if (isLocalMember) { %>
                           <b><%= nodeInfo.getHostName() %></b>
                       <%  } else { %>

--- a/xmppserver/src/main/webapp/system-emailtest.jsp
+++ b/xmppserver/src/main/webapp/system-emailtest.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
-  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 %>
 <%@ page import="java.text.SimpleDateFormat"%>
 <%@ page import="org.xmpp.packet.JID" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -238,7 +239,7 @@ function checkClick() {
             <input type="hidden" name="from" value="<%= StringUtils.escapeForXML(from) %>">
             <%= StringUtils.escapeHTMLTags(from) %>
             <span class="jive-description">
-            (<a href="user-edit-form.jsp?username=<%= URLEncoder.encode(user.getUsername(), "UTF-8")%>"><fmt:message key="system.emailtest.update-address" /></a>)
+            (<a href="user-edit-form.jsp?username=<%= URLEncoder.encode(user.getUsername(), StandardCharsets.UTF_8)%>"><fmt:message key="system.emailtest.update-address" /></a>)
             </span>
         </td>
     </tr>

--- a/xmppserver/src/main/webapp/user-create.jsp
+++ b/xmppserver/src/main/webapp/user-create.jsp
@@ -33,6 +33,7 @@
 <%@ page import="org.jivesoftware.openfire.group.GroupNotFoundException" %>
 <%@ page import="org.jivesoftware.openfire.group.Group" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -160,7 +161,7 @@
                 }
                 else {
                     response.sendRedirect("user-properties.jsp?success=true&username=" +
-                            URLEncoder.encode(newUser.getUsername(), "UTF-8"));
+                            URLEncoder.encode(newUser.getUsername(), StandardCharsets.UTF_8));
                 }
                 return;
             }

--- a/xmppserver/src/main/webapp/user-delete.jsp
+++ b/xmppserver/src/main/webapp/user-delete.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 <%@ page import="org.xmpp.packet.JID" %>
 <%@ page import="org.xmpp.packet.StreamError" %>
 <%@ page import="java.net.URLEncoder" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -53,7 +54,7 @@
 
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("user-properties.jsp?username=" + URLEncoder.encode(username, "UTF-8"));
+        response.sendRedirect("user-properties.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
         return;
     }
 
@@ -94,7 +95,7 @@
     <head>
         <title><fmt:message key="user.delete.title"/></title>
         <meta name="subPageID" content="user-delete"/>
-        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, "UTF-8") %>"/>
+        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, StandardCharsets.UTF_8) %>"/>
         <meta name="helpPage" content="remove_a_user_from_the_system.html"/>
     </head>
     <body>
@@ -107,7 +108,7 @@
 
 <p>
 <fmt:message key="user.delete.info" />
-<b><a href="user-properties.jsp?username=<%= URLEncoder.encode(user.getUsername(), "UTF-8") %>"><%= StringUtils.escapeHTMLTags(JID.unescapeNode(user.getUsername())) %></a></b>
+<b><a href="user-properties.jsp?username=<%= URLEncoder.encode(user.getUsername(), StandardCharsets.UTF_8) %>"><%= StringUtils.escapeHTMLTags(JID.unescapeNode(user.getUsername())) %></a></b>
 <fmt:message key="user.delete.info1" />
 </p>
 

--- a/xmppserver/src/main/webapp/user-edit-form.jsp
+++ b/xmppserver/src/main/webapp/user-edit-form.jsp
@@ -28,6 +28,7 @@
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="org.jivesoftware.openfire.admin.AdminManager" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -57,7 +58,7 @@
 
     // Handle a cancel
     if (request.getParameter("cancel") != null) {
-        response.sendRedirect("user-properties.jsp?username=" + URLEncoder.encode(username, "UTF-8"));
+        response.sendRedirect("user-properties.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
         return;
     }
 
@@ -99,7 +100,7 @@
             }
 
             // Changes good, so redirect
-            response.sendRedirect("user-properties.jsp?editsuccess=true&username=" + URLEncoder.encode(username, "UTF-8"));
+            response.sendRedirect("user-properties.jsp?editsuccess=true&username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
             return;
         }
     }
@@ -112,7 +113,7 @@
     <head>
         <title><fmt:message key="user.edit.form.title"/></title>
         <meta name="subPageID" content="user-properties"/>
-        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, "UTF-8") %>"/>
+        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, StandardCharsets.UTF_8) %>"/>
     </head>
     <body>
 

--- a/xmppserver/src/main/webapp/user-groups.jsp
+++ b/xmppserver/src/main/webapp/user-groups.jsp
@@ -27,6 +27,7 @@
 <%@ page import="org.xmpp.packet.JID"%>
 <%@ page import="java.net.URLEncoder"%>
 <%@ page import="java.util.*"%>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
@@ -63,7 +64,7 @@
         try {
             Group group = webManager.getGroupManager().getGroup(add);
             group.getMembers().add(jid);
-            response.sendRedirect("user-groups.jsp?username=" + URLEncoder.encode(username, "UTF-8") + "&updatesuccess=true");
+            response.sendRedirect("user-groups.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8) + "&updatesuccess=true");
         } catch (GroupNotFoundException exp) {
             return;
         }
@@ -74,7 +75,7 @@
             Group group = webManager.getGroupManager().getGroup(delete);
             group.getMembers().remove(jid);
             group.getAdmins().remove(jid);
-            response.sendRedirect("user-groups.jsp?username=" + URLEncoder.encode(username, "UTF-8") + "&updatesuccess=true");
+            response.sendRedirect("user-groups.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8) + "&updatesuccess=true");
         } catch (GroupNotFoundException exp) {
             return;
         }
@@ -143,7 +144,7 @@
 <title><fmt:message key="user.groups.title" /></title>
 <meta name="subPageID" content="user-groups" />
 <meta name="extraParams"
-    content="<%="username="+URLEncoder.encode(username, "UTF-8")%>" />
+    content="<%="username="+URLEncoder.encode(username, StandardCharsets.UTF_8)%>" />
 </head>
 <body>
     <p>
@@ -173,7 +174,7 @@
                     }
                                                             int x = 0;
                                                             for (Group group : userGroups) {
-                                                                String groupName = URLEncoder.encode(group.getName(), "UTF-8");
+                                                                String groupName = URLEncoder.encode(group.getName(), StandardCharsets.UTF_8);
                                                                 x++;
                 %>
                 <tr>
@@ -187,7 +188,7 @@
  %></td>
 
                     <td style="width: 5%"><a
-                        href="user-groups.jsp?username=<%=URLEncoder.encode(user.getUsername(), "UTF-8")%>&delete=<%=groupName%>&csrf=${csrf}"
+                        href="user-groups.jsp?username=<%=URLEncoder.encode(user.getUsername(), StandardCharsets.UTF_8)%>&delete=<%=groupName%>&csrf=${csrf}"
                         title="<fmt:message key="global.click_delete" />"><img
                             src="images/delete-16x16.gif"
                             alt="<fmt:message key="global.click_delete" />"></a></td>
@@ -260,7 +261,7 @@
                     boolean isCurrent = (i + 1) == curPage;
         %>
         <a
-            href="user-groups.jsp?username=<%=StringUtils.escapeForXML(user.getUsername())%>&start=<%=(i * range)%><%=search != null ? "&search=" + URLEncoder.encode(search, "UTF-8") : ""%>"
+            href="user-groups.jsp?username=<%=StringUtils.escapeForXML(user.getUsername())%>&start=<%=(i * range)%><%=search != null ? "&search=" + URLEncoder.encode(search, StandardCharsets.UTF_8) : ""%>"
             class="<%=((isCurrent) ? "jive-current" : "")%>"><%=(i + 1)%></a><%=sep%>
 
         <%
@@ -297,7 +298,7 @@
                     }
                     int i = 0;
                     for (Group group : groups.subList(start, groupIndex)) {
-                        String groupName = URLEncoder.encode(group.getName(), "UTF-8");
+                        String groupName = URLEncoder.encode(group.getName(), StandardCharsets.UTF_8);
                         i++;
                 %>
                 <tr>
@@ -311,7 +312,7 @@
  %></td>
 
                     <td style="width: 5%"><a
-                        href="user-groups.jsp?username=<%=URLEncoder.encode(user.getUsername(), "UTF-8")%>&add=<%=groupName%>&csrf=${csrf}"
+                        href="user-groups.jsp?username=<%=URLEncoder.encode(user.getUsername(), StandardCharsets.UTF_8)%>&add=<%=groupName%>&csrf=${csrf}"
                         title="<fmt:message key="global.click_add" />"> <img
                             src="images/add-16x16.gif"
                             alt="<fmt:message key="global.click_add" />"></a></td>
@@ -336,7 +337,7 @@
                     boolean isCurrent = (i + 1) == curPage;
         %>
         <a
-            href="user-groups.jsp?username=<%=StringUtils.escapeForXML(user.getUsername())%>&start=<%=(i * range)%><%=search != null ? "&search=" + URLEncoder.encode(search, "UTF-8") : ""%>"
+            href="user-groups.jsp?username=<%=StringUtils.escapeForXML(user.getUsername())%>&start=<%=(i * range)%><%=search != null ? "&search=" + URLEncoder.encode(search, StandardCharsets.UTF_8) : ""%>"
             class="<%=((isCurrent) ? "jive-current" : "")%>"><%=(i + 1)%></a><%=sep%>
 
         <%

--- a/xmppserver/src/main/webapp/user-lockout.jsp
+++ b/xmppserver/src/main/webapp/user-lockout.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@
 <%@ page import="org.xmpp.packet.StreamError" %>
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="java.util.Date" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -41,7 +42,7 @@
     boolean unlock = request.getParameter("unlock") != null;
     boolean lock = request.getParameter("lock") != null;
     String username = ParamUtils.getParameter(request,"username");
-    String usernameUrlEncoded = URLEncoder.encode(username, "UTF-8");
+    String usernameUrlEncoded = URLEncoder.encode(username, StandardCharsets.UTF_8);
     long startdelay = ParamUtils.getLongParameter(request,"startdelay",-1); // -1 is immediate, -2 custom
     long duration = ParamUtils.getLongParameter(request,"duration",-1); // -1 is infinite, -2 custom
     if (startdelay == -2) {

--- a/xmppserver/src/main/webapp/user-message.jsp
+++ b/xmppserver/src/main/webapp/user-message.jsp
@@ -1,8 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
-
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -30,6 +29,7 @@
     errorPage="error.jsp"
 %>
 <%@ page import="java.util.Map" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -56,7 +56,7 @@
             return;
         }
         else {
-            response.sendRedirect("user-properties.jsp?username=" + URLEncoder.encode(username, "UTF-8"));
+            response.sendRedirect("user-properties.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
             return;
         }
     }
@@ -119,7 +119,7 @@
             }
             if (username != null){
                 response.sendRedirect("user-message.jsp?success=true&username=" +
-                        URLEncoder.encode(username, "UTF-8") + "&tabs=" + tabs);
+                        URLEncoder.encode(username, StandardCharsets.UTF_8) + "&tabs=" + tabs);
             }
             else {
                 response.sendRedirect("user-message.jsp?success=true");

--- a/xmppserver/src/main/webapp/user-password.jsp
+++ b/xmppserver/src/main/webapp/user-password.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
     errorPage="error.jsp"
 %><%@ page import="org.xmpp.packet.JID"%>
 <%@ page import="org.jivesoftware.openfire.security.SecurityAuditManager" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -49,7 +50,7 @@
 
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("user-properties.jsp?username=" + URLEncoder.encode(username, "UTF-8"));
+        response.sendRedirect("user-properties.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
         return;
     }
 
@@ -69,7 +70,7 @@
                     admin.logEvent("set password for user "+username, null);
                 }
                 // Done, so redirect
-                response.sendRedirect("user-password.jsp?success=true&username=" + URLEncoder.encode(username, "UTF-8"));
+                response.sendRedirect("user-password.jsp?success=true&username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
                 return;
             }
             catch (UnsupportedOperationException uoe) {
@@ -86,7 +87,7 @@
     <head>
         <title><fmt:message key="user.password.title"/></title>
         <meta name="subPageID" content="user-password"/>
-        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, "UTF-8") %>"/>
+        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, StandardCharsets.UTF_8) %>"/>
         <meta name="helpPage" content="change_a_user_password.html"/>
     </head>
     <body>

--- a/xmppserver/src/main/webapp/user-privacylists.jsp
+++ b/xmppserver/src/main/webapp/user-privacylists.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2020-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2020-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 <%@ page import="org.jivesoftware.openfire.privacy.PrivacyListProvider" %>
 <%@ page import="org.jivesoftware.openfire.privacy.PrivacyList" %>
 <%@ page import="org.jivesoftware.openfire.privacy.PrivacyListManager" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -57,7 +58,7 @@
 <head>
 <title><fmt:message key="user.privacylists.title" /></title>
 <meta name="subPageID" content="user-privacylists" />
-<meta name="extraParams" content="<%="username="+URLEncoder.encode(username, "UTF-8")%>" />
+<meta name="extraParams" content="<%="username="+URLEncoder.encode(username, StandardCharsets.UTF_8)%>" />
 </head>
 <body>
     <p>

--- a/xmppserver/src/main/webapp/user-properties.jsp
+++ b/xmppserver/src/main/webapp/user-properties.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@
 <%@ page import="java.util.Collection" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="org.jivesoftware.util.StringUtils" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -53,13 +54,13 @@
 
     // Handle a delete
     if (delete) {
-        response.sendRedirect("user-delete.jsp?username=" + URLEncoder.encode(username, "UTF-8"));
+        response.sendRedirect("user-delete.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
         return;
     }
 
     // Handle password change
     if (password) {
-        response.sendRedirect("user-password.jsp?username=" + URLEncoder.encode(username, "UTF-8"));
+        response.sendRedirect("user-password.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
         return;
     }
 
@@ -90,7 +91,7 @@
     <head>
         <title><fmt:message key="user.properties.title"/></title>
         <meta name="subPageID" content="user-properties"/>
-        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, "UTF-8") %>"/>
+        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, StandardCharsets.UTF_8) %>"/>
         <meta name="helpPage" content="edit_user_properties.html"/>
     </head>
     <body>

--- a/xmppserver/src/main/webapp/user-roster-add.jsp
+++ b/xmppserver/src/main/webapp/user-roster-add.jsp
@@ -29,6 +29,7 @@
 <%@ page import="org.jivesoftware.openfire.user.UserAlreadyExistsException" %>
 <%@ page import="org.jivesoftware.openfire.SharedGroupException" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -49,7 +50,7 @@
     Map<String, String> errors = new HashMap<>();
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, "UTF-8"));
+        response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
         return;
     }
     Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
@@ -88,9 +89,9 @@
 
                 // Successful, so redirect
                 if (another) {
-                    response.sendRedirect("user-roster-add.jsp?success=true&username=" + URLEncoder.encode(username, "UTF-8"));
+                    response.sendRedirect("user-roster-add.jsp?success=true&username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
                 } else {
-                    response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, "UTF-8") + "&addsuccess=true");
+                    response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8) + "&addsuccess=true");
                 }
                 return;
             }
@@ -117,7 +118,7 @@
     <head>
         <title><fmt:message key="user.roster.add.title"/></title>
         <meta name="subPageID" content="user-roster"/>
-        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, "UTF-8") %>"/>
+        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, StandardCharsets.UTF_8) %>"/>
     </head>
     <body>
 

--- a/xmppserver/src/main/webapp/user-roster-delete.jsp
+++ b/xmppserver/src/main/webapp/user-roster-delete.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
     errorPage="error.jsp"
 %>
 <%@ page import="org.jivesoftware.openfire.roster.Roster" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -34,7 +35,7 @@
     boolean cancel = request.getParameter("cancel") != null;
     boolean delete = request.getParameter("delete") != null;
     String username = ParamUtils.getParameter(request, "username");
-    String usernameUrlEncoded = URLEncoder.encode(username, "UTF-8");
+    String usernameUrlEncoded = URLEncoder.encode(username, StandardCharsets.UTF_8);
     String jid = ParamUtils.getParameter(request, "jid");
 
     pageContext.setAttribute( "username", username);

--- a/xmppserver/src/main/webapp/user-roster-edit.jsp
+++ b/xmppserver/src/main/webapp/user-roster-edit.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="org.jivesoftware.openfire.group.Group" %>
 <%@ page import="java.util.Collection" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -46,7 +47,7 @@
 
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, "UTF-8"));
+        response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
         return;
     }
 
@@ -84,7 +85,7 @@
         // Log the event
         webManager.logEvent("updated roster item for "+username, "roster item:\njid = "+jid+"\nnickname = "+nickname+"\ngroupList = "+groupList);
         // Done, so redirect
-        response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, "UTF-8") + "&editsuccess=true");
+        response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8) + "&editsuccess=true");
         return;
     }
 %>
@@ -93,7 +94,7 @@
     <head>
         <title><fmt:message key="user.roster.edit.title"/></title>
         <meta name="subPageID" content="user-roster"/>
-        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, "UTF-8") %>"/>
+        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, StandardCharsets.UTF_8) %>"/>
     </head>
     <body>
 
@@ -166,7 +167,7 @@
                         if (count != 0) {
                             out.print(",");
                         }
-                        out.print("<a href='group-edit.jsp?group="+URLEncoder.encode(group.getName(), "UTF-8")+"'>");
+                        out.print("<a href='group-edit.jsp?group="+URLEncoder.encode(group.getName(), StandardCharsets.UTF_8)+"'>");
                         out.print(StringUtils.escapeForXML(group.getName()));
                         out.print("</a>");
                         count++;

--- a/xmppserver/src/main/webapp/user-roster-view.jsp
+++ b/xmppserver/src/main/webapp/user-roster-view.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="org.jivesoftware.openfire.group.Group" %>
 <%@ page import="java.util.Collection" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -44,7 +45,7 @@
 
     // Handle a cancel
     if (cancel) {
-        response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, "UTF-8"));
+        response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8));
         return;
     }
 
@@ -81,7 +82,7 @@
         // Log the event
         webManager.logEvent("deleted roster item from "+username, "roster item:\njid = "+jid);
         // Done, so redirect
-        response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, "UTF-8") + "&editsuccess=true");
+        response.sendRedirect("user-roster.jsp?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8) + "&editsuccess=true");
         return;
     }
 %>
@@ -90,7 +91,7 @@
     <head>
         <title><fmt:message key="user.roster.edit.title"/></title>
         <meta name="subPageID" content="user-roster"/>
-        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, "UTF-8") %>"/>
+        <meta name="extraParams" content="<%= "username="+URLEncoder.encode(username, StandardCharsets.UTF_8) %>"/>
     </head>
     <body>
 
@@ -157,7 +158,7 @@
                             if (count != 0) {
                                 out.print(",");
                             }
-                            out.print("<a href='group-edit.jsp?group="+URLEncoder.encode(group.getName(), "UTF-8")+"'>");
+                            out.print("<a href='group-edit.jsp?group="+URLEncoder.encode(group.getName(), StandardCharsets.UTF_8)+"'>");
                             out.print(StringUtils.escapeForXML(group.getName()));
                             out.print("</a>");
                             count++;

--- a/xmppserver/src/main/webapp/user-roster.jsp
+++ b/xmppserver/src/main/webapp/user-roster.jsp
@@ -28,6 +28,7 @@
 <%@ page import="java.util.*" %>
 <%@ page import="org.jivesoftware.openfire.group.Group" %>
 <%@ page import="org.xmpp.packet.JID" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%!
     final int DEFAULT_RANGE = 15;
@@ -62,7 +63,7 @@
     // Get parameters //
     String username = ParamUtils.getParameter(request, "username");
 
-    String usernameUrlEncoded = URLEncoder.encode(username, "UTF-8");
+    String usernameUrlEncoded = URLEncoder.encode(username, StandardCharsets.UTF_8);
     pageContext.setAttribute( "usernameUrlEncoded", usernameUrlEncoded);
     pageContext.setAttribute( "usernameHtmlEscaped", StringUtils.escapeHTMLTags(JID.unescapeNode(username)) );
 
@@ -276,7 +277,7 @@
             <%= i %>
         </td>
         <td>
-            <a href="user-roster-view.jsp?username=${usernameUrlEncoded}&jid=<%= URLEncoder.encode(rosterItem.getJid().toString(), "UTF-8") %>"
+            <a href="user-roster-view.jsp?username=${usernameUrlEncoded}&jid=<%= URLEncoder.encode(rosterItem.getJid().toString(), StandardCharsets.UTF_8) %>"
              title="<fmt:message key="user.roster.click_view" />"
              ><%= rosterItem.getJid() %></a>
         </td>
@@ -303,7 +304,7 @@
                             if (count != 0) {
                                 out.print(", ");
                             }
-                            out.print("<a style='text-decoration: underline' href='group-edit.jsp?group="+URLEncoder.encode(group.getName(), "UTF-8")+"'>");
+                            out.print("<a style='text-decoration: underline' href='group-edit.jsp?group="+URLEncoder.encode(group.getName(), StandardCharsets.UTF_8)+"'>");
                             out.print(StringUtils.escapeHTMLTags(group.getName()));
                             out.print("</a>");
                             count++;
@@ -321,13 +322,13 @@
             <%= rosterItem.getSubStatus().getName() %>
         </td>
         <td style="width: 1%; text-align: center">
-            <a href="user-roster-edit.jsp?username=${usernameUrlEncoded}&jid=<%= URLEncoder.encode(rosterItem.getJid().toString(), "UTF-8") %>"
+            <a href="user-roster-edit.jsp?username=${usernameUrlEncoded}&jid=<%= URLEncoder.encode(rosterItem.getJid().toString(), StandardCharsets.UTF_8) %>"
              title="<fmt:message key="global.click_edit" />"
              ><img src="images/edit-16x16.gif" alt="<fmt:message key="global.click_edit" />"></a>
         </td>
         <td style="width: 1%; text-align: center; border-right:1px #ccc solid;">
             <% if (sharedGroups.isEmpty()) { %>
-            <a href="user-roster-delete.jsp?username=${usernameUrlEncoded}&jid=<%= URLEncoder.encode(rosterItem.getJid().toString(), "UTF-8") %>"
+            <a href="user-roster-delete.jsp?username=${usernameUrlEncoded}&jid=<%= URLEncoder.encode(rosterItem.getJid().toString(), StandardCharsets.UTF_8) %>"
              title="<fmt:message key="global.click_delete" />"
              ><img src="images/delete-16x16.gif" alt="<fmt:message key="global.click_delete" />"></a>
             <% } else { %>

--- a/xmppserver/src/main/webapp/user-search.jsp
+++ b/xmppserver/src/main/webapp/user-search.jsp
@@ -24,6 +24,7 @@
                  java.util.Map,
                  java.net.URLEncoder"
 %><%@ page import="org.xmpp.packet.JID"%>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -55,7 +56,7 @@
         if (user != null) {
             // found the user, so redirect to the user properties page:
             response.sendRedirect("user-properties.jsp?username=" +
-                    URLEncoder.encode(user.getUsername(), "UTF-8"));
+                    URLEncoder.encode(user.getUsername(), StandardCharsets.UTF_8));
             return;
         }
     }

--- a/xmppserver/src/main/webapp/user-summary.jsp
+++ b/xmppserver/src/main/webapp/user-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@
 <%@ page import="org.xmpp.packet.Presence" %>
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="java.util.Collection" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -224,7 +225,7 @@
             <%  } %>
         </td>
         <td style="width: 20%">
-            <a href="user-properties.jsp?username=<%= URLEncoder.encode(user.getUsername(), "UTF-8") %>"<%= lockedOut ? " style='text-decoration: line-through underline;'" : "" %>><%= StringUtils.escapeHTMLTags(JID.unescapeNode(user.getUsername())) %></a>
+            <a href="user-properties.jsp?username=<%= URLEncoder.encode(user.getUsername(), StandardCharsets.UTF_8) %>"<%= lockedOut ? " style='text-decoration: line-through underline;'" : "" %>><%= StringUtils.escapeHTMLTags(JID.unescapeNode(user.getUsername())) %></a>
             <% if (isAdmin) { %><img src="/images/star-16x16.gif" alt="<fmt:message key='user.properties.isadmin'/>" title="<fmt:message key='user.properties.isadmin'/>"/><% } %>
             <% if (lockedOut) { %><img src="/images/forbidden-16x16.gif" alt="<fmt:message key='user.properties.locked'/>" title="<fmt:message key='user.properties.locked'/>"/><% } %>
             <% if (pendingLockOut) { %><img src="/images/warning-16x16.gif" alt="<fmt:message key='user.properties.locked_set'/>" title="<fmt:message key='user.properties.locked_set'/>"/><% } %>
@@ -246,7 +247,7 @@
                         if (count != 0) {
                             out.print(", ");
                         }
-                        %><a href="group-edit.jsp?group=<%= URLEncoder.encode(group.getName(), "UTF-8") %>"><%= StringUtils.escapeHTMLTags(JID.unescapeNode(group.getName())) %></a><%
+                        %><a href="group-edit.jsp?group=<%= URLEncoder.encode(group.getName(), StandardCharsets.UTF_8) %>"><%= StringUtils.escapeHTMLTags(JID.unescapeNode(group.getName())) %></a><%
                         count++;
                     }
                 }
@@ -277,12 +278,12 @@
          <%  // Don't allow editing or deleting if users are read-only.
             if (!UserManager.getUserProvider().isReadOnly()) { %>
         <td style="width: 1%; text-align: center">
-            <a href="user-edit-form.jsp?username=<%= URLEncoder.encode(user.getUsername(), "UTF-8") %>"
+            <a href="user-edit-form.jsp?username=<%= URLEncoder.encode(user.getUsername(), StandardCharsets.UTF_8) %>"
              title="<fmt:message key="global.click_edit" />"
              ><img src="images/edit-16x16.gif" alt="<fmt:message key="global.click_edit" />"></a>
         </td>
         <td style="width: 1%; text-align: center; border-right:1px #ccc solid;">
-            <a href="user-delete.jsp?username=<%= URLEncoder.encode(user.getUsername(), "UTF-8") %>"
+            <a href="user-delete.jsp?username=<%= URLEncoder.encode(user.getUsername(), StandardCharsets.UTF_8) %>"
              title="<fmt:message key="global.click_delete" />"
              ><img src="images/delete-16x16.gif" alt="<fmt:message key="global.click_delete" />"></a>
         </td>


### PR DESCRIPTION
Slightly faster, as no lookups are needed, and no longer needs to catch UnsupportedEncodingException in some cases.