### PR TITLE
DRAFT: Get client sessions irrespectively of their presence state

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
@@ -23,6 +23,7 @@ import org.xmpp.packet.Packet;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * <p>Maintains server-wide knowledge of routes to any node.</p>
@@ -205,12 +206,24 @@ public interface RoutingTable {
     /**
      * Returns the client session associated to the specified XMPP address or {@code null}
      * if none was found. When running inside of a cluster and a remote node is hosting
-     * the client session then a session surrage will be returned.
+     * the client session then a session surrogate will be returned.
      *
      * @param jid the address of the session.
      * @return the client session associated to the specified XMPP address or null if none was found.
      */
     ClientSession getClientRoute(JID jid);
+
+    /**
+     * Returns the client sessions associated to the specified XMPP address or an empty collection
+     * if none were found. When running inside of a cluster and a remote node is hosting
+     * the client session then a session surrogate will be returned. When the provided address is
+     * a full JID, at most one session is returned. If a bare JID is provided, then all sessions
+     * associated to the user will be returned.
+     *
+     * @param jid the address of the session.
+     * @return the client session associated to the specified XMPP address or null if none was found.
+     */
+    Set<ClientSession> getClientRoutes(JID jid);
 
     /**
      * Returns collection of client sessions authenticated with the server. When running inside

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
@@ -26,63 +26,32 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * <p>Maintains server-wide knowledge of routes to any node.</p>
- * <p>Routes are only concerned with node addresses. Destinations are
- * packet handlers (typically of the three following types):</p>
- * <ul>
- * <li>Session - A local or remote session belonging to the server's domain.
- * Remote sessions may be possible in clustered servers.</li>
- * <li>Chatbot - A chatbot which will have various packets routed to it.</li>
- * <li>Transport - A transport for foreign server domains. Foreign domains
- * may be hosted in the same server JVM (e.g. virtual hosted servers, groupchat
- * servers, etc).</li>
- * </ul>
- * <p>In almost all cases, the caller should not be concerned with what
- * handler is associated with a given node. Simply obtain the packet handler
- * and deliver the packet to the node, leaving the details up to the handler.</p>
- * <p>Routes are matched using the stringprep rules given in the XMPP specification.
- * Wildcard routes for a particular name or resource is indicated by a null. E.g.
- * routing to any address at server.com should set the name to null, the host to
- * 'server.com' and the resource to null. A route to the best resource for user@server.com
- * should indicate that route with a null resource component of the XMPPAddress. Session
- * managers should add a route for both the generic user@server.com as well as
- * user@server.com/resource routes (knowing that one is an alias for the other
- * is the responsibility of the session or session manager).</p>
- * <p>In order to accommodate broadcasts, you can also do partial matches by querying
- * all 'child' nodes of a particular node. The routing table contains a forest of
- * node trees. The node tree is arranged in the following hierarchy:</p>
- * <ul>
- * <li>forest - All nodes in the routing table. An XMPP address with host, name, and resource set
- * to null will match all nodes stored in the routing table. Use with extreme caution as the
- * routing table may contain hundreds of thousands of entries and iterators will be produced using
- * a copy of the table for iteration safety.</li>
- * <li>domain root - The root of each node tree is the server domain. An XMPP address
- * containing just a host entry, and null in the name and resource fields will match
- * the domain root. The children will contain both the root entry (if there is one) and
- * all entries with the same host name.</li>
- * <li>user branches - The root's immediate children are the user branches. An
- * XMPP address containing just a hast and name entry, and null in the resource field
- * will match a particular user branch. The children will contain both the user branch
- * (if there is one) and all entries with the same host and name, ignoring resources.
- * This is the most useful for conducting user broadcasts. Note that if the user
- * branch is located on a foreign server, the only route returned will the server-to-server
- * transport.</li>
- * <li>resource leaves - Each user branch can have zero or more resource leaves. A partial
- * match on an XMPP address with values in host, name, and resource fields will be equivalent
- * to the exact match calls since only one route can ever be registered for a particular. See
- * getBestRoute() if you'd like to search for both the resource leaf route, as well as a valid user
- * branch for that node if no leaf exists.</li>
- * </ul>
- * <p>Note: it is important that any component or action affecting routes
- * update the routing table immediately.</p>
+ * Maintains knowledge of routes to any XMPP entity.
+ * <p>
+ * Routes closely relate to sessions (as managed by the {@link SessionManager}). Typically, a session can be routed to
+ * almost immediately after it has been established. <em>Client</em> Sessions are somewhat special, in that they can be
+ * routed to only when they have sent Initial Presence (a variant exists for Clients Sessions to be routable only for
+ * specific entities, when the session has sent those entities Directed Presence).
+ * <p>
+ * Generally speaking, every Route will have an associated Session, but not every Session may have an associated Route.
+ * <p>
+ * As Routes are closely related to sessions, a route is represented by a Session instance. A session will normally
+ * always be obtainable from a SessionManager, but will only be obtainable from a RoutingTable when the session is
+ * 'routable'.
+ * <p>
+ * The information maintained by a routing table is entirely transient and does not need to be preserved between
+ * server restarts.
+ * <p>
+ * Note: it is important that any component or action affecting routes update the routing table immediately.
  *
  * @author Iain Shigeoka
+ * @see SessionManager
  */
 public interface RoutingTable {
 
     /**
      * Adds a route to the routing table for the specified outgoing server session, or replaces a pre-existing one.
-     *
+     * <p>
      * When running inside a cluster, this method <em>must</em> be invoked on the cluster node that is actually holding
      * the physical connection to the remote server. Additionally, replacing a pre-existing server session can only
      * occur on the same cluster node as the one that was holding the original session. A runtime exception is thrown
@@ -94,12 +63,26 @@ public interface RoutingTable {
     void addServerRoute(DomainPair route, LocalOutgoingServerSession destination);
 
     /**
-     * Adds a route to the routing table for the specified internal or external component. <p>
+     * Removes a route from the routing table for the specified outgoing server session.
+     * <p>
+     * When running inside a cluster this message <em>must</em> be sent from the cluster node that is actually holding
+     * the physical connection to the remote server.
+     * <p>
+     * Returns true if a route to an outgoing server has been successfully removed.
      *
-     * When running inside of a cluster this message {@code must} be sent from the cluster
-     * node that is actually hosting the component. The component may be available in all
-     * or some of cluster nodes. The routing table will keep track of all nodes hosting
-     * the component. 
+     * @param route the route to remove.
+     * @return true if the route was successfully removed.
+     */
+    boolean removeServerRoute(DomainPair route);
+
+    /**
+     * Adds a route to the routing table for the specified internal or external component.
+     * <p>
+     * When running inside a cluster this method <em>must</em> be invoked from the cluster node that is actually hosting
+     * the component.
+     * <p>
+     * An internal component may be installed in or an external component may be connected to one, some, or all cluster
+     * nodes. The routing table will keep track of all nodes hosting the component.
      *
      * @param route the address associated to the route.
      * @param destination the component.
@@ -107,46 +90,75 @@ public interface RoutingTable {
     void addComponentRoute(JID route, RoutableChannelHandler destination);
 
     /**
-     * Adds a route to the routing table for the specified client session. The client
-     * session will be added as soon as the user has finished authenticating with the server.
-     * Moreover, when the user becomes available or unavailable then the routing table will
-     * get updated again. When running inside of a cluster this message {@code must} be sent
-     * from the cluster node that is actually holding the client session.
+     * Removes a route from the routing table for the specified internal or external component.
+     * <p>
+     * When running inside a cluster this message <em>must</em> be sent from the cluster node that is actually hosting
+     * the component.
+     * <p>
+     * Returns true if a route of a component has been successfully removed.
+     *
+     * @param route the route to remove.
+     * @return true if a route of a component has been successfully removed.
+     */
+    boolean removeComponentRoute(JID route);
+
+    /**
+     * Adds a route to the routing table for the specified client session.
+     * <p>
+     * The client session will be added as soon as the user has finished authenticating with the server. Moreover, when
+     * the user becomes available or unavailable then the routing table will get updated again.
+     * <p>
+     * When running inside a cluster this method <em>must</em> be invoked from the cluster node that is actually holding
+     * the client session.
      *
      * @param route the address (a full JID) associated to the route.
      * @param destination the client session.
      */
+    // FIXME: "Moreover, when the user becomes available or unavailable then the routing table will get updated again."
+    //        This appears to be true: this method gets invoked when a session is added, but also when it becomes
+    //        available and unavailable. Determine if this is needed, and if so, document why.
     void addClientRoute(JID route, LocalClientSession destination);
 
     /**
-     * Routes a packet to the specified address. The packet destination can be a
-     * user on the local server, a component, or a foreign server.<p>
+     * Removes a route from the routing table for the specified client session.
+     * <p>
+     * When running inside a cluster this message <em>must</em> be sent from the cluster node that is actually hosting
+     * the client session.
+     * <p>
+     * Returns true if a route of a client session has been successfully removed.
      *
-     * When routing a packet to a remote server then a new outgoing connection
-     * will be created to the remote server if none was found and the packet
-     * will be delivered. If an existing outgoing connection already exists then
-     * it will be used for delivering the packet. Moreover, when running inside of a cluster
-     * the node that has the actual outgoing connection will be requested to deliver
-     * the requested packet.<p>
+     * @param route the route to remove.
+     * @return true if a route of a client session has been successfully removed.
+     */
+    boolean removeClientRoute(JID route);
+
+    /**
+     * Routes a stanza to the specified address. The stanza destination can be any XMPP entity, including a user on the
+     * local XMPP domain, a component, or a remote XMPP domain.
+     * <p>
+     * When routing a stanza to a remote XMPP domain, then a new outgoing server connection will be created to a server
+     * belonging to the target domain, if no preexisting outgoing server connection to that domain is available. If an
+     * existing outgoing connection already exists then it will be used for delivering the stanza. Moreover, when
+     * running inside a cluster the node that has the actual outgoing connection will be requested to deliver the
+     * stanza.
+     * <p>
+     * Stanzas routed to components will only be sent if an internal or external component for the target address is
+     * available to the server. Unlike with servers, a new connection will <em>not</em> be established when a component
+     * is not available. When running inside a cluster the node that is hosting the component will be requested to
+     * deliver the stanza. Components available in the local cluster node are preferred. When a component is not
+     * available locally, the first cluster node found hosting the component will be used.
+     * <p>
+     * Stanzas routed to users of the local domain will be delivered if the user is connected to the XMPP domain.
+     * Depending on the stanza type and the sender of the stanza, only available or all user sessions can be considered
+     * for delivery of the stanza. For instance, {@link org.xmpp.packet.Message Messages} and
+     * {@link org.xmpp.packet.Presence Presences} are only sent to available client sessions, whilst
+     * {@link org.xmpp.packet.IQ IQs} originated from the XMPP domain can be sent to available or unavailable
+     * sessions. When running inside a cluster the node that is hosting the user session will be requested to deliver
+     * the requested stanza.
      *
-     * Packets routed to components will only be sent if the internal or external
-     * component is connected to the server. Moreover, when running inside of a cluster
-     * the node that is hosting the component will be requested to deliver the requested
-     * packet. It will be first checked if the component is available in this JVM and if not
-     * then the first cluster node found hosting the component will be used.<p>
-     *
-     * Packets routed to users will be delivered if the user is connected to the server. Depending
-     * on the packet type and the sender of the packet only available or all user sessions could
-     * be considered. For instance, {@link org.xmpp.packet.Message Messages} and
-     * {@link org.xmpp.packet.Presence Presences} are only sent to available client sessions whilst
-     * {@link org.xmpp.packet.IQ IQs} originated to the server can be sent to available or unavailable
-     * sessions. When running inside of a cluster the node that is hosting the user session will be
-     * requested to deliver the requested packet.<p>
-     *
-     * @param jid the recipient of the packet to route.
-     * @param packet the packet to route.
-     * @throws PacketException thrown if the packet is malformed (results in the sender's
-     *      session being shutdown).
+     * @param jid the recipient of the stanza to route.
+     * @param packet the stanza to route.
+     * @throws PacketException thrown if the stanza is malformed (results in the sender's session being shutdown).
      */
     void routePacket(JID jid, Packet packet) throws PacketException;
 
@@ -158,14 +170,13 @@ public interface RoutingTable {
      * // TODO Should we care about available or not available????
      *
      * @param jid the full JID of the user.
-     * @return true if a registered user or anonymous user with the specified full JID is
-     * currently logged.
+     * @return true if a registered user or anonymous user with the specified full JID is currently logged in.
      */
     boolean hasClientRoute(JID jid);
 
     /**
      * Returns true if the specified address belongs to a route that is hosted by this JVM.
-     * When running inside of a cluster each cluster node will host routes to local resources.
+     * When running inside a cluster each cluster node will host routes to local resources.
      * A false value could either mean that the route is not hosted by this JVM but other
      * cluster node or that there is no route to the specified address. Use
      * {@link XMPPServer#isLocal(org.xmpp.packet.JID)} to figure out if the address
@@ -179,10 +190,10 @@ public interface RoutingTable {
     /**
      * Returns true if an outgoing server session exists to the specified remote server.
      * The JID can be a full JID or a bare JID since only the domain of the specified
-     * address will be used to look up the route.<p>
-     *
-     * When running inside of a cluster the look up will be done in all the cluster. So
-     * as long as a node has a connection to the remote server a true value will be
+     * address will be used to look up the route.
+     * <p>
+     * When running inside a cluster the look-up will be performed in all cluster nodes.
+     * As long as any node has a connection to the remote server, a true value will be
      * returned.
      *
      * @param pair DomainPair that specifies the local/remote server address.
@@ -191,12 +202,12 @@ public interface RoutingTable {
     boolean hasServerRoute(DomainPair pair);
 
     /**
-     * Returns true if an internal or external component is hosting the specified address.
+     * Returns true if an internal or external component exists that is hosting the specified address.
      * The JID can be a full JID or a bare JID since only the domain of the specified
-     * address will be used to look up the route.<p>
-     *
-     * When running inside of a cluster the look up will be done in all the cluster. So
-     * as long as a node is hosting the component  a true value will be returned.
+     * address will be used to look up the route.
+     * <p>
+     * When running inside a cluster the look-up will be performed in all cluster nodes.
+     * As long as any node is hosting the component, a true value will be returned.
      *
      * @param jid JID that specifies the component address.
      * @return true if an internal or external component is hosting the specified address.
@@ -204,9 +215,10 @@ public interface RoutingTable {
     boolean hasComponentRoute(JID jid);
 
     /**
-     * Returns the client session associated to the specified XMPP address or {@code null}
-     * if none was found. When running inside of a cluster and a remote node is hosting
-     * the client session then a session surrogate will be returned.
+     * Returns the client session associated to the specified XMPP address or {@code null} if none was found.
+     * <p>
+     * When running inside a cluster and a remote node is hosting the client session then a session surrogate will be
+     * returned.
      *
      * @param jid the address of the session.
      * @return the client session associated to the specified XMPP address or null if none was found.
@@ -215,10 +227,13 @@ public interface RoutingTable {
 
     /**
      * Returns the client sessions associated to the specified XMPP address or an empty collection
-     * if none were found. When running inside of a cluster and a remote node is hosting
-     * the client session then a session surrogate will be returned. When the provided address is
-     * a full JID, at most one session is returned. If a bare JID is provided, then all sessions
-     * associated to the user will be returned.
+     * if none were found.
+     * <p>
+     * When running inside a cluster and a remote node is hosting the client session then a session surrogate will be
+     * returned.
+     * <p>
+     * When the provided address is a full JID, at most one session is returned. If a bare JID is provided, then all
+     * sessions associated to the user will be returned.
      *
      * @param jid the address of the session.
      * @return the client session associated to the specified XMPP address or null if none was found.
@@ -226,22 +241,23 @@ public interface RoutingTable {
     Set<ClientSession> getClientRoutes(JID jid);
 
     /**
-     * Returns collection of client sessions authenticated with the server. When running inside
-     * of a cluster the returned sessions will include sessions connected to this JVM and also
-     * other cluster nodes.
+     * Returns collection of client sessions authenticated with the server.
+     * <p>
+     * When running inside a cluster the returned sessions will include sessions connected to the local cluster node.
+     * Optionally, sessions on other cluster nodes can be included in the result, too.
      *
-     * TODO Prevent usage of this message and change original requirement to avoid having to load all sessions.
+     * TODO Prevent usage of this method and change original requirement to avoid having to load all sessions.
      * TODO This may not scale when hosting millions of sessions.
      *
-     * @param onlyLocal true if only client sessions connected to this JVM must be considered.
+     * @param onlyLocal true if only client sessions connected to the local cluster node are to be returned.
      * @return collection of client sessions authenticated with the server.
      */
     Collection<ClientSession> getClientsRoutes(boolean onlyLocal);
 
     /**
-     * Returns the outgoing server session associated to the specified XMPP address or {@code null}
-     * if none was found. When running inside of a cluster and a remote node is hosting
-     * the session then a session surrage will be returned.
+     * Returns the outgoing server session associated to the specified XMPP address or {@code null} if none was found.
+     * <p>
+     * When running inside a cluster and a remote node is hosting the session then a session surrogate will be returned.
      *
      * @param pair DomainPair that specifies the local/remote server address.
      * @return the outgoing server session associated to the specified XMPP address or null if none was found.
@@ -256,11 +272,13 @@ public interface RoutingTable {
      *         packets sent from this server.
      */
     Collection<String> getServerHostnames();
+
     Collection<DomainPair> getServerRoutes();
 
     /**
-     * Returns the number of outgoing server sessions hosted in this JVM. When running inside of
-     * a cluster you will need to get this value for each cluster node to learn the total number
+     * Returns the number of outgoing server sessions hosted in the local cluster node.
+     * <p>
+     * When running inside a cluster you will need to get this value for each cluster node to learn the total number
      * of outgoing server sessions.
      *
      * @return the number of outgoing server sessions hosted in this JVM.
@@ -268,10 +286,11 @@ public interface RoutingTable {
     int getServerSessionsCount();
 
     /**
-     * Returns domains of components hosted by the server. When running in a cluster, domains of
-     * components running in any node will be returned.
+     * Returns domains (e.g. mycomponent.example.org) of all components.
+     * <p>
+     * When running in a cluster, domains of components running in any node will be returned.
      *
-     * @return domains of components hosted by the server.
+     * @return domains of all components.
      */
     Collection<String> getComponentsDomains();
 
@@ -302,37 +321,6 @@ public interface RoutingTable {
      * @return list of routes associated to the specified route address.
      */
     List<JID> getRoutes(JID route, JID requester);
-
-    /**
-     * Returns true if a route of a client session has been successfully removed. When running
-     * inside of a cluster this message {@code must} be sent from the cluster node that is
-     * actually hosting the client session.
-     *
-     * @param route the route to remove.
-     * @return true if a route of a client session has been successfully removed.
-     */
-    boolean removeClientRoute(JID route);
-
-    /**
-     * Returns true if a route to an outgoing server has been successfully removed. When running
-     * inside of a cluster this message {@code must} be sent from the cluster node that is
-     * actually holding the physical connection to the remote server.
-     *
-     * @param route the route to remove.
-     * @return true if the route was successfully removed.
-     */
-    boolean removeServerRoute(DomainPair route);
-
-    /**
-     * Returns true if a route of a component has been successfully removed. Both internal
-     * and external components have a route in the table. When running inside of a cluster
-     * this message {@code must} be sent from the cluster node that is actually hosting the
-     * component.
-     *
-     * @param route the route to remove.
-     * @return true if a route of a component has been successfully removed.
-     */
-    boolean removeComponentRoute(JID route);
 
     /**
      * Sets the {@link RemotePacketRouter} to use for delivering packets to entities hosted

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -62,11 +62,48 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Manages the sessions associated with an account. The information
- * maintained by the Session manager is entirely transient and does
- * not need to be preserved between server restarts.
+ * Manages the sessions associated to XMPP entities connected to Openfire. Such entities include:
+ *
+ * <ul>
+ * <li>Users / client sessions</li>
+ * <li>Other XMPP domains / server sessions</li>
+ * <li>(External) XMPP components sessions</li>
+ * <li>Connection Managers / multiplexer sessions</li>
+ * </ul>
+ *
+ * Sessions relate to routes (as managed by a {@link RoutingTable}), but are different: a <em>session</em> represents
+ * the connectivity between software entities, whereas a <em>route</em> represents the capability for an entity to be
+ * sent XMPP data. Although there's much overlap between the two, there are differences:
+ *
+ * <ul>
+ * <li>Not every session represents a entity that can be routed to. A <strong>Connection Manager</strong> (multiplexer),
+ * for example, is not an XMPP entity. Although multiplexer sessions exists (which represent the connection between
+ * Openfire and a Connection Manager instance), multiplexer <em>routes</em> do not exist.</li>
+ *
+ * <li>Not every route has a corresponding session: A <strong>Internal Component</strong> for example represents an
+ * addressable XMPP entity, but does not have a Session. An <em>External</em> Component, on the other hand, does have
+ * an associated session.</li>
+ *
+ * <li><strong>Client</strong> sessions are somewhat special in that they can be routed to only when they have sent
+ * Initial Presence (a variant exists for Client Sessions to be routable only for specific entities, when the session
+ * has sent those entities Directed Presence).</li>
+ * <ul>Connections to other XMPP domains (<strong>Server Sessions</strong>) are typically not bidirectional. Instead,
+ * two types of sessions exist:
+ *
+ * <ul>
+ * <li>An <em>outgoing</em> server session</li>
+ * <li>An <em>incoming</em> server session</li>
+ * </ul>
+ *
+ * Both types are supported in a SessionManager. As an 'incoming' server session is not used to route stanzas to, only
+ * 'outgoing' server sessions have routes.
+ * </li></ul>
+ *
+ * The information maintained by the Session manager is entirely transient and does not need to be preserved between
+ * server restarts.
  *
  * @author Derek DeMoro
+ * @see RoutingTable
  */
 public class SessionManager extends BasicModule implements ClusterEventListener
 {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -284,7 +284,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         // OF-1923: Only close the session if it has not been replaced by another session (if the session
         // has been replaced, then the condition below will compare to distinct instances). This *should* not
         // occur (but has been observed, prior to the fix of OF-1923). This check is left in as a safeguard.
-        final ClientSession currentSession = routingTable.getClientRoute(session.getAddress());
+        final ClientSession currentSession = getSession(session.getAddress());
         if (session == currentSession) {
             try {
                 if ((clientSession.getPresence().isAvailable() || !clientSession.wasAvailable()) &&

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -1083,14 +1083,10 @@ public class SessionManager extends BasicModule implements ClusterEventListener
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3132">OF-3132: When obtaining user sessions for bare JID, not all sessions are returned</a>
      */
     public Collection<ClientSession> getSessions(String username) {
-        List<ClientSession> sessionList = new ArrayList<>();
         if (username != null && serverName != null) {
-            List<JID> addresses = routingTable.getRoutes(new JID(username, serverName, null, true), null);
-            for (JID address : addresses) {
-                sessionList.add(routingTable.getClientRoute(address));
-            }
+            return routingTable.getClientRoutes(new JID(username, serverName, null, true));
         }
-        return sessionList;
+        return new ArrayList<>();
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
@@ -18,7 +18,6 @@ package org.jivesoftware.openfire.handler;
 
 import org.dom4j.Element;
 import org.jivesoftware.openfire.IQHandlerInfo;
-import org.jivesoftware.openfire.RoutingTable;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.auth.AuthToken;
@@ -57,7 +56,6 @@ public class IQBindHandler extends IQHandler {
 
     private IQHandlerInfo info;
     private String serverName;
-    private RoutingTable routingTable;
 
     public IQBindHandler() {
         super("Resource Binding handler");
@@ -118,7 +116,7 @@ public class IQBindHandler extends IQHandler {
             // If a session already exists with the requested JID, then check to see
             // if we should kick it off or refuse the new connection
             final JID desiredJid = new JID(username, serverName, resource, true);
-            ClientSession oldSession = routingTable.getClientRoute(desiredJid);
+            ClientSession oldSession = sessionManager.getSession(desiredJid);
             if (oldSession != null) {
                 try {
                     if (oldSession.isClosed()) {
@@ -188,7 +186,6 @@ public class IQBindHandler extends IQHandler {
     @Override
     public void initialize(XMPPServer server) {
         super.initialize(server);
-        routingTable = server.getRoutingTable();
         serverName = server.getServerInfo().getXMPPDomain();
      }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -526,8 +526,9 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
                 new HashMap<>(localDirectedPresences);
         for (Map.Entry<String, Collection<DirectedPresence>> entry : copy.entrySet()) {
             for (DirectedPresence directedPresence : entry.getValue()) {
-                if (!routingTable.hasClientRoute(directedPresence.getHandler()) &&
-                        !routingTable.hasComponentRoute(directedPresence.getHandler())) {
+                // TODO This appears to remove all directed presence for non-local entities. Determine if that's true, and if so, desirable.
+                if (sessionManager.getSession(directedPresence.getHandler()) == null &&
+                        sessionManager.getComponentSession(directedPresence.getHandler().getDomain()) == null) {
                     Collection<DirectedPresence> presences = localDirectedPresences.get(entry.getKey());
                     presences.remove(directedPresence);
                     if (presences.isEmpty()) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCRoomManager.java
@@ -16,6 +16,7 @@
 package org.jivesoftware.openfire.muc.spi;
 
 import org.jivesoftware.openfire.RoutingTable;
+import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.cluster.ClusteredCacheEntryListener;
 import org.jivesoftware.openfire.cluster.NodeID;
@@ -326,7 +327,7 @@ public class LocalMUCRoomManager
                                 Log.trace("Trying to add occupant '{}' but no role for that occupant exists in the local room. Data inconsistency?", localOccupantToRestore.getRealJID());
                                 continue;
                             } else {
-                                Log.trace("Found localOccupantRole {} for localOccupantToRestore {}, client route = {}", localOccupant, localOccupantToRestore.getRealJID(), XMPPServer.getInstance().getRoutingTable().getClientRoute(localOccupantToRestore.getRealJID()));
+                                Log.trace("Found localOccupantRole {} for localOccupantToRestore {}, client session = {}", localOccupant, localOccupantToRestore.getRealJID(), SessionManager.getInstance().getSession(localOccupantToRestore.getRealJID()));
                             }
 
                             // OF-2165

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.session;
 
+import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.spi.ClientRoute;
 import org.jivesoftware.openfire.spi.RoutingTableImpl;
@@ -54,7 +55,7 @@ public class ClientSessionTask extends RemoteSessionTask {
 
     Session getSession() {
         if (session == null) {
-            session = XMPPServer.getInstance().getRoutingTable().getClientRoute(address);
+            session = SessionManager.getInstance().getSession(address);
         }
         return session;
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/DeliverRawTextTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/DeliverRawTextTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.jivesoftware.openfire.session;
 
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.StreamID;
-import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.spi.BasicStreamIDFactory;
 import org.jivesoftware.util.cache.ClusterTask;
 import org.jivesoftware.util.cache.ExternalizableUtil;
@@ -108,7 +107,7 @@ public class DeliverRawTextTask implements ClusterTask<Void> {
 
     Session getSession() {
         if (sessionType == SessionType.client) {
-            return XMPPServer.getInstance().getRoutingTable().getClientRoute(address);
+            return SessionManager.getInstance().getSession(address);
         }
         else if (sessionType == SessionType.component) {
             return SessionManager.getInstance().getComponentSession(address.getDomain());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ProcessPacketTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ProcessPacketTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2009 Jive Software, 2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2007-2009 Jive Software, 2021-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,7 +128,7 @@ public class ProcessPacketTask implements ClusterTask<Void> {
 
     Session getSession() {
         if (sessionType == SessionType.client) {
-            return XMPPServer.getInstance().getRoutingTable().getClientRoute(address);
+            return SessionManager.getInstance().getSession(address);
         }
         else if (sessionType == SessionType.component) {
             return SessionManager.getInstance().getComponentSession(address.getDomain());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -57,7 +57,7 @@ import java.util.stream.Collectors;
  * or unavailable the routing table will be updated too.<p>
  *
  * When running inside of a cluster the routing table will also keep references to routes
- * hosted in other cluster nodes. A {@link RemotePacketRouter} will be use to route packets
+ * hosted in other cluster nodes. A {@link RemotePacketRouter} will be used to route packets
  * to routes hosted in other cluster nodes.<p>
  *
  * Failure to route a packet will end up sending {@link IQRouter#routingFailed(JID, Packet)},

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -337,8 +337,8 @@ public class StreamManager {
         Log.debug("Resuming session for '{}'. Current session: {}", fullJid, session.getStreamID());
 
         // Locate existing session.
-        final ClientSession route = XMPPServer.getInstance().getRoutingTable().getClientRoute(fullJid);
-        if (route == null) {
+        final ClientSession existingSession = XMPPServer.getInstance().getSessionManager().getSession(fullJid);
+        if (existingSession == null) {
             Log.debug("Not able for client of '{}' to resume a session on this cluster node. No session was found for this client.", fullJid);
             if (LOCATION_TERMINATE_OTHERS_ENABLED.getValue()) {
                 // When the client tries to resume a connection on this host, it is unlikely to try other hosts. Remove any detached sessions living elsewhere in the cluster. (OF-2753)
@@ -348,7 +348,7 @@ public class StreamManager {
             return;
         }
 
-        if (!(route instanceof LocalClientSession)) {
+        if (!(existingSession instanceof LocalClientSession)) {
             Log.debug("Not allowing a client of '{}' to resume a session on this cluster node. The session can only be resumed on the Openfire cluster node where the original session was connected.", fullJid);
             if (LOCATION_TERMINATE_OTHERS_ENABLED.getValue()) {
                 // When the client tries to resume a connection on this host, it is unlikely to try other hosts. Remove any detached sessions living elsewhere in the cluster. (OF-2753)
@@ -358,7 +358,7 @@ public class StreamManager {
             return;
         }
 
-        final LocalClientSession otherSession = (LocalClientSession) route;
+        final LocalClientSession otherSession = (LocalClientSession) existingSession;
         if (!otherSession.getStreamID().getID().equals(streamId)) {
             sendError(new PacketError(PacketError.Condition.item_not_found));
             return;
@@ -366,7 +366,7 @@ public class StreamManager {
         Log.debug("Found existing session for '{}', checking status", fullJid);
 
         // OF-2811: Cannot resume a session that's already closed. That session is likely busy firing its 'closeListeners'.
-        if (route.isClosed()) {
+        if (otherSession.isClosed()) {
             Log.debug("Not allowing a client of '{}' to resume a session, as the preexisting session is already in process of being closed.", fullJid);
             sendError(new PacketError(PacketError.Condition.unexpected_request));
             return;


### PR DESCRIPTION
`org.jivesoftware.openfire.SessionManager#getSessions(java.lang.String)` returned sessions only when they are 'available'. This is a (side?)effect of its implementation depending on `org.jivesoftware.openfire.RoutingTable#getRoutes`

I don't know if there are cases where it is desirable to get only 'available' sessions.

I do know that being able to retrieve only 'available' sessions introduces issues. For one, it prevents most code to evaluate non-available session. For example, code can fail to terminate a non-available session (or a session where the availability state hasn't been updated yet due to a race condition).

This commit introduces a new implementation that allows ClientSessions to be obtained irrespectively of their availability status.

I'm not at all certain that this is the right approach. I am offering this up as an illustration, for discussion purposes.