### PR TITLE
CI: Allow Openfire to log at different levels

### DIFF
--- a/.github/actions/startserver-action/action.yml
+++ b/.github/actions/startserver-action/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Set a hosts file for the given IP and host (or for example.com if running locally)'
     required: false
     default: '127.0.0.1'
+  logLevel:
+    description: 'The verbosity of logging (one of error, warn, info, debug, trace, all)'
+    required: false
+    default: 'info'
 
 runs:
   using: "composite"
@@ -30,5 +34,5 @@ runs:
     - name: Set JAVA_HOME to use Java 17
       run: echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
       shell: bash
-    - run: startCIServer.sh -i ${{ inputs.ip }} -h ${{ inputs.domain }} -b ${{ inputs.distBaseDir }}
+    - run: startCIServer.sh -i ${{ inputs.ip }} -h ${{ inputs.domain }} -b ${{ inputs.distBaseDir }} -l ${{ inputs.logLevel }}
       shell: bash

--- a/.github/actions/startserver-action/startCIServer.sh
+++ b/.github/actions/startserver-action/startCIServer.sh
@@ -6,14 +6,15 @@ HOST='example.org'
 
 usage()
 {
-	echo "Usage: $0 [-i IPADDRESS] [-h HOST] [-b BASEDIR]"
+	echo "Usage: $0 [-i IPADDRESS] [-h HOST] [-b BASEDIR] [-l LOGLEVEL]"
 	echo "    -i: Set a hosts file for the given IP and host (or for example.com if running locally). Reverted at exit."
 	echo "    -h: The network name for the Openfire under test, which will be used for both the hostname as the XMPP domain name (default: example.org)"
 	echo "    -b: The base directory of the distribution that is to be started"
+	echo "    -l: The log level (default: info)"
 	exit 2
 }
 
-while getopts h:i:b: OPTION "$@"; do
+while getopts h:i:b:l: OPTION "$@"; do
 	case $OPTION in
 		h)
 			HOST="${OPTARG}"
@@ -23,6 +24,9 @@ while getopts h:i:b: OPTION "$@"; do
 			;;
 		b)
 			BASEDIR="${OPTARG}"
+			;;
+		l)
+			LOGLEVEL="${OPTARG}"
 			;;
 		\? ) usage;;
         :  ) usage;;
@@ -55,6 +59,11 @@ function launchOpenfire {
 
 	# Replace the default XMPP domain name ('example.org') that's in the demoboot config with the configured domain name.
 	sed -i -e 's/example.org/'"${HOST}"'/g' ${BASEDIR}/conf/openfire.xml
+
+	# Replace the default log level ('info') that's in the log4j config with the configured level.
+	if [[ -n "${LOGLEVEL}" ]]; then
+	    sed -i -e 's/level=\"info\"/level=\"'"${LOGLEVEL}"'\"/' ${BASEDIR}/lib/log4j2.xml
+	fi
 
 	echo "Starting Openfire…"
 	"${OPENFIRE_SHELL_SCRIPT}" &

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -157,6 +157,8 @@ jobs:
       - name: Start CI server from distribution
         id: startCIServer
         uses: ./.github/actions/startserver-action
+        with:
+          logLevel: debug
       - name: Run aioxmpp tests
         working-directory: ./aioxmpp
         run: |
@@ -227,6 +229,8 @@ jobs:
       - name: Start CI server from distribution
         id: startCIServer
         uses: ./.github/actions/startserver-action
+        with:
+          logLevel: debug
       - name: Run connectivity tests
         uses: ./.github/actions/connectivitytests-action
       - name: Stop CI server
@@ -254,6 +258,8 @@ jobs:
       - name: Start CI server from distribution
         id: startCIServer
         uses: ./.github/actions/startserver-action
+        with:
+          logLevel: debug
       - name: Run Smack tests against server
         uses: XMPP-Interop-Testing/xmpp-interop-tests-action@main # TODO replace 'main' with a proper versioned tag, like 'v1'.
         with:


### PR DESCRIPTION
This modifies the GitHub action that's used to start Openfire to take an optional log level. When set, the log4j configuration used by Openfire is modified accordingly.

The continuous integration jobs that use this action are now logging on level 'debug'. That should provide more analytics, in case a step fails.