### PR TITLE
OF-3059 Remove anonymous route

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -413,7 +413,7 @@ public class IQRouter extends BasicModule {
                     && !XMPPServer.getInstance().isRemote(recipientJID)
                     && !userManager.isRegisteredUser(recipientJID, false)
                     && !UserManager.isPotentialFutureLocalUser(recipientJID)
-                    && !sessionManager.isAnonymousRoute(recipientJID.getNode())
+                    && !sessionManager.isAnonymousClientSession(recipientJID)
                     && sessionManager.getSession(recipientJID) == null
                     && !(recipientJID.asBareJID().equals(packet.getFrom().asBareJID()) && sessionManager.isPreAuthenticatedSession(packet.getFrom())) // A pre-authenticated session queries the server about itself.
                 )

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,7 +169,9 @@ public interface RoutingTable {
      *
      * @param jid the full JID of the anonymous user.
      * @return true if an anonymous user with the specified full JID is currently logged.
+     * @deprecated Replaced by {@link SessionManager#isAnonymousClientSession(JID)}
      */
+    @Deprecated(forRemoval = true, since = "5.0.0") // Remove in or after Openfire 5.1.0
     boolean isAnonymousRoute(JID jid);
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -855,14 +855,33 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         }
     }
 
-    public boolean isAnonymousRoute(String username) {
+    public boolean isAnonymousClientSession(@Nonnull final String username) {
         // JID's node and resource are the same for anonymous sessions
-        return isAnonymousRoute(new JID(username, serverName, username, true));
+        final JID address = new JID(username, serverName, username, true);
+        return isAnonymousClientSession(address);
     }
 
+    public boolean isAnonymousClientSession(@Nonnull final JID address) {
+        // JID's node and resource are the same for anonymous sessions. When provided with a bare JID, 'auto-complete' it.
+        final JID correctedJid = address.getResource() != null ? address : new JID(address.getNode(), address.getDomain(), address.getNode(), true);
+        final ClientSession session = getSession(correctedJid);
+        return session != null && session.isAnonymousUser();
+    }
+
+    /**
+     * @deprecated Replaced by {@link #isAnonymousClientSession(String)}
+     */
+    @Deprecated(forRemoval = true, since = "5.0.0") // Remove in or after Openfire 5.1.0
+    public boolean isAnonymousRoute(String username) {
+        return isAnonymousClientSession(username);
+    }
+
+    /**
+     * @deprecated Replaced by {@link #isAnonymousClientSession(JID)}
+     */
+    @Deprecated(forRemoval = true, since = "5.0.0") // Remove in or after Openfire 5.1.0
     public boolean isAnonymousRoute(JID address) {
-        // JID's node and resource are the same for anonymous sessions
-        return routingTable.isAnonymousRoute(address);
+        return isAnonymousClientSession(address);
     }
 
     public boolean isActiveRoute(String username, String resource) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -619,7 +619,7 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                 else {
                     // Answer with identities of users of the server.
                     final Collection<UserIdentitiesProvider> providers;
-                    if (SessionManager.getInstance().isAnonymousRoute(name))
+                    if (SessionManager.getInstance().isAnonymousClientSession(name))
                     {
                         // Answer identity of an anonymous user.
                         providers = anonymousUserIdentityProviders;
@@ -668,7 +668,7 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                 else {
                     // Answer with features of users of the server.
                     final Collection<UserFeaturesProvider> providers;
-                    if (SessionManager.getInstance().isAnonymousRoute(name))
+                    if (SessionManager.getInstance().isAnonymousClientSession(name))
                     {
                         // Answer features of an anonymous user.
                         providers = anonymousUserFeatureProviders;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
@@ -94,7 +94,7 @@ public abstract class IQHandler extends BasicModule implements ChannelHandler<IQ
         if (iq.isRequest() && recipientJID != null && recipientJID.getNode() != null
             && !XMPPServer.getInstance().isRemote(recipientJID)
             && !UserManager.getInstance().isRegisteredUser(recipientJID, false)
-            && !sessionManager.isAnonymousRoute(recipientJID.getNode())
+            && !sessionManager.isAnonymousClientSession(recipientJID)
             && !UserManager.isPotentialFutureLocalUser(recipientJID) && sessionManager.getSession(recipientJID) == null
             && !(recipientJID.asBareJID().equals(iq.getFrom().asBareJID()) && sessionManager.isPreAuthenticatedSession(iq.getFrom())) // A pre-authenticated session queries the server about itself.
         )

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -669,7 +669,7 @@ public class PubSubEngine
     private void subscribeNodeAsync(final IQ iq, final JID subscriberJID, final Node node, final JID owner, final PubSubService service, final JID from, final Element childElement, final AccessModel accessModel) {
 
         // Check if the subscriber is an anonymous user.
-        if (XMPPServer.getInstance().isLocal(subscriberJID) && SessionManager.getInstance().isAnonymousRoute(subscriberJID.getNode())) {
+        if (SessionManager.getInstance().isAnonymousClientSession(subscriberJID)) {
             // Anonymous users cannot subscribe to the node. Return forbidden error
             // TODO OF-2506: figure out why anonymous users should not be allowed to subscribe. There is no way to check if remote users are anonymous anyway.
             sendErrorPacket(iq, PacketError.Condition.forbidden, null);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
@@ -90,6 +90,16 @@ public class ClientSessionTask extends RemoteSessionTask {
                 result = session.isInitialized();
             }
         }
+        if (operation == Operation.isAnonymous) {
+            if (session instanceof RemoteClientSession) {
+                // Something is wrong since the session should be local instead of remote
+                // Assume some default value
+                result = false;
+            }
+            else {
+                result = session.isAnonymousUser();
+            }
+        }
         else if (operation == Operation.incrementConflictCount) {
             if (session instanceof RemoteClientSession) {
                 // Something is wrong since the session should be local instead of remote

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
@@ -208,6 +208,7 @@ public abstract class RemoteSessionTask implements ClusterTask<Object> {
          * Operations of c2s sessions
          */
         isInitialized,
+        isAnonymous,
         incrementConflictCount,
         hasRequestedBlocklist,
         

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -566,7 +566,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         if ( !JiveGlobals.getBooleanProperty( ConnectionSettings.Server.ALLOW_ANONYMOUS_OUTBOUND_DATA, false ) )
         {
             // Disallow anonymous local users to send data to other domains than the local domain.
-            if ( isAnonymousRoute( packet.getFrom() ) )
+            if ( SessionManager.getInstance().isAnonymousClientSession(packet.getFrom()) )
             {
                 Log.info( "The anonymous user '{}' attempted to send data to '{}', which is on a remote domain. Openfire is configured to not allow anonymous users to send data to remote domains.", packet.getFrom(), jid );
                 return false;
@@ -929,20 +929,13 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         }
     }
 
-    @Override
+    @Deprecated(forRemoval = true, since = "5.0.0") // Remove in or after Openfire 5.1.0    @Override
     public boolean isAnonymousRoute(JID jid) {
         if (jid.getNode() == null || jid.getResource() == null) {
             Log.trace("isAnonymousRoute() invoked with a JID that's not a full JID: {}", jid);
             return false;
         }
-        final Lock lock = usersSessionsCache.getLock(jid.toBareJID());
-        lock.lock();
-        try {
-            // Check if there's an anonymous route for the JID.
-            return anonymousUsersCache.containsKey(jid.toFullJID());
-        } finally {
-            lock.unlock();
-        }
+        return server.getSessionManager().isAnonymousClientSession(jid);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -522,7 +522,7 @@ public final class UserManager {
      * @return True if the address could be used for a locally registered user, potentially not having registered yet.
      */
     public static boolean isPotentialFutureLocalUser(final JID user) {
-        return ALLOW_FUTURE_USERS.getValue() && XMPPServer.getInstance().isLocal(user) && !SessionManager.getInstance().isAnonymousRoute(user.getNode());
+        return ALLOW_FUTURE_USERS.getValue() && XMPPServer.getInstance().isLocal(user) && !SessionManager.getInstance().isAnonymousClientSession(user);
     }
 
     private static void initProvider(final Class<? extends UserProvider> clazz) {

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyMonitor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/ConsistencyMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Ignite Realtime Foundation. All rights reserved
+ * Copyright (C) 2021-2025 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,7 +133,6 @@ public class ConsistencyMonitor
             if (clientRoutesFailures != null && !clientRoutesFailures.isEmpty()) {
                 // This check operates on multiple caches.
                 offenders.add(RoutingTableImpl.C2S_CACHE_NAME);
-                offenders.add(RoutingTableImpl.ANONYMOUS_C2S_CACHE_NAME);
             }
 
             final Collection<String> usersSessionsFailures = routingTable.clusteringStateConsistencyReportForUsersSessions().get("fail");

--- a/xmppserver/src/main/webapp/session-row.jspf
+++ b/xmppserver/src/main/webapp/session-row.jspf
@@ -41,7 +41,7 @@
         <td style="width: 10%; white-space: nowrap">
             <%  String name = sess.getAddress().getNode(); %>
             <a href="session-details.jsp?jid=<%= URLEncoder.encode(sess.getAddress().toString(), StandardCharsets.UTF_8) %>" title="<fmt:message key='session.row.click' />"
-            ><%= ((!sessionManager.isAnonymousRoute(sess.getUsername())) ? JID.unescapeNode(name): "<i>"+LocaleUtils.getLocalizedString("session.details.anonymous")+"</i>") %></a>
+            ><%= (!sess.isAnonymousUser() ? JID.unescapeNode(name): "<i>"+LocaleUtils.getLocalizedString("session.details.anonymous")+"</i>") %></a>
         </td>
     </c:if>
     <c:if test="${showResource}">

--- a/xmppserver/src/test/java/org/jivesoftware/util/cache/CacheFactoryConfigTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/cache/CacheFactoryConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2023-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,6 @@ public class CacheFactoryConfigTest {
         result.add(Arguments.arguments(SessionManager.COMPONENT_SESSION_CACHE_NAME));
         result.add(Arguments.arguments(SessionManager.CM_CACHE_NAME));
         result.add(Arguments.arguments(RoutingTableImpl.C2S_CACHE_NAME));
-        result.add(Arguments.arguments(RoutingTableImpl.ANONYMOUS_C2S_CACHE_NAME));
         result.add(Arguments.arguments(RoutingTableImpl.S2S_CACHE_NAME));
         result.add(Arguments.arguments(RoutingTableImpl.COMPONENT_CACHE_NAME));
         result.add(Arguments.arguments(RoutingTableImpl.C2S_SESSION_NAME));


### PR DESCRIPTION
The commits in this PR remove:
- the concept of having a _route_ that is anonymous. Instead, a _session_ can be anonymous
- the clustered cache that stores anonymous sessions (apart from 'regular' session). Instead, all sessions are stored in one cache

Please refer to the individual commit messages for more details.