### PR TITLE
OF-3188 + OF-3189: Add generic support for XEP-0128: Service Discovery Extensions

### DIFF
--- a/documentation/openfire.doap
+++ b/documentation/openfire.doap
@@ -206,7 +206,6 @@
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0128.html"/>
-                <xmpp:note xml:lang='en'>Provided by the 'MUC Service Discovery Extensions' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
@@ -245,6 +244,11 @@
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0156.html"/>
+            </xmpp:SupportedXep>
+        </implements>
+        <implements>
+            <xmpp:SupportedXep>
+                <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0157.html"/>
             </xmpp:SupportedXep>
         </implements>
         <implements>
@@ -322,6 +326,11 @@
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0223.html"/>
+            </xmpp:SupportedXep>
+        </implements>
+        <implements>
+            <xmpp:SupportedXep>
+                <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0232.html"/>
             </xmpp:SupportedXep>
         </implements>
         <implements>

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1281,6 +1281,7 @@ system_property.hybridUserProvider.tertiaryProvider.className=The third class th
 system_property.hybridUserProvider.tertiaryProvider.config=Configuration value for the third class used by the HybridUserProvider.
 system_property.propertyBasedUserMapper.fallbackProvider.className=The fallback user provider used by PropertyBasedUserProviderMapper, when no other mapper can provide a user.
 system_property.admin.authorizedJIDs=The bare JID of every admin user for the DefaultAdminProvider
+system_property.admin.disable-exposure=When set to true, suppresses extended service discovery information (contact addresses, software versions) that may expose administrative details. Use this for enhanced privacy/security when you don't want to disclose server configuration details.
 system_property.xmpp.auth.ssl.context_protocol=The TLS protocol to use for encryption context initialization, overriding the Java default.
 system_property.xmpp.parser.buffer.size=Maximum size of an XMPP stanza. Larger stanzas will cause a connection to be closed.
 system_property.xmpp.auth.ssl.enforce_sni=Controls if the server enforces the use of SNI (Server Name Indication) when clients connect using TLS.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProvider.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.disco;
+
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.user.UserManager;
+import org.jivesoftware.util.JiveGlobals;
+import org.xmpp.forms.DataForm;
+import org.xmpp.forms.FormField;
+import org.xmpp.packet.JID;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Provides XEP-0157 Contact Addresses for XMPP Services via service discovery.
+ * <p>
+ * This provider returns a data form containing administrative contact addresses for the server,
+ * including XMPP addresses for administrators and their email addresses when available.
+ * </p>
+ * <p>
+ * The contact information is only returned when:
+ * <ul>
+ *   <li>The {@code admin.disable-exposure} property is not set to true</li>
+ *   <li>The request is for the server domain (name is null or matches the server domain)</li>
+ *   <li>No specific node is requested (node is null)</li>
+ *   <li>At least one administrator is configured</li>
+ * </ul>
+ * </p>
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0157.html">XEP-0157: Contact Addresses for XMPP Services</a>
+ */
+public class ContactAddressesExtendedDiscoInfoProvider implements ExtendedDiscoInfoProvider {
+
+    @Override
+    public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
+        // Return empty set if admin exposure is disabled
+        if (JiveGlobals.getBooleanProperty("admin.disable-exposure")) {
+            return Collections.emptySet();
+        }
+
+        // Only respond for server-level requests (no node)
+        if (node != null) {
+            return Collections.emptySet();
+        }
+
+        // Only respond for server domain or null name
+        if (name != null && !name.equals(XMPPServer.getInstance().getServerInfo().getXMPPDomain())) {
+            return Collections.emptySet();
+        }
+
+        // Get admins and return empty if none
+        final Collection<JID> admins = XMPPServer.getInstance().getAdmins();
+        if (admins == null || admins.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        // Build XEP-0157 form
+        final DataForm dataForm = new DataForm(DataForm.Type.result);
+
+        final FormField fieldType = dataForm.addField();
+        fieldType.setVariable("FORM_TYPE");
+        fieldType.setType(FormField.Type.hidden);
+        fieldType.addValue("http://jabber.org/network/serverinfo");
+
+        final FormField fieldAdminAddresses = dataForm.addField();
+        fieldAdminAddresses.setVariable("admin-addresses");
+        fieldAdminAddresses.setType(FormField.Type.list_multi);
+
+        final UserManager userManager = UserManager.getInstance();
+        for (final JID admin : admins) {
+            fieldAdminAddresses.addValue("xmpp:" + admin.asBareJID());
+            if (admin.getDomain().equals(XMPPServer.getInstance().getServerInfo().getXMPPDomain())) {
+                try {
+                    final String email = userManager.getUser(admin.getNode()).getEmail();
+                    if (email != null && !email.trim().isEmpty()) {
+                        fieldAdminAddresses.addValue("mailto:" + email);
+                    }
+                } catch (Exception e) {
+                    // User not found or other error - skip email for this admin
+                    continue;
+                }
+            }
+        }
+
+        final Set<DataForm> dataForms = new HashSet<>();
+        dataForms.add(dataForm);
+        return dataForms;
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProvider.java
@@ -18,7 +18,6 @@ package org.jivesoftware.openfire.disco;
 
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.user.UserManager;
-import org.jivesoftware.util.JiveGlobals;
 import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
 import org.xmpp.packet.JID;
@@ -51,7 +50,7 @@ public class ContactAddressesExtendedDiscoInfoProvider implements ExtendedDiscoI
     @Override
     public Set<DataForm> getExtendedInfos(String domain, String name, String node, JID senderJID) {
         // Return empty set if admin exposure is disabled
-        if (JiveGlobals.getBooleanProperty("admin.disable-exposure")) {
+        if (IQDiscoInfoHandler.DISABLE_EXPOSURE.getValue()) {
             return Collections.emptySet();
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProvider.java
@@ -49,7 +49,7 @@ import java.util.Set;
 public class ContactAddressesExtendedDiscoInfoProvider implements ExtendedDiscoInfoProvider {
 
     @Override
-    public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
+    public Set<DataForm> getExtendedInfos(String domain, String name, String node, JID senderJID) {
         // Return empty set if admin exposure is disabled
         if (JiveGlobals.getBooleanProperty("admin.disable-exposure")) {
             return Collections.emptySet();
@@ -60,8 +60,14 @@ public class ContactAddressesExtendedDiscoInfoProvider implements ExtendedDiscoI
             return Collections.emptySet();
         }
 
-        // Only respond for server domain or null name
-        if (name != null && !name.equals(XMPPServer.getInstance().getServerInfo().getXMPPDomain())) {
+        // Only respond for server domain (not MUC, PubSub, etc.)
+        final String serverDomain = XMPPServer.getInstance().getServerInfo().getXMPPDomain();
+        if (!serverDomain.equals(domain)) {
+            return Collections.emptySet();
+        }
+
+        // Only respond for service-level queries (name == null)
+        if (name != null) {
             return Collections.emptySet();
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProvider.java
@@ -47,6 +47,31 @@ import java.util.Set;
  */
 public class ContactAddressesExtendedDiscoInfoProvider implements ExtendedDiscoInfoProvider {
 
+    /**
+     * Returns XEP-0157 Contact Addresses data form for the server when appropriate conditions are met.
+     * <p>
+     * This implementation only returns contact information for service-level disco#info queries
+     * targeting the server's main domain (not subdomains like MUC or PubSub). The returned data form
+     * contains XMPP addresses of configured administrators and their email addresses when available.
+     * </p>
+     * <p>
+     * Returns an empty set when:
+     * <ul>
+     *   <li>Administrative exposure is disabled ({@link IQDiscoInfoHandler#DISABLE_EXPOSURE} is true)</li>
+     *   <li>A specific disco node is requested (only responds to node-less queries)</li>
+     *   <li>The domain is not the server's main domain (e.g., MUC or PubSub subdomains)</li>
+     *   <li>A specific user/resource is targeted (only responds to service-level queries where name is null)</li>
+     *   <li>No administrators are configured</li>
+     * </ul>
+     * </p>
+     *
+     * @param domain the domain of the target JID (e.g., "localhost", "conference.localhost")
+     * @param name the node part of the target JID (null for service-level queries)
+     * @param node the requested disco node parameter (null if not specified)
+     * @param senderJID the JID of the entity that sent the disco#info request
+     * @return A set containing a single XEP-0157 data form with contact addresses, or an empty set if conditions are not met
+     * @see <a href="https://xmpp.org/extensions/xep-0157.html">XEP-0157: Contact Addresses for XMPP Services</a>
+     */
     @Override
     public Set<DataForm> getExtendedInfos(String domain, String name, String node, JID senderJID) {
         // Return empty set if admin exposure is disabled

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ExtendedDiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ExtendedDiscoInfoProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.disco;
+
+import org.xmpp.forms.DataForm;
+import org.xmpp.packet.JID;
+
+import java.util.Set;
+
+/**
+ * Provides extended service discovery information using XEP-0128 data form extensions.
+ * <p>
+ * Implementations of this interface can contribute additional XEP-0004 data forms to disco#info responses,
+ * enabling plugin-controlled additions to service discovery as defined by XEP-0128.
+ * This supports use cases such as:
+ * <ul>
+ *   <li>Adding custom fields to existing forms (e.g. what the MUC Extended Info plugin does)</li>
+ *   <li>Providing entirely new data forms with custom FORM_TYPE values (e.g. XEP-0232: Software Information, XEP-0504: Data Policy)</li>
+ * </ul>
+ * </p>
+ *
+ * When multiple providers return forms with the same FORM_TYPE, the forms are merged by combining
+ * their fields. However, <b>each field must be unique</b> within a form type. If two providers contribute
+ * fields with the same field name to the same FORM_TYPE, this is treated as a configuration error. The duplicate
+ * provider's entire contribution is skipped and a warning is logged. Other providers continue to be processed
+ * normally.
+ *
+ * Implementations should use 'JiveGlobals.getBooleanProperty( "admin.disable-exposure" )' and consider appropriate
+ * adjustments where needed.
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0004.html">XEP-0004: Data Forms</a>
+ * @see <a href="https://xmpp.org/extensions/xep-0128.html">XEP-0128: Service Discovery Extensions</a>
+ * @see <a href="https://xmpp.org/extensions/xep-0504.html">XEP-0504: Data Policy</a>
+ */
+public interface ExtendedDiscoInfoProvider {
+
+    /**
+     * Returns a collection of data forms with extended information about the entity.
+     * <p>
+     * The returned Set may be empty but should not be null. It may be immutable.
+     * Forms should include a FORM_TYPE field to enable proper merging.
+     * </p>
+     *
+     * @param name the recipient's JID.
+     * @param node the requested disco node.
+     * @param senderJID the XMPPAddress of user that sent the disco info request.
+     * @return A Set of data forms (possibly empty, never null). May be immutable.
+     */
+    Set<DataForm> getExtendedInfos(String name, String node, JID senderJID );
+
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ExtendedDiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ExtendedDiscoInfoProvider.java
@@ -39,8 +39,8 @@ import java.util.Set;
  * provider's entire contribution is skipped and a warning is logged. Other providers continue to be processed
  * normally.
  *
- * Implementations should use 'JiveGlobals.getBooleanProperty( "admin.disable-exposure" )' and consider appropriate
- * adjustments where needed.
+ * Implementations may wish to check {@link IQDiscoInfoHandler#DISABLE_EXPOSURE} and return an empty set
+ * when it is true, to respect privacy configurations that suppress exposure of administrative details.
  *
  * @see <a href="https://xmpp.org/extensions/xep-0004.html">XEP-0004: Data Forms</a>
  * @see <a href="https://xmpp.org/extensions/xep-0128.html">XEP-0128: Service Discovery Extensions</a>

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ExtendedDiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/ExtendedDiscoInfoProvider.java
@@ -55,11 +55,12 @@ public interface ExtendedDiscoInfoProvider {
      * Forms should include a FORM_TYPE field to enable proper merging.
      * </p>
      *
-     * @param name the recipient's JID.
-     * @param node the requested disco node.
-     * @param senderJID the XMPPAddress of user that sent the disco info request.
+     * @param domain the domain of the target JID (e.g., "localhost", "conference.localhost", "pubsub.localhost")
+     * @param name the node part of the target JID (null for service-level queries)
+     * @param node the requested disco node parameter (null if not specified)
+     * @param senderJID the XMPPAddress of user that sent the disco info request
      * @return A Set of data forms (possibly empty, never null). May be immutable.
      */
-    Set<DataForm> getExtendedInfos(String name, String node, JID senderJID );
+    Set<DataForm> getExtendedInfos(String domain, String name, String node, JID senderJID);
 
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -94,11 +94,8 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
     private List<UserFeaturesProvider> registeredUserFeatureProviders = new ArrayList<>();
     private List<ExtendedDiscoInfoProvider> extendedDiscoInfoProviders = new ArrayList<>();
 
-    public static final SystemProperty<Boolean> ENABLED = SystemProperty.Builder.ofType(Boolean.class)
-        .setKey("xmpp.iqdiscoinfo.xformsoftwareversion")
-        .setDefaultValue(Boolean.TRUE)
-        .setDynamic(Boolean.TRUE)
-        .build();
+    private final ContactAddressesExtendedDiscoInfoProvider contactAddressesProvider = new ContactAddressesExtendedDiscoInfoProvider();
+    private final SoftwareInfoExtendedDiscoInfoProvider softwareInfoProvider = new SoftwareInfoExtendedDiscoInfoProvider();
 
     public IQDiscoInfoHandler() {
         super("XMPP Disco Info Handler");
@@ -452,6 +449,11 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
         serverFeatures = CacheFactory.createCache("Disco Server Features");
         addServerFeature(NAMESPACE_DISCO_INFO);
         setProvider(server.getServerInfo().getXMPPDomain(), getServerInfoProvider());
+
+        // Register built-in ExtendedDiscoInfoProviders
+        addExtendedDiscoInfoProvider(contactAddressesProvider);
+        addExtendedDiscoInfoProvider(softwareInfoProvider);
+
         // Listen to cluster events
         ClusterManager.addListener(this);
     }
@@ -770,88 +772,10 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                     // Redirect the request to the disco info provider of the specified node
                     result.addAll(serverNodeProviders.get(node).getExtendedInfos(name, node, senderJID));
                 }
-                else if (name == null || name.equals(XMPPServer.getInstance().getServerInfo().getXMPPDomain())) {
-                    // Answer extended info of the server itself.
-
-                    // XEP-0157 Contact addresses for XMPP Services
-                    if ( !JiveGlobals.getBooleanProperty( "admin.disable-exposure" ) )
-                    {
-                        final Collection<JID> admins = XMPPServer.getInstance().getAdmins();
-                        if ( admins == null || admins.isEmpty() )
-                        {
-                            return null;
-                        }
-
-                        final DataForm dataForm = new DataForm(DataForm.Type.result);
-
-                        final FormField fieldType = dataForm.addField();
-                        fieldType.setVariable("FORM_TYPE");
-                        fieldType.setType(FormField.Type.hidden);
-                        fieldType.addValue("http://jabber.org/network/serverinfo");
-
-                        final FormField fieldAdminAddresses = dataForm.addField();
-                        fieldAdminAddresses.setVariable("admin-addresses");
-                        fieldAdminAddresses.setType(Type.list_multi);
-
-                        final UserManager userManager = UserManager.getInstance();
-                        for ( final JID admin : admins )
-                        {
-                            fieldAdminAddresses.addValue( "xmpp:" + admin.asBareJID() );
-                            if ( admin.getDomain().equals( XMPPServer.getInstance().getServerInfo().getXMPPDomain() ) ) {
-                                try
-                                {
-                                    final String email = userManager.getUser( admin.getNode() ).getEmail();
-                                    if ( email != null && !email.trim().isEmpty() )
-                                    {
-                                        fieldAdminAddresses.addValue( "mailto:" + email );
-                                    }
-                                }
-                                catch (Exception e)
-                                {
-                                    continue;
-                                }
-                            }
-                        }
-
-                        //XEP-0232 includes extended information about Software Version in a data form
-                        final DataForm dataFormSoftwareVersion = new DataForm(DataForm.Type.result);
-
-                        final FormField fieldTypeSoftwareVersion = dataFormSoftwareVersion.addField();
-                        fieldTypeSoftwareVersion.setVariable("FORM_TYPE");
-                        fieldTypeSoftwareVersion.setType(FormField.Type.hidden);
-                        fieldTypeSoftwareVersion.addValue("urn:xmpp:dataforms:softwareinfo");
-
-                        final FormField fieldOs = dataFormSoftwareVersion.addField();
-                        fieldOs.setType(Type.text_single);
-                        fieldOs.setVariable("os");
-                        fieldOs.addValue( System.getProperty("os.name"));
-
-                        final FormField fieldOsVersion = dataFormSoftwareVersion.addField();
-                        fieldOsVersion.setType(Type.text_single);
-                        fieldOsVersion.setVariable("os_version");
-                        fieldOsVersion.addValue(System.getProperty("os.version")+" "+System.getProperty("os.arch")+" - Java " + System.getProperty("java.version"));
-
-                        final FormField fieldSoftware = dataFormSoftwareVersion.addField();
-                        fieldSoftware.setType(Type.text_single);
-                        fieldSoftware.setVariable("software");
-                        fieldSoftware.addValue(AdminConsole.getAppName());
-
-                        final FormField fieldSoftwareVersion = dataFormSoftwareVersion.addField();
-                        fieldSoftwareVersion.setType(Type.text_single);
-                        fieldSoftwareVersion.setVariable("software_version");
-                        fieldSoftwareVersion.addValue(AdminConsole.getVersionString());
-
-                        final Set<DataForm> dataForms = new HashSet<>();
-                        if (ENABLED.getValue()){
-                            dataForms.add(dataFormSoftwareVersion);
-                        }
-                        dataForms.add(dataForm);
-                        result.addAll(dataForms);
-                    }
-                }
                 else if (node != null && name != null) {
                     result.addAll(XMPPServer.getInstance().getIQPEPHandler().getExtendedInfos(name, node, senderJID));
                 }
+
                 for (final ExtendedDiscoInfoProvider provider : extendedDiscoInfoProviders) {
                     Set<DataForm> extended = provider.getExtendedInfos(name, node, senderJID);
                     merge(result, extended);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import org.xmpp.packet.JID;
 import org.xmpp.packet.PacketError;
 import org.xmpp.resultsetmanagement.ResultSet;
 
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -91,6 +92,7 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
     private List<UserIdentitiesProvider> registeredUserIdentityProviders = new ArrayList<>();
     private List<UserFeaturesProvider> anonymousUserFeatureProviders = new ArrayList<>();
     private List<UserFeaturesProvider> registeredUserFeatureProviders = new ArrayList<>();
+    private List<ExtendedDiscoInfoProvider> extendedDiscoInfoProviders = new ArrayList<>();
 
     public static final SystemProperty<Boolean> ENABLED = SystemProperty.Builder.ofType(Boolean.class)
         .setKey("xmpp.iqdiscoinfo.xformsoftwareversion")
@@ -578,6 +580,30 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
     }
 
     /**
+     * Adds a provider that contributes extended information (as per XEP-0128) to disco#info responses.
+     * This allows plugins to add custom data forms or additional fields to existing forms.
+     * <p>
+     * Providers are called for all disco#info requests and their forms are merged with existing forms.
+     * Forms with the same FORM_TYPE are merged, assuming field names are unique.
+     *
+     * @param provider The provider of extended disco info forms.
+     * @see ExtendedDiscoInfoProvider
+     */
+    public void addExtendedDiscoInfoProvider(ExtendedDiscoInfoProvider provider){
+        extendedDiscoInfoProviders.add(provider);
+    }
+
+    /**
+     * Removes a previously registered extended disco info provider.
+     * This should be called when a plugin is unloaded.
+     *
+     * @param provider The provider to remove.
+     */
+    public void removeExtendedDiscoInfoProvider(ExtendedDiscoInfoProvider provider) {
+        extendedDiscoInfoProviders.remove(provider);
+    }
+
+    /**
      * Returns the DiscoInfoProvider responsible for providing information at the server level. This
      * means that this DiscoInfoProvider will provide information whenever a disco request whose
      * recipient JID is the server (e.g. localhost) is made.
@@ -739,11 +765,12 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
 
             @Override
             public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
+                Set<DataForm> result = new HashSet<>();
                 if (node != null && serverNodeProviders.get(node) != null) {
                     // Redirect the request to the disco info provider of the specified node
-                    return serverNodeProviders.get(node).getExtendedInfos(name, node, senderJID);
+                    result.addAll(serverNodeProviders.get(node).getExtendedInfos(name, node, senderJID));
                 }
-                if (name == null || name.equals(XMPPServer.getInstance().getServerInfo().getXMPPDomain())) {
+                else if (name == null || name.equals(XMPPServer.getInstance().getServerInfo().getXMPPDomain())) {
                     // Answer extended info of the server itself.
 
                     // XEP-0157 Contact addresses for XMPP Services
@@ -819,14 +846,110 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                             dataForms.add(dataFormSoftwareVersion);
                         }
                         dataForms.add(dataForm);
-                        return dataForms;
+                        result.addAll(dataForms);
                     }
                 }
-                if (node != null && name != null) {
-                    return XMPPServer.getInstance().getIQPEPHandler().getExtendedInfos(name, node, senderJID);
+                else if (node != null && name != null) {
+                    result.addAll(XMPPServer.getInstance().getIQPEPHandler().getExtendedInfos(name, node, senderJID));
                 }
-                return Collections.emptySet();
+                for (final ExtendedDiscoInfoProvider provider : extendedDiscoInfoProviders) {
+                    Set<DataForm> extended = provider.getExtendedInfos(name, node, senderJID);
+                    merge(result, extended);
+                }
+                return result;
             }
+
+            private void merge(Set<DataForm> result, Set<DataForm> incoming) {
+                for (DataForm incomingForm : incoming) {
+                    String incomingType = getFormType(incomingForm);
+                    if (incomingType == null || incomingType.isBlank()) {
+                        continue; // Only possible for bad DataForms
+                    }
+
+                    DataForm target = result.stream()
+                        .filter(existing -> incomingType.equals(getFormType(existing)))
+                        .findFirst()
+                        .orElse(null);
+
+                    if (target != null) {
+                        // Form exists - attempt to merge fields
+                        try {
+                            mergeFields(target, incomingForm);
+                        } catch (IllegalArgumentException e) {
+                            // Duplicate field detected - log error and skip this provider's contribution
+                            Log.warn("Skipping extended disco info contribution due to duplicate field: {}", e.getMessage());
+                            // Don't add the form, continue processing other providers
+                        }
+                    } else {
+                        // No matching form - add the entire form
+                        result.add(incomingForm);
+                    }
+                }
+            }
+
+            @Nullable
+            private String getFormType(DataForm form) {
+                return form.getFields().stream()
+                    .filter(f -> "FORM_TYPE".equals(f.getVariable()))
+                    .map(FormField::getFirstValue)
+                    .findFirst()
+                    .orElse(null);
+            }
+
+            /**
+             * Merges fields from an incoming form into a target form.
+             * <p>
+             * Each field should be contributed by only one provider. If a duplicate field is detected
+             * (a field with the same variable name already exists in the target form), an
+             * {@link IllegalArgumentException} is thrown to signal the conflict.
+             * </p>
+             *
+             * @param target The form to merge fields into
+             * @param incoming The form whose fields should be merged
+             * @throws IllegalArgumentException if a duplicate field is detected
+             */
+            private void mergeFields(DataForm target, DataForm incoming) {
+                // First pass: Validate all fields to ensure atomicity
+                // (either all fields are added, or none are)
+                for (FormField incomingField : incoming.getFields()) {
+                    String fieldName = incomingField.getVariable();
+
+                    // Skip FORM_TYPE - it's the same for both forms
+                    if ("FORM_TYPE".equals(fieldName)) {
+                        continue;
+                    }
+
+                    // Check if field already exists
+                    FormField existingField = target.getField(fieldName);
+                    if (existingField != null) {
+                        // Duplicate field - throw exception to be caught by caller
+                        String formType = target.getField("FORM_TYPE").getFirstValue();
+                        throw new IllegalArgumentException(
+                            String.format("Duplicate field '%s' in form FORM_TYPE '%s'",
+                                fieldName, formType)
+                        );
+                    }
+                }
+
+                // Second pass: Add all fields (we know none are duplicates)
+                for (FormField incomingField : incoming.getFields()) {
+                    String fieldName = incomingField.getVariable();
+
+                    // Skip FORM_TYPE - it's the same for both forms
+                    if ("FORM_TYPE".equals(fieldName)) {
+                        continue;
+                    }
+
+                    // Add the field
+                    FormField newField = target.addField(
+                        incomingField.getVariable(),
+                        incomingField.getLabel(),
+                        incomingField.getType()
+                    );
+                    incomingField.getValues().forEach(newField::addValue);
+                }
+            }
+
         };
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -52,6 +52,7 @@ import org.xmpp.resultsetmanagement.ResultSet;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.locks.Lock;
 
@@ -90,7 +91,7 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
     private List<UserIdentitiesProvider> registeredUserIdentityProviders = new ArrayList<>();
     private List<UserFeaturesProvider> anonymousUserFeatureProviders = new ArrayList<>();
     private List<UserFeaturesProvider> registeredUserFeatureProviders = new ArrayList<>();
-    private List<ExtendedDiscoInfoProvider> extendedDiscoInfoProviders = new ArrayList<>();
+    private List<ExtendedDiscoInfoProvider> extendedDiscoInfoProviders = new CopyOnWriteArrayList<>();
 
     private final ContactAddressesExtendedDiscoInfoProvider contactAddressesProvider = new ContactAddressesExtendedDiscoInfoProvider();
     private final SoftwareInfoExtendedDiscoInfoProvider softwareInfoProvider = new SoftwareInfoExtendedDiscoInfoProvider();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -211,10 +211,18 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                         }
                     }
                     // Add to the reply the multiple extended info (XDataForm) provided by the DiscoInfoProvider
-                    final Set<DataForm> dataForms = infoProvider.getExtendedInfos(name, node, packet.getFrom());
-                    if (dataForms != null) {
-                        dataForms.forEach(dataForm -> queryElement.add(dataForm.getElement()));
+                    Set<DataForm> dataForms = infoProvider.getExtendedInfos(name, node, packet.getFrom());
+                    if (dataForms == null) {
+                        dataForms = new HashSet<>();
                     }
+
+                    // Apply global ExtendedDiscoInfoProviders (creates mutable copy and merges)
+                    final String targetDomain = packet.getTo() == null ?
+                        XMPPServer.getInstance().getServerInfo().getXMPPDomain() : packet.getTo().getDomain();
+                    final Set<DataForm> enrichedForms = applyExtendedDiscoInfoProviders(dataForms, targetDomain, name, node, packet.getFrom());
+
+                    // Add all forms to the response (clone elements to avoid parent conflicts)
+                    enrichedForms.forEach(dataForm -> queryElement.add(dataForm.getElement().createCopy()));
                 } else {
                     // If the DiscoInfoProvider has no information for the requested name and node
                     // then answer a not found error
@@ -606,6 +614,127 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
     }
 
     /**
+     * Merges incoming forms into the result set, combining forms with matching FORM_TYPE.
+     * Forms with the same FORM_TYPE have their fields merged. If duplicate field names
+     * are detected, the offending provider's contribution is skipped with a warning.
+     */
+    private void merge(Set<DataForm> result, Set<DataForm> incoming) {
+        for (DataForm incomingForm : incoming) {
+            String incomingType = getFormType(incomingForm);
+            if (incomingType == null || incomingType.isBlank()) {
+                continue; // Only possible for bad DataForms
+            }
+
+            DataForm target = result.stream()
+                .filter(existing -> incomingType.equals(getFormType(existing)))
+                .findFirst()
+                .orElse(null);
+
+            if (target != null) {
+                // Form exists - attempt to merge fields
+                try {
+                    mergeFields(target, incomingForm);
+                } catch (IllegalArgumentException e) {
+                    // Duplicate field detected - log error and skip this provider's contribution
+                    Log.warn("Skipping extended disco info contribution due to duplicate field: {}", e.getMessage());
+                    // Don't add the form, continue processing other providers
+                }
+            } else {
+                // No matching form - add the entire form
+                result.add(incomingForm);
+            }
+        }
+    }
+
+    @Nullable
+    private String getFormType(DataForm form) {
+        return form.getFields().stream()
+            .filter(f -> "FORM_TYPE".equals(f.getVariable()))
+            .map(FormField::getFirstValue)
+            .findFirst()
+            .orElse(null);
+    }
+
+    /**
+     * Merges fields from an incoming form into a target form.
+     * <p>
+     * Each field should be contributed by only one provider. If a duplicate field is detected
+     * (a field with the same variable name already exists in the target form), an
+     * {@link IllegalArgumentException} is thrown to signal the conflict.
+     * </p>
+     *
+     * @param target The form to merge fields into
+     * @param incoming The form whose fields should be merged
+     * @throws IllegalArgumentException if a duplicate field is detected
+     */
+    private void mergeFields(DataForm target, DataForm incoming) {
+        // First pass: Validate all fields to ensure atomicity
+        // (either all fields are added, or none are)
+        for (FormField incomingField : incoming.getFields()) {
+            String fieldName = incomingField.getVariable();
+
+            // Skip FORM_TYPE - it's the same for both forms
+            if ("FORM_TYPE".equals(fieldName)) {
+                continue;
+            }
+
+            // Check if field already exists
+            FormField existingField = target.getField(fieldName);
+            if (existingField != null) {
+                // Duplicate field - throw exception to be caught by caller
+                String formType = target.getField("FORM_TYPE").getFirstValue();
+                throw new IllegalArgumentException(
+                    String.format("Duplicate field '%s' in form FORM_TYPE '%s'",
+                        fieldName, formType)
+                );
+            }
+        }
+
+        // Second pass: Add all fields (we know none are duplicates)
+        for (FormField incomingField : incoming.getFields()) {
+            String fieldName = incomingField.getVariable();
+
+            // Skip FORM_TYPE - it's the same for both forms
+            if ("FORM_TYPE".equals(fieldName)) {
+                continue;
+            }
+
+            // Add the field
+            FormField newField = target.addField(
+                incomingField.getVariable(),
+                incomingField.getLabel(),
+                incomingField.getType()
+            );
+            incomingField.getValues().forEach(newField::addValue);
+        }
+    }
+
+    /**
+     * Applies all registered extended disco info providers to a set of data forms.
+     * Creates a mutable copy of the input, applies all providers, and returns the merged result.
+     *
+     * @param existingForms The existing set of data forms (from component provider)
+     * @param targetDomain The domain of the target entity
+     * @param name The node part of the target JID
+     * @param node The requested disco node parameter
+     * @param senderJID The sender of the disco request
+     * @return A new set containing the merged forms (never null)
+     */
+    private Set<DataForm> applyExtendedDiscoInfoProviders(Set<DataForm> existingForms, String targetDomain,
+                                                           String name, String node, JID senderJID) {
+        // Create mutable copy of existing forms
+        Set<DataForm> result = new HashSet<>(existingForms != null ? existingForms : Collections.emptySet());
+
+        // Apply each registered provider
+        for (final ExtendedDiscoInfoProvider provider : extendedDiscoInfoProviders) {
+            Set<DataForm> extended = provider.getExtendedInfos(targetDomain, name, node, senderJID);
+            merge(result, extended);
+        }
+
+        return result;
+    }
+
+    /**
      * Returns the DiscoInfoProvider responsible for providing information at the server level. This
      * means that this DiscoInfoProvider will provide information whenever a disco request whose
      * recipient JID is the server (e.g. localhost) is made.
@@ -776,102 +905,10 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
                     result.addAll(XMPPServer.getInstance().getIQPEPHandler().getExtendedInfos(name, node, senderJID));
                 }
 
-                for (final ExtendedDiscoInfoProvider provider : extendedDiscoInfoProviders) {
-                    Set<DataForm> extended = provider.getExtendedInfos(name, node, senderJID);
-                    merge(result, extended);
-                }
+                // Note: Global ExtendedDiscoInfoProviders are now applied in handleIQ (line ~215)
+                // to avoid double-application
+
                 return result;
-            }
-
-            private void merge(Set<DataForm> result, Set<DataForm> incoming) {
-                for (DataForm incomingForm : incoming) {
-                    String incomingType = getFormType(incomingForm);
-                    if (incomingType == null || incomingType.isBlank()) {
-                        continue; // Only possible for bad DataForms
-                    }
-
-                    DataForm target = result.stream()
-                        .filter(existing -> incomingType.equals(getFormType(existing)))
-                        .findFirst()
-                        .orElse(null);
-
-                    if (target != null) {
-                        // Form exists - attempt to merge fields
-                        try {
-                            mergeFields(target, incomingForm);
-                        } catch (IllegalArgumentException e) {
-                            // Duplicate field detected - log error and skip this provider's contribution
-                            Log.warn("Skipping extended disco info contribution due to duplicate field: {}", e.getMessage());
-                            // Don't add the form, continue processing other providers
-                        }
-                    } else {
-                        // No matching form - add the entire form
-                        result.add(incomingForm);
-                    }
-                }
-            }
-
-            @Nullable
-            private String getFormType(DataForm form) {
-                return form.getFields().stream()
-                    .filter(f -> "FORM_TYPE".equals(f.getVariable()))
-                    .map(FormField::getFirstValue)
-                    .findFirst()
-                    .orElse(null);
-            }
-
-            /**
-             * Merges fields from an incoming form into a target form.
-             * <p>
-             * Each field should be contributed by only one provider. If a duplicate field is detected
-             * (a field with the same variable name already exists in the target form), an
-             * {@link IllegalArgumentException} is thrown to signal the conflict.
-             * </p>
-             *
-             * @param target The form to merge fields into
-             * @param incoming The form whose fields should be merged
-             * @throws IllegalArgumentException if a duplicate field is detected
-             */
-            private void mergeFields(DataForm target, DataForm incoming) {
-                // First pass: Validate all fields to ensure atomicity
-                // (either all fields are added, or none are)
-                for (FormField incomingField : incoming.getFields()) {
-                    String fieldName = incomingField.getVariable();
-
-                    // Skip FORM_TYPE - it's the same for both forms
-                    if ("FORM_TYPE".equals(fieldName)) {
-                        continue;
-                    }
-
-                    // Check if field already exists
-                    FormField existingField = target.getField(fieldName);
-                    if (existingField != null) {
-                        // Duplicate field - throw exception to be caught by caller
-                        String formType = target.getField("FORM_TYPE").getFirstValue();
-                        throw new IllegalArgumentException(
-                            String.format("Duplicate field '%s' in form FORM_TYPE '%s'",
-                                fieldName, formType)
-                        );
-                    }
-                }
-
-                // Second pass: Add all fields (we know none are duplicates)
-                for (FormField incomingField : incoming.getFields()) {
-                    String fieldName = incomingField.getVariable();
-
-                    // Skip FORM_TYPE - it's the same for both forms
-                    if ("FORM_TYPE".equals(fieldName)) {
-                        continue;
-                    }
-
-                    // Add the field
-                    FormField newField = target.addField(
-                        incomingField.getVariable(),
-                        incomingField.getLabel(),
-                        incomingField.getType()
-                    );
-                    incomingField.getValues().forEach(newField::addValue);
-                }
             }
 
         };

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -19,7 +19,6 @@ package org.jivesoftware.openfire.disco;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.QName;
-import org.jivesoftware.admin.AdminConsole;
 import org.jivesoftware.openfire.IQHandlerInfo;
 import org.jivesoftware.openfire.SessionManager;
 import org.jivesoftware.openfire.XMPPServer;
@@ -45,7 +44,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
-import org.xmpp.forms.FormField.Type;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.PacketError;
@@ -96,6 +94,18 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
 
     private final ContactAddressesExtendedDiscoInfoProvider contactAddressesProvider = new ContactAddressesExtendedDiscoInfoProvider();
     private final SoftwareInfoExtendedDiscoInfoProvider softwareInfoProvider = new SoftwareInfoExtendedDiscoInfoProvider();
+
+    /**
+     * Controls whether extended service discovery information that may expose
+     * administrative details (e.g. contact addresses, software versions) should be
+     * included in disco#info responses. When set to true, such information is
+     * suppressed for security/privacy reasons.
+     */
+    public static final SystemProperty<Boolean> DISABLE_EXPOSURE = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("admin.disable-exposure")
+        .setDefaultValue(Boolean.FALSE)
+        .setDynamic(Boolean.TRUE)
+        .build();
 
     public IQDiscoInfoHandler() {
         super("XMPP Disco Info Handler");

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandler.java
@@ -611,6 +611,10 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
      * @see ExtendedDiscoInfoProvider
      */
     public void addExtendedDiscoInfoProvider(ExtendedDiscoInfoProvider provider){
+        if ( provider == null )
+        {
+            throw new NullPointerException( "Argument 'provider' cannot be null." );
+        }
         extendedDiscoInfoProviders.add(provider);
     }
 
@@ -629,7 +633,11 @@ public class IQDiscoInfoHandler extends IQHandler implements ClusterEventListene
      * Forms with the same FORM_TYPE have their fields merged. If duplicate field names
      * are detected, the offending provider's contribution is skipped with a warning.
      */
-    private void merge(Set<DataForm> result, Set<DataForm> incoming) {
+    private void merge(Set<DataForm> result, @Nullable Set<DataForm> incoming) {
+        if (incoming == null) {
+            Log.debug("Extended disco info provider returned null DataForms; treating as empty set.");
+            return;
+        }
         for (DataForm incomingForm : incoming) {
             String incomingType = getFormType(incomingForm);
             if (incomingType == null || incomingType.isBlank()) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProvider.java
@@ -59,7 +59,7 @@ public class SoftwareInfoExtendedDiscoInfoProvider implements ExtendedDiscoInfoP
         .build();
 
     @Override
-    public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
+    public Set<DataForm> getExtendedInfos(String domain, String name, String node, JID senderJID) {
         // Check if feature is enabled
         if (!ENABLED.getValue()) {
             return Collections.emptySet();
@@ -75,8 +75,14 @@ public class SoftwareInfoExtendedDiscoInfoProvider implements ExtendedDiscoInfoP
             return Collections.emptySet();
         }
 
-        // Only respond for server domain or null name
-        if (name != null && !name.equals(XMPPServer.getInstance().getServerInfo().getXMPPDomain())) {
+        // Only respond for server domain (not MUC, PubSub, etc.)
+        final String serverDomain = XMPPServer.getInstance().getServerInfo().getXMPPDomain();
+        if (!serverDomain.equals(domain)) {
+            return Collections.emptySet();
+        }
+
+        // Only respond for service-level queries (name == null)
+        if (name != null) {
             return Collections.emptySet();
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.disco;
+
+import org.jivesoftware.admin.AdminConsole;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.SystemProperty;
+import org.xmpp.forms.DataForm;
+import org.xmpp.forms.FormField;
+import org.xmpp.packet.JID;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Provides XEP-0232 Software Information via service discovery.
+ * <p>
+ * This provider returns a data form containing information about the server's operating system,
+ * software name, and version information. This allows clients to discover what software is running
+ * on the server.
+ * </p>
+ * <p>
+ * The software information is only returned when:
+ * <ul>
+ *   <li>The {@code xmpp.iqdiscoinfo.xformsoftwareversion} property is enabled (default: true)</li>
+ *   <li>The {@code admin.disable-exposure} property is not set to true</li>
+ *   <li>The request is for the server domain (name is null or matches the server domain)</li>
+ *   <li>No specific node is requested (node is null)</li>
+ * </ul>
+ * </p>
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0232.html">XEP-0232: Software Information</a>
+ */
+public class SoftwareInfoExtendedDiscoInfoProvider implements ExtendedDiscoInfoProvider {
+
+    /**
+     * Controls whether XEP-0232 software information is included in disco#info responses.
+     */
+    public static final SystemProperty<Boolean> ENABLED = SystemProperty.Builder.ofType(Boolean.class)
+        .setKey("xmpp.iqdiscoinfo.xformsoftwareversion")
+        .setDefaultValue(Boolean.TRUE)
+        .setDynamic(Boolean.TRUE)
+        .build();
+
+    @Override
+    public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
+        // Check if feature is enabled
+        if (!ENABLED.getValue()) {
+            return Collections.emptySet();
+        }
+
+        // Return empty set if admin exposure is disabled
+        if (JiveGlobals.getBooleanProperty("admin.disable-exposure")) {
+            return Collections.emptySet();
+        }
+
+        // Only respond for server-level requests (no node)
+        if (node != null) {
+            return Collections.emptySet();
+        }
+
+        // Only respond for server domain or null name
+        if (name != null && !name.equals(XMPPServer.getInstance().getServerInfo().getXMPPDomain())) {
+            return Collections.emptySet();
+        }
+
+        // Build XEP-0232 form
+        final DataForm dataFormSoftwareVersion = new DataForm(DataForm.Type.result);
+
+        final FormField fieldTypeSoftwareVersion = dataFormSoftwareVersion.addField();
+        fieldTypeSoftwareVersion.setVariable("FORM_TYPE");
+        fieldTypeSoftwareVersion.setType(FormField.Type.hidden);
+        fieldTypeSoftwareVersion.addValue("urn:xmpp:dataforms:softwareinfo");
+
+        final FormField fieldOs = dataFormSoftwareVersion.addField();
+        fieldOs.setType(FormField.Type.text_single);
+        fieldOs.setVariable("os");
+        fieldOs.addValue(System.getProperty("os.name"));
+
+        final FormField fieldOsVersion = dataFormSoftwareVersion.addField();
+        fieldOsVersion.setType(FormField.Type.text_single);
+        fieldOsVersion.setVariable("os_version");
+        fieldOsVersion.addValue(System.getProperty("os.version") + " " + System.getProperty("os.arch") + " - Java " + System.getProperty("java.version"));
+
+        final FormField fieldSoftware = dataFormSoftwareVersion.addField();
+        fieldSoftware.setType(FormField.Type.text_single);
+        fieldSoftware.setVariable("software");
+        fieldSoftware.addValue(AdminConsole.getAppName());
+
+        final FormField fieldSoftwareVersion = dataFormSoftwareVersion.addField();
+        fieldSoftwareVersion.setType(FormField.Type.text_single);
+        fieldSoftwareVersion.setVariable("software_version");
+        fieldSoftwareVersion.addValue(AdminConsole.getVersionString());
+
+        final Set<DataForm> dataForms = new HashSet<>();
+        dataForms.add(dataFormSoftwareVersion);
+        return dataForms;
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProvider.java
@@ -18,7 +18,6 @@ package org.jivesoftware.openfire.disco;
 
 import org.jivesoftware.admin.AdminConsole;
 import org.jivesoftware.openfire.XMPPServer;
-import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.SystemProperty;
 import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
@@ -66,7 +65,7 @@ public class SoftwareInfoExtendedDiscoInfoProvider implements ExtendedDiscoInfoP
         }
 
         // Return empty set if admin exposure is disabled
-        if (JiveGlobals.getBooleanProperty("admin.disable-exposure")) {
+        if (IQDiscoInfoHandler.DISABLE_EXPOSURE.getValue()) {
             return Collections.emptySet();
         }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProvider.java
@@ -57,6 +57,31 @@ public class SoftwareInfoExtendedDiscoInfoProvider implements ExtendedDiscoInfoP
         .setDynamic(Boolean.TRUE)
         .build();
 
+    /**
+     * Returns XEP-0232 Software Information data form for the server when appropriate conditions are met.
+     * <p>
+     * This implementation only returns software information for service-level disco#info queries
+     * targeting the server's main domain (not subdomains like MUC or PubSub). The returned data form
+     * contains details about the operating system, OS version, server software name, and version.
+     * </p>
+     * <p>
+     * Returns an empty set when:
+     * <ul>
+     *   <li>The feature is disabled ({@link #ENABLED} is false)</li>
+     *   <li>Administrative exposure is disabled ({@link IQDiscoInfoHandler#DISABLE_EXPOSURE} is true)</li>
+     *   <li>A specific disco node is requested (only responds to node-less queries)</li>
+     *   <li>The domain is not the server's main domain (e.g., MUC or PubSub subdomains)</li>
+     *   <li>A specific user/resource is targeted (only responds to service-level queries where name is null)</li>
+     * </ul>
+     * </p>
+     *
+     * @param domain the domain of the target JID (e.g., "localhost", "conference.localhost")
+     * @param name the node part of the target JID (null for service-level queries)
+     * @param node the requested disco node parameter (null if not specified)
+     * @param senderJID the JID of the entity that sent the disco#info request
+     * @return A set containing a single XEP-0232 data form with software information, or an empty set if conditions are not met
+     * @see <a href="https://xmpp.org/extensions/xep-0232.html">XEP-0232: Software Information</a>
+     */
     @Override
     public Set<DataForm> getExtendedInfos(String domain, String name, String node, JID senderJID) {
         // Check if feature is enabled

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProviderTest.java
@@ -63,7 +63,7 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         when(xmppServer.getAdmins()).thenReturn(admins);
 
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -96,7 +96,7 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         when(xmppServer.getAdmins()).thenReturn(admins);
 
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -111,7 +111,7 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         when(xmppServer.getAdmins()).thenReturn(admins);
 
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, "somenode", new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, "somenode", new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -119,14 +119,29 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
     }
 
     @Test
-    public void testReturnsEmptyWhenNameDoesNotMatchServerDomain() {
+    public void testReturnsEmptyWhenDomainDoesNotMatchServerDomain() {
         // Setup
         Set<JID> admins = new HashSet<>();
         admins.add(new JID("admin@" + Fixtures.XMPP_DOMAIN));
         when(xmppServer.getAdmins()).thenReturn(admins);
 
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos("other.domain", null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos("other.domain", null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertTrue(forms.isEmpty());
+    }
+
+    @Test
+    public void testReturnsEmptyWhenNameIsNotNull() {
+        // Setup
+        Set<JID> admins = new HashSet<>();
+        admins.add(new JID("admin@" + Fixtures.XMPP_DOMAIN));
+        when(xmppServer.getAdmins()).thenReturn(admins);
+
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, "someuser", null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -139,7 +154,7 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         when(xmppServer.getAdmins()).thenReturn(Collections.emptySet());
 
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -152,7 +167,7 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         when(xmppServer.getAdmins()).thenReturn(null);
 
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -166,8 +181,8 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         admins.add(new JID("admin@" + Fixtures.XMPP_DOMAIN));
         when(xmppServer.getAdmins()).thenReturn(admins);
 
-        // Execute with name matching server domain
-        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        // Execute with domain matching server domain
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -184,7 +199,7 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         when(xmppServer.getAdmins()).thenReturn(admins);
 
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -209,7 +224,7 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         when(xmppServer.getAdmins()).thenReturn(admins);
 
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify form has correct structure
         assertNotNull(forms);

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProviderTest.java
@@ -31,6 +31,27 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Unit tests for {@link ContactAddressesExtendedDiscoInfoProvider}.
+ *
+ * <p>This test class verifies the behavior of the ContactAddressesExtendedDiscoInfoProvider,
+ * which provides contact address information (admin addresses) in service discovery responses
+ * according to XEP-0157: Contact Addresses for XMPP Services.</p>
+ *
+ * <p>The tests cover various scenarios including:
+ * <ul>
+ *   <li>Inclusion of admin contact addresses when admins exist</li>
+ *   <li>Exclusion of information when admin exposure is disabled</li>
+ *   <li>Proper filtering based on domain, node, and name parameters</li>
+ *   <li>Handling of multiple administrators and external admin JIDs</li>
+ *   <li>Correct form structure and field types</li>
+ * </ul>
+ * </p>
+ *
+ * @author Dan Caseley, dan@caseley.me.uk
+ * @see ContactAddressesExtendedDiscoInfoProvider
+ * @see <a href="https://xmpp.org/extensions/xep-0157.html">XEP-0157: Contact Addresses for XMPP Services</a>
+ */
 class ContactAddressesExtendedDiscoInfoProviderTest {
 
     private ContactAddressesExtendedDiscoInfoProvider provider;
@@ -55,6 +76,17 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         Fixtures.clearExistingProperties();
     }
 
+    /**
+     * Verifies that the provider returns a properly formatted data form containing admin contact addresses
+     * when administrators are configured on the server.
+     *
+     * <p>The form should include:
+     * <ul>
+     *   <li>A hidden FORM_TYPE field with value "http://jabber.org/network/serverinfo"</li>
+     *   <li>A list_multi field called admin-addresses containing XMPP addresses</li>
+     * </ul>
+     * </p>
+     */
     @Test
     public void testReturnsContactAddressesWhenAdminsExist() {
         // Setup
@@ -87,10 +119,14 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         // Email addresses might be included if UserManager can resolve the user
     }
 
+    /**
+     * Verifies that the provider returns an empty set when admin exposure is disabled
+     * via the "admin.disable-exposure" system property
+     */
     @Test
     public void testReturnsEmptyWhenAdminExposureDisabled() {
         // Setup
-        JiveGlobals.setProperty("admin.disable-exposure", "true");
+        IQDiscoInfoHandler.DISABLE_EXPOSURE.setValue(true);
         Set<JID> admins = new HashSet<>();
         admins.add(new JID("admin@" + Fixtures.XMPP_DOMAIN));
         when(xmppServer.getAdmins()).thenReturn(admins);
@@ -103,6 +139,10 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         assertTrue(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the provider returns an empty set when querying a specific node,
+     * as contact addresses are only provided for the server itself, not for nodes.
+     */
     @Test
     public void testReturnsEmptyWhenNodeIsNotNull() {
         // Setup
@@ -118,6 +158,11 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         assertTrue(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the provider returns an empty set when querying a domain that
+     * doesn't match the server's domain, as contact addresses are only provided for
+     * the local server.
+     */
     @Test
     public void testReturnsEmptyWhenDomainDoesNotMatchServerDomain() {
         // Setup
@@ -133,6 +178,10 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         assertTrue(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the provider returns an empty set when querying a specific user,
+     * as contact addresses are only provided for server-level queries, not user-level queries.
+     */
     @Test
     public void testReturnsEmptyWhenNameIsNotNull() {
         // Setup
@@ -148,6 +197,10 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         assertTrue(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the provider returns an empty set when no administrators are configured,
+     * as there are no contact addresses to expose.
+     */
     @Test
     public void testReturnsEmptyWhenNoAdmins() {
         // Setup
@@ -161,6 +214,10 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         assertTrue(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the provider handles null admin sets gracefully by returning an empty set,
+     * preventing null pointer exceptions.
+     */
     @Test
     public void testReturnsEmptyWhenAdminsIsNull() {
         // Setup
@@ -174,6 +231,10 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         assertTrue(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the provider correctly returns contact addresses when querying
+     * the server domain itself with no node or name specified.
+     */
     @Test
     public void testWorksForServerDomain() {
         // Setup
@@ -189,6 +250,10 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         assertEquals(1, forms.size());
     }
 
+    /**
+     * Verifies that the provider correctly includes all administrators, including those
+     * with JIDs from external domains, in the admin-addresses field.
+     */
     @Test
     public void testHandlesMultipleAdmins() {
         // Setup
@@ -216,6 +281,10 @@ class ContactAddressesExtendedDiscoInfoProviderTest {
         assertTrue(values.contains("xmpp:admin3@other.domain"));
     }
 
+    /**
+     * Verifies that the returned data form has the correct structure with exactly
+     * two fields: FORM_TYPE and admin-addresses.
+     */
     @Test
     public void testFormStructure() {
         // Setup

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/disco/ContactAddressesExtendedDiscoInfoProviderTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.disco;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.user.UserManager;
+import org.jivesoftware.util.JiveGlobals;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xmpp.forms.DataForm;
+import org.xmpp.forms.FormField;
+import org.xmpp.packet.JID;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ContactAddressesExtendedDiscoInfoProviderTest {
+
+    private ContactAddressesExtendedDiscoInfoProvider provider;
+    private XMPPServer xmppServer;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        Fixtures.reconfigureOpenfireHome();
+        Fixtures.disableDatabasePersistence();
+
+        // Create provider
+        provider = new ContactAddressesExtendedDiscoInfoProvider();
+
+        // Mock XMPPServer
+        xmppServer = Fixtures.mockXMPPServer();
+        XMPPServer.setInstance(xmppServer);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        XMPPServer.setInstance(null);
+        Fixtures.clearExistingProperties();
+    }
+
+    @Test
+    public void testReturnsContactAddressesWhenAdminsExist() {
+        // Setup
+        Set<JID> admins = new HashSet<>();
+        admins.add(new JID("admin@" + Fixtures.XMPP_DOMAIN));
+        when(xmppServer.getAdmins()).thenReturn(admins);
+
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertEquals(1, forms.size());
+
+        DataForm form = forms.iterator().next();
+        assertEquals(DataForm.Type.result, form.getType());
+
+        // Check FORM_TYPE field
+        FormField formType = form.getField("FORM_TYPE");
+        assertNotNull(formType);
+        assertEquals(FormField.Type.hidden, formType.getType());
+        assertEquals("http://jabber.org/network/serverinfo", formType.getFirstValue());
+
+        // Check admin-addresses field
+        FormField adminAddresses = form.getField("admin-addresses");
+        assertNotNull(adminAddresses);
+        assertEquals(FormField.Type.list_multi, adminAddresses.getType());
+        List<String> values = adminAddresses.getValues();
+        assertTrue(values.contains("xmpp:admin@" + Fixtures.XMPP_DOMAIN));
+        // Email addresses might be included if UserManager can resolve the user
+    }
+
+    @Test
+    public void testReturnsEmptyWhenAdminExposureDisabled() {
+        // Setup
+        JiveGlobals.setProperty("admin.disable-exposure", "true");
+        Set<JID> admins = new HashSet<>();
+        admins.add(new JID("admin@" + Fixtures.XMPP_DOMAIN));
+        when(xmppServer.getAdmins()).thenReturn(admins);
+
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertTrue(forms.isEmpty());
+    }
+
+    @Test
+    public void testReturnsEmptyWhenNodeIsNotNull() {
+        // Setup
+        Set<JID> admins = new HashSet<>();
+        admins.add(new JID("admin@" + Fixtures.XMPP_DOMAIN));
+        when(xmppServer.getAdmins()).thenReturn(admins);
+
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, "somenode", new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertTrue(forms.isEmpty());
+    }
+
+    @Test
+    public void testReturnsEmptyWhenNameDoesNotMatchServerDomain() {
+        // Setup
+        Set<JID> admins = new HashSet<>();
+        admins.add(new JID("admin@" + Fixtures.XMPP_DOMAIN));
+        when(xmppServer.getAdmins()).thenReturn(admins);
+
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos("other.domain", null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertTrue(forms.isEmpty());
+    }
+
+    @Test
+    public void testReturnsEmptyWhenNoAdmins() {
+        // Setup
+        when(xmppServer.getAdmins()).thenReturn(Collections.emptySet());
+
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertTrue(forms.isEmpty());
+    }
+
+    @Test
+    public void testReturnsEmptyWhenAdminsIsNull() {
+        // Setup
+        when(xmppServer.getAdmins()).thenReturn(null);
+
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertTrue(forms.isEmpty());
+    }
+
+    @Test
+    public void testWorksForServerDomain() {
+        // Setup
+        Set<JID> admins = new HashSet<>();
+        admins.add(new JID("admin@" + Fixtures.XMPP_DOMAIN));
+        when(xmppServer.getAdmins()).thenReturn(admins);
+
+        // Execute with name matching server domain
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertEquals(1, forms.size());
+    }
+
+    @Test
+    public void testHandlesMultipleAdmins() {
+        // Setup
+        Set<JID> admins = new HashSet<>();
+        admins.add(new JID("admin1@" + Fixtures.XMPP_DOMAIN));
+        admins.add(new JID("admin2@" + Fixtures.XMPP_DOMAIN));
+        admins.add(new JID("admin3@other.domain")); // External admin
+        when(xmppServer.getAdmins()).thenReturn(admins);
+
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertEquals(1, forms.size());
+
+        DataForm form = forms.iterator().next();
+        FormField adminAddresses = form.getField("admin-addresses");
+        assertNotNull(adminAddresses);
+        List<String> values = adminAddresses.getValues();
+
+        // Check all XMPP addresses are included
+        assertTrue(values.contains("xmpp:admin1@" + Fixtures.XMPP_DOMAIN));
+        assertTrue(values.contains("xmpp:admin2@" + Fixtures.XMPP_DOMAIN));
+        assertTrue(values.contains("xmpp:admin3@other.domain"));
+    }
+
+    @Test
+    public void testFormStructure() {
+        // Setup
+        Set<JID> admins = new HashSet<>();
+        admins.add(new JID("admin@" + Fixtures.XMPP_DOMAIN));
+        when(xmppServer.getAdmins()).thenReturn(admins);
+
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify form has correct structure
+        assertNotNull(forms);
+        assertEquals(1, forms.size());
+
+        DataForm form = forms.iterator().next();
+        assertNotNull(form.getField("FORM_TYPE"));
+        assertNotNull(form.getField("admin-addresses"));
+        assertEquals(2, form.getFields().size()); // FORM_TYPE + admin-addresses
+    }
+}

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandlerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandlerTest.java
@@ -1,0 +1,547 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.disco;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.XMPPServerInfo;
+import org.jivesoftware.util.Version;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xmpp.forms.DataForm;
+import org.xmpp.forms.FormField;
+import org.xmpp.packet.JID;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class IQDiscoInfoHandlerTest {
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        Fixtures.reconfigureOpenfireHome();
+        Fixtures.disableDatabasePersistence();
+
+        // Mock XMPPServer
+        XMPPServer xmppServer = Fixtures.mockXMPPServer();
+        // Provide at least one admin to avoid null return from getExtendedInfos
+        Set<JID> admins = new HashSet<>();
+        admins.add(new JID("admin@" + Fixtures.XMPP_DOMAIN));
+        when(xmppServer.getAdmins()).thenReturn(admins);
+
+        // Mock XMPPServerInfo with version
+        XMPPServerInfo serverInfo = xmppServer.getServerInfo();
+        Version version = mock(Version.class);
+        when(version.getVersionString()).thenReturn("5.1.0-TEST");
+        when(serverInfo.getVersion()).thenReturn(version);
+
+        XMPPServer.setInstance(xmppServer);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        XMPPServer.setInstance(null);
+    }
+
+    class TestExtendedDiscoInfoProvider implements ExtendedDiscoInfoProvider {
+
+        private final Set<DataForm> forms;
+
+        TestExtendedDiscoInfoProvider(Set<DataForm> forms) {
+            this.forms = forms;
+        }
+
+        @Override
+        public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
+            return forms;
+        }
+    }
+
+
+    private DataForm createForm(String formType, String field, String value) {
+        DataForm form = new DataForm(DataForm.Type.result);
+
+        FormField type = form.addField();
+        type.setVariable("FORM_TYPE");
+        type.setType(FormField.Type.hidden);
+        type.addValue(formType);
+
+        FormField f = form.addField();
+        f.setVariable(field);
+        f.setType(FormField.Type.text_single);
+        f.addValue(value);
+
+        return form;
+    }
+
+    private DataForm testForm(String field, String value) {
+        return createForm("urn:xmpp:dataforms:openfire-unittest", field, value);
+    }
+
+    private String getFormType(DataForm form) {
+        return form.getFields().stream()
+            .filter(f -> "FORM_TYPE".equals(f.getVariable()))
+            .map(FormField::getFirstValue)
+            .findFirst()
+            .orElse(null);
+    }
+
+    private DiscoInfoProvider invokeGetServerInfoProvider(IQDiscoInfoHandler handler) {
+        try {
+            Method m = IQDiscoInfoHandler.class
+                .getDeclaredMethod("getServerInfoProvider");
+            m.setAccessible(true);
+            return (DiscoInfoProvider) m.invoke(handler);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+
+    @Test
+    void testSameFormTypeIsMerged() {
+        IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
+
+        DataForm f1 = testForm("field1", "value1");
+        DataForm f2 = testForm("field2", "value2");
+
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(f1))
+        );
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(f2))
+        );
+
+        DiscoInfoProvider provider =
+            invokeGetServerInfoProvider(handler);
+
+        Set<DataForm> result =
+            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+
+        DataForm merged = result.stream()
+            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
+            .findFirst()
+            .orElseThrow();
+
+        Set<String> fieldNames = merged.getFields().stream()
+            .map(FormField::getVariable)
+            .collect(Collectors.toSet());
+
+        assertTrue(fieldNames.contains("FORM_TYPE"));
+        assertTrue(fieldNames.contains("field1"));
+        assertTrue(fieldNames.contains("field2"));
+        assertEquals(3, fieldNames.size()); // FORM_TYPE + field1 + field2
+    }
+
+    @Test
+    void testDifferentFormTypesAreAdded() {
+        IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
+
+        DataForm form1 = testForm("field1", "value1");
+        DataForm form2 = createForm("urn:xmpp:dataforms:openfire-unittest:other", "field2", "value2");
+
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form1))
+        );
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form2))
+        );
+
+        DiscoInfoProvider provider =
+            invokeGetServerInfoProvider(handler);
+
+        Set<DataForm> result =
+            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+
+        long testFormCount = result.stream()
+            .filter(f -> {
+                String formType = getFormType(f);
+                return formType != null && formType.startsWith("urn:xmpp:dataforms:openfire-unittest");
+            })
+            .count();
+
+        assertEquals(2, testFormCount);
+    }
+
+    @Test
+    void testEmptySetIsHandled() {
+        IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
+
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Collections.emptySet())
+        );
+
+        DiscoInfoProvider provider =
+            invokeGetServerInfoProvider(handler);
+
+        Set<DataForm> result =
+            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+
+        assertNotNull(result);
+        // Result should not contain our test forms since provider returned empty set
+        long testFormCount = result.stream()
+            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
+            .count();
+        assertEquals(0, testFormCount);
+    }
+
+    @Test
+    void testAdditionalFieldsToExistingForm() {
+        IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
+
+        // Form 1 with mixed field types
+        DataForm form1 = new DataForm(DataForm.Type.result);
+        FormField typeField1 = form1.addField();
+        typeField1.setVariable("FORM_TYPE");
+        typeField1.setType(FormField.Type.hidden);
+        typeField1.addValue("urn:xmpp:dataforms:openfire-unittest");
+
+        FormField field1 = form1.addField();
+        field1.setVariable("field1");
+        field1.setType(FormField.Type.text_single); // Single-value
+        field1.addValue("value1");
+
+        // Form 2 with multiple fields (mixed types)
+        DataForm form2 = new DataForm(DataForm.Type.result);
+        FormField typeField2 = form2.addField();
+        typeField2.setVariable("FORM_TYPE");
+        typeField2.setType(FormField.Type.hidden);
+        typeField2.addValue("urn:xmpp:dataforms:openfire-unittest");
+
+        FormField field2 = form2.addField();
+        field2.setVariable("field2");
+        field2.setType(FormField.Type.list_multi); // Multi-value
+        field2.addValue("value2");
+
+        FormField field3 = form2.addField();
+        field3.setVariable("field3");
+        field3.setType(FormField.Type.boolean_type); // Single-value
+        field3.addValue("true");
+
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form1))
+        );
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form2))
+        );
+
+        DiscoInfoProvider provider =
+            invokeGetServerInfoProvider(handler);
+
+        Set<DataForm> result =
+            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+
+        DataForm merged = result.stream()
+            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
+            .findFirst()
+            .orElseThrow();
+
+        Set<String> fieldNames = merged.getFields().stream()
+            .map(FormField::getVariable)
+            .collect(Collectors.toSet());
+
+        assertEquals(4, fieldNames.size()); // FORM_TYPE + field1 + field2 + field3
+        assertTrue(fieldNames.contains("field1"));
+        assertTrue(fieldNames.contains("field2"));
+        assertTrue(fieldNames.contains("field3"));
+
+        // Verify field types are preserved
+        assertEquals(FormField.Type.text_single, merged.getField("field1").getType());
+        assertEquals(FormField.Type.list_multi, merged.getField("field2").getType());
+        assertEquals(FormField.Type.boolean_type, merged.getField("field3").getType());
+    }
+
+    @Test
+    void testImmutableSetIsHandled() {
+        IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
+
+        // Use Set.of() to create an immutable set
+        DataForm form = testForm("field1", "value1");
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form))
+        );
+
+        DiscoInfoProvider provider =
+            invokeGetServerInfoProvider(handler);
+
+        // This should not throw an exception even though provider returns immutable set
+        Set<DataForm> result =
+            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+
+        assertNotNull(result);
+        assertTrue(result.stream()
+            .anyMatch(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f))));
+    }
+
+    @Test
+    void testTypeNotAddedIfNeitherHadType() {
+        IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
+
+        // Both providers create field without type
+        DataForm form1 = new DataForm(DataForm.Type.result);
+        FormField typeField1 = form1.addField();
+        typeField1.setVariable("FORM_TYPE");
+        typeField1.setType(FormField.Type.hidden);
+        typeField1.addValue("urn:xmpp:dataforms:openfire-unittest");
+
+        FormField field1 = form1.addField();
+        field1.setVariable("field1");
+        // No type set
+        field1.addValue("value1");
+
+        DataForm form2 = new DataForm(DataForm.Type.result);
+        FormField typeField2 = form2.addField();
+        typeField2.setVariable("FORM_TYPE");
+        typeField2.setType(FormField.Type.hidden);
+        typeField2.addValue("urn:xmpp:dataforms:openfire-unittest");
+
+        FormField field2 = form2.addField();
+        field2.setVariable("field2");
+        // No type set
+        field2.addValue("value2");
+
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form1))
+        );
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form2))
+        );
+
+        DiscoInfoProvider provider =
+            invokeGetServerInfoProvider(handler);
+
+        Set<DataForm> result =
+            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+
+        DataForm merged = result.stream()
+            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
+            .findFirst()
+            .orElseThrow();
+
+        FormField mergedField1 = merged.getField("field1");
+        assertNotNull(mergedField1);
+        // Field should still have no type
+        assertNull(mergedField1.getType());
+
+        FormField mergedField2 = merged.getField("field2");
+        assertNotNull(mergedField2);
+        // Field should still have no type
+        assertNull(mergedField2.getType());
+    }
+
+    @Test
+    void testDuplicateFieldIsSkipped() {
+        IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
+
+        // First provider: field1
+        DataForm form1 = new DataForm(DataForm.Type.result);
+        FormField typeField1 = form1.addField();
+        typeField1.setVariable("FORM_TYPE");
+        typeField1.setType(FormField.Type.hidden);
+        typeField1.addValue("urn:xmpp:dataforms:openfire-unittest");
+
+        FormField field1 = form1.addField();
+        field1.setVariable("field1");
+        field1.addValue("value1");
+
+        // Second provider: same field1 (duplicate) - should be skipped
+        DataForm form2 = new DataForm(DataForm.Type.result);
+        FormField typeField2 = form2.addField();
+        typeField2.setVariable("FORM_TYPE");
+        typeField2.setType(FormField.Type.hidden);
+        typeField2.addValue("urn:xmpp:dataforms:openfire-unittest");
+
+        FormField field2 = form2.addField();
+        field2.setVariable("field1");  // Duplicate field name
+        field2.addValue("value1-again");
+
+        // Third provider: different field - should still be processed
+        DataForm form3 = new DataForm(DataForm.Type.result);
+        FormField typeField3 = form3.addField();
+        typeField3.setVariable("FORM_TYPE");
+        typeField3.setType(FormField.Type.hidden);
+        typeField3.addValue("urn:xmpp:dataforms:openfire-unittest");
+
+        FormField field3 = form3.addField();
+        field3.setVariable("field2");
+        field3.addValue("value2");
+
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form1))
+        );
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form2))
+        );
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form3))
+        );
+
+        DiscoInfoProvider provider = invokeGetServerInfoProvider(handler);
+
+        // Should not throw - should continue processing and return valid response
+        Set<DataForm> result = provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+
+        DataForm merged = result.stream()
+            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
+            .findFirst()
+            .orElseThrow();
+
+        // Should have field1 from first provider (value1) and field2 from third provider
+        // Second provider's contribution (duplicate field1) should be skipped
+        assertNotNull(merged.getField("field1"));
+        assertEquals("value1", merged.getField("field1").getFirstValue());
+        assertNotNull(merged.getField("field2"));
+        assertEquals("value2", merged.getField("field2").getFirstValue());
+
+        // Should only have 3 fields total: FORM_TYPE, field1, field2
+        assertEquals(3, merged.getFields().size());
+    }
+
+    @Test
+    void testDuplicateFieldRejectsEntireForm() {
+        IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
+
+        // First provider: field1 only
+        DataForm form1 = new DataForm(DataForm.Type.result);
+        FormField typeField1 = form1.addField();
+        typeField1.setVariable("FORM_TYPE");
+        typeField1.setType(FormField.Type.hidden);
+        typeField1.addValue("urn:xmpp:dataforms:openfire-unittest");
+
+        FormField field1 = form1.addField();
+        field1.setVariable("field1");
+        field1.addValue("value1");
+
+        // Second provider: field1 (duplicate) + field2 (non-duplicate)
+        // Expected: Neither field should be added because the form contains a duplicate
+        DataForm form2 = new DataForm(DataForm.Type.result);
+        FormField typeField2 = form2.addField();
+        typeField2.setVariable("FORM_TYPE");
+        typeField2.setType(FormField.Type.hidden);
+        typeField2.addValue("urn:xmpp:dataforms:openfire-unittest");
+
+        FormField field2new = form2.addField();
+        field2new.setVariable("field2");  // Non-duplicate field
+        field2new.addValue("value2");
+
+        FormField field2duplicate = form2.addField();
+        field2duplicate.setVariable("field1");  // Duplicate field name
+        field2duplicate.addValue("value1-from-second-provider");
+
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form1))
+        );
+        handler.addExtendedDiscoInfoProvider(
+            new TestExtendedDiscoInfoProvider(Set.of(form2))
+        );
+
+        DiscoInfoProvider provider = invokeGetServerInfoProvider(handler);
+
+        Set<DataForm> result = provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+
+        DataForm merged = result.stream()
+            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
+            .findFirst()
+            .orElseThrow();
+
+        // Should have field1 from first provider only
+        assertNotNull(merged.getField("field1"));
+        assertEquals("value1", merged.getField("field1").getFirstValue());
+
+        // field2 should NOT exist - entire second provider's form was rejected due to duplicate
+        assertNull(merged.getField("field2"));
+
+        // Should only have 2 fields total: FORM_TYPE and field1
+        assertEquals(2, merged.getFields().size());
+    }
+
+    @Test
+    void testRemoveProviderRemovesContributions() {
+        IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
+
+        // Create a provider with a test form
+        DataForm form = testForm("field1", "value1");
+        TestExtendedDiscoInfoProvider provider = new TestExtendedDiscoInfoProvider(Set.of(form));
+
+        // Add the provider
+        handler.addExtendedDiscoInfoProvider(provider);
+
+        DiscoInfoProvider serverProvider = invokeGetServerInfoProvider(handler);
+
+        // Verify the form appears in the response
+        Set<DataForm> result = serverProvider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        long formCountBefore = result.stream()
+            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
+            .count();
+        assertEquals(1, formCountBefore, "Form should be present after adding provider");
+
+        // Remove the provider
+        handler.removeExtendedDiscoInfoProvider(provider);
+
+        // Verify the form no longer appears in the response
+        result = serverProvider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        long formCountAfter = result.stream()
+            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
+            .count();
+        assertEquals(0, formCountAfter, "Form should be removed after removing provider");
+    }
+
+    @Test
+    void testRemoveAndReAddProvider() {
+        IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
+
+        // Create a provider with a test form
+        DataForm form = testForm("field1", "value1");
+        TestExtendedDiscoInfoProvider provider = new TestExtendedDiscoInfoProvider(Set.of(form));
+
+        DiscoInfoProvider serverProvider = invokeGetServerInfoProvider(handler);
+
+        // Add the provider and verify form appears
+        handler.addExtendedDiscoInfoProvider(provider);
+        Set<DataForm> result = serverProvider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        long formCountAfterAdd = result.stream()
+            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
+            .count();
+        assertEquals(1, formCountAfterAdd, "Form should be present after adding provider");
+
+        // Remove the provider and verify form disappears
+        handler.removeExtendedDiscoInfoProvider(provider);
+        result = serverProvider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        long formCountAfterRemove = result.stream()
+            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
+            .count();
+        assertEquals(0, formCountAfterRemove, "Form should be removed after removing provider");
+
+        // Re-add the same provider and verify form appears again
+        handler.addExtendedDiscoInfoProvider(provider);
+        result = serverProvider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        long formCountAfterReAdd = result.stream()
+            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
+            .count();
+        assertEquals(1, formCountAfterReAdd, "Form should be present after re-adding provider");
+    }
+
+
+}
+

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandlerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandlerTest.java
@@ -35,6 +35,29 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Unit tests for {@link IQDiscoInfoHandler}.
+ *
+ * <p>This test class verifies the form merging and management logic within IQDiscoInfoHandler,
+ * specifically testing how the handler processes and combines data forms from multiple
+ * {@link ExtendedDiscoInfoProvider} instances according to XEP-0128: Service Discovery Extensions.</p>
+ *
+ * <p>The tests focus on:
+ * <ul>
+ *   <li>Merging of forms with the same FORM_TYPE</li>
+ *   <li>Addition of forms with different FORM_TYPEs</li>
+ *   <li>Handling of duplicate field names (entire form rejection)</li>
+ *   <li>Preservation of field types and values during merging</li>
+ *   <li>Dynamic provider addition and removal</li>
+ *   <li>Edge cases like empty sets, immutable collections, and fields without types</li>
+ * </ul>
+ * </p>
+ *
+ * @author Dan Caseley, dan@caseley.me.uk
+ * @see IQDiscoInfoHandler
+ * @see ExtendedDiscoInfoProvider
+ * @see <a href="https://xmpp.org/extensions/xep-0128.html">XEP-0128: Service Discovery Extensions</a>
+ */
 class IQDiscoInfoHandlerTest {
 
     @BeforeEach
@@ -63,6 +86,12 @@ class IQDiscoInfoHandlerTest {
         XMPPServer.setInstance(null);
     }
 
+    /**
+     * Test implementation of {@link ExtendedDiscoInfoProvider} that returns a predefined set of data forms.
+     *
+     * <p>This provider mimics the behavior of real providers by only returning forms for
+     * server-level queries (no node, no name, matching server domain).</p>
+     */
     class TestExtendedDiscoInfoProvider implements ExtendedDiscoInfoProvider {
 
         private final Set<DataForm> forms;
@@ -129,7 +158,15 @@ class IQDiscoInfoHandlerTest {
 
     /**
      * Helper method to get extended disco info forms from a handler by simulating a disco#info request.
-     * This tests through the full handleIQ() flow where ExtendedDiscoInfoProviders are now applied.
+     *
+     * <p>This method tests through the full handleIQ() flow where ExtendedDiscoInfoProviders are applied.
+     * It creates a disco#info IQ request, processes it through the handler, and extracts the resulting
+     * data forms from the response.</p>
+     *
+     * @param handler the IQDiscoInfoHandler instance to test
+     * @param from the JID of the requesting entity
+     * @param to the JID of the target entity (null for server domain)
+     * @return the set of data forms included in the disco#info response
      */
     private Set<DataForm> getExtendedInfosViaHandleIQ(IQDiscoInfoHandler handler, JID from, JID to) {
         try {
@@ -169,6 +206,12 @@ class IQDiscoInfoHandlerTest {
         }
     }
 
+    /**
+     * Verifies that when multiple providers return forms with the same FORM_TYPE,
+     * the handler merges them into a single form containing all fields.
+     *
+     * <p>This is the core functionality for XEP-0128 form aggregation.</p>
+     */
     @Test
     void testSameFormTypeIsMerged() {
         IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
@@ -201,6 +244,10 @@ class IQDiscoInfoHandlerTest {
         assertEquals(3, fieldNames.size()); // FORM_TYPE + field1 + field2
     }
 
+    /**
+     * Verifies that when multiple providers return forms with different FORM_TYPEs,
+     * all forms are included in the response without merging.
+     */
     @Test
     void testDifferentFormTypesAreAdded() {
         IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
@@ -228,6 +275,10 @@ class IQDiscoInfoHandlerTest {
         assertEquals(2, testFormCount);
     }
 
+    /**
+     * Verifies that the handler gracefully handles providers that return empty sets
+     * without errors or including empty forms in the response.
+     */
     @Test
     void testEmptySetIsHandled() {
         IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
@@ -247,6 +298,10 @@ class IQDiscoInfoHandlerTest {
         assertEquals(0, testFormCount);
     }
 
+    /**
+     * Verifies that when merging forms with the same FORM_TYPE, fields with different types
+     * (text_single, list_multi, boolean_type) are correctly preserved and merged together.
+     */
     @Test
     void testAdditionalFieldsToExistingForm() {
         IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
@@ -310,6 +365,10 @@ class IQDiscoInfoHandlerTest {
         assertEquals(FormField.Type.boolean_type, merged.getField("field3").getType());
     }
 
+    /**
+     * Verifies that the handler can process immutable sets (created via Set.of())
+     * returned by providers without throwing UnsupportedOperationException.
+     */
     @Test
     void testImmutableSetIsHandled() {
         IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
@@ -329,6 +388,10 @@ class IQDiscoInfoHandlerTest {
             .anyMatch(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f))));
     }
 
+    /**
+     * Verifies that when merging fields without explicit types, the merged result
+     * also has no type set (preserving the absence of type information).
+     */
     @Test
     void testTypeNotAddedIfNeitherHadType() {
         IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
@@ -382,73 +445,14 @@ class IQDiscoInfoHandlerTest {
         assertNull(mergedField2.getType());
     }
 
-    @Test
-    void testDuplicateFieldIsSkipped() {
-        IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
-
-        // First provider: field1
-        DataForm form1 = new DataForm(DataForm.Type.result);
-        FormField typeField1 = form1.addField();
-        typeField1.setVariable("FORM_TYPE");
-        typeField1.setType(FormField.Type.hidden);
-        typeField1.addValue("urn:xmpp:dataforms:openfire-unittest");
-
-        FormField field1 = form1.addField();
-        field1.setVariable("field1");
-        field1.addValue("value1");
-
-        // Second provider: same field1 (duplicate) - should be skipped
-        DataForm form2 = new DataForm(DataForm.Type.result);
-        FormField typeField2 = form2.addField();
-        typeField2.setVariable("FORM_TYPE");
-        typeField2.setType(FormField.Type.hidden);
-        typeField2.addValue("urn:xmpp:dataforms:openfire-unittest");
-
-        FormField field2 = form2.addField();
-        field2.setVariable("field1");  // Duplicate field name
-        field2.addValue("value1-again");
-
-        // Third provider: different field - should still be processed
-        DataForm form3 = new DataForm(DataForm.Type.result);
-        FormField typeField3 = form3.addField();
-        typeField3.setVariable("FORM_TYPE");
-        typeField3.setType(FormField.Type.hidden);
-        typeField3.addValue("urn:xmpp:dataforms:openfire-unittest");
-
-        FormField field3 = form3.addField();
-        field3.setVariable("field2");
-        field3.addValue("value2");
-
-        handler.addExtendedDiscoInfoProvider(
-            new TestExtendedDiscoInfoProvider(Set.of(form1))
-        );
-        handler.addExtendedDiscoInfoProvider(
-            new TestExtendedDiscoInfoProvider(Set.of(form2))
-        );
-        handler.addExtendedDiscoInfoProvider(
-            new TestExtendedDiscoInfoProvider(Set.of(form3))
-        );
-
-        // Should not throw - should continue processing and return valid response
-        Set<DataForm> result = getExtendedInfosViaHandleIQ(handler,
-            new JID("tester@example.org"), null);
-
-        DataForm merged = result.stream()
-            .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
-            .findFirst()
-            .orElseThrow();
-
-        // Should have field1 from first provider (value1) and field2 from third provider
-        // Second provider's contribution (duplicate field1) should be skipped
-        assertNotNull(merged.getField("field1"));
-        assertEquals("value1", merged.getField("field1").getFirstValue());
-        assertNotNull(merged.getField("field2"));
-        assertEquals("value2", merged.getField("field2").getFirstValue());
-
-        // Should only have 3 fields total: FORM_TYPE, field1, field2
-        assertEquals(3, merged.getFields().size());
-    }
-
+    /**
+     * Verifies that when a provider's form contains a field that duplicates an existing field name,
+     * the entire form from that provider is rejected to maintain data integrity.
+     *
+     * <p>This ensures that conflicting field definitions don't corrupt the merged form.
+     * If provider A adds field1, and provider B's form contains both field1 (duplicate) and field2 (new),
+     * neither field from provider B should be added.</p>
+     */
     @Test
     void testDuplicateFieldRejectsEntireForm() {
         IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
@@ -506,6 +510,10 @@ class IQDiscoInfoHandlerTest {
         assertEquals(2, merged.getFields().size());
     }
 
+    /**
+     * Verifies that removing a provider dynamically removes its contributed forms
+     * from subsequent disco#info responses.
+     */
     @Test
     void testRemoveProviderRemovesContributions() {
         IQDiscoInfoHandler handler = new IQDiscoInfoHandler();
@@ -537,6 +545,10 @@ class IQDiscoInfoHandlerTest {
         assertEquals(0, formCountAfter, "Form should be removed after removing provider");
     }
 
+    /**
+     * Verifies that a provider can be removed and then re-added, with its forms
+     * correctly appearing, disappearing, and reappearing in the disco#info responses.
+     */
     @Test
     void testRemoveAndReAddProvider() {
         IQDiscoInfoHandler handler = new IQDiscoInfoHandler();

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandlerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandlerTest.java
@@ -29,6 +29,7 @@ import org.xmpp.packet.JID;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -59,6 +60,8 @@ import static org.mockito.Mockito.*;
  * @see <a href="https://xmpp.org/extensions/xep-0128.html">XEP-0128: Service Discovery Extensions</a>
  */
 class IQDiscoInfoHandlerTest {
+
+    private final Set<IQDiscoInfoHandler> initializedHandlers = Collections.newSetFromMap(new IdentityHashMap<>());
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -170,9 +173,11 @@ class IQDiscoInfoHandlerTest {
      */
     private Set<DataForm> getExtendedInfosViaHandleIQ(IQDiscoInfoHandler handler, JID from, JID to) {
         try {
-            // Initialize the handler (this registers the server disco info provider)
-            handler.initialize(XMPPServer.getInstance());
-            handler.start();
+            // Initialize the handler (this registers the server disco info provider), if not already done.
+            if (initializedHandlers.add(handler)) {
+                handler.initialize(XMPPServer.getInstance());
+                handler.start();
+            }
 
             // Create disco#info request
             org.xmpp.packet.IQ request = new org.xmpp.packet.IQ(org.xmpp.packet.IQ.Type.get);

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandlerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/disco/IQDiscoInfoHandlerTest.java
@@ -72,7 +72,17 @@ class IQDiscoInfoHandlerTest {
         }
 
         @Override
-        public Set<DataForm> getExtendedInfos(String name, String node, JID senderJID) {
+        public Set<DataForm> getExtendedInfos(String domain, String name, String node, JID senderJID) {
+            // Only return forms for server domain, service-level queries (matching real provider behavior)
+            if (domain != null && !domain.equals(Fixtures.XMPP_DOMAIN)) {
+                return Collections.emptySet();
+            }
+            if (name != null) {
+                return Collections.emptySet();
+            }
+            if (node != null) {
+                return Collections.emptySet();
+            }
             return forms;
         }
     }
@@ -117,7 +127,47 @@ class IQDiscoInfoHandlerTest {
         }
     }
 
+    /**
+     * Helper method to get extended disco info forms from a handler by simulating a disco#info request.
+     * This tests through the full handleIQ() flow where ExtendedDiscoInfoProviders are now applied.
+     */
+    private Set<DataForm> getExtendedInfosViaHandleIQ(IQDiscoInfoHandler handler, JID from, JID to) {
+        try {
+            // Initialize the handler (this registers the server disco info provider)
+            handler.initialize(XMPPServer.getInstance());
+            handler.start();
 
+            // Create disco#info request
+            org.xmpp.packet.IQ request = new org.xmpp.packet.IQ(org.xmpp.packet.IQ.Type.get);
+            request.setFrom(from);
+            if (to != null) {
+                request.setTo(to);
+            } else {
+                // If no 'to' specified, it goes to the server domain
+                request.setTo(new JID(Fixtures.XMPP_DOMAIN));
+            }
+            request.setChildElement("query", "http://jabber.org/protocol/disco#info");
+
+            // Handle the request
+            org.xmpp.packet.IQ response = handler.handleIQ(request);
+
+            // Parse the response to extract DataForms
+            Set<DataForm> forms = new HashSet<>();
+            if (response != null && response.getChildElement() != null) {
+                for (Object element : response.getChildElement().elements("x")) {
+                    if (element instanceof org.dom4j.Element) {
+                        org.dom4j.Element xElement = (org.dom4j.Element) element;
+                        if ("jabber:x:data".equals(xElement.getNamespaceURI())) {
+                            forms.add(new DataForm(xElement));
+                        }
+                    }
+                }
+            }
+            return forms;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get extended infos via handleIQ", e);
+        }
+    }
 
     @Test
     void testSameFormTypeIsMerged() {
@@ -133,11 +183,8 @@ class IQDiscoInfoHandlerTest {
             new TestExtendedDiscoInfoProvider(Set.of(f2))
         );
 
-        DiscoInfoProvider provider =
-            invokeGetServerInfoProvider(handler);
-
-        Set<DataForm> result =
-            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        Set<DataForm> result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
 
         DataForm merged = result.stream()
             .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
@@ -168,11 +215,8 @@ class IQDiscoInfoHandlerTest {
             new TestExtendedDiscoInfoProvider(Set.of(form2))
         );
 
-        DiscoInfoProvider provider =
-            invokeGetServerInfoProvider(handler);
-
-        Set<DataForm> result =
-            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        Set<DataForm> result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
 
         long testFormCount = result.stream()
             .filter(f -> {
@@ -192,11 +236,8 @@ class IQDiscoInfoHandlerTest {
             new TestExtendedDiscoInfoProvider(Collections.emptySet())
         );
 
-        DiscoInfoProvider provider =
-            invokeGetServerInfoProvider(handler);
-
-        Set<DataForm> result =
-            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        Set<DataForm> result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
 
         assertNotNull(result);
         // Result should not contain our test forms since provider returned empty set
@@ -246,11 +287,8 @@ class IQDiscoInfoHandlerTest {
             new TestExtendedDiscoInfoProvider(Set.of(form2))
         );
 
-        DiscoInfoProvider provider =
-            invokeGetServerInfoProvider(handler);
-
-        Set<DataForm> result =
-            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        Set<DataForm> result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
 
         DataForm merged = result.stream()
             .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
@@ -282,12 +320,9 @@ class IQDiscoInfoHandlerTest {
             new TestExtendedDiscoInfoProvider(Set.of(form))
         );
 
-        DiscoInfoProvider provider =
-            invokeGetServerInfoProvider(handler);
-
         // This should not throw an exception even though provider returns immutable set
-        Set<DataForm> result =
-            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        Set<DataForm> result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
 
         assertNotNull(result);
         assertTrue(result.stream()
@@ -328,11 +363,8 @@ class IQDiscoInfoHandlerTest {
             new TestExtendedDiscoInfoProvider(Set.of(form2))
         );
 
-        DiscoInfoProvider provider =
-            invokeGetServerInfoProvider(handler);
-
-        Set<DataForm> result =
-            provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        Set<DataForm> result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
 
         DataForm merged = result.stream()
             .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
@@ -397,10 +429,9 @@ class IQDiscoInfoHandlerTest {
             new TestExtendedDiscoInfoProvider(Set.of(form3))
         );
 
-        DiscoInfoProvider provider = invokeGetServerInfoProvider(handler);
-
         // Should not throw - should continue processing and return valid response
-        Set<DataForm> result = provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        Set<DataForm> result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
 
         DataForm merged = result.stream()
             .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
@@ -456,9 +487,8 @@ class IQDiscoInfoHandlerTest {
             new TestExtendedDiscoInfoProvider(Set.of(form2))
         );
 
-        DiscoInfoProvider provider = invokeGetServerInfoProvider(handler);
-
-        Set<DataForm> result = provider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        Set<DataForm> result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
 
         DataForm merged = result.stream()
             .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
@@ -487,20 +517,20 @@ class IQDiscoInfoHandlerTest {
         // Add the provider
         handler.addExtendedDiscoInfoProvider(provider);
 
-        DiscoInfoProvider serverProvider = invokeGetServerInfoProvider(handler);
-
         // Verify the form appears in the response
-        Set<DataForm> result = serverProvider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        Set<DataForm> result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
         long formCountBefore = result.stream()
             .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
             .count();
         assertEquals(1, formCountBefore, "Form should be present after adding provider");
 
-        // Remove the provider
+        // Remove the provider - need to create a new handler instance to test removal
         handler.removeExtendedDiscoInfoProvider(provider);
 
         // Verify the form no longer appears in the response
-        result = serverProvider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
         long formCountAfter = result.stream()
             .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
             .count();
@@ -515,11 +545,10 @@ class IQDiscoInfoHandlerTest {
         DataForm form = testForm("field1", "value1");
         TestExtendedDiscoInfoProvider provider = new TestExtendedDiscoInfoProvider(Set.of(form));
 
-        DiscoInfoProvider serverProvider = invokeGetServerInfoProvider(handler);
-
         // Add the provider and verify form appears
         handler.addExtendedDiscoInfoProvider(provider);
-        Set<DataForm> result = serverProvider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        Set<DataForm> result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
         long formCountAfterAdd = result.stream()
             .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
             .count();
@@ -527,7 +556,8 @@ class IQDiscoInfoHandlerTest {
 
         // Remove the provider and verify form disappears
         handler.removeExtendedDiscoInfoProvider(provider);
-        result = serverProvider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
         long formCountAfterRemove = result.stream()
             .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
             .count();
@@ -535,7 +565,8 @@ class IQDiscoInfoHandlerTest {
 
         // Re-add the same provider and verify form appears again
         handler.addExtendedDiscoInfoProvider(provider);
-        result = serverProvider.getExtendedInfos(null, null, new JID("tester@example.org"));
+        result = getExtendedInfosViaHandleIQ(handler,
+            new JID("tester@example.org"), null);
         long formCountAfterReAdd = result.stream()
             .filter(f -> "urn:xmpp:dataforms:openfire-unittest".equals(getFormType(f)))
             .count();

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProviderTest.java
@@ -32,6 +32,29 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Unit tests for {@link SoftwareInfoExtendedDiscoInfoProvider}.
+ *
+ * <p>This test class verifies the behavior of the SoftwareInfoExtendedDiscoInfoProvider,
+ * which provides software and operating system information in service discovery responses
+ * according to XEP-0232: Software Information.</p>
+ *
+ * <p>The tests cover various scenarios including:
+ * <ul>
+ *   <li>Inclusion of software/OS information when enabled</li>
+ *   <li>Exclusion when disabled via system property</li>
+ *   <li>Exclusion when admin exposure is disabled</li>
+ *   <li>Proper filtering based on domain, node, and name parameters</li>
+ *   <li>Dynamic enable/disable behavior</li>
+ *   <li>Correct form structure with all required fields (os, os_version, software, software_version)</li>
+ *   <li>SystemProperty configuration validation</li>
+ * </ul>
+ * </p>
+ *
+ * @author Dan Caseley, dan@caseley.me.uk
+ * @see SoftwareInfoExtendedDiscoInfoProvider
+ * @see <a href="https://xmpp.org/extensions/xep-0232.html">XEP-0232: Software Information</a>
+ */
 class SoftwareInfoExtendedDiscoInfoProviderTest {
 
     private SoftwareInfoExtendedDiscoInfoProvider provider;
@@ -63,6 +86,20 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
         Fixtures.clearExistingProperties();
     }
 
+    /**
+     * Verifies that the provider returns a properly formatted data form containing software and
+     * operating system information when enabled (the default state).
+     *
+     * <p>The form should include:
+     * <ul>
+     *   <li>A hidden FORM_TYPE field with value "urn:xmpp:dataforms:softwareinfo"</li>
+     *   <li>An os field containing the operating system name</li>
+     *   <li>An os_version field containing OS version, architecture, and Java version</li>
+     *   <li>A software field containing the software name</li>
+     *   <li>A software_version field containing the software version</li>
+     * </ul>
+     * </p>
+     */
     @Test
     public void testReturnsSoftwareInfoWhenEnabled() {
         // Setup - ENABLED defaults to true
@@ -111,6 +148,10 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
         assertNotNull(softwareVersion.getFirstValue());
     }
 
+    /**
+     * Verifies that the provider returns an empty set when disabled via the ENABLED
+     * system property, allowing administrators to suppress software information disclosure.
+     */
     @Test
     public void testReturnsEmptyWhenDisabled() {
         // Setup
@@ -124,10 +165,14 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
         assertTrue(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the provider returns an empty set when admin exposure is disabled
+     * via the "admin.disable-exposure" system property, respecting the broader privacy setting.
+     */
     @Test
     public void testReturnsEmptyWhenAdminExposureDisabled() {
         // Setup
-        JiveGlobals.setProperty("admin.disable-exposure", "true");
+        IQDiscoInfoHandler.DISABLE_EXPOSURE.setValue(true);
 
         // Execute
         Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
@@ -137,6 +182,10 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
         assertTrue(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the provider returns an empty set when querying a specific node,
+     * as software information is only provided for the server itself, not for nodes.
+     */
     @Test
     public void testReturnsEmptyWhenNodeIsNotNull() {
         // Execute
@@ -147,6 +196,11 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
         assertTrue(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the provider returns an empty set when querying a domain that
+     * doesn't match the server's domain, as software information is only provided for
+     * the local server.
+     */
     @Test
     public void testReturnsEmptyWhenDomainDoesNotMatchServerDomain() {
         // Execute
@@ -157,6 +211,10 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
         assertTrue(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the provider returns an empty set when querying a specific user,
+     * as software information is only provided for server-level queries, not user-level queries.
+     */
     @Test
     public void testReturnsEmptyWhenNameIsNotNull() {
         // Execute
@@ -167,6 +225,10 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
         assertTrue(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the provider correctly returns software information when querying
+     * the server domain itself with no node or name specified.
+     */
     @Test
     public void testWorksForServerDomain() {
         // Execute with domain matching server domain
@@ -177,6 +239,12 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
         assertEquals(1, forms.size());
     }
 
+    /**
+     * Verifies that the provider dynamically responds to changes in the ENABLED system property.
+     *
+     * <p>This test confirms that the SystemProperty is configured as dynamic, allowing
+     * administrators to enable/disable software information exposure without restarting the server.</p>
+     */
     @Test
     public void testRespectsEnabledPropertyChanges() {
         // Initial state - enabled
@@ -194,24 +262,40 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
         assertFalse(forms.isEmpty());
     }
 
+    /**
+     * Verifies that the ENABLED SystemProperty is configured with the correct key
+     * for consistent configuration management.
+     */
     @Test
     public void testEnabledPropertyHasCorrectKey() {
         // Verify the property key is correct
         assertEquals("xmpp.iqdiscoinfo.xformsoftwareversion", SoftwareInfoExtendedDiscoInfoProvider.ENABLED.getKey());
     }
 
+    /**
+     * Verifies that the ENABLED SystemProperty defaults to true, enabling software
+     * information disclosure by default while allowing administrators to opt out.
+     */
     @Test
     public void testEnabledPropertyDefaultsToTrue() {
         // Verify the default value is true
         assertTrue(SoftwareInfoExtendedDiscoInfoProvider.ENABLED.getDefaultValue());
     }
 
+    /**
+     * Verifies that the ENABLED SystemProperty is configured as dynamic, allowing
+     * runtime changes without server restart.
+     */
     @Test
     public void testEnabledPropertyIsDynamic() {
         // Verify the property is dynamic
         assertTrue(SoftwareInfoExtendedDiscoInfoProvider.ENABLED.isDynamic());
     }
 
+    /**
+     * Verifies that the returned data form contains all required fields per XEP-0232:
+     * FORM_TYPE, os, os_version, software, and software_version.
+     */
     @Test
     public void testAllFieldsArePresent() {
         // Execute

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProviderTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.disco;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.XMPPServerInfo;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.Version;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xmpp.forms.DataForm;
+import org.xmpp.forms.FormField;
+import org.xmpp.packet.JID;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SoftwareInfoExtendedDiscoInfoProviderTest {
+
+    private SoftwareInfoExtendedDiscoInfoProvider provider;
+    private XMPPServer xmppServer;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        Fixtures.reconfigureOpenfireHome();
+        Fixtures.disableDatabasePersistence();
+
+        // Create provider
+        provider = new SoftwareInfoExtendedDiscoInfoProvider();
+
+        // Mock XMPPServer
+        xmppServer = Fixtures.mockXMPPServer();
+
+        // Mock XMPPServerInfo with version (required by AdminConsole.getVersionString())
+        XMPPServerInfo serverInfo = xmppServer.getServerInfo();
+        Version version = mock(Version.class);
+        when(version.getVersionString()).thenReturn("5.1.0-TEST");
+        when(serverInfo.getVersion()).thenReturn(version);
+
+        XMPPServer.setInstance(xmppServer);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        XMPPServer.setInstance(null);
+        Fixtures.clearExistingProperties();
+    }
+
+    @Test
+    public void testReturnsSoftwareInfoWhenEnabled() {
+        // Setup - ENABLED defaults to true
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertEquals(1, forms.size());
+
+        DataForm form = forms.iterator().next();
+        assertEquals(DataForm.Type.result, form.getType());
+
+        // Check FORM_TYPE field
+        FormField formType = form.getField("FORM_TYPE");
+        assertNotNull(formType);
+        assertEquals(FormField.Type.hidden, formType.getType());
+        assertEquals("urn:xmpp:dataforms:softwareinfo", formType.getFirstValue());
+
+        // Check os field
+        FormField os = form.getField("os");
+        assertNotNull(os);
+        assertEquals(FormField.Type.text_single, os.getType());
+        assertNotNull(os.getFirstValue());
+        assertEquals(System.getProperty("os.name"), os.getFirstValue());
+
+        // Check os_version field
+        FormField osVersion = form.getField("os_version");
+        assertNotNull(osVersion);
+        assertEquals(FormField.Type.text_single, osVersion.getType());
+        assertNotNull(osVersion.getFirstValue());
+        String expectedOsVersion = System.getProperty("os.version") + " " +
+            System.getProperty("os.arch") + " - Java " + System.getProperty("java.version");
+        assertEquals(expectedOsVersion, osVersion.getFirstValue());
+
+        // Check software field
+        FormField software = form.getField("software");
+        assertNotNull(software);
+        assertEquals(FormField.Type.text_single, software.getType());
+        assertNotNull(software.getFirstValue());
+
+        // Check software_version field
+        FormField softwareVersion = form.getField("software_version");
+        assertNotNull(softwareVersion);
+        assertEquals(FormField.Type.text_single, softwareVersion.getType());
+        assertNotNull(softwareVersion.getFirstValue());
+    }
+
+    @Test
+    public void testReturnsEmptyWhenDisabled() {
+        // Setup
+        SoftwareInfoExtendedDiscoInfoProvider.ENABLED.setValue(false);
+
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertTrue(forms.isEmpty());
+    }
+
+    @Test
+    public void testReturnsEmptyWhenAdminExposureDisabled() {
+        // Setup
+        JiveGlobals.setProperty("admin.disable-exposure", "true");
+
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertTrue(forms.isEmpty());
+    }
+
+    @Test
+    public void testReturnsEmptyWhenNodeIsNotNull() {
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, "somenode", new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertTrue(forms.isEmpty());
+    }
+
+    @Test
+    public void testReturnsEmptyWhenNameDoesNotMatchServerDomain() {
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos("other.domain", null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertTrue(forms.isEmpty());
+    }
+
+    @Test
+    public void testWorksForServerDomain() {
+        // Execute with name matching server domain
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertEquals(1, forms.size());
+    }
+
+    @Test
+    public void testRespectsEnabledPropertyChanges() {
+        // Initial state - enabled
+        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        assertFalse(forms.isEmpty());
+
+        // Disable
+        SoftwareInfoExtendedDiscoInfoProvider.ENABLED.setValue(false);
+        forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        assertTrue(forms.isEmpty());
+
+        // Re-enable
+        SoftwareInfoExtendedDiscoInfoProvider.ENABLED.setValue(true);
+        forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        assertFalse(forms.isEmpty());
+    }
+
+    @Test
+    public void testEnabledPropertyHasCorrectKey() {
+        // Verify the property key is correct
+        assertEquals("xmpp.iqdiscoinfo.xformsoftwareversion", SoftwareInfoExtendedDiscoInfoProvider.ENABLED.getKey());
+    }
+
+    @Test
+    public void testEnabledPropertyDefaultsToTrue() {
+        // Verify the default value is true
+        assertTrue(SoftwareInfoExtendedDiscoInfoProvider.ENABLED.getDefaultValue());
+    }
+
+    @Test
+    public void testEnabledPropertyIsDynamic() {
+        // Verify the property is dynamic
+        assertTrue(SoftwareInfoExtendedDiscoInfoProvider.ENABLED.isDynamic());
+    }
+
+    @Test
+    public void testAllFieldsArePresent() {
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify all expected fields are present
+        assertNotNull(forms);
+        assertEquals(1, forms.size());
+
+        DataForm form = forms.iterator().next();
+        assertEquals(5, form.getFields().size()); // FORM_TYPE + 4 info fields
+
+        assertNotNull(form.getField("FORM_TYPE"));
+        assertNotNull(form.getField("os"));
+        assertNotNull(form.getField("os_version"));
+        assertNotNull(form.getField("software"));
+        assertNotNull(form.getField("software_version"));
+    }
+}

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/disco/SoftwareInfoExtendedDiscoInfoProviderTest.java
@@ -67,7 +67,7 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
     public void testReturnsSoftwareInfoWhenEnabled() {
         // Setup - ENABLED defaults to true
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -117,7 +117,7 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
         SoftwareInfoExtendedDiscoInfoProvider.ENABLED.setValue(false);
 
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -130,7 +130,7 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
         JiveGlobals.setProperty("admin.disable-exposure", "true");
 
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -140,7 +140,7 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
     @Test
     public void testReturnsEmptyWhenNodeIsNotNull() {
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, "somenode", new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, "somenode", new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -148,9 +148,19 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
     }
 
     @Test
-    public void testReturnsEmptyWhenNameDoesNotMatchServerDomain() {
+    public void testReturnsEmptyWhenDomainDoesNotMatchServerDomain() {
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos("other.domain", null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos("other.domain", null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+
+        // Verify
+        assertNotNull(forms);
+        assertTrue(forms.isEmpty());
+    }
+
+    @Test
+    public void testReturnsEmptyWhenNameIsNotNull() {
+        // Execute
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, "someuser", null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -159,8 +169,8 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
 
     @Test
     public void testWorksForServerDomain() {
-        // Execute with name matching server domain
-        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        // Execute with domain matching server domain
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify
         assertNotNull(forms);
@@ -170,17 +180,17 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
     @Test
     public void testRespectsEnabledPropertyChanges() {
         // Initial state - enabled
-        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
         assertFalse(forms.isEmpty());
 
         // Disable
         SoftwareInfoExtendedDiscoInfoProvider.ENABLED.setValue(false);
-        forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
         assertTrue(forms.isEmpty());
 
         // Re-enable
         SoftwareInfoExtendedDiscoInfoProvider.ENABLED.setValue(true);
-        forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
         assertFalse(forms.isEmpty());
     }
 
@@ -205,7 +215,7 @@ class SoftwareInfoExtendedDiscoInfoProviderTest {
     @Test
     public void testAllFieldsArePresent() {
         // Execute
-        Set<DataForm> forms = provider.getExtendedInfos(null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
+        Set<DataForm> forms = provider.getExtendedInfos(Fixtures.XMPP_DOMAIN, null, null, new JID("user@" + Fixtures.XMPP_DOMAIN));
 
         // Verify all expected fields are present
         assertNotNull(forms);


### PR DESCRIPTION
I want to implement XEP-0504: Data Policy (https://xmpp.org/extensions/xep-0504.html) which relies on [XEP-0128: Service Discovery Extensions](https://xmpp.org/extensions/xep-0128.html).

We've already got 2 specific XEP implementations (Contact Addresses, Software Info) that depend on XEP-0128, and we've got the MUC Extended Info plugin that extends disco responses too.

This change creates a pluggable ExtendedDiscoInfoProviders capability for plugins to add support for XEPs (or other functionality) that rely on XEP-0128.

It also moves the Contact Addresses and the Software Info implementations to use the new thing, and updates the DOAP.

Lots of AI in the JavaDoc and unit tests, which I think I've fixed up, but use sufficient scepticism.