### PR TITLE
OF-3095: Adjust user idle ping cache max lifetime

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/CacheFactory.java
@@ -244,7 +244,7 @@ public class CacheFactory {
         cacheProps.put(PROPERTY_PREFIX_CACHE + "mucHistory" + PROPERTY_SUFFIX_SIZE, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "mucHistory" + PROPERTY_SUFFIX_MAX_LIFE_TIME, -1L);
         cacheProps.put(PROPERTY_PREFIX_CACHE + "mucPings" + PROPERTY_SUFFIX_SIZE, -1L);
-        cacheProps.put(PROPERTY_PREFIX_CACHE + "mucPings" + PROPERTY_SUFFIX_MAX_LIFE_TIME, Duration.ofMinutes(30).toMillis());
+        cacheProps.put(PROPERTY_PREFIX_CACHE + "mucPings" + PROPERTY_SUFFIX_MAX_LIFE_TIME, Duration.ofMinutes(135).toMillis()); // OF-3095
 
         // The JID-based classes (wrappers for Caffeine caches) take their default values from whatever is hardcoded in the JID implementation.
         cacheProps.put(PROPERTY_PREFIX_CACHE + "jidNodeprep" + PROPERTY_SUFFIX_SIZE, JID.NODEPREP_CACHE.policy().eviction().get().getMaximum() );


### PR DESCRIPTION
Using the default / unchanged cache settings, Openfire currently logs:

> WARN [main]: org.jivesoftware.openfire.muc.spi.MultiUserChatServiceImpl - The cache that tracks Ping requests (MUC Service Pings Sent) has a maximum lifetime entry (PT30M) that is shorter than the time that we wait for responses (PT1H). This will result in (some) occupants not being removed when they fail to respond to Pings. An Openfire admin should adjust the configuration.

The default values should be configured in such a way that this warning does not need to be given.

The default maximum user idle time is 4 hours. A ping response is checked at every 25% of that time. Thus, the default cache life time should at least be an hour (but not more than 4 hours).