### PR TITLE
OF-3061: Improve DB query to get last pubsub items

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultPubSubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultPubSubPersistenceProvider.java
@@ -98,7 +98,7 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
             "subscriptionEnabled, configSubscription, accessModel, payloadType, " +
             "bodyXSLT, dataformXSLT, creator, description, language, name, " +
             "replyPolicy, associationPolicy, maxLeafNodes FROM ofPubsubNode " +
- "WHERE serviceID=?";
+            "WHERE serviceID=?";
 
 	private static final String LOAD_NODE = LOAD_NODES + " AND nodeID=?";
 
@@ -572,7 +572,7 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
             	CollectionNode parent = (CollectionNode) nodes.get(entry.getValue());
             	
             	if (parent == null) {
-            		log.error("Could not find parent node " + entry.getValue() + " for node " + entry.getKey());
+            		log.error("Could not find parent node {} for node {}", entry.getValue(), entry.getKey());
             	}
             	else {
                     child.changeParent(parent);
@@ -842,7 +842,7 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
             String nodeID = decodeNodeID(rs.getString(1));
             Node node = lookupNode(nodes, nodeID);
             if (node == null) {
-                log.warn("Roster Group associated to a non-existent node: " + nodeID);
+                log.warn("Roster Group associated to a non-existent node: {}", nodeID);
                 return;
             }
             node.addAllowedRosterGroup(rs.getString(2));
@@ -857,7 +857,7 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
             String nodeID = decodeNodeID(rs.getString(1));
             Node node = lookupNode(nodes, nodeID);
             if (node == null) {
-                log.warn("Affiliations found for a non-existent node: " + nodeID);
+                log.warn("Affiliations found for a non-existent node: {}", nodeID);
                 return;
             }
             NodeAffiliate affiliate = new NodeAffiliate(node, new JID(rs.getString(2)));
@@ -962,15 +962,14 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
             String nodeID = decodeNodeID(rs.getString(1));
             Node node = lookupNode(nodes, nodeID);
             if (node == null) {
-                log.warn("Subscription found for a non-existent node: " + nodeID);
+                log.warn("Subscription found for a non-existent node: {}", nodeID);
                 return;
             }
             String subID = rs.getString(2);
             JID subscriber = new JID(rs.getString(3));
             JID owner = new JID(rs.getString(4));
             if (node.getAffiliate(owner) == null) {
-                log.warn("Subscription found for a non-existent affiliate: " + owner +
-                        " in node: " + node.getUniqueIdentifier());
+                log.warn("Subscription found for a non-existent affiliate: {} in node: {}", owner, node.getUniqueIdentifier());
                 return;
             }
             NodeSubscription.State state = NodeSubscription.State.valueOf(rs.getString(5));
@@ -1462,7 +1461,7 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
                         result = config;
                     }
                     catch (Exception sqle) {
-                        log.error(sqle.getMessage(), sqle);
+                        log.error("An exception occurred while trying to load default configuration from the database for service {} (is leaf type: {})", serviceIdentifier, isLeafType, sqle);
                     }
                     finally {
                         DbConnectionManager.closeConnection(rs, pstmt, con);
@@ -1519,7 +1518,7 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
                 defaultNodeConfigurationCache.put( key, config );
             }
             catch (SQLException sqle) {
-                log.error(sqle.getMessage(), sqle);
+                log.error("An exception occurred while trying to store default configuration to the database for service {} (is leaf type: {})", serviceIdentifier, config.isLeaf(), sqle);
             }
             finally {
                 DbConnectionManager.closeConnection(pstmt, con);
@@ -1573,7 +1572,7 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
                 defaultNodeConfigurationCache.put( getDefaultNodeConfigurationCacheKey( serviceIdentifier, config.isLeaf() ), config );
             }
             catch (SQLException sqle) {
-                log.error(sqle.getMessage(), sqle);
+                log.error("An exception occurred while trying to update default configuration in the database for service {} (is leaf type: {})", serviceIdentifier, config.isLeaf(), sqle);
             }
             finally {
                 DbConnectionManager.closeConnection(pstmt, con);
@@ -1641,14 +1640,15 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
                 	item.setPayloadXML(rs.getString(4));
                 }
                 // Add the published item to the node
-				if (descending)
-					results.add(item);
-				else
-					results.addFirst(item);
+				if (descending) {
+                    results.add(item);
+                } else {
+                    results.addFirst(item);
+                }
             }
         }
         catch (Exception sqle) {
-            log.error(sqle.getMessage(), sqle);
+            log.error("An exception occurred while trying to load the last {} published item(s) from node {}", maxRows, node.getUniqueIdentifier(), sqle);
         }
         finally {
             DbConnectionManager.closeConnection(rs, pstmt, con);
@@ -1682,7 +1682,6 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
                 if (rs.getString(3) != null) {
                     result.setPayloadXML(rs.getString(3));
                 }
-                log.debug("Loaded item from DB");
                 return result;
             }
         } catch (Exception exc) {
@@ -1707,7 +1706,7 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
 		}
 		catch (SQLException exc)
 		{
-			log.error(exc.getMessage(), exc);
+            log.error("An exception occurred while trying to purge node {}", leafNode.getUniqueIdentifier(), exc);
 			rollback = true;
 		}
 		finally
@@ -1757,7 +1756,7 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
                 pepService = new PEPService(XMPPServer.getInstance(), jid);
             }
         } catch (SQLException sqle) {
-            log.error(sqle.getMessage(), sqle);
+            log.error("An exception occurred while trying to load a PEP service from the database for {}", jid, sqle);
         } finally {
             DbConnectionManager.closeConnection(rs, pstmt, con);
         }
@@ -1842,7 +1841,7 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
 		}
 		catch (Exception sqle)
 		{
-		    log.error(sqle.getMessage(), sqle);
+            log.error("An exception occurred while trying to purge all items from the database that exceed the defined item count on all nodes.", sqle);
 			abortTransaction = true;
 		}
 		finally

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/InMemoryPubSubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/InMemoryPubSubPersistenceProvider.java
@@ -348,7 +348,7 @@ public class InMemoryPubSubPersistenceProvider implements PubSubPersistenceProvi
 
         if ( publishedItems != null )
         {
-            final List<PublishedItem> collect = publishedItems.stream().filter( publishedItem -> publishedItem.getID().equals( itemIdentifier.getItemId() ) ).collect( Collectors.toList() );
+            final List<PublishedItem> collect = publishedItems.stream().filter( publishedItem -> publishedItem.getID().equals( itemIdentifier.getItemId() ) ).toList();
             if ( !collect.isEmpty() )
             {
                 if ( collect.size() > 1 )

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/InMemoryPubSubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/InMemoryPubSubPersistenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2020-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -322,25 +322,13 @@ public class InMemoryPubSubPersistenceProvider implements PubSubPersistenceProvi
     @Override
     public List<PublishedItem> getPublishedItems( LeafNode node, int maxRows )
     {
-        log.debug( "Getting published items for node {} (max: {}).", node.getUniqueIdentifier(), maxRows );
+        log.debug( "Getting last published items for node {} (max: {}).", node.getUniqueIdentifier(), maxRows );
         List<PublishedItem> publishedItems = getPublishedItems( node );
         if ( maxRows >= 0 && publishedItems.size() > maxRows )
         {
             publishedItems = publishedItems.subList( publishedItems.size() - maxRows, publishedItems.size() );
         }
         return publishedItems;
-    }
-
-    @Override
-    public PublishedItem getLastPublishedItem( LeafNode node )
-    {
-        log.debug( "Getting last published item for node {}", node.getUniqueIdentifier() );
-        final List<PublishedItem> publishedItems = getPublishedItems( node );
-        if ( publishedItems != null && !publishedItems.isEmpty() ) {
-            return publishedItems.get( publishedItems.size() - 1 );
-        }
-
-        return null;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProvider.java
@@ -30,7 +30,19 @@ import java.util.Set;
  */
 public interface PubSubPersistenceProvider
 {
+    /**
+     * Starts the provider.
+     *
+     * This method is invoked before the provider is used to interact with the backend datastore.
+     */
     void initialize();
+
+    /**
+     * Stops the provider.
+     *
+     * This method is invoked when the system is to be shut down. The provider should not be used after this method is
+     * invoked.
+     */
     void shutdown();
 
     /**
@@ -71,6 +83,12 @@ public interface PubSubPersistenceProvider
      */
     void loadNode(PubSubService service, Node.UniqueIdentifier nodeIdentifier);
 
+    /**
+     * Loads a subscription from the database, storing it in the provided node.
+     *
+     * @param node The node for which a subscription is to be loaded from the database.
+     * @param subId The identifier of the subscription that is to be loaded from the database.
+     */
     void loadSubscription(Node node, String subId);
 
     /**
@@ -211,8 +229,20 @@ public interface PubSubPersistenceProvider
         }
     }
 
+    /**
+     * Fetches a published item (by ID) for a node.
+     *
+     * @param node The node for which to get a published item.
+     * @param itemIdentifier The unique identifier of the item to fetch.
+     * @return The item, or null if no item was found.
+     */
     PublishedItem getPublishedItem(LeafNode node, PublishedItem.UniqueIdentifier itemIdentifier);
 
+    /**
+     * Deletes all published items of a node.
+     *
+     * @param leafNode the node for which to delete all published items.
+     */
     void purgeNode(LeafNode leafNode);
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubPersistenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2020-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,7 +202,14 @@ public interface PubSubPersistenceProvider
      *
      * @param node the leaf node to load its last published items.
      */
-    PublishedItem getLastPublishedItem(LeafNode node);
+    default PublishedItem getLastPublishedItem(LeafNode node) {
+        final List<PublishedItem> items = getPublishedItems(node, 1);
+        if (items.isEmpty()) {
+            return null;
+        } else {
+            return items.get(0);
+        }
+    }
 
     PublishedItem getPublishedItem(LeafNode node, PublishedItem.UniqueIdentifier itemIdentifier);
 


### PR DESCRIPTION
The old codebase defined two queries to get the last item for a pubsub node, and to get all items for a pubsub node. The actual SQL of both definitions is the same. It does not contain any ‘limit’ or ‘top’ clause (although database driver hints are given).

This is likely the result of Openfire supporting multiple database systems, that each have their own clauses to limit a resultset. SQLServer uses `SELECT TOP(?) ...`, Oracle has `... FETCH FIRST ? ROWS ONLY` while other databases generally use `... LIMIT ?`. It is inconvenient to fold all these alternatives in one implementation.

In this commit, the code is modified to:

- limit the size of the requested resultset from the database appropriately.
- remove SQL duplication (getting the latest item can use the same query as getting the latest X items, using an argument value of 1).

This intends to make the database interaction more efficient (by reducing the likelihood that the database offers up all items for a node, when only a few (or one!) is needed.