### PR TITLE
OF-3064: Fix Roster Versioning

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRosterHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRosterHandler.java
@@ -191,7 +191,7 @@ public class IQRosterHandler extends IQHandler implements ServerFeaturesProvider
 
                 if (RosterManager.isRosterVersioningEnabled()) {
                     String clientVersion = packet.getChildElement().attributeValue("ver");
-                    String latestVersion = String.valueOf( cachedRoster.hashCode() );
+                    String latestVersion = String.valueOf( cachedRoster.getVersion() );
                     // Whether or not the roster has been modified since the version ID enumerated by the client, ...
                     if (!latestVersion.equals(clientVersion)) {
                         // ... the server MUST either return the complete roster

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItem.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItem.java
@@ -681,4 +681,13 @@ public class RosterItem implements Cacheable, Externalizable {
     public void setStoredSubscribeStanza(Presence subscribeStanza) {
         this.subscribeStanza = subscribeStanza;
     }
+
+    /**
+     * Generates a hash code based on only those fields that are relevant for Roster Versioning (as defined in RFC 6121 section 2.6).
+     *
+     * @return A hash code
+     */
+    public int rosterVerHashCode() {
+        return Objects.hash(recvStatus, jid, nickname, groups, sharedGroups, invisibleSharedGroups, subStatus, askStatus, rosterID);
+    }
 }


### PR DESCRIPTION
When calculating the 'version' of a roster:
- apply changes before the calculation;
- base the calculation on state of the roster, not on a memory address (`Object#hashCode()`)

Instead of using Roster's `hashCode()` implementation, this commit introduces a very similar method. This calculates a hash based on only those bits of state that are relevent for roster versioning (notably, it excludes RosterItem's 'subscribeStanza' field).