### PR TITLE
i18n: remove preamble in properties files

### DIFF
--- a/documentation/translator-guide.html
+++ b/documentation/translator-guide.html
@@ -66,25 +66,26 @@ skin.message=<i>Beitrag</i></pre>
         <h2>Construct a Resource Bundle</h2>
 
         <p>
-            To start, make a copy of the default (English) locale file "openfire_i18n.properties".
-            It can be found in the <code>resources\i18n</code> directory of your Openfire
-            installation. Note: the files found in <code>resources\i18n</code> are copies of the
+            To start, make a copy of the default (English) locale file <code>openfire_i18n.properties</code>.
+            It can be found in the <code>resources/i18n</code> directory of your Openfire
+            installation. Note: the files found in <code>resources/i18n</code> are copies of the
             real resource bundles used by the application (the real resource bundles are contained
-            in the openfire.jar file). Editing the resource files in the <code>resources\i18n</code>
+            in the <code>openfire.jar</code> file). Editing the resource files in the <code>resources/i18n</code>
             directory will not affect your running copy of Openfire.
         </p>
         <p>
             Next, you'll need to rename the file to match the locale that you're making a
-            translation for. The syntax of the name is "openfire_i18n_[lang]_[country].properties".
+            translation for. The syntax of the name is <code>openfire_i18n_[lang]_[country].properties</code>.
             However, the country code should be used in most cases. For example, the German resource
-            bundle should be named "openfire_i18n_de.properties" because
-            "de" is the language code for German. For French, the file would be called
-            "openfire_i18n_fr.properties". A list of language codes can
-            be found at: <a href="https://www.ics.uci.edu/pub/ietf/http/related/iso639.txt"
-            target="_new">http://www.ics.uci.edu/pub/ietf/http/related/iso639.txt</a>.
+            bundle should be named <code>openfire_i18n_de.properties</code> because
+            <code>de</code> is the language code for German. For French, the file would be called
+            <code>openfire_i18n_fr.properties</code>. A list of language codes can
+            be found at: <a href="https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes" target="_blank">Wikipedia</a>.
             Some locales require a combination of language and country code. For example
-            simplified Chinese would have the name "openfire_i18n_zh_CN.properties"
-            while traditional Chinese would have the name "openfire_i18n_zh_TW.properties".
+            simplified Chinese would have the name <code>openfire_i18n_zh_CN.properties</code>
+            while traditional Chinese would have the name <code>openfire_i18n_zh_TW.properties</code>.
+            Please note that the two digit language code should be in lower case, and the
+            two digit country code should be in uppercase.
         </p>
 
     </section>
@@ -97,6 +98,10 @@ skin.message=<i>Beitrag</i></pre>
             Next, use your favorite text editor to translate the English values into
             your language. The key names must not be changed.
         </p>
+        <p>
+            In property strings that are parameterized, single quotes can be used to quote the <code>{</code> (curly brace) if necessary.
+            A real single quote is represented by <code>''</code>.
+        </p>
 
     </section>
 
@@ -106,10 +111,10 @@ skin.message=<i>Beitrag</i></pre>
 
         <p>
             To test your translation, copy the translated resource bundle file (example,
-            openfire_i18n_de.properties) to the <code>lib/</code> directory of your Openfire
+            <code>openfire_i18n_de.properties</code>) to the <code>lib/</code> directory of your Openfire
             installation. Make sure Openfire is stopped and then edit the <code>conf/openfire.xml</code>
             file. Set the <code>locale</code> property to match your new resource
-            bundle such as "de" or "zh_CN". Start Openfire and the admin console
+            bundle such as <code>de</code> or <code>zh_CN</code>. Start Openfire and the admin console
             should now be using your translation. If you still see English text you may have
             named your bundle incorrectly or used the wrong value for the <code>locale</code>
             property.

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1,30 +1,6 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
+## See https://download.igniterealtime.org/openfire/docs/latest/documentation/translator-guide.html
 ## In property strings that are parameterized, single quotes can be used to
 ## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
 
 short.title = Openfire
 title = Openfire

--- a/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
+++ b/i18n/src/main/resources/openfire_i18n_cs_CZ.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_de.properties
+++ b/i18n/src/main/resources/openfire_i18n_de.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_es.properties
+++ b/i18n/src/main/resources/openfire_i18n_es.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_fa_IR.properties
+++ b/i18n/src/main/resources/openfire_i18n_fa_IR.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = اوپن‌فایر
 title = اوپن‌فایر
 

--- a/i18n/src/main/resources/openfire_i18n_fr.properties
+++ b/i18n/src/main/resources/openfire_i18n_fr.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_he.properties
+++ b/i18n/src/main/resources/openfire_i18n_he.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_it_IT.properties
+++ b/i18n/src/main/resources/openfire_i18n_it_IT.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_ja_JP.properties
+++ b/i18n/src/main/resources/openfire_i18n_ja_JP.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_pl_PL.properties
+++ b/i18n/src/main/resources/openfire_i18n_pl_PL.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_pt_BR.properties
+++ b/i18n/src/main/resources/openfire_i18n_pt_BR.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_pt_PT.properties
+++ b/i18n/src/main/resources/openfire_i18n_pt_PT.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_ru_RU.properties
+++ b/i18n/src/main/resources/openfire_i18n_ru_RU.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_sk.properties
+++ b/i18n/src/main/resources/openfire_i18n_sk.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_sv.properties
+++ b/i18n/src/main/resources/openfire_i18n_sv.properties
@@ -32,13 +32,13 @@ title = Openfire
 # Sidebar, tabs (preserve the indenting below -- helps to visualize the structure:
 
 tab.server=Server
-tab.server.descr=Klicka för att hantera serverinställningar
+tab.server.descr=Klicka fÃ¶r att hantera serverinstÃ¤llningar
 sidebar.server-manager=Serverhanterare
 sidebar.server-settings=Serverinformation
-sidebar.server-settings.descr=Klicka för att visa systeminformation
+sidebar.server-settings.descr=Klicka fÃ¶r att visa systeminformation
 sidebar.system-props=Systemegenskaper
-sidebar.system-props.descr=Klicka för att hantera serveregenskaper
-sidebar.server-locale=Språk och tid
-sidebar.server-locale.descr=Klicka för att ställa in språk och tidszon
+sidebar.system-props.descr=Klicka fÃ¶r att hantera serveregenskaper
+sidebar.server-locale=SprÃ¥k och tid
+sidebar.server-locale.descr=Klicka fÃ¶r att stÃ¤lla in sprÃ¥k och tidszon
 sidebar.system-clustering=Klustring
-sidebar.system-clustering.descr=Klicka för att hantera klusterinställningar
+sidebar.system-clustering.descr=Klicka fÃ¶r att hantera klusterinstÃ¤llningar

--- a/i18n/src/main/resources/openfire_i18n_sv.properties
+++ b/i18n/src/main/resources/openfire_i18n_sv.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_tr_TR.properties
+++ b/i18n/src/main/resources/openfire_i18n_tr_TR.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_uk_UA.properties
+++ b/i18n/src/main/resources/openfire_i18n_uk_UA.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 

--- a/i18n/src/main/resources/openfire_i18n_zh_CN.properties
+++ b/i18n/src/main/resources/openfire_i18n_zh_CN.properties
@@ -1,31 +1,3 @@
-## Openfire Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   openfire_i18n "_" language "_" country ".properties"
-##   openfire_i18n "_" language ".properties"
-##
-## e.g.
-##    openfire_i18n_en.properties      <- English resources
-##    openfire_i18n_en_US.properties   <- American US resources
-##    openfire_i18n_de.properties      <- German resources
-##    openfire_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A full list of language codes can be found at
-## http://www-old.ics.uci.edu/pub/ietf/http/related/iso639.txt
-## and a full list of country codes can be found at
-## http://www.chemie.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
-# Openfire
-
 short.title = Openfire
 title = Openfire
 


### PR DESCRIPTION
Keep only important note about { and ''.
Move important notes to the Translations documentation.

The dead link to language codes replaced with Wikipedia article.

This saves 20kb of space and makes it faster to parse the props.