### PR TITLE
OF-3115: Mark sessions as unresumable when not closed neatly

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,30 +174,7 @@ public interface Connection extends Closeable {
      */
     @Override
     default void close() {
-        close(null, false);
-    }
-
-    /**
-     * Close this connection including associated session, optionally citing a stream error. The events for closing
-     * the connection are:
-     *
-     * <ul>
-     *      <li>Set closing flag to prevent redundant shutdowns.
-     *      <li>Close the socket.
-     *      <li>Notify all listeners that the channel is shut down.
-     * </ul>
-     *
-     * Not all implementations use the same order of events.
-     *
-     * Invocation of this method is expected to occur when a coordinated, 'clean' disconnect occurs. Such disconnects
-     * are expected to be user (or server) initiated. As a result, a session closed by this method is not resumable,
-     * even if Stream Management was activated for this session. Refer to {@link #close(StreamError, boolean)} for
-     * processing of unexpected disconnects (that <em>are</em> potentially resumable).
-     *
-     * @param error If non-null, the end-stream tag will be preceded with this error.
-     */
-    default void close(@Nullable final StreamError error) {
-        close(error, false);
+        close(null);
     }
 
     /**
@@ -222,7 +199,7 @@ public interface Connection extends Closeable {
      *
      * @param error If non-null, the end-stream tag will be preceded with this error.
      */
-    void close(@Nullable final StreamError error, final boolean networkInterruption);
+    void close(@Nullable final StreamError error);
 
     /**
      * Notification message indicating that the server is being shutdown. Implementors

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -106,8 +106,7 @@ public class IQRouter extends BasicModule {
                 handle(packet);
             } else if (SessionPacketRouter.isInvalidStanzaSentPriorToResourceBinding(packet, session)) {
                 Log.debug("Closing session that attempts to send stanza to an entity other than the server itself or the client's account, before completing resource binding. Session closed: {}", session);
-                session.deliverRawText(new StreamError(StreamError.Condition.not_authorized, "Do not send invalid stanza prior to authentication/resource binding.").toXML());
-                session.close();
+                session.close(new StreamError(StreamError.Condition.not_authorized, "Do not send invalid stanza prior to authentication/resource binding."));
                 return;
             } else {
                 Log.debug("Rejecting stanza from client that has not (yet?) established an authenticated session: {}", packet.toXML());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/DisableUser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/DisableUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2024-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,8 +133,7 @@ public class DisableUser extends AdHocCommand
             final StreamError error = new StreamError(StreamError.Condition.not_authorized);
             final Collection<ClientSession> sessions = SessionManager.getInstance().getSessions(user.getUsername());
             for (final ClientSession session : sessions) {
-                session.deliverRawText(error.toXML());
-                session.close();
+                session.close(error);
             }
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/EndUserSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/commands/admin/user/EndUserSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2024-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,6 +115,7 @@ public class EndUserSession extends AdHocCommand
             }
 
             for (final ClientSession session : sessions) {
+                session.markNonResumable();
                 session.close();
             }
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/component/ExternalComponentManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/component/ExternalComponentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,7 @@ public class ExternalComponentManager {
         Session session = SessionManager.getInstance().getComponentSession(domain);
         if (session != null) {
             Log.debug( "Closing session for external component '{}' as the domain is being blocked. Affected session: {}", domain, session );
+            session.markNonResumable();
             session.close();
         }
     }
@@ -467,6 +468,7 @@ public class ExternalComponentManager {
             for (String domain : session.getExternalComponent().getSubdomains()) {
                 if (!canAccess(domain)) {
                     Log.debug( "Closing session for external component '{}' as a changed permission policy is taken into effect. Affected session: {}", domain, session );
+                    session.markNonResumable();
                     session.close();
                     break;
                 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQBindHandler.java
@@ -143,7 +143,7 @@ public class IQBindHandler extends IQHandler {
                             Log.debug("Kick out an old connection that is conflicting with a new one. Old session: {}", oldSession);
                             StreamError error = new StreamError(StreamError.Condition.conflict);
                             oldSession.deliverRawText(error.toXML());
-                            oldSession.close(); // When living on a remote cluster node, this will prevent that session from becoming 'resumable'.
+                            oldSession.markNonResumable();
 
                             // OF-1923: As the session is now replaced, the old session will never be resumed.
                             if (oldSession instanceof LocalClientSession) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQHandler.java
@@ -24,6 +24,7 @@ import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
 import org.jivesoftware.openfire.container.BasicModule;
+import org.jivesoftware.openfire.session.ClientSession;
 import org.jivesoftware.openfire.user.UserManager;
 import org.jivesoftware.util.LocaleUtils;
 import org.slf4j.Logger;
@@ -129,15 +130,17 @@ public abstract class IQHandler extends BasicModule implements ChannelHandler<IQ
         }
         catch (org.jivesoftware.openfire.auth.UnauthorizedException e) {
             if (iq != null) {
+                final ClientSession session = sessionManager.getSession(iq.getFrom());
                 try {
                     IQ response = IQ.createResultIQ(iq);
                     response.setChildElement(iq.getChildElement().createCopy());
                     response.setError(PacketError.Condition.not_authorized);
-                    sessionManager.getSession(iq.getFrom()).process(response);
+                    session.process(response);
                 }
                 catch (Exception de) {
                     Log.error(LocaleUtils.getLocalizedString("admin.error"), de);
-                    sessionManager.getSession(iq.getFrom()).close();
+                    session.markNonResumable();
+                    session.close();
                 }
             }
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRegisterHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQRegisterHandler.java
@@ -251,8 +251,7 @@ public class IQRegisterHandler extends IQHandler implements ServerFeaturesProvid
                             final StreamError error = new StreamError(StreamError.Condition.not_authorized);
                             for (ClientSession sess : sessionManager.getSessions(user.getUsername()) )
                             {
-                                sess.deliverRawText(error.toXML());
-                                sess.close();
+                                sess.close(error);
                             }
                             // The reply has been sent so clean up the variable
                             reply = null;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpBindServlet.java
@@ -279,6 +279,7 @@ public class HttpBindServlet extends HttpServlet {
         finally {
             if (bindingError.getErrorType() == BoshBindingError.Type.terminate) {
                 Log.debug( "Closing session due to error: {}. Affected session: {}", bindingError, session );
+                session.markNonResumable();
                 session.close();
             }
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/http/HttpSession.java
@@ -799,6 +799,7 @@ public class HttpSession extends LocalClientSession {
             try {
                 HttpBindManager.getInstance().getSessionManager().execute(this, () -> {
                     Log.trace("Stream {}: Closing", streamID);
+                    super.markNonResumable();
                     super.close();
                 });
             } catch (Throwable t) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ComponentStanzaHandler.java
@@ -59,11 +59,13 @@ public class ComponentStanzaHandler extends StanzaHandler {
             // External component is trying to authenticate
             if (!((LocalComponentSession) session).authenticate(doc.getStringValue())) {
                 Log.debug( "Closing session that failed to authenticate: {}", session );
+                session.markNonResumable();
                 session.close();
             }
             return true;
         } else if ("error".equals(tag) && "stream".equals(doc.getNamespacePrefix())) {
             Log.debug( "Closing session because of received stream error {}. Affected session: {}", doc.asXML(), session );
+            session.markNonResumable();
             session.close();
             return true;
         } else if ("bind".equals(tag)) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/MultiplexerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/MultiplexerStanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,11 +112,13 @@ public class MultiplexerStanzaHandler extends StanzaHandler {
         } else if ("handshake".equals(tag)) {
             if (!((LocalConnectionMultiplexerSession) session).authenticate(doc.getStringValue())) {
                 Log.debug( "Closing session that failed to authenticate: {}", session );
+                session.markNonResumable();
                 session.close();
             }
             return true;
         } else if ("error".equals(tag) && "stream".equals(doc.getNamespacePrefix())) {
             Log.debug( "Closing session because of received stream error {}. Affected session: {}", doc.asXML(), session );
+            session.markNonResumable();
             session.close();
             return true;
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -572,6 +572,7 @@ public class SASLAuthentication {
         if (retries >= JiveGlobals.getIntProperty("xmpp.auth.retries", 3) ) {
             // Close the connection
             Log.debug( "Closing session that failed to authenticate {} times: {}", retries, session );
+            session.markNonResumable();
             session.close();
         }
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -374,8 +374,8 @@ public class SocketConnection extends AbstractConnection {
         return backupDeliverer;
     }
 
-    public void close(@Nullable final StreamError error, final boolean networkInterruption) {
-        close(error, networkInterruption, false);
+    public void close(@Nullable final StreamError error) {
+        close(error, false);
     }
 
     /**
@@ -383,14 +383,10 @@ public class SocketConnection extends AbstractConnection {
      * forces the connection closed immediately. This method will be called when  we need to close the socket, discard
      * the connection and its session.
      */
-    private void close(@Nullable final StreamError error, final boolean networkInterruption, final boolean force) {
+    private void close(@Nullable final StreamError error, final boolean force) {
         if (state.compareAndSet(State.OPEN, State.CLOSED)) {
             
             if (session != null) {
-                if (!force && !networkInterruption) {
-                    // A 'clean' closure should never be resumed (see #onRemoteDisconnect for handling of unclean disconnects). OF-2752
-                    session.getStreamManager().formalClose();
-                }
                 session.setStatus(Session.Status.CLOSED);
             }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReadingMode.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketReadingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ abstract class SocketReadingMode {
         catch (SSLHandshakeException e) {
             // RFC6120, section 5.4.3.2 "STARTTLS Failure" - close the socket *without* sending any more data (<failure/> nor </stream>).
             Log.info( "STARTTLS negotiation (with: {}) failed.", socketReader.connection, e );
-            socketReader.connection.close(null, false);
+            socketReader.connection.close(null);
             return false;
         }
         catch (IOException | RuntimeException e) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/VirtualConnection.java
@@ -119,14 +119,10 @@ public abstract class VirtualConnection extends AbstractConnection
      * @param error If non-null, the end-stream tag will be preceded with this error.
      */
     @Override
-    public void close(@Nullable final StreamError error, final boolean networkInterruption) {
+    public void close(@Nullable final StreamError error) {
         if (state.compareAndSet(State.OPEN, State.CLOSED)) {
             
             if (session != null) {
-                if (!networkInterruption) {
-                    // A 'clean' closure should never be resumed (see #onRemoteDisconnect for handling of unclean disconnects). OF-2752
-                    session.getStreamManager().formalClose();
-                }
                 session.setStatus(Session.Status.CLOSED);
             }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyConnection.java
@@ -190,16 +190,15 @@ public class NettyConnection extends AbstractConnection
     }
 
     @Override
-    public void close(@Nullable final StreamError error, final boolean networkInterruption) {
+    public void close(@Nullable final StreamError error) {
         if (state.compareAndSet(State.OPEN, State.CLOSED)) {
             Log.trace("Closing {} with optional error: {}", this, error);
 
             ChannelFuture f;
 
             if (session != null) {
-
-                if (!networkInterruption) {
-                    // A 'clean' closure should never be resumed (OF-2752).
+                // If the stream was ended because of an error, it should not be possible to resume it (OF-2751).
+                if (error != null) {
                     session.getStreamManager().formalClose();
                 }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyIdleStateKeepAliveHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyIdleStateKeepAliveHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ public class NettyIdleStateKeepAliveHandler extends ChannelDuplexHandler {
                 // Idle flag already present. Connection has been idle for a while. Close it.
                 final NettyConnection connection = channel.attr(CONNECTION).get();
                 Log.debug("Closing connection because of inactivity: {}", connection);
-                connection.close(new StreamError(StreamError.Condition.connection_timeout, doPing ? "Connection has been idle and did not respond to a keep-alive check." : "Connection has been idle."), doPing);
+                connection.close(new StreamError(StreamError.Condition.connection_timeout, doPing ? "Connection has been idle and did not respond to a keep-alive check." : "Connection has been idle."));
             }
         }
         super.userEventTriggered(ctx, evt);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/nio/NettyXMPPDecoder.java
@@ -79,7 +79,7 @@ public class NettyXMPPDecoder extends ByteToMessageDecoder {
         if (isNotSslRecord(cause)) {
             Log.warn("Closing connection with {}, as unencrypted data was received, while encrypted data was expected (A full stack trace will be logged on the ‘debug’ level).", connection.getPeer() == null ? "(unknown)" : connection.getPeer(), cause);
             Log.debug("Error occurred while decoding XMPP stanza: {}", connection, cause);
-            connection.close(new StreamError(StreamError.Condition.internal_server_error, "Received unencrypted data while encrypted data was expected."), cause instanceof IOException);
+            connection.close(new StreamError(StreamError.Condition.internal_server_error, "Received unencrypted data while encrypted data was expected."));
             return;
         }
 
@@ -94,7 +94,7 @@ public class NettyXMPPDecoder extends ByteToMessageDecoder {
         } else {
             Log.warn("Error occurred while decoding XMPP stanza, closing connection: {}", connection, cause);
         }
-        connection.close(new StreamError(StreamError.Condition.internal_server_error, "An error occurred in XMPP Decoder"), cause instanceof IOException);
+        connection.close(new StreamError(StreamError.Condition.internal_server_error, "An error occurred in XMPP Decoder"));
     }
 
     private boolean isNotSslRecord(Throwable t)

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/RemoteServerManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/RemoteServerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +101,7 @@ public class RemoteServerManager {
         // Check if the remote server was connected and proceed to close the connection
         for (Session session : SessionManager.getInstance().getIncomingServerSessions(domain)) {
             Log.debug( "Closing session for domain '{}' as the domain is being blocked. Affected session: {}", domain, session );
+            session.markNonResumable();
             session.close();
         }
         // Can't just lookup a single remote server anymore, so check them all.
@@ -108,6 +109,7 @@ public class RemoteServerManager {
             if (domainPair.getRemote().equals(domain)) {
                 Session session = SessionManager.getInstance().getOutgoingServerSession(domainPair);
                 Log.debug( "Closing (domain-pair) session for domain '{}' as the domain is being blocked. Affected session: {}", domain, session );
+                session.markNonResumable();
                 session.close();
             }
         }
@@ -370,6 +372,7 @@ public class RemoteServerManager {
             if (!canAccess(hostname)) {
                 for (Session session : SessionManager.getInstance().getIncomingServerSessions(hostname)) {
                     Log.debug( "Closing session for hostname '{}' as a changed permission policy is taken into effect. Affected session: {}", hostname, session );
+                    session.markNonResumable();
                     session.close();
                 }
             }
@@ -378,6 +381,7 @@ public class RemoteServerManager {
             if (!canAccess(domainPair.getRemote())) {
                 Session session = SessionManager.getInstance().getOutgoingServerSession(domainPair);
                 Log.debug( "Closing session as a changed permission policy is taken into effect. Affected session: {}", session );
+                session.markNonResumable();
                 session.close();
                 // After the session has been close, inform all listeners as well.
                 ServerSessionEventDispatcher.dispatchEvent(session, ServerSessionEventDispatcher.EventType.session_destroyed);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalSession.java
@@ -111,6 +111,11 @@ public abstract class LocalSession implements Session {
     private final Locale language;
 
     /**
+     * Indicates if peer has sent &lt;/stream:stream>
+     */
+    private boolean hasReceivedEndOfStream;
+
+    /**
      * Creates a session with an underlying connection and permission protection.
      *
      * @param serverName domain of the XMPP server where the new session belongs.
@@ -599,4 +604,41 @@ public abstract class LocalSession implements Session {
         softwareVersionData.put(key, value);
     }
 
+    /**
+     * Mark this session in the associated stream manager as non-resumable.
+     *
+     * If a session was not resumable before invoking this method, or if stream management wasn't in effect at all, an
+     * invocation of this method has no effect.
+     */
+    @Override
+    public void markNonResumable()
+    {
+        if (streamManager != null) {
+            streamManager.formalClose();
+        }
+    }
+
+    /**
+     * Sets a boolean value indicating that the client associated to this session has sent an 'end of stream' event to
+     * the server (typically, this is a <tt></stream:stream></tt> tag). This is an indication that the client wishes to
+     * end the session.
+     *
+     * Sending such an end-of-stream is unrecoverable. This boolean can therefor not be changed from 'true' to 'false'.
+     */
+    public void setHasReceivedEndOfStream()
+    {
+        hasReceivedEndOfStream = true;
+        markNonResumable();
+    }
+
+    /**
+     * Returns a boolean value indicating if this client has sent an 'end of stream' event to the server (typically, this
+     * is a <tt></stream:stream></tt> tag). This is an indication that the client wishes to end the session.
+     *
+     * @return 'true' if an 'end of stream' event was received from the client, otherwise 'false'.
+     */
+    public boolean getHasReceivedEndOfStream()
+    {
+        return hasReceivedEndOfStream;
+    }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
@@ -184,6 +184,10 @@ public abstract class RemoteSession implements Session {
         doClusterTask(getDeliverRawTextTask(text));
     }
 
+    public void markNonResumable() {
+        doSynchronousClusterTask(getRemoteSessionTask(RemoteSessionTask.Operation.markNonResumable));
+    }
+
     public boolean validate() {
         ClusterTask<Object> task = getRemoteSessionTask(RemoteSessionTask.Operation.validate);
         final Object clusterTaskResult = doSynchronousClusterTask(task);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -387,7 +387,7 @@ public class StreamManager {
             Connection oldConnection = otherSession.getConnection();
             otherSession.setDetached();
             assert oldConnection != null; // If the other session is not detached, the connection can't be null.
-            oldConnection.close(new StreamError(StreamError.Condition.conflict, "The stream previously served over this connection is resumed on a new connection."), true);
+            oldConnection.close(new StreamError(StreamError.Condition.conflict, "The stream previously served over this connection is resumed on a new connection."));
         }
         Log.debug("Attaching to other session '{}' of '{}'.", otherSession.getStreamID(), fullJid);
         // If we're all happy, re-attach the connection from the pre-existing session to the new session, discarding the old session.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans, 2023-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2023-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,10 +173,10 @@ public class WebSocketClientConnectionHandler
         try {
             if (isWebSocketOpen()) {
                 Log.warn("Attempting to close connection on which an error occurred: {}", wsConnection, error);
-                wsConnection.close(new StreamError(StreamError.Condition.internal_server_error), !isWebSocketOpen());
+                wsConnection.close(new StreamError(StreamError.Condition.internal_server_error));
             } else {
                 Log.debug("Error detected on websocket that isn't open (any more):", error);
-                wsConnection.close(null, !isWebSocketOpen());
+                wsConnection.close(null);
             }
         } catch (Exception e) {
             Log.error("Error disconnecting websocket", e);

--- a/xmppserver/src/main/webapp/component-session-summary.jsp
+++ b/xmppserver/src/main/webapp/component-session-summary.jsp
@@ -67,6 +67,7 @@
         try {
             Session sess = sessionManager.getComponentSession(jid);
             if (sess != null) {
+                sess.markNonResumable();
                 sess.close();
             }
             // Log the event

--- a/xmppserver/src/main/webapp/server-session-details.jsp
+++ b/xmppserver/src/main/webapp/server-session-details.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
 --%>
 
 <%@ page import="org.jivesoftware.openfire.SessionManager,
-                 org.jivesoftware.openfire.session.IncomingServerSession,
-                 org.jivesoftware.openfire.session.OutgoingServerSession,
                  org.jivesoftware.util.ParamUtils"
     errorPage="error.jsp"
 %>
@@ -28,7 +26,7 @@
 <%@ page import="java.net.InetAddress" %>
 <%@ page import="org.jivesoftware.util.CookieUtils" %>
 <%@ page import="org.jivesoftware.util.StringUtils" %>
-<%@ page import="org.jivesoftware.openfire.session.Session" %>
+<%@ page import="org.jivesoftware.openfire.session.*" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -60,12 +58,14 @@
         try {
             final List<IncomingServerSession> incomingServerSessions = sessionManager.getIncomingServerSessions(domainname);
             for (Session incomingServerSession : incomingServerSessions) {
+                incomingServerSession.markNonResumable();
                 incomingServerSession.close();
             }
 
             Collection<OutgoingServerSession> outgoingServerSessions = sessionManager.getOutgoingServerSessions(domainname);
             for (OutgoingServerSession outgoingServerSession : outgoingServerSessions) {
                 if (outgoingServerSession != null) {
+                    outgoingServerSession.markNonResumable();
                     outgoingServerSession.close();
                 }
             }

--- a/xmppserver/src/main/webapp/server-session-summary.jsp
+++ b/xmppserver/src/main/webapp/server-session-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -17,14 +17,13 @@
 --%>
 
 <%@ page import="org.jivesoftware.openfire.SessionManager,
-                 org.jivesoftware.openfire.session.OutgoingServerSession,
-                 org.jivesoftware.openfire.session.Session,
                  org.jivesoftware.util.ParamUtils,
                  org.jivesoftware.util.StringUtils,
                  org.jivesoftware.util.CookieUtils,
                  java.util.*"
     errorPage="error.jsp"
 %>
+<%@ page import="org.jivesoftware.openfire.session.*" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -65,12 +64,14 @@
         try {
             final List<IncomingServerSession> incomingServerSessions = sessionManager.getIncomingServerSessions(domainName);
             for (Session incomingServerSession : incomingServerSessions) {
+                incomingServerSession.markNonResumable();
                 incomingServerSession.close();
             }
 
             Collection<OutgoingServerSession> outgoingServerSessions = sessionManager.getOutgoingServerSessions(domainName);
             for (OutgoingServerSession outgoingServerSession : outgoingServerSessions) {
                 if (outgoingServerSession != null) {
+                    outgoingServerSession.markNonResumable();
                     outgoingServerSession.close();
                 }
             }

--- a/xmppserver/src/main/webapp/session-details.jsp
+++ b/xmppserver/src/main/webapp/session-details.jsp
@@ -18,8 +18,6 @@
 
 <%@ page import="org.jivesoftware.openfire.PresenceManager,
                  org.jivesoftware.openfire.SessionManager,
-                 org.jivesoftware.openfire.session.ClientSession,
-                 org.jivesoftware.openfire.session.LocalClientSession,
                  org.jivesoftware.openfire.user.User,
                  org.jivesoftware.openfire.user.UserManager,
                  org.jivesoftware.util.JiveGlobals,
@@ -30,7 +28,6 @@
                  java.util.Collection"
     errorPage="error.jsp"
 %>
-<%@ page import="org.jivesoftware.openfire.session.LocalSession" %>
 <%@ page import="org.jivesoftware.openfire.nio.NettyConnection" %>
 <%@ page import="org.jivesoftware.openfire.websocket.WebSocketConnection" %>
 <%@ page import="org.jivesoftware.openfire.http.HttpSession" %>
@@ -42,6 +39,7 @@
 <%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
+<%@ page import="org.jivesoftware.openfire.session.*" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -70,9 +68,7 @@
         JID address = new JID(jid);
         try {
             Session sess = sessionManager.getSession(address);
-            if (sess instanceof LocalClientSession) {
-                ((LocalClientSession) sess).getStreamManager().formalClose();
-            }
+            sess.markNonResumable();
             sess.close();
             // Log the event
             webManager.logEvent("closed session for address "+address, null);

--- a/xmppserver/src/main/webapp/session-summary.jsp
+++ b/xmppserver/src/main/webapp/session-summary.jsp
@@ -18,7 +18,6 @@
 
 <%@ page import="org.jivesoftware.openfire.SessionManager,
                  org.jivesoftware.openfire.SessionResultFilter,
-                 org.jivesoftware.openfire.session.ClientSession,
                  org.jivesoftware.util.JiveGlobals,
                  org.jivesoftware.util.ParamUtils,
                  org.jivesoftware.util.CookieUtils,
@@ -33,6 +32,7 @@
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
+<%@ page import="org.jivesoftware.openfire.session.*" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -84,9 +84,7 @@
         JID address = new JID(jid);
         try {
             Session sess = sessionManager.getSession(address);
-            if (sess instanceof LocalClientSession) {
-                ((LocalClientSession) sess).getStreamManager().formalClose();
-            }
+            sess.markNonResumable();
             sess.close();
             // Log the event
             webManager.logEvent("closed session for address "+address, null);

--- a/xmppserver/src/main/webapp/user-delete.jsp
+++ b/xmppserver/src/main/webapp/user-delete.jsp
@@ -75,8 +75,7 @@
         final StreamError error = new StreamError(StreamError.Condition.not_authorized);
         for (ClientSession sess : webManager.getSessionManager().getSessions(user.getUsername()) )
         {
-            sess.deliverRawText(error.toXML());
-            sess.close();
+            sess.close(error);
         }
         // Deleted your own user account, force login
         if (username.equals(webManager.getAuthToken().getUsername())){

--- a/xmppserver/src/main/webapp/user-lockout.jsp
+++ b/xmppserver/src/main/webapp/user-lockout.jsp
@@ -95,8 +95,7 @@
             final StreamError error = new StreamError(StreamError.Condition.not_authorized);
             for (ClientSession sess : webManager.getSessionManager().getSessions(username) )
             {
-                sess.deliverRawText(error.toXML());
-                sess.close();
+                sess.close(error);
             }
             // Disabled your own user account, force login
             if (username.equals(webManager.getAuthToken().getUsername())){


### PR DESCRIPTION
This inverts the approach of 'assume that a connection is closed correctly, unless some kind of error was detected' with 'assume that the connection is closed with some kind of error state, unless we can detect that it was closed correctly'.

It is assumed that this results in better behavior, in particular with regards to the resumability of sessions (in context of Stream Management).

To detect that a connection is closed correctly:
- see if the peer sent an 'end of stream' (typically a `</stream:stream>` tag)
- determine if close was invoked through some administrative action (eg: an admin killing a session on the admin console).

This commit:
- Stores the 'has received end-of-stream' in a boolean property of a session (although this property currently goes unused)
- Explicitly marks a session as non-resumable in many more cases
- Adds clustering support for marking a session as non-resumable (allowing an admin to properly close a session on another node)
- Enhances the `close()` API with a method that takes a Stream Error object. When not null, the session is automatically marked as non-resumable
- Applies all of the above to all types of sessions with XMPP entities. Apart from clients, this includes servers, components, and multiplexers. This facilitates Stream Management on those types of connection.