### PR TITLE
OF-2526: SystemD: process exit code 143 returned by JVM and successful

### DIFF
--- a/distribution/src/dist/usr/lib/systemd/system/openfire.service
+++ b/distribution/src/dist/usr/lib/systemd/system/openfire.service
@@ -10,6 +10,7 @@ Type=simple
 WorkingDirectory=/usr/share/openfire/
 ExecStart=/bin/bash -c '/usr/share/openfire/bin/openfire.sh ${DAEMON_OPTS}'
 Restart=on-failure
+SuccessExitStatus=143
 RuntimeDirectory=openfire
 
 # Specify resource limits in the slice


### PR DESCRIPTION
When calling `systemctl stop openfire` and then check for the service status `systemctl status openfire` then if will be in failed state:

```
× openfire.service - Openfire XMPP Server
     Loaded: loaded (/usr/lib/systemd/system/openfire.service; disabled; preset: enabled)
     Active: failed (Result: exit-code) 
    Process: 88888 ExecStart=/bin/bash -c /usr/share/openfire/bin/openfire.sh ${DAEMON_OPTS} (code=exited, status=143)
   Main PID: 88888 (code=exited, status=143)
```

Yes, it was properly shutdown but the SystemD thinks this was an error exit code 143.

> Exit code 143 means that the program received a SIGTERM signal to instruct it to exit. The JVM catches the signal, does a clean shutdown, i.e. it runs all registered shutdown hooks, but still exits with an exit code of 143. That's just how Java works.


* https://serverfault.com/a/695863
* https://stackoverflow.com/questions/45953678/unit-falling-into-a-failed-state-status-143-when-stopping-service
