### PR TITLE
OF-3106 Fix: when JAVA_HOME is empty it fails to detect the best java version

### DIFF
--- a/build/debian/openfire.init.d
+++ b/build/debian/openfire.init.d
@@ -28,7 +28,7 @@ fi
 if [ -z $JAVA_HOME ]; then
  JAVA_HOME=$(LC_ALL=C update-alternatives --display java \
     | grep best \
-    | grep -oe \/.*\/bin\/java \
+    | grep -oe '\/.*\/bin\/java' \
     | sed 's/\/bin\/java//g')
     echo "best java alternative in: "$JAVA_HOME
 fi


### PR DESCRIPTION
The Dash which is the default shell in the Debian/Ubuntu the command returns nothing:

    grep -oe \/.*\/bin\/java

To solve this we need to quote the regexp argument.

https://igniterealtime.atlassian.net/jira/software/c/projects/OF/issues/OF-3106