### PR TITLE
OF-3059: Remove 'anonymous route' concept

### DIFF
--- a/.github/actions/startserver-action/action.yml
+++ b/.github/actions/startserver-action/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Set a hosts file for the given IP and host (or for example.com if running locally)'
     required: false
     default: '127.0.0.1'
+  logLevel:
+    description: 'The verbosity of logging (one of error, warn, info, debug, trace, all)'
+    required: false
+    default: 'info'
 
 runs:
   using: "composite"
@@ -30,5 +34,5 @@ runs:
     - name: Set JAVA_HOME to use Java 17
       run: echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
       shell: bash
-    - run: startCIServer.sh -i ${{ inputs.ip }} -h ${{ inputs.domain }} -b ${{ inputs.distBaseDir }}
+    - run: startCIServer.sh -i ${{ inputs.ip }} -h ${{ inputs.domain }} -b ${{ inputs.distBaseDir }} -l ${{ inputs.logLevel }}
       shell: bash

--- a/.github/actions/startserver-action/startCIServer.sh
+++ b/.github/actions/startserver-action/startCIServer.sh
@@ -6,14 +6,15 @@ HOST='example.org'
 
 usage()
 {
-	echo "Usage: $0 [-i IPADDRESS] [-h HOST] [-b BASEDIR]"
+	echo "Usage: $0 [-i IPADDRESS] [-h HOST] [-b BASEDIR] [-l LOGLEVEL]"
 	echo "    -i: Set a hosts file for the given IP and host (or for example.com if running locally). Reverted at exit."
 	echo "    -h: The network name for the Openfire under test, which will be used for both the hostname as the XMPP domain name (default: example.org)"
 	echo "    -b: The base directory of the distribution that is to be started"
+	echo "    -l: The log level (default: info)"
 	exit 2
 }
 
-while getopts h:i:b: OPTION "$@"; do
+while getopts h:i:b:l: OPTION "$@"; do
 	case $OPTION in
 		h)
 			HOST="${OPTARG}"
@@ -23,6 +24,9 @@ while getopts h:i:b: OPTION "$@"; do
 			;;
 		b)
 			BASEDIR="${OPTARG}"
+			;;
+		l)
+			LOGLEVEL="${OPTARG}"
 			;;
 		\? ) usage;;
         :  ) usage;;
@@ -55,6 +59,11 @@ function launchOpenfire {
 
 	# Replace the default XMPP domain name ('example.org') that's in the demoboot config with the configured domain name.
 	sed -i -e 's/example.org/'"${HOST}"'/g' ${BASEDIR}/conf/openfire.xml
+
+	# Replace the default log level ('info') that's in the log4j config with the configured level.
+	if [[ -n "${LOGLEVEL}" ]]; then
+	    sed -i -e 's/info/'"${LOGLEVEL}"'/g' ${BASEDIR}/lib/log4j2.xml
+	fi
 
 	echo "Starting Openfire…"
 	"${OPENFIRE_SHELL_SCRIPT}" &

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -157,6 +157,8 @@ jobs:
       - name: Start CI server from distribution
         id: startCIServer
         uses: ./.github/actions/startserver-action
+        with:
+          logLevel: all
       - name: Run aioxmpp tests
         working-directory: ./aioxmpp
         run: |

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Build with Maven # We install instead of package, because we want the result in the local mvn repo
         run: |
           if [[ ${{ github.ref_name }} == 'main' ]]; then            
-            ./mvnw -B install -Pcoverage --file pom.xml
+            ./mvnw -B install -Dmaven.test.skip=true -Pcoverage --file pom.xml
           else
-            ./mvnw -B install
+            ./mvnw -B install -Dmaven.test.skip=true
           fi
       - name: Upload failed test reports
         uses: actions/upload-artifact@v4

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -413,7 +413,7 @@ public class IQRouter extends BasicModule {
                     && !XMPPServer.getInstance().isRemote(recipientJID)
                     && !userManager.isRegisteredUser(recipientJID, false)
                     && !UserManager.isPotentialFutureLocalUser(recipientJID)
-                    && !sessionManager.isAnonymousRoute(recipientJID.getNode())
+                    && !sessionManager.isAnonymousClientSession(recipientJID)
                     && sessionManager.getSession(recipientJID) == null
                     && !(recipientJID.asBareJID().equals(packet.getFrom().asBareJID()) && sessionManager.isPreAuthenticatedSession(packet.getFrom())) // A pre-authenticated session queries the server about itself.
                 )

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/RoutingTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,7 +169,9 @@ public interface RoutingTable {
      *
      * @param jid the full JID of the anonymous user.
      * @return true if an anonymous user with the specified full JID is currently logged.
+     * @deprecated Replaced by {@link SessionManager#isAnonymousClientSession(JID)}
      */
+    @Deprecated(forRemoval = true, since = "5.0.0") // Remove in or after Openfire 5.1.0
     boolean isAnonymousRoute(JID jid);
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -855,14 +855,32 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         }
     }
 
-    public boolean isAnonymousRoute(String username) {
+    public boolean isAnonymousClientSession(@Nonnull final String username) {
         // JID's node and resource are the same for anonymous sessions
-        return isAnonymousRoute(new JID(username, serverName, username, true));
+        final JID address = new JID(username, serverName, username, true);
+        return isAnonymousClientSession(address);
     }
 
-    public boolean isAnonymousRoute(JID address) {
+    public boolean isAnonymousClientSession(@Nonnull final JID address) {
         // JID's node and resource are the same for anonymous sessions
-        return routingTable.isAnonymousRoute(address);
+        final ClientSession session = getSession(address);
+        return session != null && session.isAnonymousUser();
+    }
+
+    /**
+     * @deprecated Replaced by {@link #isAnonymousClientSession(String)}
+     */
+    @Deprecated(forRemoval = true, since = "5.0.0") // Remove in or after Openfire 5.1.0
+    public boolean isAnonymousRoute(String username) {
+        return isAnonymousClientSession(username);
+    }
+
+    /**
+     * @deprecated Replaced by {@link #isAnonymousClientSession(JID)}
+     */
+    @Deprecated(forRemoval = true, since = "5.0.0") // Remove in or after Openfire 5.1.0
+    public boolean isAnonymousRoute(JID address) {
+        return isAnonymousClientSession(address);
     }
 
     public boolean isActiveRoute(String username, String resource) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -699,6 +699,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
     public void addSession(LocalClientSession session) {
         // Add session to the routing table (routing table will know session is not available yet)
         routingTable.addClientRoute(session.getAddress(), session);
+        Log.error("DEBUG! Added {} {} to routingtable: {}", session.getAuthToken().isAnonymous(), session.isAnonymousUser(), session);
         // Remove the pre-Authenticated session but remember to use the temporary ID as the key
         localSessionManager.removePreAuthenticatedSession(session);
         SessionEventDispatcher.EventType event = session.getAuthToken().isAnonymous() ?
@@ -862,8 +863,13 @@ public class SessionManager extends BasicModule implements ClusterEventListener
     }
 
     public boolean isAnonymousClientSession(@Nonnull final JID address) {
-        // JID's node and resource are the same for anonymous sessions
-        final ClientSession session = getSession(address);
+        // JID's node and resource are the same for anonymous sessions. When a bare JID was provided, auto-complete it.
+        final JID correctedJid = address.getResource() != null ? address : new JID(address.getNode(), address.getDomain(), address.getNode(), true);
+        final ClientSession session = getSession(correctedJid);
+        Log.error("DEBUG! session for {}: {}", address, session);
+        Log.error("DEBUG! has null session: {}", session == null);
+        Log.error("DEBUG! has anon session: {}", session == null ? "NULL" : session.isAnonymousUser());
+
         return session != null && session.isAnonymousUser();
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -619,7 +619,7 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                 else {
                     // Answer with identities of users of the server.
                     final Collection<UserIdentitiesProvider> providers;
-                    if (SessionManager.getInstance().isAnonymousRoute(name))
+                    if (SessionManager.getInstance().isAnonymousClientSession(name))
                     {
                         // Answer identity of an anonymous user.
                         providers = anonymousUserIdentityProviders;
@@ -668,7 +668,7 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                 else {
                     // Answer with features of users of the server.
                     final Collection<UserFeaturesProvider> providers;
-                    if (SessionManager.getInstance().isAnonymousRoute(name))
+                    if (SessionManager.getInstance().isAnonymousClientSession(name))
                     {
                         // Answer features of an anonymous user.
                         providers = anonymousUserFeatureProviders;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
@@ -91,6 +91,19 @@ public abstract class IQHandler extends BasicModule implements ChannelHandler<IQ
 
         final JID recipientJID = iq.getTo();
 
+        Log.error("DEBUG! req: {}", iq.toXML());
+        Log.error("DEBUG! isRequest: {}", iq.isRequest());
+        Log.error("DEBUG! reci=null: {}", recipientJID != null);
+        if (recipientJID != null) {
+            Log.error("DEBUG! reci=====: {}", recipientJID);
+            Log.error("DEBUG! node=null: {}", recipientJID.getNode() != null);
+            Log.error("DEBUG! !isRemote: {}", !XMPPServer.getInstance().isRemote(recipientJID));
+            Log.error("DEBUG! !isRegist: {}", !UserManager.getInstance().isRegisteredUser(recipientJID, false));
+            Log.error("DEBUG! !isAnonym: {}", !sessionManager.isAnonymousClientSession(recipientJID));
+            Log.error("DEBUG! !isFuture: {}", !UserManager.isPotentialFutureLocalUser(recipientJID));
+            Log.error("DEBUG! !hasSessi: {}", sessionManager.getSession(recipientJID) == null);
+            Log.error("DEBUG! !preauthd: {}", !(recipientJID.asBareJID().equals(iq.getFrom().asBareJID()) && sessionManager.isPreAuthenticatedSession(iq.getFrom())));
+        }
         if (iq.isRequest() && recipientJID != null && recipientJID.getNode() != null
             && !XMPPServer.getInstance().isRemote(recipientJID)
             && !UserManager.getInstance().isRegisteredUser(recipientJID, false)

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
@@ -94,7 +94,7 @@ public abstract class IQHandler extends BasicModule implements ChannelHandler<IQ
         if (iq.isRequest() && recipientJID != null && recipientJID.getNode() != null
             && !XMPPServer.getInstance().isRemote(recipientJID)
             && !UserManager.getInstance().isRegisteredUser(recipientJID, false)
-            && !sessionManager.isAnonymousRoute(recipientJID.getNode())
+            && !sessionManager.isAnonymousClientSession(recipientJID)
             && !UserManager.isPotentialFutureLocalUser(recipientJID) && sessionManager.getSession(recipientJID) == null
             && !(recipientJID.asBareJID().equals(iq.getFrom().asBareJID()) && sessionManager.isPreAuthenticatedSession(iq.getFrom())) // A pre-authenticated session queries the server about itself.
         )

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -669,7 +669,7 @@ public class PubSubEngine
     private void subscribeNodeAsync(final IQ iq, final JID subscriberJID, final Node node, final JID owner, final PubSubService service, final JID from, final Element childElement, final AccessModel accessModel) {
 
         // Check if the subscriber is an anonymous user.
-        if (XMPPServer.getInstance().isLocal(subscriberJID) && SessionManager.getInstance().isAnonymousRoute(subscriberJID.getNode())) {
+        if (SessionManager.getInstance().isAnonymousClientSession(subscriberJID)) {
             // Anonymous users cannot subscribe to the node. Return forbidden error
             // TODO OF-2506: figure out why anonymous users should not be allowed to subscribe. There is no way to check if remote users are anonymous anyway.
             sendErrorPacket(iq, PacketError.Condition.forbidden, null);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ClientSessionTask.java
@@ -90,6 +90,16 @@ public class ClientSessionTask extends RemoteSessionTask {
                 result = session.isInitialized();
             }
         }
+        if (operation == Operation.isAnonymous) {
+            if (session instanceof RemoteClientSession) {
+                // Something is wrong since the session should be local instead of remote
+                // Assume some default value
+                result = false;
+            }
+            else {
+                result = session.isAnonymousUser();
+            }
+        }
         else if (operation == Operation.incrementConflictCount) {
             if (session instanceof RemoteClientSession) {
                 // Something is wrong since the session should be local instead of remote

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
@@ -208,6 +208,7 @@ public abstract class RemoteSessionTask implements ClusterTask<Object> {
          * Operations of c2s sessions
          */
         isInitialized,
+        isAnonymous,
         incrementConflictCount,
         hasRequestedBlocklist,
         

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -566,7 +566,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         if ( !JiveGlobals.getBooleanProperty( ConnectionSettings.Server.ALLOW_ANONYMOUS_OUTBOUND_DATA, false ) )
         {
             // Disallow anonymous local users to send data to other domains than the local domain.
-            if ( isAnonymousRoute( packet.getFrom() ) )
+            if ( SessionManager.getInstance().isAnonymousClientSession(packet.getFrom()) )
             {
                 Log.info( "The anonymous user '{}' attempted to send data to '{}', which is on a remote domain. Openfire is configured to not allow anonymous users to send data to remote domains.", packet.getFrom(), jid );
                 return false;
@@ -929,20 +929,13 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
         }
     }
 
-    @Override
+    @Deprecated(forRemoval = true, since = "5.0.0") // Remove in or after Openfire 5.1.0    @Override
     public boolean isAnonymousRoute(JID jid) {
         if (jid.getNode() == null || jid.getResource() == null) {
             Log.trace("isAnonymousRoute() invoked with a JID that's not a full JID: {}", jid);
             return false;
         }
-        final Lock lock = usersSessionsCache.getLock(jid.toBareJID());
-        lock.lock();
-        try {
-            // Check if there's an anonymous route for the JID.
-            return anonymousUsersCache.containsKey(jid.toFullJID());
-        } finally {
-            lock.unlock();
-        }
+        return server.getSessionManager().isAnonymousClientSession(jid);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserManager.java
@@ -522,7 +522,7 @@ public final class UserManager {
      * @return True if the address could be used for a locally registered user, potentially not having registered yet.
      */
     public static boolean isPotentialFutureLocalUser(final JID user) {
-        return ALLOW_FUTURE_USERS.getValue() && XMPPServer.getInstance().isLocal(user) && !SessionManager.getInstance().isAnonymousRoute(user.getNode());
+        return ALLOW_FUTURE_USERS.getValue() && XMPPServer.getInstance().isLocal(user) && !SessionManager.getInstance().isAnonymousClientSession(user);
     }
 
     private static void initProvider(final Class<? extends UserProvider> clazz) {

--- a/xmppserver/src/main/webapp/session-row.jspf
+++ b/xmppserver/src/main/webapp/session-row.jspf
@@ -41,7 +41,7 @@
         <td style="width: 10%; white-space: nowrap">
             <%  String name = sess.getAddress().getNode(); %>
             <a href="session-details.jsp?jid=<%= URLEncoder.encode(sess.getAddress().toString(), StandardCharsets.UTF_8) %>" title="<fmt:message key='session.row.click' />"
-            ><%= ((!sessionManager.isAnonymousRoute(sess.getUsername())) ? JID.unescapeNode(name): "<i>"+LocaleUtils.getLocalizedString("session.details.anonymous")+"</i>") %></a>
+            ><%= (!sess.isAnonymousUser() ? JID.unescapeNode(name): "<i>"+LocaleUtils.getLocalizedString("session.details.anonymous")+"</i>") %></a>
         </td>
     </c:if>
     <c:if test="${showResource}">


### PR DESCRIPTION
Openfire used the definition of an ‘anonymous route’ in various places (notably the routing table and session manager).

An anonymous route should be defined as “a route-able session of which the users has an anonymous authentication token.”

A ‘route’ is not inherently anonymous or non-anonymous, a session is.

Implementation that previously used the 'anonymous route' definition is interested only in the fact if the corresponding session is anonymous, not if the session is route-able.

In this commit, the implementations of methods named `isAnonymousRoute` are deprecated. Their implementation is replaced by checks that evaluate the authentication mechanism used in a session.