### PR TITLE
OF-3056: Refactor processing of directed presence

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/PresenceUpdateHandler.java
@@ -394,28 +394,13 @@ public class PresenceUpdateHandler extends BasicModule implements ChannelHandler
                     if (Presence.Type.unavailable.equals(update.getType())) {
                         if (directedPresences != null) {
                             // It's a directed unavailable presence
-                            if (routingTable.hasClientRoute(handlerJID)) {
-                                // Client sessions will receive only presences to the same JID (the
-                                // address of the session) so remove the handler from the map
-                                for (DirectedPresence directedPresence : directedPresences) {
-                                    if (directedPresence.getHandler().equals(handlerJID)) {
+                            for (DirectedPresence directedPresence : directedPresences) {
+                                if (directedPresence.getHandler().equals(handlerJID)) {
+                                    directedPresence.removeReceiver(jid);
+                                    if (directedPresence.isEmpty()) {
                                         directedPresences.remove(directedPresence);
-                                        break;
                                     }
-                                }
-                            }
-                            else {
-                                // A service may receive presences for many JIDs so in this case we
-                                // just need to remove the jid that has received a directed
-                                // unavailable presence
-                                for (DirectedPresence directedPresence : directedPresences) {
-                                    if (directedPresence.getHandler().equals(handlerJID)) {
-                                        directedPresence.removeReceiver(jid);
-                                        if (directedPresence.isEmpty()) {
-                                            directedPresences.remove(directedPresence);
-                                        }
-                                        break;
-                                    }
+                                    break;
                                 }
                             }
                             if (directedPresences.isEmpty()) {


### PR DESCRIPTION
When _removing_ a directed presence from memory (which happens when an 'unavailable' is sent), the previous code seems to try to 'optimize' things, by differentiating between a presence removal that's registered for a client session, or any other session.

Such an optimization is undesirable, for a number of reasons:
- it requires the client to currently be online;
- it sets a cluster-side lock (through the lookup on RoutingTable)
- it adds quite a bit of code complexity (making maintenance harder)

When _adding_ the directed presence, the distinction is _not_ made, which adds to the believe that there is code smell.

In this commit, the 'optimization' is replaced by a simpler code path.