### PR TITLE
OF-3118: Bump org.apache.commons:commons-lang3 from 3.9 to 3.18.0

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -387,7 +387,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This update addresses a recently discovered vulnerability:

The vulnerability appears to reside in an utility class. Openfire isn’t using that class directly, but may be indirectly. In any case, it would be good to not have this vulnerability pop up in static analyzers, which tends to generate noise.