### PR TITLE
Revert "OF-2945: Prevent stack traces when pre-compiling JSP pages"

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -309,19 +309,6 @@
                             </configuration>
                         </execution>
                     </executions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.eclipse.jetty.ee8</groupId>
-                            <artifactId>jetty-ee8-glassfish-jstl</artifactId>
-                            <version>${jetty.version}</version>
-                            <exclusions>
-                                <exclusion> <!-- The exclusion of Xalan is no longer needed when Jetty bug https://github.com/jetty/jetty.project/issues/12674 is fixed. The fix is expected to be part of Jetty release 12.0.17. -->
-                                    <groupId>xalan</groupId>
-                                    <artifactId>xalan</artifactId>
-                                </exclusion>
-                            </exclusions>
-                        </dependency>
-                    </dependencies>
                 </plugin>
 
                 <plugin>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -175,19 +175,6 @@
                         </configuration>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.ee8</groupId>
-                        <artifactId>jetty-ee8-glassfish-jstl</artifactId>
-                        <version>${jetty.version}</version>
-                        <exclusions>
-                            <exclusion> <!-- The exclusion of Xalan is no longer needed when Jetty bug https://github.com/jetty/jetty.project/issues/12674 is fixed. The fix is expected to be part of Jetty release 12.0.17. -->
-                                <groupId>xalan</groupId>
-                                <artifactId>xalan</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
-                </dependencies>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
This reverts commit 9a9b25351f65079b35ba788cf691e1a0019d5aad.

Now that Jetty has been upgraded to a version later than 12.0.17, the work-around introduced under OF-2945 is no longer needed.