### PR TITLE
OF-3084 OF-3087: Remove deprecated `PluginManager#getPlugin()`

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -626,7 +626,7 @@ public class XMPPServer {
                         // Otherwise, the page that requested the setup finish won't
                         // render properly!
                         Thread.sleep(1000);
-                        ((AdminConsolePlugin) pluginManager.getPlugin("admin")).restart();
+                        pluginManager.getPluginByCanonicalName("admin").ifPresent(plugin -> ((AdminConsolePlugin) plugin).restart());
                     }
 
                     verifyDataSource();
@@ -923,7 +923,7 @@ public class XMPPServer {
                 // Otherwise, this page won't render properly!
                 try {
                     Thread.sleep(1000);
-                    ((AdminConsolePlugin) pluginManager.getPlugin("admin")).restart();
+                    pluginManager.getPluginByCanonicalName("admin").ifPresent(plugin -> ((AdminConsolePlugin) plugin).restart());
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetAdminConsoleInfo.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/GetAdminConsoleInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ public class GetAdminConsoleInfo extends AdHocCommand {
 
         // Gets a valid bind interface
         PluginManager pluginManager = XMPPServer.getInstance().getPluginManager();
-        AdminConsolePlugin adminConsolePlugin = ((AdminConsolePlugin) pluginManager.getPlugin("admin"));
+        AdminConsolePlugin adminConsolePlugin = ((AdminConsolePlugin) pluginManager.getPluginByCanonicalName("admin").orElseThrow());
 
         String bindInterface = adminConsolePlugin.getBindInterface();
         int adminPort = adminConsolePlugin.getAdminUnsecurePort();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
@@ -67,7 +67,7 @@ public class AdminConsolePlugin implements Plugin {
         .setKey("adminConsole.forwarded.enabled")
         .setDynamic(false)
         .setDefaultValue(false)
-        .addListener(enabled -> ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).restartNeeded = true)
+        .addListener(enabled -> XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin").ifPresent(plugin -> ((AdminConsolePlugin) plugin).restartNeeded = true))
         .build();
 
     /**
@@ -77,7 +77,7 @@ public class AdminConsolePlugin implements Plugin {
         .setKey("adminConsole.forwarded.for.header")
         .setDynamic(false)
         .setDefaultValue(HttpHeader.X_FORWARDED_FOR.toString())
-        .addListener(enabled -> ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).restartNeeded = true)
+        .addListener(enabled -> XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin").ifPresent(plugin -> ((AdminConsolePlugin) plugin).restartNeeded = true))
         .build();
 
     /**
@@ -87,7 +87,7 @@ public class AdminConsolePlugin implements Plugin {
         .setKey("adminConsole.forwarded.server.header")
         .setDynamic(false)
         .setDefaultValue(HttpHeader.X_FORWARDED_SERVER.toString())
-        .addListener(enabled -> ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).restartNeeded = true)
+        .addListener(enabled -> XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin").ifPresent(plugin -> ((AdminConsolePlugin) plugin).restartNeeded = true))
         .build();
 
     /**
@@ -97,7 +97,7 @@ public class AdminConsolePlugin implements Plugin {
         .setKey("adminConsole.forwarded.host.header")
         .setDynamic(false)
         .setDefaultValue(HttpHeader.X_FORWARDED_HOST.toString())
-        .addListener(enabled -> ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).restartNeeded = true)
+        .addListener(enabled -> XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin").ifPresent(plugin -> ((AdminConsolePlugin) plugin).restartNeeded = true))
         .build();
 
     /**
@@ -107,7 +107,7 @@ public class AdminConsolePlugin implements Plugin {
         .setKey("adminConsole.forwarded.host.name")
         .setDynamic(false)
         .setDefaultValue(null)
-        .addListener(enabled -> ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).restartNeeded = true)
+        .addListener(enabled -> XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin").ifPresent(plugin -> ((AdminConsolePlugin) plugin).restartNeeded = true))
         .build();
 
     /**
@@ -466,7 +466,8 @@ public class AdminConsolePlugin implements Plugin {
      * process. The following pseudo code demonstrates how to do this:
      *
      * <pre>
-     *   ContextHandlerCollection contexts = ((AdminConsolePlugin)pluginManager.getPlugin("admin")).getContexts();
+     *   AdminConsolePlugin plugin = ((AdminConsolePlugin) pluginManager.getPluginByCanonicalName("admin").orElseThrow())
+     *   ContextHandlerCollection contexts = plugin.getContexts();
      *   context = new WebAppContext(SOME_DIRECTORY, "/CONTEXT_NAME");
      *   contexts.addHandler(context);
      *   context.setWelcomeFiles(new String[]{"index.jsp"});

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/GetAdminConsoleInfoTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/GetAdminConsoleInfoTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public class GetAdminConsoleInfoTask implements ClusterTask<GetAdminConsoleInfoT
     @Override
     public void run() {
         PluginManager pluginManager = XMPPServer.getInstance().getPluginManager();
-        AdminConsolePlugin adminConsolePlugin = ((AdminConsolePlugin) pluginManager.getPlugin("admin"));
+        AdminConsolePlugin adminConsolePlugin = ((AdminConsolePlugin) pluginManager.getPluginByCanonicalName("admin").orElseThrow());
 
         bindInterface = adminConsolePlugin.getBindInterface();
         adminPort = adminConsolePlugin.getAdminUnsecurePort();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/IsPluginInstalledTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/IsPluginInstalledTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ public class IsPluginInstalledTask implements ClusterTask<Boolean> {
 
     @Override
     public void run() {
-        installed = XMPPServer.getInstance().getPluginManager().getPlugin(pluginName) != null;
+        installed = XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName(pluginName).isPresent();
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -381,15 +381,15 @@ public class PluginManager
      * Returns a loaded plugin by its canonical name or {@code null} if a plugin with that name does not exist. The
      * canonical name is the lowercase-name of the plugin archive, without the file extension. For example: "broadcast".
      *
-     * @deprecated in Openfire 4.4 in favour of {@link #getPluginByName(String)}
+     * Note that the canonical name of the plugin is sensitive to filenames outside of the plugin's author direct
+     * control. Prefer using {@link #getPluginByName(String)}.
+     *
      * @param canonicalName the name of the plugin.
      * @return the plugin.
      */
-    // TODO: (2019-03-26) Remove with Openfire 5.0
-    @Deprecated(since = "4.4", forRemoval = true)
-    public synchronized Plugin getPlugin( String canonicalName )
+    public synchronized Optional<Plugin> getPluginByCanonicalName( String canonicalName )
     {
-        return pluginsLoaded.get( canonicalName.toLowerCase() );
+        return Optional.ofNullable(pluginsLoaded.get( canonicalName.toLowerCase() ));
     }
 
     /**
@@ -774,7 +774,7 @@ public class PluginManager
     {
         Log.debug( "Reloading plugin '{}'...", pluginName );
 
-        final Plugin plugin = getPlugin( pluginName );
+        final Plugin plugin = pluginsLoaded.get( pluginName.toLowerCase() );
         if ( plugin == null )
         {
             Log.warn( "Unable to reload plugin '{}'. No such plugin loaded.", pluginName );

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMonitor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginMonitor.java
@@ -16,7 +16,6 @@
 
 package org.jivesoftware.openfire.container;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -334,7 +333,7 @@ public class PluginMonitor implements PropertyEventListener
 
                         // Before running any plugin, make sure that the admin plugin is loaded. It is a dependency
                         // of all plugins that attempt to modify the admin panel.
-                        if ( pluginManager.getPlugin( "admin" ) == null )
+                        if ( !pluginManager.isLoaded( "admin"))
                         {
                             pluginManager.loadPlugin( "admin", dirs.getFirst().get( 0 ) );
                         }
@@ -350,9 +349,9 @@ public class PluginMonitor implements PropertyEventListener
                                     int loaded = 0;
                                     for (final Path path : hierarchy) {
                                         // If the plugin hasn't already been started, start it.
-                                        final String canonicalName = PluginMetadataHelper.getCanonicalName(path);
-                                        if (pluginManager.getPlugin(canonicalName) == null) {
-                                            if (pluginManager.loadPlugin(canonicalName, path)) {
+                                        final String name = PluginMetadataHelper.getName(path);
+                                        if (pluginManager.getPluginByName(name).isEmpty()) {
+                                            if (pluginManager.loadPlugin(PluginMetadataHelper.getCanonicalName(path), path)) {
                                                 loaded++;
                                             }
                                         }

--- a/xmppserver/src/main/java/org/jivesoftware/util/LocaleUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/LocaleUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -563,10 +563,8 @@ public class LocaleUtils {
         // Retrieve classloader from pluginName.
         final XMPPServer xmppServer = XMPPServer.getInstance();
         PluginManager pluginManager = xmppServer.getPluginManager();
-        Plugin plugin = pluginManager.getPlugin(pluginName);
-        if (plugin == null) {
-            throw new NullPointerException("Plugin could not be located: " + pluginName);
-        }
+        Plugin plugin = pluginManager.getPluginByCanonicalName(pluginName)
+            .orElseThrow(() -> new NullPointerException("Plugin could not be located: " + pluginName) );
 
         ClassLoader pluginClassLoader = pluginManager.getPluginClassloader(plugin);
         try {
@@ -600,11 +598,8 @@ public class LocaleUtils {
         // Retrieve classloader from pluginName.
         final XMPPServer xmppServer = XMPPServer.getInstance();
         PluginManager pluginManager = xmppServer.getPluginManager();
-        Plugin plugin = pluginManager.getPlugin(pluginName);
-        if (plugin == null) {
-            throw new NullPointerException("Plugin could not be located.");
-        }
-
+        Plugin plugin = pluginManager.getPluginByCanonicalName(pluginName)
+            .orElseThrow(() -> new NullPointerException("Plugin could not be located: " + pluginName) );
         ClassLoader pluginClassLoader = pluginManager.getPluginClassloader(plugin);
         return ResourceBundle.getBundle(i18nFile, locale, pluginClassLoader);
     }

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -859,13 +859,10 @@ public class CacheFactory {
 
     private static ClassLoader getClusteredCacheStrategyClassLoader() {
         PluginManager pluginManager = XMPPServer.getInstance().getPluginManager();
-        Plugin plugin = pluginManager.getPlugin("hazelcast");
-        if (plugin == null) {
-            plugin = pluginManager.getPlugin("clustering");
-            if (plugin == null) {
-                plugin = pluginManager.getPlugin("enterprise");
-            }
-        }
+        Plugin plugin = pluginManager.getPluginByCanonicalName("hazelcast")
+            .or(() -> pluginManager.getPluginByCanonicalName("clustering"))
+            .or(() -> pluginManager.getPluginByCanonicalName("enterprise"))
+            .orElse(null);
         PluginClassLoader pluginLoader = pluginManager.getPluginClassloader(plugin);
         if (pluginLoader != null) {
             if (log.isDebugEnabled()) {

--- a/xmppserver/src/main/webapp/import-keystore-certificate.jsp
+++ b/xmppserver/src/main/webapp/import-keystore-certificate.jsp
@@ -75,7 +75,8 @@
             try {
                 // When updating certificates through the admin console, do not immediately restart the website, as that
                 // is very likely to lock out the administrator that is performing the changes.
-                ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+                XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin")
+                    .ifPresent(plugin -> ((AdminConsolePlugin) plugin).pauseAutoRestartEnabled(Duration.ofMinutes(5)));
 
                 final IdentityStore identityStore = XMPPServer.getInstance().getCertificateStoreManager().getIdentityStore( connectionType );
 

--- a/xmppserver/src/main/webapp/import-truststore-certificate.jsp
+++ b/xmppserver/src/main/webapp/import-truststore-certificate.jsp
@@ -89,7 +89,8 @@
             {
                 // When updating certificates through the admin console, do not immediately restart the website, as that
                 // is very likely to lock out the administrator that is performing the changes.
-                ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+                XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin")
+                    .ifPresent(plugin -> ((AdminConsolePlugin) plugin).pauseAutoRestartEnabled(Duration.ofMinutes(5)));
 
                 // Import certificate
                 trustStoreConfig.installCertificate( alias, certificate );

--- a/xmppserver/src/main/webapp/plugin-showfile.jsp
+++ b/xmppserver/src/main/webapp/plugin-showfile.jsp
@@ -16,7 +16,6 @@
 
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page import="org.jivesoftware.util.ParamUtils" %>
-<%@ page import="org.jivesoftware.openfire.container.Plugin" %>
 <%@ page import="org.jivesoftware.openfire.container.PluginManager" %>
 <%@ page import="java.nio.file.Path" %>
 <%@ page import="java.io.*" %>
@@ -33,8 +32,7 @@
         final PluginManager pluginManager = webManager.getXMPPServer().getPluginManager();
 
         final String pluginName = ParamUtils.getParameter(request, "plugin" );
-        final Plugin plugin = pluginManager.getPlugin( pluginName );
-        if ( plugin != null )
+        pluginManager.getPluginByCanonicalName( pluginName ).ifPresent(plugin ->
         {
             final Path filePath;
             final Path pluginPath = pluginManager.getPluginPath( plugin );
@@ -62,6 +60,6 @@
                     ioe.printStackTrace();
                 }
             }
-        }
+        });
     }
 %>

--- a/xmppserver/src/main/webapp/security-keystore-signing-request.jsp
+++ b/xmppserver/src/main/webapp/security-keystore-signing-request.jsp
@@ -110,7 +110,8 @@
                // When updating certificates through the admin console, do not cause changes to restart the website, as
                // that is very likely to log out the administrator that is performing the changes. As the keystore change
                // event is async, this line disables restarting the plugin for a few minutes.
-               ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+               XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin")
+                   .ifPresent(plugin -> ((AdminConsolePlugin) plugin).pauseAutoRestartEnabled(Duration.ofMinutes(5)));
 
                X500NameBuilder builder = new X500NameBuilder();
                builder.addRDN(BCStyle.CN, name);

--- a/xmppserver/src/main/webapp/security-keystore.jsp
+++ b/xmppserver/src/main/webapp/security-keystore.jsp
@@ -105,7 +105,8 @@
                     // When updating certificates through the admin console, do not cause changes to restart the website, as
                     // that is very likely to log out the administrator that is performing the changes. As the keystore change
                     // event is async, this line disables restarting the plugin for a few minutes.
-                    ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+                    XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin")
+                        .ifPresent(plugin -> ((AdminConsolePlugin) plugin).pauseAutoRestartEnabled(Duration.ofMinutes(5)));
 
                     identityStore.delete( alias );
 
@@ -130,7 +131,8 @@
             // When updating certificates through the admin console, do not cause changes to restart the website, as
             // that is very likely to log out the administrator that is performing the changes. As the keystore change
             // event is async, this line disables restarting the plugin for a few minutes.
-            ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+            XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin")
+                .ifPresent(plugin -> ((AdminConsolePlugin) plugin).pauseAutoRestartEnabled(Duration.ofMinutes(5)));
 
             if (!identityStore.containsAllIdentityCertificate()) {
                 identityStore.addSelfSignedDomainCertificate();
@@ -157,7 +159,8 @@
                 // When updating certificates through the admin console, do not cause changes to restart the website, as
                 // that is very likely to log out the administrator that is performing the changes. As the keystore change
                 // event is async, this line disables restarting the plugin for a few minutes.
-                ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+                XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin")
+                    .ifPresent(plugin -> ((AdminConsolePlugin) plugin).pauseAutoRestartEnabled(Duration.ofMinutes(5)));
 
                 identityStore.installCSRReply(alias, reply);
                 identityStore.persist();
@@ -172,7 +175,8 @@
         }
     }
 
-    final boolean restartNeeded = ( (AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin( "admin" ) ).isRestartNeeded();
+    final AdminConsolePlugin plugin = (AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin").orElse(null);
+    final boolean restartNeeded = plugin != null && plugin.isRestartNeeded();
     pageContext.setAttribute( "restartNeeded", restartNeeded );
 
     boolean offerUpdateIssuer = false;

--- a/xmppserver/src/main/webapp/security-truststore.jsp
+++ b/xmppserver/src/main/webapp/security-truststore.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2018-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2018-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -97,7 +97,8 @@
                     // When updating certificates through the admin console, do not cause changes to restart the website, as
                     // that is very likely to log out the administrator that is performing the changes. As the keystore change
                     // event is async, this line disables restarting the plugin for a few minutes.
-                    ((AdminConsolePlugin) XMPPServer.getInstance().getPluginManager().getPlugin("admin")).pauseAutoRestartEnabled(Duration.ofMinutes(5));
+                    XMPPServer.getInstance().getPluginManager().getPluginByCanonicalName("admin")
+                        .ifPresent(plugin -> ((AdminConsolePlugin) plugin).pauseAutoRestartEnabled(Duration.ofMinutes(5)));
 
                     trustStore.delete( alias );
 


### PR DESCRIPTION
The method removed by this commit depends on a name which is not under control of the plugin's author: the file name of the JAR that is used to deploy the plugin. The `getPluginByName` method provides more predictable results.

In some instances, the filename-based lookup is still required (for example, the Admin Console, which is loaded as a plugin, does not have a 'name'). For those instances, a new method is introduces (`getPluginByCanonicalName`) that is equivalent to the removed method (this effectively is a rename of that method, wrapping the result in an `Optional`). Now that the old method name is no longer available, developers are forced to explicitly choose between the two available alternatives. Generally speaking, the `getPluginByName` method should be used.