### PR TITLE
OF-2034: Add support for XEP-0398: User Avatar to vCard-Based Avatars Conversion

### DIFF
--- a/documentation/openfire.doap
+++ b/documentation/openfire.doap
@@ -422,6 +422,13 @@
         </implements>
         <implements>
             <xmpp:SupportedXep>
+                <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0398.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.0.0</xmpp:version>
+            </xmpp:SupportedXep>
+        </implements>
+        <implements>
+            <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0011.html"/>
                 <xmpp:status>complete</xmpp:status>
                 <xmpp:version>1.3.1</xmpp:version>

--- a/documentation/protocol-support.html
+++ b/documentation/protocol-support.html
@@ -409,6 +409,8 @@
             </tr><tr>
                 <td><a href="https://www.xmpp.org/extensions/xep-0359.html">XEP-0359</a>: Unique and Stable Stanza IDs</td>
             </tr><tr>
+                <td><a href="https://www.xmpp.org/extensions/xep-0398.html">XEP-0398</a>: User Avatar to vCard-Based Avatars Conversion</td>
+            </tr><tr>
                 <td><a href="https://www.xmpp.org/extensions/xep-0478.html">XEP-0478</a>: Stream Limits Advertisement</td>
             </tr><tr>
                 <td><a href="https://www.xmpp.org/extensions/xep-0433.html">XEP-0433</a>: Extended Channel Search</td>

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1245,6 +1245,7 @@ server.db_stats.no_queries=No queries
 #
 # System property descriptions
 #
+system_property.avatar.xep0398.disabled=Disables functionality that converts vCard-based avatars in PEP-based avatars and vice versa (as defined by XEP-0398).
 system_property.cache.checks.consistency.enabled=Controls if caches are periodically checked for consistency (beware: this can be very resource intensive).
 system_property.cache.checks.consistency.delay=The duration after which the first consistency check is executed after system start or reconfiguration.
 system_property.cache.checks.consistency.period=The frequency in which consistency checks for caches is executed.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -67,6 +67,7 @@ import org.jivesoftware.openfire.transport.TransportHandler;
 import org.jivesoftware.openfire.update.UpdateManager;
 import org.jivesoftware.openfire.user.User;
 import org.jivesoftware.openfire.user.UserManager;
+import org.jivesoftware.openfire.vcard.xep0398.UserAvatarToVCardConvertor;
 import org.jivesoftware.openfire.vcard.VCardManager;
 import org.jivesoftware.util.*;
 import org.jivesoftware.util.cache.CacheFactory;
@@ -800,6 +801,7 @@ public class XMPPServer {
         loadModule(SoftwareVersionManager.class.getName());
         loadModule(SoftwareServerVersionManager.class.getName());
         loadModule(CertificateExpiryChecker.class.getName());
+        loadModule(UserAvatarToVCardConvertor.class.getName());
 
         // Load this module always last since we don't want to start listening for clients
         // before the rest of the modules have been started
@@ -1732,6 +1734,17 @@ public class XMPPServer {
      */
     public CertificateExpiryChecker getCertificateExpiryChecker() {
         return (CertificateExpiryChecker) modules.get(CertificateExpiryChecker.class);
+    }
+
+    /**
+     * Returns the <code>UserAvatarToVCardConvertor</code> registered with this server. The
+     * <code>UserAvatarToVCardConvertor</code> was registered with the server as a module while starting up
+     * the server.
+     *
+     * @return the <code>UserAvatarToVCardConvertor</code> registered with this server.
+     */
+    public UserAvatarToVCardConvertor getUserAvatarToVCardConvertor() {
+        return (UserAvatarToVCardConvertor) modules.get(UserAvatarToVCardConvertor.class);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/VCardManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/VCardManager.java
@@ -245,6 +245,9 @@ public class VCardManager extends BasicModule implements ServerFeaturesProvider 
             vCardElement = provider.loadVCard(username);
             if (vCardElement != null) {
                 vcardCache.put(username, (DefaultElement) vCardElement);
+
+                // Check if the vCard-to-PEP conversion needs to happen. This allows conversion for VCards that are modified outside Openfire.
+                XMPPServer.getInstance().getUserAvatarToVCardConvertor().attemptPepUpdate(username, vCardElement);
             }
         }
         return vCardElement;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/xep0398/PresenceEnhancer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/xep0398/PresenceEnhancer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.vcard.xep0398;
+
+import org.dom4j.Element;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.interceptor.PacketInterceptor;
+import org.jivesoftware.openfire.interceptor.PacketRejectedException;
+import org.jivesoftware.openfire.pep.IQPEPHandler;
+import org.jivesoftware.openfire.pep.PEPService;
+import org.jivesoftware.openfire.pep.PEPServiceManager;
+import org.jivesoftware.openfire.pubsub.Node;
+import org.jivesoftware.openfire.pubsub.PublishedItem;
+import org.jivesoftware.openfire.session.LocalClientSession;
+import org.jivesoftware.openfire.session.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.Packet;
+import org.xmpp.packet.Presence;
+
+/**
+ * Packet Interceptor that augments presence stanzas sent by uses, as defined in section 4 of XEP-0398.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="https://xmpp.org/extensions/xep-0398.html">XEP-0398: User Avatar to vCard-Based Avatars Conversion</a>
+ */
+public class PresenceEnhancer implements PacketInterceptor
+{
+    private static final Logger Log = LoggerFactory.getLogger(PresenceEnhancer.class);
+
+    @Override
+    public void interceptPacket(Packet packet, Session session, boolean incoming, boolean processed) throws PacketRejectedException
+    {
+        if (UserAvatarToVCardConvertor.DISABLED.getValue()) {
+            return;
+        }
+
+        if (!incoming || processed) {
+            return;
+        }
+
+        if (!(session instanceof LocalClientSession)) {
+            return;
+        }
+
+        if (!(packet instanceof Presence presence)) {
+            return;
+        }
+
+        if (presence.getType() != null) {
+            return;
+        }
+
+        Element x = presence.getChildElement("x", "vcard-temp:x:update");
+        if (x == null) {
+            x = presence.addChildElement("x", "vcard-temp:x:update");
+        }
+        Element photo = x.element("photo");
+        if (photo != null && photo.getTextTrim().isEmpty()) {
+            Log.trace("Not enhancing presence available stanza from '{}'. The original stanza contains an empty 'photo' element.", session.getAddress());
+            return;
+        }
+        if (photo == null) {
+            photo = x.addElement("photo");
+        }
+
+        final IQPEPHandler pepHandler = XMPPServer.getInstance().getIQPEPHandler();
+        final PEPServiceManager serviceManager = pepHandler.getServiceManager();
+        final PEPService pepService = serviceManager.getPEPService(session.getAddress(), false);
+        if (pepService == null) {
+            Log.trace("Not enhancing presence available stanza from '{}'. No PEP service exists for user.", session.getAddress());
+            return;
+        }
+
+        final Node metadataNode = pepService.getNode("urn:xmpp:avatar:metadata");
+        if (metadataNode == null) {
+            Log.trace("Not enhancing presence available stanza from '{}'. PEP service does not contain an avatar 'metadata' node.", session.getAddress());
+            return;
+        }
+
+        final PublishedItem lastPublishedItem = metadataNode.getLastPublishedItem();
+        if (lastPublishedItem == null) {
+            Log.trace("Not enhancing presence available stanza from '{}'. PEP service does not contain an avatar 'metadata' item", session.getAddress());
+            return;
+        }
+
+        final String hash = lastPublishedItem.getID();
+        if (hash == null || hash.isEmpty()) {
+            return;
+        }
+
+        Log.trace("Enhancing presence available stanza from '{}' with value '{}'", session.getAddress(), hash);
+        photo.addText(hash);
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/xep0398/UserAvatarToVCardConvertor.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/vcard/xep0398/UserAvatarToVCardConvertor.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.vcard.xep0398;
+
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.QName;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.container.Module;
+import org.jivesoftware.openfire.interceptor.InterceptorManager;
+import org.jivesoftware.openfire.pep.IQPEPHandler;
+import org.jivesoftware.openfire.pep.PEPService;
+import org.jivesoftware.openfire.pep.PEPServiceManager;
+import org.jivesoftware.openfire.pubsub.*;
+import org.jivesoftware.openfire.vcard.VCardEventDispatcher;
+import org.jivesoftware.openfire.vcard.VCardListener;
+import org.jivesoftware.openfire.vcard.VCardManager;
+import org.jivesoftware.util.StringUtils;
+import org.jivesoftware.util.SystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.IQ;
+import org.xmpp.packet.JID;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility methods that help convert various User Avatar representations into each-other.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="https://xmpp.org/extensions/xep-0398.html">XEP-0398: User Avatar to vCard-Based Avatars Conversion</a>
+ */
+public class UserAvatarToVCardConvertor implements VCardListener, PubSubListener, Module
+{
+    public static final Logger Log = LoggerFactory.getLogger(UserAvatarToVCardConvertor.class);
+
+    private final PresenceEnhancer presenceEnhancer = new PresenceEnhancer();
+
+    public static final SystemProperty<Boolean> DISABLED = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("avatar.xep0398.disabled")
+        .setDefaultValue(false)
+        .setDynamic(true)
+        .build();
+
+    @Override
+    public String getName()
+    {
+        return "UserAvatarToVCardConvertor";
+    }
+
+    @Override
+    public void initialize(XMPPServer server)
+    {
+        VCardEventDispatcher.addListener(this);
+        PubSubEventDispatcher.addListener(this);
+        InterceptorManager.getInstance().addInterceptor(presenceEnhancer);
+    }
+
+    @Override
+    public void start()
+    {
+    }
+
+    @Override
+    public void stop()
+    {
+    }
+
+    @Override
+    public void destroy()
+    {
+        InterceptorManager.getInstance().removeInterceptor(presenceEnhancer);
+        PubSubEventDispatcher.removeListener(this);
+        VCardEventDispatcher.removeListener(this);
+    }
+
+    @Override
+    public void itemsPublished(@Nonnull final LeafNode.UniqueIdentifier nodeId, @Nonnull final Collection<PublishedItem> items)
+    {
+        if (DISABLED.getValue()) {
+            return;
+        }
+
+        if (!nodeId.getNodeId().equals("urn:xmpp:avatar:metadata")) {
+            return;
+        }
+
+        final IQPEPHandler pepHandler = XMPPServer.getInstance().getIQPEPHandler();
+        final PEPServiceManager serviceManager = pepHandler.getServiceManager();
+        final PEPService pepService = serviceManager.getPEPService(nodeId.getServiceIdentifier(), false);
+        if (pepService == null) {
+            return;
+        }
+
+        final String owner = pepService.getAddress().getNode();
+
+        // Check if there's a suitable 'info' within an 'item'.
+        item: for (final PublishedItem item : items)
+        {
+            final String id = item.getID();
+            final Element metadata = item.getPayload();
+            if (metadata != null && metadata.getName().equals("metadata"))
+            {
+                for (final Element info : metadata.elements("info"))
+                {
+                    if (info.attributeValue("url") != null) {
+                        continue;
+                    }
+                    final String type = info.attributeValue("type");
+                    // Even to the XEP specifically states image/png MUST be used, in practice, it isn't.
+                    //if (type == null || !type.equalsIgnoreCase("image/png")) {
+                    //    continue;
+                    //}
+                    final Node dataNode = pepService.getNode("urn:xmpp:avatar:data");
+                    if (dataNode == null) {
+                        return; // No need to evaluate any other info if there's no published avatar.
+                    }
+                    final PublishedItem publishedAvatarItem = dataNode.getPublishedItem(id);
+                    if (publishedAvatarItem == null) {
+                        continue item; // No need to evaluate any of these info's if there's no avatar with an ID that matches this metadata.
+                    }
+                    final Element avatarPayload = publishedAvatarItem.getPayload();
+                    if (avatarPayload == null || !avatarPayload.getName().equals("data") || !Objects.equals(avatarPayload.getNamespaceURI(), "urn:xmpp:avatar:data")) {
+                        continue;
+                    }
+                    final String avatarBase64 = avatarPayload.getTextTrim();
+                    if (avatarBase64 == null || avatarBase64.isEmpty()) {
+                        continue;
+                    }
+
+                    Log.debug("Avatar published via PEP for user '{}'. Cross-posting it to vCard.", owner);
+                    Element vCard = VCardManager.getInstance().getVCard(owner);
+                    if (vCard == null) {
+                        vCard = DocumentHelper.createElement(QName.get("vCard", "vcard-temp"));
+                    }
+                    if (vCard.element("PHOTO") == null) {
+                        vCard.addElement("PHOTO");
+                    }
+                    Element photoEl = vCard.element("PHOTO");
+                    if (photoEl == null) {
+                        photoEl = vCard.addElement("PHOTO");
+                    }
+                    Element binvalEl = photoEl.element("BINVAL");
+                    if (binvalEl == null) {
+                        binvalEl = photoEl.addElement("BINVAL");
+                    }
+                    Element typeEl = photoEl.element("TYPE");
+                    if (typeEl == null) {
+                        typeEl = photoEl.addElement("TYPE");
+                    }
+
+                    // TODO Services SHOULD verify that the SHA-1 hash of the image matches the id.
+
+                    try {
+                        // Only update if there's a difference.
+                        if (avatarBase64.equals(binvalEl.getTextTrim())) {
+                            Log.debug("Not converting PEP avatar to vCard photo, as vCard already has this photo for {}", owner);
+                        } else {
+                            Log.debug("Publishing photo to VCard for user '{}'", owner);
+                            binvalEl.setText(avatarBase64);
+                            typeEl.setText(type);
+                            VCardManager.getInstance().setVCard(owner, vCard);
+                        }
+                        return;
+                    } catch (Exception e) {
+                        Log.warn("Unable to store avatar in vCard of user '{}'", owner, e);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void itemsDeleted(@Nonnull final LeafNode.UniqueIdentifier nodeId, @Nonnull final Collection<PublishedItem> items)
+    {
+    }
+
+    @Override
+    public void vCardCreated(String username, Element vCard)
+    {
+        attemptPepUpdate(username, vCard);
+    }
+
+    @Override
+    public void vCardUpdated(String username, Element vCard)
+    {
+        attemptPepUpdate(username, vCard);
+    }
+
+    @Override
+    public void vCardDeleted(String username, Element vCard)
+    {
+    }
+
+    public void attemptPepUpdate(final String username, final Element vCard) throws RuntimeException
+    {
+        if (DISABLED.getValue()) {
+            return;
+        }
+
+        if (username == null || vCard == null) {
+            return;
+        }
+        if (vCard.element("PHOTO") == null) {
+            return;
+        }
+        final Element photoEl = vCard.element("PHOTO");
+        if (photoEl == null) {
+            return;
+        }
+        final Element binvalEl = photoEl.element("BINVAL");
+        if (binvalEl == null) {
+            return;
+        }
+        final String binVal = binvalEl.getTextTrim();
+        if (binVal == null || binVal.isEmpty()) {
+            return;
+        }
+        final Element typeEl = photoEl.element("TYPE");
+        if (typeEl == null) {
+            return;
+        }
+        final String type = typeEl.getTextTrim();
+
+        final IQPEPHandler pepHandler = XMPPServer.getInstance().getIQPEPHandler();
+        final PEPServiceManager serviceManager = pepHandler.getServiceManager();
+        final PEPService pepService = serviceManager.getPEPService(XMPPServer.getInstance().createJID(username, null), false);
+        if (pepService == null) {
+            return;
+        }
+
+        // XEP-0084 requires a _PNG_ image, but in practise not all clients do this. We'll use _any_ image type.
+        final byte[] decodedBinVal = decode(binVal);
+        final String hash = StringUtils.hash(decodedBinVal, "SHA-1");
+
+        // Check if this is an update.
+        final Node metadataNode = pepService.getNode("urn:xmpp:avatar:metadata");
+        if (metadataNode != null) {
+            if (metadataNode.getPublishedItem(hash) != null) {
+                Log.debug("Not converting vCard photo to PEP, as PEP already has this photo for {}", username);
+                return;
+            }
+        }
+
+        final IQ publishDataRequest = generatePublishDataRequest(pepService.getAddress(), binVal, hash);
+        final IQ publishMetaDataRequest = generatePublishMetadataRequest(pepService.getAddress(), decodedBinVal, hash, type);
+
+        try {
+            Log.debug("Publishing photo to PEP for user '{}'", username);
+            // It is important to have the data published _before_ the metadata is published.
+            serviceManager.process(pepService, publishDataRequest).get(500, TimeUnit.MILLISECONDS); // TODO replace this with a chained invocation, like the ones provided by CompletableFuture.
+            serviceManager.process(pepService, publishMetaDataRequest);
+        } catch (Throwable e) {
+            Log.warn("An unexpected exception occurred while trying to publish an avatar for '{}' via PEP.", username, e);
+        }
+    }
+
+    /**
+     * Decodes a base64-encoded binary value. This method can decode both Mime-encoded as well as non-Mime-encoded values.
+     *
+     * @param binVal The value to decode
+     * @return the decoded value.
+     */
+    public static byte[] decode(final String binVal)
+    {
+        final Base64.Decoder decoder;
+        if (binVal.length() > 76 && Character.isWhitespace(binVal.charAt(76))) {
+            decoder = Base64.getMimeDecoder();
+        } else {
+            decoder = Base64.getDecoder();
+        }
+        return decoder.decode(binVal);
+    }
+
+    /**
+     * Creates an IQ stanza that is appropriate to publish an item to the avatar data node of the PEP service of
+     * a particular user.
+     *
+     * @param owner The owner of the PEP service on which data is to be published
+     * @param binVal The hex-encoded binary representation of the avatar that is published
+     * @param hash (optional) The SHA-1 hash of the binary data (will be calculated from decodedBinVal if not provided)
+     * @return An IQ stanza
+     */
+    public static IQ generatePublishDataRequest(@Nonnull final JID owner, @Nonnull final String binVal, @Nullable String hash)
+    {
+        if (hash == null || hash.isEmpty()) {
+            final byte[] decodedBinVal = decode(binVal);
+            hash = StringUtils.hash(decodedBinVal, "SHA-1");
+        }
+        final IQ request = new IQ(IQ.Type.set);
+        request.setFrom(owner);
+        final Element pubsubEl = request.setChildElement("pubsub", "http://jabber.org/protocol/pubsub");
+        final Element publishEl = pubsubEl.addElement("publish");
+        publishEl.addAttribute("node", "urn:xmpp:avatar:data");
+        final Element itemEl = publishEl.addElement("item");
+        itemEl.addAttribute("id", hash);
+        final Element dataEl = itemEl.addElement("data", "urn:xmpp:avatar:data");
+        dataEl.setText(binVal);
+
+        return request;
+    }
+
+    /**
+     * Creates an IQ stanza that is appropriate to publish an item to the avatar metadata node of the PEP service of
+     * a particular user.
+     *
+     * @param owner The owner of the PEP service on which data is to be published
+     * @param decodedBinVal The binary representation of the avatar for which metadata is published
+     * @param hash (optional) The SHA-1 hash of the binary data (will be calculated from decodedBinVal if not provided)
+     * @param type The media type of the image
+     * @return An IQ stanza
+     */
+    public static IQ generatePublishMetadataRequest(@Nonnull final JID owner, @Nonnull final byte[] decodedBinVal, @Nullable String hash, @Nonnull final String type)
+    {
+        if (hash == null || hash.isEmpty()) {
+            hash = StringUtils.hash(decodedBinVal, "SHA-1");
+        }
+        final IQ request = new IQ(IQ.Type.set);
+        request.setFrom(owner);
+        final Element pubsubEl = request.setChildElement("pubsub", "http://jabber.org/protocol/pubsub");
+        final Element publishEl = pubsubEl.addElement("publish");
+        publishEl.addAttribute("node", "urn:xmpp:avatar:metadata");
+        final Element itemEl = publishEl.addElement("item");
+        itemEl.addAttribute("id", hash);
+        final Element metadataEl = itemEl.addElement("metadata","urn:xmpp:avatar:metadata");
+        final Element infoEl = metadataEl.addElement("info");
+        infoEl.addAttribute("bytes", String.valueOf(decodedBinVal.length));
+        infoEl.addAttribute("id", hash);
+        infoEl.addAttribute("type", type);
+
+        final int[] dimensions = getDimensions(decodedBinVal);
+        if (dimensions != null) {
+            infoEl.addAttribute("width", String.valueOf(dimensions[0]));
+            infoEl.addAttribute("height", String.valueOf(dimensions[1]));
+        }
+        return request;
+    }
+
+    /**
+     * Finds the width and height (in pixels) of an image.
+     *
+     * This method returns an array of size 2. The first element is the width, the second element the height of the
+     * image. When the provided data could not be processed, this method returns null.
+     *
+     * @param bytes the raw bytes of an image.
+     * @return an array containing the width and height of the image, or null if the dimensions could not be determined.
+     */
+    public static int[] getDimensions(byte[] bytes)
+    {
+        BufferedImage avatar;
+        try ( final ByteArrayInputStream stream = new ByteArrayInputStream( bytes ) )
+        {
+            avatar = ImageIO.read( stream );
+            return new int[] { avatar.getWidth(), avatar.getHeight()};
+        }
+        catch (IOException | RuntimeException ex )
+        {
+            Log.warn( "Failed to determine dimensions of image. An unexpected exception occurred while reading the image.", ex );
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This adds basic support for XEP-0398, that:
- converts vCard avatars into PEP avatars
- converts PEP avatars into vCard avatars
- adds an avatar hash to presence available stanzas sent by users (per section 4)

Additionally, the code checks if vCard avatars are to be migrated when a vCard is loaded from a vCard provider. This aims to pick up changes that are applied to external data stores (such as LDAP / AD).

The existing code does not _remove_ avatars, when a removal is initiated in one of both systems.