### PR TITLE
OF-2280: Properly close secondary s2s connection on cluster join

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/RoutingTableImpl.java
@@ -1025,6 +1025,7 @@ public class RoutingTableImpl extends BasicModule implements RoutingTable, Clust
             final NodeID host = serversCache.get(route);
             if (host != null && !host.equals(XMPPServer.getInstance().getNodeID())) {
                 Log.warn("Unable to remove Server Route for '{}': Server Routes can only be removed by the cluster node that holds the physical connection. The cluster node that holds the physical connection for this route is not the local node, but: '{}'", route, host, new IllegalStateException());
+                localServerRoutingTable.removeRoute(route); // If the connection is not connected locally, then there shouldn't be a registration in the local routing table (this happens when closing duplicate s2s connections on cluster join).
                 return false;
             }
             removed = serversCache.remove(route) != null;


### PR DESCRIPTION
When two servers that already have an outbound server-to-server connection to a remote domain join the same local Openfire cluster, Openfire will close one of the s2s connections (this is because Openfire currently does not support having more than one cluster node with an outbound s2s connection to the same domain - something that is subject to improvement under OF-2301).

This commit fixes an issue that prevented the second connection to be removed from the local routing table of the host that it got removed in. This bug is likely introduced by the previous commit for OF-2280.