### PR TITLE
OF-2549: Fix JavaScript error and improve UX in MUC Create Permission page

### DIFF
--- a/xmppserver/src/main/webapp/muc-create-permission.jsp
+++ b/xmppserver/src/main/webapp/muc-create-permission.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -126,6 +126,7 @@
         if (add) {
             mucService.addUsersAllowedToCreate(allowedJIDs);
             mucService.setAllRegisteredUsersAllowedToCreate(allowAllRegisteredUsers);
+            mucService.setRoomCreationRestricted(true);
             // Log the event
             webManager.logEvent("updated MUC room creation permissions for service "+mucname, null);
             response.sendRedirect("muc-create-permission.jsp?addsuccess=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
@@ -151,6 +152,22 @@
 <meta name="subPageID" content="muc-perms"/>
 <meta name="extraParams" content="<%= "mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8) %>"/>
 <meta name="helpPage" content="set_group_chat_room_creation_permissions.html"/>
+<script>
+    function toggleAllowedUsers() {
+        const isRestricted = document.getElementById('rb02').checked;
+        const container = document.getElementById('allowedUsersContainer');
+        const input = document.getElementById('userJIDtf');
+
+        if (isRestricted) {
+            container.style.display = 'block';
+            if (input) {
+                input.focus();
+            }
+        } else {
+            container.style.display = 'none';
+        }
+    }
+</script>
 </head>
 <body>
 
@@ -202,6 +219,7 @@
             <tr>
                 <td style="width: 1%">
                     <input type="radio" name="openPerms" value="true" id="rb01"
+                     onchange="toggleAllowedUsers()"
                      <%= ((!mucService.isRoomCreationRestricted()) ? "checked" : "") %>>
                 </td>
                 <td>
@@ -211,7 +229,7 @@
             <tr>
                 <td style="width: 1%">
                     <input type="radio" name="openPerms" value="false" id="rb02"
-                     onfocus="this.form.userJID.focus();"
+                     onchange="toggleAllowedUsers()"
                      <%= ((mucService.isRoomCreationRestricted()) ? "checked" : "") %>>
                 </td>
                 <td>
@@ -227,8 +245,7 @@
 
 <br>
 
-
-<%  if (mucService.isRoomCreationRestricted()) { %>
+<div id="allowedUsersContainer" style="display: <%= (mucService.isRoomCreationRestricted() ? "block" : "none") %>">
 <!-- BEGIN 'Allowed Users' -->
 <form action="muc-create-permission.jsp?add" method="post">
     <input type="hidden" name="csrf" value="${csrf}">
@@ -238,13 +255,13 @@
     </div>
     <div class="jive-contentBox">
         <p>
-            <input type="checkbox" id="allowAllRegisteredUsers" name="allowAllRegisteredUsers" <%=mucService.isAllRegisteredUsersAllowedToCreate()?"checked":""%> onChange="this.form.submit()">
+            <input type="checkbox" id="allowAllRegisteredUsers" name="allowAllRegisteredUsers" <%=mucService.isAllRegisteredUsersAllowedToCreate()?"checked":""%>>
             <label for="allowAllRegisteredUsers"><fmt:message key="muc.create.permission.allow_registered" /></label>
         </p>
         <p>
         <label for="groupJIDs"><fmt:message key="muc.create.permission.add_group" /></label><br/>
         <select name="groupNames" size="6" multiple style="width:400px;font-family:verdana,arial,helvetica,sans-serif;font-size:8pt;" 
-         onclick="this.form.openPerms[1].checked=true;" id="groupJIDs">
+         id="groupJIDs">
         <%  for (Group g : webManager.getGroupManager().getGroups()) {	%>
             <option value="<%= URLEncoder.encode(g.getName(), StandardCharsets.UTF_8) %>"
              <%= (StringUtils.contains(groupNames, g.getName()) ? "selected" : "") %>
@@ -254,8 +271,8 @@
         </p>
         <p>
         <label for="userJIDtf"><fmt:message key="muc.create.permission.add_jid" /></label>
-        <input type="text" name="userJID" size="30" maxlength="100" value="<%= (userJID != null ? userJID : "") %>"
-         onclick="this.form.openPerms[1].checked=true;" id="userJIDtf">
+        <input type="text" name="userJID" size="30" maxlength="100" value="<%= StringUtils.escapeForXML(userJID != null ? userJID : "") %>"
+         id="userJIDtf">
         <input type="submit" value="Add">
         </p>
 
@@ -308,7 +325,7 @@
 </form>
 <!-- END 'Allowed Users' -->
 
-<%  } %>
+</div>
 
 
 </body>

--- a/xmppserver/src/main/webapp/muc-create-permission.jsp
+++ b/xmppserver/src/main/webapp/muc-create-permission.jsp
@@ -86,6 +86,7 @@
         }
         else {
             mucService.setRoomCreationRestricted(true);
+            mucService.setAllRegisteredUsersAllowedToCreate(allowAllRegisteredUsers);
             // Log the event
             webManager.logEvent("set MUC room creation to not restricted for service "+mucname, null);
             response.sendRedirect("muc-create-permission.jsp?success=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
@@ -154,7 +155,7 @@
 <meta name="helpPage" content="set_group_chat_room_creation_permissions.html"/>
 <script>
     function toggleAllowedUsers() {
-        const isRestricted = document.getElementById('rb02').checked;
+        const isRestricted = document.getElementById('restrictedPermissionsRadio').checked;
         const container = document.getElementById('allowedUsersContainer');
         const input = document.getElementById('userJIDtf');
 
@@ -165,6 +166,13 @@
             }
         } else {
             container.style.display = 'none';
+        }
+    }
+    function syncAllowAllRegistered() {
+        const cb = document.getElementById('allowAllRegisteredUsers');
+        const hidden = document.getElementById('allowAllRegisteredUsersHidden');
+        if (cb && hidden) {
+            hidden.value = cb.checked ? 'true' : 'false';
         }
     }
 </script>
@@ -210,6 +218,7 @@
 <form action="muc-create-permission.jsp?save" method="post">
     <input type="hidden" name="csrf" value="${csrf}">
     <input type="hidden" name="mucname" value="<%= StringUtils.escapeForXML(mucname) %>" />
+    <input type="hidden" name="allowAllRegisteredUsers" id="allowAllRegisteredUsersHidden" value="<%= mucService.isAllRegisteredUsersAllowedToCreate() ? "true" : "false" %>" />
     <div class="jive-contentBoxHeader">
         <fmt:message key="muc.create.permission.policy" />
     </div>
@@ -228,7 +237,7 @@
             </tr>
             <tr>
                 <td style="width: 1%">
-                    <input type="radio" name="openPerms" value="false" id="rb02"
+                    <input type="radio" name="openPerms" value="false" id="restrictedPermissionsRadio"
                      onchange="toggleAllowedUsers()"
                      <%= ((mucService.isRoomCreationRestricted()) ? "checked" : "") %>>
                 </td>
@@ -255,7 +264,7 @@
     </div>
     <div class="jive-contentBox">
         <p>
-            <input type="checkbox" id="allowAllRegisteredUsers" name="allowAllRegisteredUsers" <%=mucService.isAllRegisteredUsersAllowedToCreate()?"checked":""%>>
+            <input type="checkbox" id="allowAllRegisteredUsers" name="allowAllRegisteredUsers" onchange="syncAllowAllRegistered()" <%=mucService.isAllRegisteredUsersAllowedToCreate()?"checked":""%>>
             <label for="allowAllRegisteredUsers"><fmt:message key="muc.create.permission.allow_registered" /></label>
         </p>
         <p>

--- a/xmppserver/src/main/webapp/muc-create-permission.jsp
+++ b/xmppserver/src/main/webapp/muc-create-permission.jsp
@@ -242,7 +242,7 @@
                      <%= ((mucService.isRoomCreationRestricted()) ? "checked" : "") %>>
                 </td>
                 <td>
-                    <label for="rb02"><fmt:message key="muc.create.permission.specific_created" /></label>
+                    <label for="restrictedPermissionsRadio"><fmt:message key="muc.create.permission.specific_created" /></label>
                 </td>
             </tr>
         </tbody>


### PR DESCRIPTION
This PR resolves a JavaScript error (Uncaught TypeError: Cannot read properties of undefined (reading 'focus')) on the MUC room creation permissions page and enhances the user interface to be more responsive.

Root Cause
The error was caused by a scope conflict where a radio button tried to focus an input field (userJID) located in a separate form. Additionally, the target field was often missing from the DOM because it was only rendered by the server when the room creation restriction was already enabled.

Changes
 - Dynamic Visibility: Replaced server-side JSP conditional rendering with client-side CSS toggling (display: block/none) for the             "Allowed Users" section  .
 
 - Robust Event Handling: Introduced a toggleAllowedUsers() JavaScript function to manage visibility and safely apply focus only when the element is available.
 - Improved UX: The "Allowed Users" section now appears or disappears immediately upon selecting a policy, without requiring a page reload.
 - Code Cleanup: Removed redundant and broken inline onclick handlers from JID and Group selection fields that were using incorrect this.form references.


Verification
 - Verified that the "Allowed Users" section shows/hides correctly on toggle.
 - Confirmed that the JID input field is automatically focused when "Only specific..." is selected.
 - Manually tested that no JavaScript errors are thrown in the browser console.
 - Ensured that "Add" and "Delete" actions still persist correctly after the UI changes.