### PR TITLE
Improve tests usage of fail

### DIFF
--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/AbstractGroupProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/AbstractGroupProviderTest.java
@@ -39,6 +39,7 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests that verify the functionality of {@link AbstractGroupProvider} methods not overridden by the
@@ -67,9 +68,9 @@ public class AbstractGroupProviderTest extends DBTestCase {
         System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_CONNECTION_URL, URL );
         System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_USERNAME, USERNAME );
         System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_PASSWORD, PASSWORD );
-        
+
       } catch ( URISyntaxException e) {
-        assertFalse(false, e.getMessage());
+        fail(e.getMessage());
       }
     }
 

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/DefaultGroupProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/DefaultGroupProviderTest.java
@@ -72,9 +72,9 @@ public class DefaultGroupProviderTest extends DBTestCase
           System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_CONNECTION_URL, URL );
           System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_USERNAME, USERNAME );
           System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_PASSWORD, PASSWORD );
-          
+
         } catch ( URISyntaxException e) {
-          assertFalse(false, e.getMessage());
+          fail(e.getMessage());
         }
     }
 

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
@@ -40,10 +40,10 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests that verify the functionality of {@link GroupManager}.
@@ -71,9 +71,9 @@ public class GroupManagerNoMockTest extends DBTestCase
         System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_CONNECTION_URL, URL );
         System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_USERNAME, USERNAME );
         System.setProperty( PropertiesBasedJdbcDatabaseTester.DBUNIT_PASSWORD, PASSWORD );
-        
+
       } catch ( URISyntaxException e) {
-        assertFalse(false, e.getMessage());
+        fail(e.getMessage());
       }
     }
 

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -98,13 +98,8 @@ public class GroupManagerTest {
 
         groupCache.put(GROUP_NAME, CacheableOptional.of(null));
 
-        try {
-            groupManager.getGroup(GROUP_NAME, false);
-        } catch (final GroupNotFoundException ignored) {
-            verifyNoMoreInteractions(groupProvider);
-            return;
-        }
-        fail();
+        assertThrows(GroupNotFoundException.class, () -> groupManager.getGroup(GROUP_NAME, false));
+        verifyNoMoreInteractions(groupProvider);
     }
 
     @Test
@@ -124,14 +119,9 @@ public class GroupManagerTest {
 
         doThrow(new GroupNotFoundException()).when(groupProvider).getGroup(GROUP_NAME);
 
-        try {
-            groupManager.getGroup(GROUP_NAME, false);
-        } catch (final GroupNotFoundException ignored) {
-            verify(groupProvider).getGroup(GROUP_NAME);
-            assertThat(groupCache.get(GROUP_NAME), is(CacheableOptional.of(null)));
-            return;
-        }
-        fail();
+        assertThrows(GroupNotFoundException.class, () -> groupManager.getGroup(GROUP_NAME, false));
+        verify(groupProvider).getGroup(GROUP_NAME);
+        assertThat(groupCache.get(GROUP_NAME), is(CacheableOptional.of(null)));
     }
 
     @Test
@@ -151,14 +141,9 @@ public class GroupManagerTest {
         groupCache.put(GROUP_NAME, CacheableOptional.of(cachedGroup));
         doThrow(new GroupNotFoundException()).when(groupProvider).getGroup(GROUP_NAME);
 
-        try {
-            groupManager.getGroup(GROUP_NAME, true);
-        } catch (final GroupNotFoundException ignored) {
-            verify(groupProvider).getGroup(GROUP_NAME);
-            assertThat(groupCache.get(GROUP_NAME), is(CacheableOptional.of(null)));
-            return;
-        }
-        fail();
+        assertThrows(GroupNotFoundException.class, () -> groupManager.getGroup(GROUP_NAME, true));
+        verify(groupProvider).getGroup(GROUP_NAME);
+        assertThat(groupCache.get(GROUP_NAME), is(CacheableOptional.of(null)));
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
@@ -91,9 +91,7 @@ public class ScramSha1SaslServerTest
 
         // Verify result (first server message should match a pattern, and contain a number of properties)
         final Matcher firstServerResponseMatcher = Pattern.compile("r=([^,]*),s=([^,]*),i=(.*)$").matcher(firstServerResponse);
-        if (!firstServerResponseMatcher.matches()) {
-            fail("First server message does not match expected pattern.");
-        }
+        assertTrue(firstServerResponseMatcher.matches(), "First server message does not match expected pattern.");
         final String serverNonce = firstServerResponseMatcher.group(1);
         assertTrue(serverNonce != null && !serverNonce.isBlank(), "First server message should contain a non-empty server nonce (but did not)");
         assertTrue(serverNonce.startsWith(hardCodedClientNonce), "First server message should contain a server nonce that starts with the client nonce, but did not.");

--- a/xmppserver/src/test/java/org/jivesoftware/util/AdminConsoleTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/AdminConsoleTest.java
@@ -71,9 +71,7 @@ public class AdminConsoleTest {
                 assertEquals("Click to see foo bar", tab.attributeValue("description"));
             }
         }
-        if (!found) {
-            fail("Expected new item 'foobar' was not found.");
-        }
+        assertTrue(found, "Expected new item 'foobar' was not found.");
     }
 
     @Test
@@ -91,8 +89,6 @@ public class AdminConsoleTest {
                 assertEquals("Testing 1 2 3", tab.attributeValue("description"));
             }
         }
-        if (!found) {
-            fail("Failed to overwrite 'server' tab with new properties.");
-        }
+        assertTrue(found, "Failed to overwrite 'server' tab with new properties.");
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/util/CertificateManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/CertificateManagerTest.java
@@ -40,6 +40,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
+import java.security.cert.CertificateException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
@@ -605,14 +606,7 @@ public class CertificateManagerTest
 
     public static void assertCertificateDateNotValid( String message, X509Certificate certificate, Date date )
     {
-        try
-        {
-            certificate.checkValidity( date );
-            fail( message );
-        }
-        catch ( CertificateExpiredException | CertificateNotYetValidException e )
-        {
-            // This is expected to be thrown.
-        }
+        CertificateException e = assertThrows(CertificateException.class, () -> certificate.checkValidity( date ), message);
+        assertTrue( e instanceof CertificateExpiredException || e instanceof CertificateNotYetValidException, message );
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/util/SAXReaderUtilTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/SAXReaderUtilTest.java
@@ -104,15 +104,8 @@ public class SAXReaderUtilTest
         // Setup test fixture.
         final InputStream input = new ByteArrayInputStream("this is not valid XML".getBytes(StandardCharsets.UTF_8));
 
-        final ExecutionException result;
-        try {
-            // Execute system under test.
-            SAXReaderUtil.readDocument(input);
-            fail("An ExecutionException should have been thrown.");
-            return;
-        } catch (ExecutionException e) {
-            result = e;
-        }
+        final ExecutionException result =
+            assertThrows(ExecutionException.class, () -> SAXReaderUtil.readDocument(input), "An ExecutionException should have been thrown.");
 
         // Verify result.
         assertNotNull(result);

--- a/xmppserver/src/test/java/org/jivesoftware/util/StringUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/StringUtilsTest.java
@@ -28,15 +28,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class StringUtilsTest {
-    
+
     @BeforeEach
     public void setUp() {
         JiveGlobals.setLocale(Locale.ENGLISH);
     }
-    
+
     @Test
     public void testValidDomainNames() {
-        
+
         assertValidDomainName("www.mycompany.com");
         assertValidDomainName("www.my-company.com");
         assertValidDomainName("abc.de");
@@ -44,10 +44,10 @@ public class StringUtilsTest {
         assertValidDomainName("öbb.at", "xn--bb-eka.at");
 
     }
-    
+
     @Test
     public void testInvalidDomainNames() {
-        
+
         assertInvalidDomainName("www.my_company.com", "Contains non-LDH characters");
         assertInvalidDomainName("www.-dash.com", "Has leading or trailing hyphen");
         assertInvalidDomainName("www.dash-.com", "Has leading or trailing hyphen");
@@ -64,13 +64,10 @@ public class StringUtilsTest {
     }
 
     private void assertInvalidDomainName(String domain, String expectedCause) {
-        try {
-            StringUtils.validateDomainName(domain);
-            fail("Domain should not be valid: " + domain);
-        } catch (IllegalArgumentException iae) {
-            // this is not part of the official API, so leave off for now
-            //assertEquals("Unexpected cause: " + iae.getMessage(), expectedCause, iae.getMessage());
-        }
+        IllegalArgumentException iae =
+            assertThrows(IllegalArgumentException.class, () -> StringUtils.validateDomainName(domain), "Domain should not be valid: " + domain);
+        // this is not part of the official API, so leave off for now
+        //assertEquals("Unexpected cause: " + iae.getMessage(), expectedCause, iae.getMessage());
     }
 
     @Test

--- a/xmppserver/src/test/java/org/jivesoftware/util/XMPPDateTimeFormatTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/XMPPDateTimeFormatTest.java
@@ -30,7 +30,7 @@ public class XMPPDateTimeFormatTest {
     private final String TEST_DATE = "2013-01-25T18:07:22.768Z";
     DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
     private final XMPPDateTimeFormat xmppDateTimeFormat = new XMPPDateTimeFormat();
-    
+
     @Test
     public void failTest() {
         Date parsedDate = null;
@@ -77,14 +77,11 @@ public class XMPPDateTimeFormatTest {
         final String testValue = "This is not a valid date value";
 
         // Execute system under test
-        try {
-            xmppDateTimeFormat.parseString(testValue);
+        ParseException e =
+            assertThrows(ParseException.class, () -> xmppDateTimeFormat.parseString(testValue), "An exception should have been thrown (but was not).");
 
-            // Verify results
-            fail("An exception should have been thrown (but was not).");
-        } catch (ParseException e) {
-            assertTrue(e.getMessage().contains(testValue));
-        }
+        // Verify results
+        assertTrue(e.getMessage().contains(testValue));
     }
 
     @Test


### PR DESCRIPTION
The test suite contains several patterns where `fail` was used in a way that does follow JUnit Jupiter's best practices.
This PR attempts to improve those calls, and use (or not use) `fail` in a more idiomatic way,
Note that all the tests modified in this PR were functionally correct. The PR does not attempt to improve their correctness, just the style in which they use JUnit.

The PR addresses three main patterns:

**Boolean assertion with a constant value:**
```java
assertFalse(false, "If we reached here, the test should fail");
```
Since the condition is a literal, there's no point in using a conditional assertion, and the unconditional `fail` should be used instead:
```java
fail("If we reached here, the test should fail");
```


**Using `if` statements to assess conditions for failure instead of built-in assertions:**
```java
if (!condition) {
    fail("condition should be true");
}
```
This logic can be expressed more concisely by using JUnit's built in assertions:
```java
assertTrue(condition, "condition should be true");
```


**Using a `try`-`catch` to assert expected exceptions:**
```java
try {
    codeThatShouldFail();
    fail("Shouldn't have gotten here");
} catch (SomeException e) {
    assertEquals("some error message", e.getMessage());
}
```

This was a common idiom when using JUnit 3, but it's often hard to follow the flow of code written like this, and it's relatively easy to introduce mistakes when refactoring it.

 Instead of this boilerplate, JUnit 5 allows an easier approach, using `assertThrows`:
 ```java
 SomeException e = assertThrows(SomeException.class, () -> codeThatShouldFail());
 assertEquals("some error message", e.getMessage());
 ```