### PR TITLE
OF-2717: Bump Jetty from 12.0.14 to 12.0.21

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -124,7 +124,7 @@
         <!-- Versions -->
         <openfire.version>5.0.0-SNAPSHOT</openfire.version>
         <!-- Note; the following jetty.version should be identical to the jetty.version in xmppserver/pom.xml -->
-        <jetty.version>12.0.14</jetty.version>
+        <jetty.version>12.0.21</jetty.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 
         <!-- Versions -->
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
-        <jetty.version>12.0.14</jetty.version>
+        <jetty.version>12.0.21</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <netty.version>4.1.118.Final</netty.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>


### PR DESCRIPTION
For good measure, use the latest available release. Also prevents CVE-2025-1948 from popping up in static code analyzers (I'm not sure if Openfire was affected by this issue).