### PR TITLE
OF-2554: Link the docker-related documentation together

### DIFF
--- a/documentation/docker.html
+++ b/documentation/docker.html
@@ -69,6 +69,8 @@
 
         <p>In this example, we've used <a href="https://github.com/vishnubob/wait-for-it/blob/master/wait-for-it.sh">wait-for-it</a> to allow a postgres database service (not shown) to finish launching prior to starting Openfire. This allows us to have premade files in /data/conf with which to launch Openfire.</p>
 
+        <p>For developer-specific workflows — including building images from source, running with all XMPP ports, remote debugging, and Docker Compose test stacks — see <a href="working-with-openfire.html#tooling-docker">Working with Openfire: Docker</a>.</p>
+
     </section>
 
     <footer>

--- a/documentation/working-with-openfire.html
+++ b/documentation/working-with-openfire.html
@@ -60,6 +60,8 @@
 
             <p>Nothing has sped me up more than being able to throw up environments quickly using Docker. Whether it's comparing behaviour, or testing a branch, Docker is fast and trouble free. The only time it's less useful is when you're testing integrations, e.g. Active Directory.</p>
 
+            <p>For production deployment — including running official images and docker-compose setups with an external database — see the <a href="docker.html">Docker Guide</a>.</p>
+
             <section>
 
                 <h4>Building an Openfire container image</h4>


### PR DESCRIPTION
We've got 2 disparate bits of docker documentation. I considered unifying them, but they're addressing 2 different audiences, so I've added links in both directions.