### PR TITLE
OF-3054: HybridUserProvider throws IndexOutOfBoundsException

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserMultiProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserMultiProvider.java
@@ -302,7 +302,7 @@ public abstract class UserMultiProvider implements UserProvider
                 final int providerResultMax = numResults - userList.size();
                 final List<User> providerList = providerResults instanceof List<?> ?
                         (List<User>) providerResults : new ArrayList<>( providerResults );
-                userList.addAll( providerList.subList( providerStartIndex, providerResultMax ) );
+                userList.addAll( providerList.subList( providerStartIndex, Math.min( providerList.size(), providerResultMax ) ));
 
                 // Check if we have enough results.
                 if ( userList.size() >= numResults )


### PR DESCRIPTION
HybridUserProvider throws IndexOutOfBoundsException when trying to rerieve users with a paged search.

When using the function UserProvider.findUSers( crit, query, index, maxPage ) and a configured HybridUserProvider, an exception is thrown: 
java.lang.IndexOutOfBoundsException: toIndex = 50
	at java.util.AbstractList.subListRangeCheck(AbstractList.java:509) ~[?:?]
	at java.util.ArrayList.subList(ArrayList.java:1190) ~[?:?]
	at org.jivesoftware.openfire.user.UserMultiProvider.findUsers(UserMultiProvider.java:306) ~[xmppserver-5.0.0-alpha-org.jar:5.0.0-alpha]
	at org.jivesoftware.openfire.user.UserManager.findUsers(UserManager.java:418) ~[xmppserver-5.0.0-alpha-org.jar:5.0.0-alpha]

Solved by conditionally setting the toIndex value.
