### PR TITLE
OF-3114: More info in EndUserSession adhoc command result

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -3815,6 +3815,7 @@ commands.admin.user.endusersession.form.field.accountjid.label=The Jabber ID(s) 
 commands.admin.user.endusersession.note.jid-not-local=Cannot end session of remote user: {0}
 commands.admin.user.endusersession.note.jid-required=JID required parameter.
 commands.admin.user.endusersession.note.jid-invalid=Invalid values were provided. Please provide one or more valid JIDs.
+commands.admin.user.endusersession.note.ended-session-count={0} user session(s) have been ended.
 
 commands.admin.user.getuserroster.label=Get User Roster
 commands.admin.user.getuserroster.form.title=Get user roster

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/EndUserSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/EndUserSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2024-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,7 @@ public class EndUserSession extends AdHocCommand
         }
 
         // No errors. Disable all users.
+        int affectedSessionCount = 0;
         for (final JID address : addresses) {
             // Note: If the JID is of the form <user@host>, the service MUST end all of the user's sessions; if the JID
             // is of the form <user@host/resource>, the service MUST end only the session associated with that resource.
@@ -116,12 +117,14 @@ public class EndUserSession extends AdHocCommand
 
             for (final ClientSession session : sessions) {
                 session.close();
+                affectedSessionCount++;
             }
         }
 
         // Answer that the operation was successful
         note.addAttribute("type", "info");
-        note.setText(LocaleUtils.getLocalizedString("commands.global.operation.finished.success", preferredLocale));
+        note.setText(LocaleUtils.getLocalizedString("commands.global.operation.finished.success", preferredLocale)
+             + " " + LocaleUtils.getLocalizedString("commands.admin.user.endusersession.note.ended-session-count", List.of(String.valueOf(affectedSessionCount)), preferredLocale));
     }
 
     @Override


### PR DESCRIPTION
After executing the EndUserSession adhoc command, the result now includes a count for the number of affected sessions.

This has helped me debug a different issue with Openfire. The information added may be useful for others, so I don't see harm in adding it for everyone's benefit.