### PR TITLE
OF-3127: Make MUCRoom's 'occupants' field more thread-safe

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -103,7 +103,7 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
     /**
      * All occupants that are associated with this room.
      */
-    public final ArrayList<MUCOccupant> occupants = new ArrayList<>();
+    public final CopyOnWriteArrayList<MUCOccupant> occupants = new CopyOnWriteArrayList<>();
 
     /**
      * The name of the room.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/muc/MUCRoomTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/muc/MUCRoomTest.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Field;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -85,7 +86,7 @@ public class MUCRoomTest {
         populateField(roomSelfOccupant, "affiliation", Affiliation.member);
         populateField(roomSelfOccupant, "occupantJID", new JID("room-test-jid@conference.example.org"));
 
-        final List<MUCOccupant> occupants = new ArrayList<>();
+        final List<MUCOccupant> occupants = new CopyOnWriteArrayList<>();
         final MUCOccupant occupantA = new MUCOccupant();
         populateField(occupantA, "roomJid", new JID("occupantA@example.org/Ψ+"));
         populateField(occupantA, "role", Role.participant);


### PR DESCRIPTION
By switching the implementation of the List used to represent occupants of a MUC room, the chance of a concurrency issue occurring is reduced (notably, it is no longer possible that a ConcurrentModificationException is thrown when the occupants are iterated over while a change to the list is applied).

The new implementation is less efficient when the collection changes (or `size` is invoked). The number of these events should be small as compared to the amount of times that the collection is iterated over.