### PR TITLE
OF-3055: When removing childelement, don't assume there's only one

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoItemsHandler.java
@@ -208,9 +208,8 @@ public class IQDiscoItemsHandler extends IQHandler implements ServerFeaturesProv
                     }
 
                     // overwrite the 'set' element.
-                    queryElement.remove(queryElement.element(
-                            QName.get("set",
-                                    ResultSet.NAMESPACE_RESULT_SET_MANAGEMENT)));
+                    queryElement.elements(QName.get("set", ResultSet.NAMESPACE_RESULT_SET_MANAGEMENT))
+                        .forEach(queryElement::remove);
                     queryElement.add(rs.generateSetElementFromResults(rsmResults));
                 } else {
                     // don't apply RSM:

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapVCardProvider.java
@@ -249,10 +249,7 @@ public class LdapVCardProvider implements VCardProvider, PropertyEventListener {
             Element avatarElement = loadAvatarFromDatabase(username);
             if (avatarElement != null) {
                 Log.debug("LdapVCardProvider: Adding avatar element from local storage");
-                Element currentElement = vcard.element("PHOTO");
-                if (currentElement != null) {
-                    vcard.remove(currentElement);
-                }
+                vcard.elements("PHOTO").forEach(vcard::remove);
                 vcard.add(avatarElement);
             }
         }
@@ -302,10 +299,7 @@ public class LdapVCardProvider implements VCardProvider, PropertyEventListener {
             return vcard;
         }
         Log.debug("LdapVCardProvider: Merging avatar element from passed vcard");
-        Element currentElement = vcard.element("PHOTO");
-        if (currentElement != null) {
-            vcard.remove(currentElement);
-        }
+        vcard.elements("PHOTO").forEach(vcard::remove);
         vcard.add(photoElement);
         return vcard;
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCOccupant.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCOccupant.java
@@ -218,10 +218,9 @@ public class MUCOccupant implements Cacheable, Externalizable {
     public synchronized void setPresence(Presence newPresence) {
         // Try to remove the element whose namespace is "http://jabber.org/protocol/muc" since we
         // don't need to include that element in future presence broadcasts
-        Element element = newPresence.getElement().element(QName.get("x", "http://jabber.org/protocol/muc"));
-        if (element != null) {
-            newPresence.getElement().remove(element);
-        }
+        final Element presenceEl = newPresence.getElement();
+        presenceEl.elements(QName.get("x", "http://jabber.org/protocol/muc"))
+            .forEach(presenceEl::remove);
 
         synchronized (this) {
             this.presence = newPresence;
@@ -578,13 +577,12 @@ public class MUCOccupant implements Cacheable, Externalizable {
     private void updatePresence() {
         if (extendedInformation != null && presence != null) {
             // Remove any previous extendedInformation, then re-add it.
-            Element mucUser = presence.getElement().element(QName.get("x", "http://jabber.org/protocol/muc#user"));
-            if (mucUser != null) {
-                // Remove any previous extendedInformation, then re-add it.
-                presence.getElement().remove(mucUser);
-            }
+            final Element presenceEl = presence.getElement();
+            presenceEl.elements(QName.get("x", "http://jabber.org/protocol/muc#user"))
+                .forEach(presenceEl::remove);
+
             Element exi = extendedInformation.createCopy();
-            presence.getElement().add(exi);
+            presenceEl.add(exi);
             cacheSize = -1;
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCRegisterHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/IQMUCRegisterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,18 +147,8 @@ class IQMUCRegisterHandler {
                     ElementUtil.setProperty(currentRegistration, "query.registered", null);
                     currentRegistration.addElement("username").addText(nickname);
 
-                    Element form = currentRegistration.element(QName.get("x", "jabber:x:data"));
-                    currentRegistration.remove(form);
-        //                @SuppressWarnings("unchecked")
-        //				Iterator<Element> fields = form.elementIterator("field");
-        //
-        //                Element field;
-        //                while (fields.hasNext()) {
-        //                    field = fields.next();
-        //                    if ("muc#register_roomnick".equals(field.attributeValue("var"))) {
-        //                        field.addElement("value").addText(nickname);
-        //                    }
-        //                }
+                    currentRegistration.elements(QName.get("x", "jabber:x:data"))
+                        .forEach(currentRegistration::remove);
                     reply.setChildElement(currentRegistration);
                 }
                 else {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -36,19 +36,10 @@ import org.jivesoftware.openfire.session.*;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.LocaleUtils;
 import org.jivesoftware.util.TaskEngine;
-import org.jivesoftware.util.cache.Cache;
-import org.jivesoftware.util.cache.CacheFactory;
-import org.jivesoftware.util.cache.CacheUtil;
-import org.jivesoftware.util.cache.ConsistencyChecks;
-import org.jivesoftware.util.cache.ReverseLookupComputingCacheEntryListener;
-import org.jivesoftware.util.cache.ReverseLookupUpdatingCacheEntryListener;
+import org.jivesoftware.util.cache.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xmpp.packet.IQ;
-import org.xmpp.packet.JID;
-import org.xmpp.packet.Message;
-import org.xmpp.packet.Packet;
-import org.xmpp.packet.Presence;
+import org.xmpp.packet.*;
 
 import java.time.Duration;
 import java.util.*;
@@ -379,9 +370,9 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
     private boolean routeToLocalDomain(JID jid, Packet packet)
     {
         boolean routed = false;
-        Element privateElement = packet.getElement().element(QName.get("private", Received.NAMESPACE));
         // The receiving server and SHOULD remove the <private/> element before delivering to the recipient.
-        packet.getElement().remove(privateElement);
+        final Element packetEl = packet.getElement();
+        packetEl.elements(QName.get("private", Received.NAMESPACE)).forEach(packetEl::remove);
 
         if (jid.getResource() == null) {
             // RFC 6121: 8.5.2. localpart@domainpart (Packet sent to a bare JID of a user)


### PR DESCRIPTION
There are various bits in the code where an XML snippet (typically an XMPP stanza) is being manipulated by removing a particular child element. This can have various reasons, including:

- removing client-provided data that should be server-provided (to avoid spoofing)
- re-use of an element for other purposes

When an element is removed, a common assumption is that there will be at most one such element in the XML snippet. This is driven mostly by an expectation, not by inspection.

To be safe, remove all occurrences, not just the first one.