### PR TITLE
OF-3102 Improve error handling in the embedded db

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProvider.java
@@ -94,7 +94,6 @@ public class DefaultConnectionProvider implements ConnectionProvider {
 
     @Override
     public void start() {
-
         try {
             Class.forName(driver);
         } catch (final ClassNotFoundException e) {
@@ -105,7 +104,7 @@ public class DefaultConnectionProvider implements ConnectionProvider {
         final PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, null);
         poolableConnectionFactory.setValidationQuery(testSQL);
         poolableConnectionFactory.setValidationQueryTimeout((int)testTimeout.toSeconds());
-        poolableConnectionFactory.setMaxConnLifetimeMillis((long) connectionTimeout.toMillis());
+        poolableConnectionFactory.setMaxConnLifetimeMillis(connectionTimeout.toMillis());
 
         final GenericObjectPoolConfig<PoolableConnection> poolConfig = new GenericObjectPoolConfig<>();
         poolConfig.setTestOnBorrow(testBeforeUse);
@@ -131,7 +130,9 @@ public class DefaultConnectionProvider implements ConnectionProvider {
     @Override
     public void destroy() {
         try {
-            dataSource.close();
+            if (dataSource != null) {
+                dataSource.close();
+            }
         } catch (final Exception e) {
             Log.error("Unable to close the data source", e);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
@@ -72,6 +72,7 @@ public class EmbeddedConnectionProvider implements ConnectionProvider {
             }
         } catch (IOException e) {
             Log.error("Unable to create 'embedded-db' directory", e);
+            throw new RuntimeException("Unable to create 'embedded-db' directory", e);
         }
 
         serverURL = "jdbc:hsqldb:" + databaseDir.resolve("openfire");

--- a/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
@@ -65,14 +65,14 @@ public class EmbeddedConnectionProvider implements ConnectionProvider {
     @Override
     public void start() {
         final Path databaseDir = JiveGlobals.getHomePath().resolve("embedded-db");
-        try {
-            // If the database doesn't exist, create it.
-            if (!Files.exists(databaseDir)) {
+        // If the database doesn't exist, create it.
+        if (!Files.exists(databaseDir)) {
+            try {
                 Files.createDirectory(databaseDir);
+            } catch (IOException e) {
+                Log.error("Unable to create 'embedded-db' directory", e);
+                throw new RuntimeException("Unable to create 'embedded-db' directory", e);
             }
-        } catch (IOException e) {
-            Log.error("Unable to create 'embedded-db' directory", e);
-            throw new RuntimeException("Unable to create 'embedded-db' directory", e);
         }
 
         serverURL = "jdbc:hsqldb:" + databaseDir.resolve("openfire");

--- a/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
@@ -117,7 +117,9 @@ public class EmbeddedConnectionProvider implements ConnectionProvider {
             DbConnectionManager.closeConnection(pstmt, con);
         }
         try {
-            dataSource.close();
+            if (dataSource != null) {
+                dataSource.close();
+            }
         } catch (final Exception e) {
             Log.error("Unable to close the data source", e);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
@@ -111,6 +111,11 @@ public class EmbeddedConnectionProvider implements ConnectionProvider {
         finally {
             DbConnectionManager.closeConnection(pstmt, con);
         }
+        try {
+            dataSource.close();
+        } catch (final Exception e) {
+            Log.error("Unable to close the data source", e);
+        }
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,10 @@ public class EmbeddedConnectionProvider implements ConnectionProvider {
         final Path databaseDir = JiveGlobals.getHomePath().resolve("embedded-db");
         // If the database doesn't exist, create it.
         if (!Files.exists(databaseDir)) {
+            if (Files.isSymbolicLink(databaseDir)) {
+                Log.error("'embedded-db' {} is a link to a directory that doesn't exists", databaseDir);
+                throw new RuntimeException("'embedded-db' %s is a link to a directory that doesn't exists".formatted(databaseDir));
+            }
             try {
                 Files.createDirectory(databaseDir);
             } catch (IOException e) {


### PR DESCRIPTION
While making a Debian package I made an error when the /var/lib/openfire/embedded-db wasn't created during setup. And the Embedded DB folder  /usr/share/openfire/embedded-db is a link to the non esisting /var/lib/openfire/embedded-db.

I fixed it but before that I had a problem on the http://localhost:9090/setup/setup-datasource-settings.jsp page. It saw that the folder is not exists and tried to create it. But there was the link, it just was broken. So the PR just improved error handling for this situation to simplify debugging.
Additionally it contains some changes:
Remove deprecated finialize() method since it won't be called anyway anymore.
Commits on Jul 7, 2025
[EmbeddedConnectionProvider.destroy(): add dataSource.close()](https://github.com/igniterealtime/Openfire/commit/0f6b0cf3c7bdc51955edbb27f81e5fb636272c1f) to make it similar to the `destroy()` method of the `DefaultConnectionProvider`.
