### PR TITLE
Improve docker caching

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -754,7 +754,7 @@ jobs:
           images: ${{ env.REGISTRY }}/igniterealtime/${{ env.IMAGE_NAME }}
 
       - name: Setup buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -753,6 +753,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/igniterealtime/${{ env.IMAGE_NAME }}
 
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -755,12 +755,14 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
The goal here is to ensure that docker rebuilds are fast, and especially so when inside CI.

This PR achieves this by two methods:

Using build-time cache mounts to handle the Maven repository. These are held independent of the "hash", so can persist (or not) between builds even if the calling hash changes. In our case, this means that if the pom.xml files change, we may reuse an "old" Maven repo and just fetch the changes.

Having the docker engine upload the docker cache (which includes the above, and also layers) to Github's cache API, and restore it prior to a build.

Tested by:

Enabling the docker build for this branch, and disabling push. Forced a rebuild which executed very quickly. This is as far as I think we can go at this stage. Realistically, I would expect this to be a step on the way, rather than the endpoint solution, because we'll learn more. There may be a way of reusing the maven repo from the first CI stage build, for example, but this will need to wait.