### PR TITLE
Docker build: use local Maven repo to cache build artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN ./mvnw -e -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -D
 
 # Now, copy in all the source, and actually build it, skipping the tests.
 COPY . .
-RUN ./mvnw -o -e -B package -Dmaven.test.skip -Dmaven.repo.local=/tmp/m2_repo
+RUN ./mvnw -o -e -B install -Dmaven.test.skip -Dmaven.repo.local=/tmp/m2_repo
 # In case of Windows, break glass.
 RUN sed -i 's/\r//g' /usr/src/distribution/target/distribution-base/bin/openfire.sh
 


### PR DESCRIPTION
By installing Maven-build artifacts, subsequent steps in the build can obtain those artifacts again.