### PR TITLE
OF-3187: Make AuthCheckFilter's destroy a no-op

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/AuthCheckFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -316,8 +316,11 @@ public class AuthCheckFilter implements Filter {
 
     @Override
     public void destroy() {
-        // reset excludes to an empty set to prevent state carry over
-        excludes = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        // Intentionally left empty. The static 'excludes' set is shared across filter instances
+        // so that plugin-registered excludes survive admin-console restarts. Plugins are
+        // responsible for calling removeExclude() in their destroyPlugin() lifecycle.
+        // Web.xml excludes are re-added by init() on each restart (Set semantics prevent duplicates).
+        // Setup-mode excludes are cleaned up explicitly in AdminConsolePlugin.startup().
     }
 
     private String getRedirectURL(HttpServletRequest request, String loginPage,

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/AdminConsolePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -283,8 +283,12 @@ public class AdminConsolePlugin implements Plugin {
         try {
             adminServer.start(); // excludes initialised
 
-            if(XMPPServer.getInstance().isSetupMode()) {
+            if (XMPPServer.getInstance().isSetupMode()) {
                 AuthCheckFilter.loadSetupExcludes();
+            } else {
+                // Explicitly remove setup-only excludes. If the admin console is restarting
+                // after setup completion, destroy() no longer clears them automatically.
+                Arrays.stream(JiveGlobals.setupExcludePaths).forEach(AuthCheckFilter::removeExclude);
             }
 
             // Log the ports that the admin server is listening on.


### PR DESCRIPTION
This is called when the AdminConsolePlugin restarts (by PluginServlet). It wipes all exclusions that have been registered, requiring plugins to re-register them. This change retains the static list of excludes. Plugins remain responsible for unregistering their excludes, which they should have been doing anyway, rather than relying on an eventual restart of the AdminConsole.

Fixes the generic case of https://github.com/igniterealtime/openfire-restAPI-plugin/issues/205 (which has a fix in https://github.com/igniterealtime/openfire-restAPI-plugin/pull/232, but feels like it should be unnecessary)