### PR TITLE
OF-3079: Bump Jetty from 12.0.21 to 12.0.22 (restore plugin compat)

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.7.1</version>
                 <configuration>
                     <descriptors>
                         <descriptor>src/assembly/basic-distribution.xml</descriptor>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -255,7 +255,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.7.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.igniterealtime.openfire.plugins</groupId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -124,7 +124,7 @@
         <!-- Versions -->
         <openfire.version>5.0.0-SNAPSHOT</openfire.version>
         <!-- Note; the following jetty.version should be identical to the jetty.version in xmppserver/pom.xml -->
-        <jetty.version>12.0.21</jetty.version>
+        <jetty.version>12.0.22</jetty.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 
         <!-- Versions -->
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
-        <jetty.version>12.0.21</jetty.version>
+        <jetty.version>12.0.22</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <netty.version>4.1.118.Final</netty.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.7.1</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
This should fix a stacktrace that's shown when opening admin console pages of plugins that are compiled against older versions of Openfire (this issue appears only in unreleased versions of Openfire).