### PR TITLE
OF-3096: Update bundled 'search' plugin to 1.7.5

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.igniterealtime.openfire.plugins</groupId>
             <artifactId>search</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.5</version>
             <classifier>openfire-plugin-assembly</classifier>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
In version 1.7.5, a compatibility issue with Openfire 5.0.0 is fixed.