### PR TITLE
OF-3108: Bump Jetty from 12.0.22 to 12.0.24

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -124,7 +124,7 @@
         <!-- Versions -->
         <openfire.version>5.1.0-SNAPSHOT</openfire.version>
         <!-- Note; the following jetty.version should be identical to the jetty.version in xmppserver/pom.xml -->
-        <jetty.version>12.0.22</jetty.version>
+        <jetty.version>12.0.24</jetty.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 
         <!-- Versions -->
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
-        <jetty.version>12.0.22</jetty.version>
+        <jetty.version>12.0.24</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <netty.version>4.1.118.Final</netty.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>


### PR DESCRIPTION
Jetty 12.0.24 contains a fix that for the failure of recreation of Jetty TMP directories upon server restart (as discussed in https://github.com/jetty/jetty.project/discussions/13362 ).