### PR TITLE
OF-3072: Fix server handling of NoSuchUser / Presence probe

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/PresenceManagerImpl.java
@@ -317,7 +317,7 @@ public class PresenceManagerImpl extends BasicModule implements PresenceManager,
         }
         catch (UserNotFoundException e) {
             Presence presenceToSend = new Presence();
-            presenceToSend.setError(PacketError.Condition.forbidden);
+            presenceToSend.setType(Presence.Type.unsubscribed);
             presenceToSend.setTo(packet.getFrom());
             presenceToSend.setFrom(packet.getTo());
             deliverer.deliver(presenceToSend);


### PR DESCRIPTION
[RFC6162, Section 8.5.1](https://datatracker.ietf.org/doc/html/rfc6121#section-8.5.1):

> If the 'to' address specifies a [...] full JID <localpart@domainpart/resourcepart> where the domainpart of the JID matches a configured domain that is serviced by the server itself, the server MUST proceed as follows. [...] If the user account identified by the 'to' attribute does not exist, how the stanza is processed depends on the stanza type. [...] For a presence stanza of type "probe", the server MUST either (a) silently ignore the stanza or (b) return a presence stanza of type "unsubscribed"."

Openfire used to send 'forbidden' in this case. That's corrected in this commit.