### PR TITLE
OF-3212: Add robustness in handling a PEP service without a root collection node

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,20 +174,26 @@ public class PEPService implements PubSubService, Cacheable {
     public void initialize() {
         // Load nodes to memory
         XMPPServer.getInstance().getPubSubModule().getPersistenceProvider().loadNodes(this);
-        // Ensure that we have a root collection node
-        if (nodes.isEmpty()) {
-            // Create root collection node
-            rootCollectionNode = new CollectionNode(this.getUniqueIdentifier(), null, this.serviceOwner.toString(), this.serviceOwner, collectionDefaultConfiguration);
 
-            // Save new root node
-            rootCollectionNode.saveToDB();
+        // Ensure that we have a root collection node.
+        final Node rootNode = getNode(this.serviceOwner.toString());
+        if (rootNode instanceof CollectionNode) {
+            rootCollectionNode = (CollectionNode) rootNode;
+            return;
+        }
 
-            // Add the creator as the node owner
-            rootCollectionNode.addOwner(this.serviceOwner);
+        if (rootNode != null || !nodes.isEmpty()) {
+            Log.warn("PEP service '{}' has nodes but no root collection node. Recreating missing root node.", getServiceID());
         }
-        else {
-            rootCollectionNode = (CollectionNode) getNode(this.serviceOwner.toString());
-        }
+
+        // Create root collection node
+        rootCollectionNode = new CollectionNode(this.getUniqueIdentifier(), null, this.serviceOwner.toString(), this.serviceOwner, collectionDefaultConfiguration);
+
+        // Save new root node
+        rootCollectionNode.saveToDB();
+
+        // Add the creator as the node owner
+        rootCollectionNode.addOwner(this.serviceOwner);
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPService.java
@@ -189,9 +189,6 @@ public class PEPService implements PubSubService, Cacheable {
         // Create root collection node
         rootCollectionNode = new CollectionNode(this.getUniqueIdentifier(), null, this.serviceOwner.toString(), this.serviceOwner, collectionDefaultConfiguration);
 
-        // Save new root node
-        rootCollectionNode.saveToDB();
-
         // Add the creator as the node owner
         rootCollectionNode.addOwner(this.serviceOwner);
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPServiceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,10 +147,10 @@ public class PEPServiceManager implements EntityCapabilitiesListener {
             } else {
                 // lookup in database.
                 pepService = XMPPServer.getInstance().getPubSubModule().getPersistenceProvider().loadPEPServiceFromDB(jid);
-                pepServices.put(jid, CacheableOptional.of(pepService));
                 if ( pepService != null ) {
                     pepService.initialize();
                 }
+                pepServices.put(jid, CacheableOptional.of(pepService));
             }
 
             if ( pepService != null ) {
@@ -196,8 +196,8 @@ public class PEPServiceManager implements EntityCapabilitiesListener {
 
             if (pepService == null) {
                 pepService = new PEPService(XMPPServer.getInstance(), bareJID);
-                pepServices.put(bareJID, CacheableOptional.of(pepService));
                 pepService.initialize();
+                pepServices.put(bareJID, CacheableOptional.of(pepService));
 
                 Log.debug("PEPService created for: '{}'", bareJID);
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPServiceManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPServiceManager.java
@@ -151,6 +151,10 @@ public class PEPServiceManager implements EntityCapabilitiesListener {
                     pepService.initialize();
                 }
                 pepServices.put(jid, CacheableOptional.of(pepService));
+                if (pepService != null) {
+                    // Save new root node (which can happen only _after_ the service has been registered to the cache).
+                    pepService.getRootCollectionNode().saveToDB();
+                }
             }
 
             if ( pepService != null ) {
@@ -198,6 +202,8 @@ public class PEPServiceManager implements EntityCapabilitiesListener {
                 pepService = new PEPService(XMPPServer.getInstance(), bareJID);
                 pepService.initialize();
                 pepServices.put(bareJID, CacheableOptional.of(pepService));
+                // Save new root node (which can happen only _after_ the service has been registered to the cache).
+                pepService.getRootCollectionNode().saveToDB();
 
                 Log.debug("PEPService created for: '{}'", bareJID);
             }


### PR DESCRIPTION
This PR contains two commits:
1. that defensively creates a missing root collection node if it's missing
2. fixes a race condition that potentially allows a PEP service to be used while it is still being initialized by another thread.