### PR TITLE
OF-3108: Properly stop Jetty Server components

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -431,7 +431,7 @@ public final class HttpBindManager implements CertificateEventListener {
         if (httpBindServer != null) {
             try {
                 if ( extensionHandlers.getHandlers() != null ) {
-                    Arrays.stream(handlerList.getHandlers().toArray()).forEach(handler  -> {
+                    Arrays.stream(extensionHandlers.getHandlers().toArray()).forEach(handler  -> {
                         try {
                             ((Handler)handler).stop();
                         } catch (Exception e) {


### PR DESCRIPTION
When Jetty is being stopped, individual components need to be stopped too. This prevents issues when those components are restarted again (eg: after a reconfiguration of the server).

This commit fixes what appears to be a copy/paste bug in the method that intends to stop all components (the bug caused one component to be stopped twice, while another didn't get stopped at all).