### PR TITLE
OF-3108: Properly start Jetty Server components

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindManager.java
@@ -395,7 +395,7 @@ public final class HttpBindManager implements CertificateEventListener {
             handlerList.start();
 
             if ( extensionHandlers.getHandlers() != null ) {
-                Arrays.stream(handlerList.getHandlers().toArray()).forEach(handler  -> {
+                Arrays.stream(extensionHandlers.getHandlers().toArray()).forEach(handler  -> {
                     try {
                         ((Handler)handler).start();
                     } catch (Exception e) {


### PR DESCRIPTION
When Jetty is being started, individual components need to be started too.

This commit fixes what appears to be a copy/paste bug in the method that intends to start all components (the bug caused one component to be started twice, while another didn't get stopped at all).

Note that this is very, very similar to a recent commit that fixed the exact same problem when _stopping_ things...