### PR TITLE
OF-2309 Fix NPE when plugin was removed manually

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginManager.java
@@ -872,12 +872,15 @@ public class PluginManager
         // Anyway, for a few seconds admins may not see the plugin in the admin console
         // and in a subsequent refresh it will appear if failed to be removed
         pluginsLoaded.remove( canonicalName );
-        final String pluginName = getMetadata(canonicalName).getName();
-        Log.info("Removing all System Properties for the plugin '{}'", pluginName);
-        SystemProperty.removePropertiesForPlugin(pluginName);
+        PluginMetadata metadata = getMetadata(canonicalName);
+        if (metadata != null) {
+            final String pluginName = metadata.getName();
+            Log.info("Removing all System Properties for the plugin '{}'", pluginName);
+            SystemProperty.removePropertiesForPlugin(pluginName);
+        }
         Path pluginFile = pluginDirs.remove( canonicalName );
         PluginClassLoader pluginLoader = classloaders.remove( plugin );
-        PluginMetadata metadata = pluginMetadata.remove( canonicalName );
+        pluginMetadata.remove( canonicalName );
 
         // try to close the cached jar files from the plugin class loader
         if ( pluginLoader != null )


### PR DESCRIPTION
I manually removed the search plugin from `plugins` folder and then the Openfire didn't started because of null pointer exception in the line:

    final String pluginName = getMetadata(canonicalName).getName();

This happened because the getMetadata(canonicalName) returned null.
So I added the null check to avoid the problem.

Additionally I noticed the isLocalizedTextRTL() method that can be simplified but also it should support more RTL languages. 