### PR TITLE
OF-3109 DB-Viewer does not start under windows 

### DIFF
--- a/distribution/src/bin/extra/embedded-db-viewer.bat
+++ b/distribution/src/bin/extra/embedded-db-viewer.bat
@@ -11,4 +11,4 @@ SET CLASSPATH=%~dp0..\..\lib\*
 
 echo Starting embedded database viewer...
 
-java -cp %CLASSPATH% org.hsqldb.util.DatabaseManagerSwing --rcfile embedded-db.rc --urlid embedded-db
+java -cp "%CLASSPATH%" org.hsqldb.util.DatabaseManagerSwing --rcfile embedded-db.rc --urlid embedded-db


### PR DESCRIPTION
because of unresolved dependencies, because of filenames with spaces.