### PR TITLE
OF-3107 Debian: Use openfire.sh in the /etc/init.d/openfire similarly to SystemD serivice

### DIFF
--- a/build/debian/openfire.init.d
+++ b/build/debian/openfire.init.d
@@ -24,32 +24,9 @@ if [ -f /etc/default/openfire ] ; then
 	. /etc/default/openfire
 fi
 
-# Attempt to locate JAVA_HOME
-if [ -z $JAVA_HOME ]; then
- JAVA_HOME=$(LC_ALL=C update-alternatives --display java \
-    | grep best \
-    | grep -oe '\/.*\/bin\/java' \
-    | sed 's/\/bin\/java//g')
-    echo "best java alternative in: "$JAVA_HOME
-fi
-
-PATH=/sbin:/bin:/usr/sbin:/usr/bin:${JAVA_HOME}/bin
-JAVA=${JAVA_HOME}/bin/java
 NAME=openfire
 DESC=openfire
-DAEMON_DIR=/usr/share/openfire
-DAEMON_LIB=${DAEMON_DIR}/lib
 PIDFILE="/var/run/$NAME.pid"
-
-
-test -x $JAVA || exit 1
-
-DAEMON_OPTS="$DAEMON_OPTS -server -DopenfireHome=${DAEMON_DIR} \
- -Dlog4j.configurationFile=${DAEMON_LIB}/log4j2.xml \
- -Dlog4j2.formatMsgNoLookups=true \
- -Djdk.tls.ephemeralDHKeySize=matched -Djsse.SSLEngine.acceptLargeFragments=true -Djava.net.preferIPv6Addresses=system \
- -Dopenfire.lib.dir=${DAEMON_LIB} -classpath ${DAEMON_LIB}/startup.jar\
- -jar ${DAEMON_LIB}/startup.jar"
 
 #set -e
 
@@ -57,7 +34,7 @@ DAEMON_OPTS="$DAEMON_OPTS -server -DopenfireHome=${DAEMON_DIR} \
 start() {
         start-stop-daemon --start --quiet --background --make-pidfile \
                 --pidfile "$PIDFILE" --chuid openfire:openfire \
-                --exec $JAVA -- $DAEMON_OPTS
+                --exec /bin/bash -- -c "/usr/share/openfire/bin/openfire.sh ${DAEMON_OPTS}"
 }
 
 stop() {

--- a/build/debian/openfire.init.d
+++ b/build/debian/openfire.init.d
@@ -1,14 +1,4 @@
 #!/bin/sh
-#
-#		Written by Miquel van Smoorenburg <miquels@cistron.nl>.
-#		Modified for Debian 
-#		by Ian Murdock <imurdock@gnu.ai.mit.edu>.
-#       LSBize the script
-#       by Erwan 'Labynocle' Ben Souiden <erwan@aleikoum.net>
-#
-# Version:	@(#)skeleton  1.9  26-Feb-2001  miquels@cistron.nl
-#
-
 ### BEGIN INIT INFO
 # Provides:             openfire
 # Required-Start:       $local_fs $remote_fs $network $syslog
@@ -17,7 +7,7 @@
 # Default-Stop:         0 1 6
 # Short-Description:    Start/stop openfire jabber server
 # Description:          Start/stop openfire jabber server
-### END INIT INFO 
+### END INIT INFO
 
 # Include openfire defaults if available
 if [ -f /etc/default/openfire ] ; then

--- a/build/debian/openfire.init.d
+++ b/build/debian/openfire.init.d
@@ -62,7 +62,7 @@ start() {
 
 stop() {
         start-stop-daemon --stop --quiet --pidfile "$PIDFILE" \
-		--exec $JAVA --retry 4
+        --retry 4
 }
 
 status(){

--- a/build/debian/openfire.init.d
+++ b/build/debian/openfire.init.d
@@ -40,6 +40,7 @@ start() {
 stop() {
         start-stop-daemon --stop --quiet --pidfile "$PIDFILE" \
         --retry 4
+        rm -f "$PIDFILE"
 }
 
 status(){

--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -96,11 +96,6 @@ fi
 OPENFIRE_LIB="${OPENFIRE_HOME}/lib"
 OPENFIRE_OPTS="${OPENFIRE_OPTS} -Dopenfire.lib.dir=\"${OPENFIRE_LIB}\""
 
-# Override with bundled jre if it exists.
-if [ -f "$OPENFIRE_HOME/jre/bin/java" ]; then
-  JAVA_HOME="$OPENFIRE_HOME/jre"
-  JAVACMD="$OPENFIRE_HOME/jre/bin/java"
-fi
 
 if [ -z "$JAVACMD" ] ; then
   if [ -n "$JAVA_HOME"  ] ; then


### PR DESCRIPTION
Since v5.0 the Debian installer installs both /etc/init.d/openfire and SystemD unit in the /usr/lib/systemd/system/openfire.service. The SystemD itself will work with the unit file but some users may have still use the old init.d script directly. They should migrate to using of the `systemctl start openfire` command instead.

The SystemD unit doesn't construct JVM options but instead it calls the `openfire.sh` script as an entry point.
The init.d script constructs the options itself and it turned out that it had a bug when JAVA_HOME wasn't detected that is fixed now.

To make the transition more smoother and to minimize code duplication we should make the `/etc/init.d/openfire` to work similarly to the SystemD unit and call the `openfire.sh` instead.

https://igniterealtime.atlassian.net/browse/OF-3107

The change needs to increment minor version i.e. 5.1.0.
