### PR TITLE
OF-3067: Allow for more concurrent s2s connections.

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -61,7 +61,7 @@ public class OutgoingSessionPromise {
     public static final SystemProperty<Integer> QUEUE_MAX_THREADS = SystemProperty.Builder.ofType(Integer.class)
         .setKey(ConnectionSettings.Server.QUEUE_MAX_THREADS)
         .setDynamic(false)
-        .setDefaultValue(20)
+        .setDefaultValue(100)
         .setMinValue(0) // RejectedExecutionHandler is CallerRunsPolicy, meaning that the calling thread would execute the task.
         .build();
 


### PR DESCRIPTION
This prevents an artificial resource constraint to kick in whenever a user with contacts on many different domains logs in.