### PR TITLE
OF-3044: When resource binding, ensure that old detached sessions are removed

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -284,7 +284,8 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         // OF-1923: Only close the session if it has not been replaced by another session (if the session
         // has been replaced, then the condition below will compare to distinct instances). This *should* not
         // occur (but has been observed, prior to the fix of OF-1923). This check is left in as a safeguard.
-        if (session == routingTable.getClientRoute(session.getAddress())) {
+        final ClientSession currentSession = routingTable.getClientRoute(session.getAddress());
+        if (session == currentSession) {
             try {
                 if ((clientSession.getPresence().isAvailable() || !clientSession.wasAvailable()) &&
                     routingTable.hasClientRoute(session.getAddress())) {
@@ -303,7 +304,8 @@ public class SessionManager extends BasicModule implements ClusterEventListener
                 removeSession(clientSession);
             }
         } else {
-            Log.warn("Not removing detached session '{}' ({}) that appears to have been replaced by another session.", session.getAddress(), session.getStreamID());
+            // This could be the start of data state inconsistency. See OF-3044.
+            Log.warn("Not removing detached session '{}' ({}) that appears to have been replaced by another session. New session: {} - original session {}", session.getAddress(), session.getStreamID(), currentSession, session);
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
@@ -25,7 +25,10 @@ import org.jivesoftware.openfire.auth.AuthToken;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.event.SessionEventDispatcher;
 import org.jivesoftware.openfire.session.ClientSession;
+import org.jivesoftware.openfire.session.ClientSessionTask;
 import org.jivesoftware.openfire.session.LocalClientSession;
+import org.jivesoftware.openfire.session.RemoteSessionTask;
+import org.jivesoftware.util.cache.CacheFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.IQ;
@@ -111,38 +114,51 @@ public class IQBindHandler extends IQHandler {
             String username = authToken.getUsername().toLowerCase();
             // If a session already exists with the requested JID, then check to see
             // if we should kick it off or refuse the new connection
-            ClientSession oldSession = routingTable.getClientRoute(new JID(username, serverName, resource, true));
-            if (oldSession != null && !oldSession.isClosed()) {
+            final JID desiredJid = new JID(username, serverName, resource, true);
+            ClientSession oldSession = routingTable.getClientRoute(desiredJid);
+            if (oldSession != null) {
                 try {
-                    int conflictLimit = sessionManager.getConflictKickLimit();
-                    if (conflictLimit == SessionManager.NEVER_KICK) {
-                        reply.setChildElement(packet.getChildElement().createCopy());
-                        reply.setError(PacketError.Condition.conflict);
-                        // Send the error directly since a route does not exist at this point.
-                        session.process(reply);
-                        return null;
+                    if (oldSession.isClosed()) {
+                        // If there's an old session that's already closed, then this could be a detached session. The
+                        // new session does not conflict with the old one, but the old one needs to be cleaned up to
+                        // prevent data consistency issues (OF-3044).
+                        Log.debug("Instructing all cluster nodes to remove any detached session for '{}' as a new session is binding to that resource.", desiredJid);
+                        CacheFactory.doSynchronousClusterTask(new ClientSessionTask(desiredJid, RemoteSessionTask.Operation.removeDetached), true);
                     }
-
-                    int conflictCount = oldSession.incrementConflictCount();
-                    if (conflictCount > conflictLimit) {
-                        Log.debug( "Kick out an old connection that is conflicting with a new one. Old session: {}", oldSession );
-                        StreamError error = new StreamError(StreamError.Condition.conflict);
-                        oldSession.deliverRawText(error.toXML());
-                        oldSession.close(); // When living on a remote cluster node, this will prevent that session from becoming 'resumable'.
-
-                        // OF-1923: As the session is now replaced, the old session will never be resumed.
-                        if ( oldSession instanceof LocalClientSession ) {
-                            // As the new session has already replaced the old session, we're not explicitly closing
-                            // the old session again, as that would cause the state of the new session to be affected.
-                            sessionManager.removeDetached((LocalClientSession) oldSession);
+                    else
+                    {
+                        Log.debug("Found a pre-existing, non-closed session for '{}'. Performing resource conflict resolution.", desiredJid);
+                        int conflictLimit = sessionManager.getConflictKickLimit();
+                        if (conflictLimit == SessionManager.NEVER_KICK) {
+                            Log.debug("Conflict resolution configuration is 'NEVER KICK'. Rejecting the bind request with error condition 'conflict'.");
+                            reply.setChildElement(packet.getChildElement().createCopy());
+                            reply.setError(PacketError.Condition.conflict);
+                            // Send the error directly since a route does not exist at this point.
+                            session.process(reply);
+                            return null;
                         }
-                    }
-                    else {
-                        reply.setChildElement(packet.getChildElement().createCopy());
-                        reply.setError(PacketError.Condition.conflict);
-                        // Send the error directly since a route does not exist at this point.
-                        session.process(reply);
-                        return null;
+
+                        int conflictCount = oldSession.incrementConflictCount();
+                        if (conflictCount > conflictLimit) {
+                            Log.debug("Kick out an old connection that is conflicting with a new one. Old session: {}", oldSession);
+                            StreamError error = new StreamError(StreamError.Condition.conflict);
+                            oldSession.deliverRawText(error.toXML());
+                            oldSession.close(); // When living on a remote cluster node, this will prevent that session from becoming 'resumable'.
+
+                            // OF-1923: As the session is now replaced, the old session will never be resumed.
+                            if (oldSession instanceof LocalClientSession) {
+                                // As the new session has already replaced the old session, we're not explicitly closing
+                                // the old session again, as that would cause the state of the new session to be affected.
+                                sessionManager.removeDetached((LocalClientSession) oldSession);
+                            }
+                        } else {
+                            Log.debug("Conflict resolution configuration does not allow kicking of old session (yet). Conflict count: {}, conflict limit: {}. Rejecting the bind request with error condition 'conflict'.", conflictCount, conflictLimit);
+                            reply.setChildElement(packet.getChildElement().createCopy());
+                            reply.setError(PacketError.Condition.conflict);
+                            // Send the error directly since a route does not exist at this point.
+                            session.process(reply);
+                            return null;
+                        }
                     }
                 }
                 catch (Exception e) {


### PR DESCRIPTION
After resource binding succeeds, clean-up of older, detached sessions will be problematic (as that needs to update state, but typically also sends out presence unavailable on behalf of the user).

In this commit, any detached sessions matching the full JID that will be the result of a successful resource binding is terminated, prior to resource binding being allowed to complete.