### PR TITLE
OF-2526: Don't include SystemD artifacts in RPM

### DIFF
--- a/build/rpm/openfire.spec
+++ b/build/rpm/openfire.spec
@@ -76,6 +76,9 @@ rm -rf $RPM_BUILD_ROOT%{homedir}/resources/nativeAuth/osx-ppc
 rm -rf $RPM_BUILD_ROOT%{homedir}/resources/nativeAuth/win32-x86
 rm -f $RPM_BUILD_ROOT%{homedir}/lib/*.dll
 rm -f $RPM_BUILD_ROOT%{homedir}/conf/openfire-demoboot.xml
+rm -f $RPM_BUILD_ROOT%{homedir}/dist/etc/ufw/applications.d/openfire
+rm -f $RPM_BUILD_ROOT%{homedir}/dist/usr/lib/systemd/system/openfire.service
+rm -f $RPM_BUILD_ROOT%{homedir}/dist/usr/lib/systemd/system/openfire.slice
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
After new SystemD config files were added (for Debian), the RPM build failed with this error:

```
+ /usr/lib/rpm/check-buildroot
error: Installed (but unpackaged) file(s) found:
   /opt/openfire/dist/etc/ufw/applications.d/openfire
   /opt/openfire/dist/usr/lib/systemd/system/openfire.service
   /opt/openfire/dist/usr/lib/systemd/system/openfire.slice
    Installed (but unpackaged) file(s) found:
   /opt/openfire/dist/etc/ufw/applications.d/openfire
   /opt/openfire/dist/usr/lib/systemd/system/openfire.service
   /opt/openfire/dist/usr/lib/systemd/system/openfire.slice
mv: cannot stat '/home/bamboo-agent3/bamboo-agent-home/xml-data/build-dir/OPENFIRE-NMRB-JOB1/rpmbuild/RPMS/noarch/openfire*rpm': No such file or directory
```

The new files for Debian seem to break the RPM build.

The changes in this commit exclude those files from the RPM build.