### PR TITLE
OF-3084 OF-3086: Remove deprecated date/time API

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/SessionData.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/SessionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,11 +79,6 @@ public class SessionData {
      */
     public JID getOwner() {
         return owner;
-    }
-
-    @Deprecated(since = "4.8.1", forRemoval = true) // replaced by getCreationInstant. Remove in Openfire 5.0.0 or later.
-    public long getCreationStamp() {
-        return creationStamp.toEpochMilli();
     }
 
     public Instant getCreationInstant() {


### PR DESCRIPTION
Use `getCreationInstant` instead of the method removed in this commit.