### PR TITLE
OF-2526 .github/continuous-integration-workflow.yml upgrade Ubuntu pacakges

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -791,6 +791,6 @@ jobs:
       - name: untar distribution # sharing artifacts that consist of many files can be slow. Share one file instead.
         run: tar -xf distribution-artifact.tar
       - name: Install build deps
-        run: sudo apt-get install -y debhelper-compat=13
+        run: sudo apt install -y debhelper
       - name: Run build script
         run: bash build/debian/build_debs.sh


### PR DESCRIPTION
The debhelper and other packages are outdated on the default Ubuntu Latest version.

I hope this can fix the problem that the debhelper didn't generated post-install script correctly 
https://igniterealtime.atlassian.net/browse/OF-2526?focusedCommentId=23965

I decided to add a step to update the apt cache on the very beginning 