### PR TITLE
OF-3084 OF-3088: Refactor Cache Locking implementation

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/Cache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/Cache.java
@@ -256,10 +256,8 @@ public interface Cache<K extends Serializable, V extends Serializable> extends j
      * @param key the object that defines the visibility or scope of the lock.
      * @return an existing lock on the specified key or creates a new one if none was found.
      */
-    @SuppressWarnings("deprecation")
-    default Lock getLock(final K key) {
-        return CacheFactory.getLock(key, this);
-    }
+    @Nonnull
+    Lock getLock(final K key);
 
     AtomicBoolean secretKey = new AtomicBoolean(false);
     AtomicBoolean secretValue = new AtomicBoolean(false);

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -604,31 +604,6 @@ public class CacheFactory {
         }
     }
 
-    /**
-     * @deprecated in favour of {@link Cache#getLock}. Will be removed in Openfire 5.0.0.
-     *
-     * <p>Returns an existing {@link java.util.concurrent.locks.Lock} on the specified key or creates a new one
-     * if none was found. This operation is thread safe. Successive calls with the same key may or may not
-     * return the same {@link java.util.concurrent.locks.Lock}. However, different threads asking for the
-     * same Lock at the same time will get the same Lock object.<p>
-     *
-     * The supplied cache may or may not be used depending whether the server is running on cluster mode
-     * or not. When not running as part of a cluster then the lock will be unrelated to the cache and will
-     * only be visible in this JVM.
-     *
-     * @param key the object that defines the visibility or scope of the lock.
-     * @param cache the cache used for holding the lock.
-     * @return an existing lock on the specified key or creates a new one if none was found.
-     */
-    @Deprecated(since = "4.5", forRemoval = true)
-    public static synchronized Lock getLock(Object key, Cache cache) {
-        if (localOnly.contains(cache.getName())) {
-            return localCacheFactoryStrategy.getLock(key, cache);
-        } else {
-            return cacheFactoryStrategy.getLock(key, cache);
-        }
-    }
-
     @SuppressWarnings("unchecked")
     private static <T extends Cache> T wrapCache(T cache, String name) {
         if ("Routing Components Cache".equals(name)) {

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactoryStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactoryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import org.jivesoftware.openfire.cluster.ClusterNodeInfo;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.concurrent.locks.Lock;
 
 /**
  * Implementation of CacheFactory that relies on the specific clustering solution.
@@ -177,18 +176,6 @@ public interface CacheFactoryStrategy {
      */
     void updateCacheStats(Map<String, Cache> caches);
 
-    /**
-     * Returns an existing lock on the specified key or creates a new one if none was found. This
-     * operation is thread safe. The supplied cache may or may not be used depending whether
-     * the server is running on cluster mode or not. When not running as part of a cluster then
-     * the lock will be unrelated to the cache and will only be visible in this JVM.
-     *
-     * @param key the object that defines the visibility or scope of the lock.
-     * @param cache the cache used for holding the lock.
-     * @return an existing lock on the specified key or creates a new one if none was found.
-     */
-    Lock getLock(Object key, Cache cache);
-    
     /**
      * Get the plugin name corresponding to this clustering implementation
      * 

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheWrapper.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Acts as a proxy for a Cache implementation. The Cache implementation can be switched on the fly,
@@ -148,6 +149,12 @@ public class CacheWrapper<K extends Serializable, V extends Serializable> implem
     @Override
     public Set<K> keySet() {
         return Collections.unmodifiableSet(cache.keySet());
+    }
+
+    @Nonnull
+    @Override
+    public Lock getLock(K key) {
+        return cache.getLock(key);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CaffeineCache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CaffeineCache.java
@@ -16,6 +16,7 @@
 package org.jivesoftware.util.cache;
 
 import org.jivesoftware.openfire.cluster.ClusteredCacheEntryListener;
+import org.jivesoftware.util.cache.lock.LocalLock;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
@@ -25,6 +26,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Wraps an instance of Ben Manes' Caffeine cache in a class that inherits from
@@ -431,7 +433,7 @@ public class CaffeineCache<K extends Serializable, V extends Serializable> imple
     /**
      * Copies all of the mappings from the specified map to this map
      * (optional operation).  The effect of this call is equivalent to that
-     * of calling {@link #put(Object, Object) put(k, v)} on this map once
+     * of calling {@link #put(Serializable, Serializable)} on this map once
      * for each mapping from key <tt>k</tt> to value <tt>v</tt> in the
      * specified map.  The behavior of this operation is undefined if the
      * specified map is modified while the operation is in progress.
@@ -476,6 +478,12 @@ public class CaffeineCache<K extends Serializable, V extends Serializable> imple
     public Set<K> keySet()
     {
         return Collections.unmodifiableSet( cache.asMap().keySet() );
+    }
+
+    @Override
+    @Nonnull
+    public Lock getLock(K key) {
+        return LocalLock.getLock(key, this);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultCache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import org.jivesoftware.openfire.cluster.ClusteredCacheEntryListener;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.LinkedListNode;
 import org.jivesoftware.util.StringUtils;
+import org.jivesoftware.util.cache.lock.LocalLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,7 @@ import java.io.Serializable;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 
 /**
@@ -64,7 +66,6 @@ public class DefaultCache<K extends Serializable, V extends Serializable> implem
     private static final Logger Log = LoggerFactory.getLogger(DefaultCache.class);
     // Contains the set of times when the Cache was last culled
     private final Set<Long> cullTimes;
-
 
     /**
      * The map the keys and values are stored in.
@@ -336,6 +337,12 @@ public class DefaultCache<K extends Serializable, V extends Serializable> implem
         synchronized (this) {
             return new HashSet<>(map.keySet());
         }
+    }
+
+    @Override
+    @Nonnull
+    public Lock getLock(K key) {
+        return LocalLock.getLock(key, this);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/SerializingCache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/SerializingCache.java
@@ -31,6 +31,7 @@ import java.io.*;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 
 /**
@@ -366,6 +367,13 @@ public class SerializingCache<K extends Serializable, V extends Serializable> im
                 return result;
             })
             .collect(Collectors.toSet());
+    }
+
+    @Override
+    @Nonnull
+    public Lock getLock(K key) {
+        final String marshalledKey = marshall(key, keyClass);
+        return delegate.getLock(marshalledKey);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/lock/CacheKey.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/lock/CacheKey.java
@@ -1,0 +1,35 @@
+package org.jivesoftware.util.cache.lock;
+
+import org.jivesoftware.util.cache.Cache;
+
+import java.util.Objects;
+
+/**
+ * A key of a cache, namespaced by the cache that it belongs to.
+ */
+class CacheKey
+{
+    final String cacheName;
+    final Object key;
+
+    CacheKey(Cache cache, Object key)
+    {
+        this.cacheName = cache.getName();
+        this.key = key;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CacheKey cacheKey = (CacheKey) o;
+        return cacheName.equals(cacheKey.cacheName) && key.equals(cacheKey.key);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(cacheName, key);
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/lock/LocalLock.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/lock/LocalLock.java
@@ -1,0 +1,122 @@
+package org.jivesoftware.util.cache.lock;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+import org.jivesoftware.util.cache.Cache;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class LocalLock implements Lock
+{
+    /**
+     * Keep track of the locks that are currently being used.
+     */
+    private static final Map<CacheKey, LockAndCount> locks = new ConcurrentHashMap<>();
+
+    private static final Interner<CacheKey> interner = Interners.newWeakInterner();
+
+    private final CacheKey key;
+
+    public static LocalLock getLock(Object key, Cache cache) {
+        return new LocalLock(new CacheKey(cache, key));
+    }
+
+    LocalLock(CacheKey key)
+    {
+        this.key = key;
+    }
+
+    @Override
+    public void lock()
+    {
+        acquireLock(key);
+    }
+
+    @Override
+    public void unlock()
+    {
+        releaseLock(key);
+    }
+
+    @Override
+    public void lockInterruptibly() throws InterruptedException
+    {
+        ReentrantLock lock = lookupLockForAcquire(key);
+        lock.lockInterruptibly();
+    }
+
+    @Nonnull
+    @Override
+    public Condition newCondition()
+    {
+        ReentrantLock lock = lookupLockForAcquire(key);
+        return lock.newCondition();
+    }
+
+    @Override
+    public boolean tryLock()
+    {
+        ReentrantLock lock = lookupLockForAcquire(key);
+        return lock.tryLock();
+    }
+
+    @Override
+    public boolean tryLock(long time, @Nonnull TimeUnit unit) throws InterruptedException
+    {
+        ReentrantLock lock = lookupLockForAcquire(key);
+        return lock.tryLock(time, unit);
+    }
+
+    @SuppressWarnings( "LockAcquiredButNotSafelyReleased" )
+    private void acquireLock(CacheKey key) {
+        ReentrantLock lock = lookupLockForAcquire(key);
+        lock.lock();
+    }
+
+    private void releaseLock(CacheKey key) {
+        ReentrantLock lock = lookupLockForRelease(key);
+        lock.unlock();
+    }
+
+    private ReentrantLock lookupLockForAcquire(CacheKey cacheKey) {
+        CacheKey mutex = interner.intern(cacheKey); // Ensure that the mutex used in the next line is the same for objects that are equal.
+        synchronized(mutex) {
+            LockAndCount lac = locks.get(mutex);
+            if (lac == null) {
+                lac = new LockAndCount(new ReentrantLock());
+                lac.count = 1;
+                locks.put(mutex, lac);
+            }
+            else {
+                lac.count++;
+            }
+
+            return lac.lock;
+        }
+    }
+
+    private ReentrantLock lookupLockForRelease(CacheKey cacheKey) {
+        CacheKey mutex = interner.intern(cacheKey); // Ensure that the mutex used in the next line is the same for objects that are equal.
+        synchronized(mutex) {
+            LockAndCount lac = locks.get(mutex);
+            if (lac == null) {
+                throw new IllegalStateException("No lock found for object " + mutex);
+            }
+
+            if (lac.count <= 1) {
+                locks.remove(mutex);
+            }
+            else {
+                lac.count--;
+            }
+
+            return lac.lock;
+        }
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/lock/LockAndCount.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/lock/LockAndCount.java
@@ -1,0 +1,14 @@
+package org.jivesoftware.util.cache.lock;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+class LockAndCount
+{
+    final ReentrantLock lock;
+    int count;
+
+    LockAndCount(ReentrantLock lock)
+    {
+        this.lock = lock;
+    }
+}


### PR DESCRIPTION
Based on the single responsibility principle, the CacheFactory should not be managing Locks. Instead, Caches should do that themselves.

Back in 2019, the method in CacheFactory that generates locks was marked as deprecated because of that, with a removal note in the distant future: 5.0.0.

As 5.0.0 is upon us, the deprecated code has now been removed. The cache locking implementation has been moved to a dedicated class (`LocalCache`) that is used by caches directly.

This commit attempts to achieve the desired removal of deprecated methods with a minimum of refactoring.

Further improvements may be desired (e.g. not storing locks for all caches in one shared data structure, but rather in a per-cache data structure).