### PR TITLE
OF-3239: Add MariaDB as a first-class supported database

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -411,7 +411,7 @@ jobs:
           set -e
           CODE_SAYS=$(grep 'int DATABASE_VERSION =' xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java | sed -e 's/.*= //' -e 's/;//')
           NEXT=$((CODE_SAYS + 1))
-          for dbname in db2 hsqldb mysql oracle postgresql sqlserver sybase; do
+          for dbname in db2 hsqldb mariadb mysql oracle postgresql sqlserver sybase; do
             # Ensure that a file exists for CODE_SAYS
             if [ ! -f distribution/src/database/upgrade/${CODE_SAYS}/openfire_${dbname}.sql ]; then
               echo "ERROR: Expected to find a database upgrade script for ${dbname} and version ${CODE_SAYS}, but no such file exists."
@@ -912,6 +912,87 @@ jobs:
           ./mvnw -B clean package exec:java -Dexec.args="$GITHUB_WORKSPACE"
 
 
+  mariadb-install:
+    name: Test MariaDB install script
+    needs: [build, should-do-database-tests, check_branch]
+    runs-on: ubuntu-latest
+    if: ${{ needs.should-do-database-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
+    steps:
+      - name: Checkout Openfire
+        uses: actions/checkout@v6
+      - name: Set up JDK 17 Zulu
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: zulu
+          cache: maven
+      - name: Restore mvn repo artifacts from build job
+        uses: actions/download-artifact@v8
+        with:
+          name: Maven Repository
+          path: ~/.m2/repository/org/igniterealtime/openfire/
+      - name: Set environment variables
+        run: |
+          echo "CONNECTION_STRING=jdbc:mariadb://localhost:3306/openfire?rewriteBatchedStatements=true&characterEncoding=UTF-8&characterSetResults=UTF-8&serverTimezone=UTC" >> $GITHUB_ENV
+          echo "CONNECTION_DRIVER=org.mariadb.jdbc.Driver" >> $GITHUB_ENV
+          echo "CONNECTION_USERNAME=root" >> $GITHUB_ENV
+          echo "CONNECTION_PASSWORD=SecurePa55w0rd" >> $GITHUB_ENV
+          OPENFIREVSN=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "OPENFIREVSN=$OPENFIREVSN" >> $GITHUB_ENV
+          echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
+      - name: Start database server with an empty database
+        run: |
+          mkdir olddb
+          echo 'CREATE TABLE imready AS (SELECT 1);' > $GITHUB_WORKSPACE/olddb/ZZZ-signal-ready.sql
+          docker compose -f ./build/ci/compose/mariadb.yml up --detach --wait
+      - name: Build & run database tester
+        run: |
+          pushd ./build/ci/updater
+          ./mvnw -B clean package exec:java -Dexec.args="$GITHUB_WORKSPACE"
+
+
+  mariadb-upgrade:
+    name: Test MariaDB upgrade scripts
+    needs: [build, should-do-database-tests, check_branch]
+    runs-on: ubuntu-latest
+    if: ${{ needs.should-do-database-tests.outputs.check == 'true' || needs.check_branch.outputs.is_publishable_branch == 'true'}}
+    steps:
+      - name: Checkout Openfire
+        uses: actions/checkout@v6
+      - name: Set up JDK 17 Zulu
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: zulu
+          cache: maven
+      - name: Restore mvn repo artifacts from build job
+        uses: actions/download-artifact@v8
+        with:
+          name: Maven Repository
+          path: ~/.m2/repository/org/igniterealtime/openfire/
+      - name: Set environment variables
+        run: |
+          echo "CONNECTION_STRING=jdbc:mariadb://localhost:3306/openfire?rewriteBatchedStatements=true&characterEncoding=UTF-8&characterSetResults=UTF-8&serverTimezone=UTC" >> $GITHUB_ENV
+          echo "CONNECTION_DRIVER=org.mariadb.jdbc.Driver" >> $GITHUB_ENV
+          echo "CONNECTION_USERNAME=root" >> $GITHUB_ENV
+          echo "CONNECTION_PASSWORD=SecurePa55w0rd" >> $GITHUB_ENV
+          OPENFIREVSN=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "OPENFIREVSN=$OPENFIREVSN" >> $GITHUB_ENV
+          echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
+      - name: Download an old Openfire database installation script
+        run: |
+          mkdir olddb
+          curl https://raw.githubusercontent.com/igniterealtime/Openfire/v4.3.0/distribution/src/database/openfire_mysql.sql > $GITHUB_WORKSPACE/olddb/openfire_mariadb.sql
+          echo 'CREATE TABLE imready AS (SELECT 1);' > $GITHUB_WORKSPACE/olddb/ZZZ-signal-ready.sql
+      - name: Start database server, install old version of the Openfire database
+        run: |
+          docker compose -f ./build/ci/compose/mariadb.yml up --detach --wait
+      - name: Execute Openfire's database upgrade scripts
+        run: |
+          pushd ./build/ci/updater
+          ./mvnw -B clean package exec:java -Dexec.args="$GITHUB_WORKSPACE"
+
+
   oracle-install:
     name: Test Oracle install scripts
     needs: [build, should-do-database-tests, check_branch]
@@ -1010,7 +1091,7 @@ jobs:
   publish-maven:
     name: Publish to Maven
     runs-on: ubuntu-latest
-    needs: [aioxmpp, connectivity, integration, xitf, check_branch, hsqldb-install, hsqldb-upgrade, sqlserver-install, sqlserver-upgrade, postgres-install, postgres-upgrade, firebird-install, firebird-upgrade, mysql-install, mysql-upgrade, oracle-install, oracle-upgrade]
+    needs: [aioxmpp, connectivity, integration, xitf, check_branch, hsqldb-install, hsqldb-upgrade, sqlserver-install, sqlserver-upgrade, postgres-install, postgres-upgrade, firebird-install, firebird-upgrade, mysql-install, mysql-upgrade, mariadb-install, mariadb-upgrade, oracle-install, oracle-upgrade]
     if: ${{github.repository == 'igniterealtime/Openfire' && github.event_name == 'push' && needs.check_branch.outputs.is_publishable_branch == 'true'}}
 
     steps:
@@ -1044,7 +1125,7 @@ jobs:
   publish-docker:
     name: Publish to GitHub's Docker registry
     runs-on: ubuntu-latest
-    needs: [build-docker, aioxmpp, connectivity, integration, xitf, check_branch, hsqldb-install, hsqldb-upgrade, sqlserver-install, sqlserver-upgrade, postgres-install, postgres-upgrade, firebird-install, firebird-upgrade, mysql-install, mysql-upgrade, oracle-install, oracle-upgrade]
+    needs: [build-docker, aioxmpp, connectivity, integration, xitf, check_branch, hsqldb-install, hsqldb-upgrade, sqlserver-install, sqlserver-upgrade, postgres-install, postgres-upgrade, firebird-install, firebird-upgrade, mysql-install, mysql-upgrade, mariadb-install, mariadb-upgrade, oracle-install, oracle-upgrade]
     if: |
       github.event_name == 'push' && 
       (contains(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')
@@ -1103,7 +1184,7 @@ jobs:
   build-deb-artifact:
     name: Generate DEB artifact
     runs-on: ubuntu-latest
-    needs: [aioxmpp, connectivity, integration, xitf, check_branch, hsqldb-install, hsqldb-upgrade, sqlserver-install, sqlserver-upgrade, postgres-install, postgres-upgrade, firebird-install, firebird-upgrade, mysql-install, mysql-upgrade, oracle-install, oracle-upgrade]
+    needs: [aioxmpp, connectivity, integration, xitf, check_branch, hsqldb-install, hsqldb-upgrade, sqlserver-install, sqlserver-upgrade, postgres-install, postgres-upgrade, mysql-install, mysql-upgrade, firebird-install, firebird-upgrade, mariadb-install, mariadb-upgrade, oracle-install, oracle-upgrade]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/build/ci/compose/mariadb.yml
+++ b/build/ci/compose/mariadb.yml
@@ -1,0 +1,17 @@
+services:
+  db:
+    image: mariadb:12.2.2
+    ports:
+      - "3306:3306"
+    environment:
+      - MARIADB_ROOT_PASSWORD=${CONNECTION_PASSWORD}
+      - MARIADB_DATABASE=openfire
+    healthcheck:
+      test: [ "CMD-SHELL", "exit | mariadb -h 127.0.0.1 -u root -p$$MARIADB_ROOT_PASSWORD openfire -e 'select * from imready'" ]
+      interval: 5s
+      timeout: 20s
+      retries: 30
+    volumes:
+      - ${GITHUB_WORKSPACE}/olddb:/docker-entrypoint-initdb.d
+
+

--- a/build/ci/updater/pom.xml
+++ b/build/ci/updater/pom.xml
@@ -60,6 +60,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+      <version>3.5.8</version>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <version>42.7.11</version>

--- a/distribution/src/database/openfire_mariadb.sql
+++ b/distribution/src/database/openfire_mariadb.sql
@@ -1,0 +1,384 @@
+
+CREATE TABLE ofUser (
+  username              VARCHAR(64)     NOT NULL,
+  storedKey             VARCHAR(32),
+  serverKey             VARCHAR(32),
+  salt                  VARCHAR(32),
+  iterations            INTEGER,
+  plainPassword         VARCHAR(32),
+  encryptedPassword     VARCHAR(255),
+  name                  VARCHAR(100),
+  email                 VARCHAR(100),
+  creationDate          CHAR(15)        NOT NULL,
+  modificationDate      CHAR(15)        NOT NULL,
+  PRIMARY KEY (username),
+  INDEX ofUser_cDate_idx (creationDate)
+);
+
+CREATE TABLE ofUserProp (
+  username              VARCHAR(64)     NOT NULL,
+  name                  VARCHAR(100)    NOT NULL,
+  propValue             TEXT            NOT NULL,
+  PRIMARY KEY (username, name)
+);
+
+CREATE TABLE ofUserFlag (
+  username              VARCHAR(64)     NOT NULL,
+  name                  VARCHAR(100)    NOT NULL,
+  startTime             CHAR(15),
+  endTime               CHAR(15),
+  PRIMARY KEY (username, name),
+  INDEX ofUserFlag_sTime_idx (startTime),
+  INDEX ofUserFlag_eTime_idx (endTime)
+);
+
+CREATE TABLE ofOffline (
+  username              VARCHAR(64)     NOT NULL,
+  messageID             BIGINT          NOT NULL,
+  creationDate          CHAR(15)        NOT NULL,
+  messageSize           INTEGER         NOT NULL,
+  stanza                TEXT            NOT NULL,
+  PRIMARY KEY (username, messageID)
+);
+
+CREATE TABLE ofPresence (
+  username              VARCHAR(64)     NOT NULL,
+  offlinePresence       TEXT,
+  offlineDate           CHAR(15)     NOT NULL,
+  PRIMARY KEY (username)
+);
+
+CREATE TABLE ofRoster (
+  rosterID              BIGINT          NOT NULL,
+  username              VARCHAR(64)     NOT NULL,
+  jid                   VARCHAR(1024)   NOT NULL,
+  sub                   TINYINT         NOT NULL,
+  ask                   TINYINT         NOT NULL,
+  recv                  TINYINT         NOT NULL,
+  nick                  VARCHAR(255),
+  stanza                TEXT,
+  PRIMARY KEY (rosterID),
+  INDEX ofRoster_unameid_idx (username),
+  INDEX ofRoster_jid_idx (jid(255))
+);
+
+CREATE TABLE ofRosterGroups (
+  rosterID              BIGINT          NOT NULL,
+  `rank`                  TINYINT         NOT NULL,
+  groupName             VARCHAR(255)    NOT NULL,
+  PRIMARY KEY (rosterID, `rank`),
+  INDEX ofRosterGroup_rosterid_idx (rosterID)
+);
+
+CREATE TABLE ofVCard (
+  username              VARCHAR(64)     NOT NULL,
+  vcard                 MEDIUMTEXT      NOT NULL,
+  PRIMARY KEY (username)
+);
+
+CREATE TABLE ofGroup (
+  groupName             VARCHAR(50)     NOT NULL,
+  description           VARCHAR(255),
+  PRIMARY KEY (groupName)
+);
+
+CREATE TABLE ofGroupProp (
+  groupName             VARCHAR(50)     NOT NULL,
+  name                  VARCHAR(100)    NOT NULL,
+  propValue             TEXT            NOT NULL,
+  PRIMARY KEY (groupName, name)
+);
+
+CREATE TABLE ofGroupUser (
+  groupName             VARCHAR(50)     NOT NULL,
+  username              VARCHAR(100)    NOT NULL,
+  administrator         TINYINT         NOT NULL,
+  PRIMARY KEY (groupName, username, administrator)
+);
+
+CREATE TABLE ofID (
+  idType                INTEGER         NOT NULL,
+  id                    BIGINT          NOT NULL,
+  PRIMARY KEY (idType)
+);
+
+CREATE TABLE ofProperty (
+  name        VARCHAR(100)              NOT NULL,
+  propValue   TEXT                      NOT NULL,
+  encrypted   INTEGER,
+  iv          CHAR(24),
+  PRIMARY KEY (name)
+);
+
+
+CREATE TABLE ofVersion (
+  name     VARCHAR(50)  NOT NULL,
+  version  INTEGER  NOT NULL,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE ofExtComponentConf (
+  subdomain             VARCHAR(255)    NOT NULL,
+  wildcard              TINYINT         NOT NULL,
+  secret                VARCHAR(255),
+  permission            VARCHAR(10)     NOT NULL,
+  PRIMARY KEY (subdomain)
+);
+
+CREATE TABLE ofRemoteServerConf (
+  xmppDomain            VARCHAR(255)    NOT NULL,
+  remotePort            INTEGER,
+  permission            VARCHAR(10)     NOT NULL,
+  PRIMARY KEY (xmppDomain)
+);
+
+CREATE TABLE ofPrivacyList (
+  username              VARCHAR(64)     NOT NULL,
+  name                  VARCHAR(100)    NOT NULL,
+  isDefault             TINYINT         NOT NULL,
+  list                  TEXT            NOT NULL,
+  PRIMARY KEY (username, name),
+  INDEX ofPrivacyList_default_idx (username, isDefault)
+);
+
+CREATE TABLE ofSecurityAuditLog (
+  msgID                 BIGINT          NOT NULL,
+  username              VARCHAR(64)     NOT NULL,
+  entryStamp            BIGINT          NOT NULL,
+  summary               VARCHAR(255)    NOT NULL,
+  node                  VARCHAR(255)    NOT NULL,
+  details               TEXT,
+  PRIMARY KEY (msgID),
+  INDEX ofSecurityAuditLog_tstamp_idx (entryStamp),
+  INDEX ofSecurityAuditLog_uname_idx (username)
+);
+
+# MUC Tables
+
+CREATE TABLE ofMucService (
+  serviceID           BIGINT        NOT NULL,
+  subdomain           VARCHAR(255)  NOT NULL,
+  description         VARCHAR(255),
+  isHidden            TINYINT       NOT NULL,
+  PRIMARY KEY (subdomain),
+  INDEX ofMucService_serviceid_idx (serviceID)
+);
+
+CREATE TABLE ofMucServiceProp (
+  serviceID           BIGINT        NOT NULL,
+  name                VARCHAR(100)  NOT NULL,
+  propValue           TEXT          NOT NULL,
+  PRIMARY KEY (serviceID, name)
+);
+
+CREATE TABLE ofMucRoom (
+  serviceID           BIGINT        NOT NULL,
+  roomID              BIGINT        NOT NULL,
+  creationDate        CHAR(15)      NOT NULL,
+  modificationDate    CHAR(15)      NOT NULL,
+  name                VARCHAR(50)   NOT NULL,
+  naturalName         VARCHAR(255)  NOT NULL,
+  description         VARCHAR(255),
+  lockedDate          CHAR(15)      NOT NULL,
+  emptyDate           CHAR(15)      NULL,
+  canChangeSubject    TINYINT       NOT NULL,
+  maxUsers            INTEGER       NOT NULL,
+  publicRoom          TINYINT       NOT NULL,
+  moderated           TINYINT       NOT NULL,
+  membersOnly         TINYINT       NOT NULL,
+  canInvite           TINYINT       NOT NULL,
+  roomPassword        VARCHAR(50)   NULL,
+  canDiscoverJID      TINYINT       NOT NULL,
+  logEnabled          TINYINT       NOT NULL,
+  retireOnDeletion    TINYINT       NOT NULL,
+  preserveHistOnDel   TINYINT       NOT NULL,
+  subject             TEXT          NULL,
+  rolesToBroadcast    TINYINT       NOT NULL,
+  useReservedNick     TINYINT       NOT NULL,
+  canChangeNick       TINYINT       NOT NULL,
+  canRegister         TINYINT       NOT NULL,
+  allowpm             TINYINT       NULL,
+  fmucEnabled         TINYINT       NULL,
+  fmucOutboundNode    VARCHAR(255)  NULL,
+  fmucOutboundMode    TINYINT       NULL,
+  fmucInboundNodes    VARCHAR(4000) NULL,
+  PRIMARY KEY (serviceID,name),
+  INDEX ofMucRoom_roomid_idx (roomID),
+  INDEX ofMucRoom_serviceid_idx (serviceID)
+);
+
+CREATE TABLE ofMucRoomProp (
+  roomID                BIGINT          NOT NULL,
+  name                  VARCHAR(100)    NOT NULL,
+  propValue             TEXT            NOT NULL,
+  PRIMARY KEY (roomID, name)
+);
+
+CREATE TABLE ofMucRoomRetiree (
+  serviceID           BIGINT        NOT NULL,
+  name                VARCHAR(50)   NOT NULL,
+  alternateJID        VARCHAR(2000),
+  reason              VARCHAR(1024),
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (serviceID,name)
+);
+
+CREATE TABLE ofMucAffiliation (
+  roomID              BIGINT        NOT NULL,
+  jid                 TEXT          NOT NULL,
+  affiliation         TINYINT       NOT NULL,
+  PRIMARY KEY (roomID,jid(70))
+);
+
+CREATE TABLE ofMucMember (
+  roomID              BIGINT        NOT NULL,
+  jid                 TEXT          NOT NULL,
+  nickname            VARCHAR(255)  NULL,
+  firstName           VARCHAR(100)  NULL,
+  lastName            VARCHAR(100)  NULL,
+  url                 VARCHAR(100)  NULL,
+  email               VARCHAR(100)  NULL,
+  faqentry            VARCHAR(100)  NULL,
+  PRIMARY KEY (roomID,jid(70))
+);
+
+CREATE TABLE ofMucConversationLog (
+  roomID              BIGINT        NOT NULL,
+  messageID        BIGINT     NOT NULL,
+  sender              TEXT          NOT NULL,
+  nickname            VARCHAR(255)  NULL,
+  logTime             CHAR(15)      NOT NULL,
+  subject             VARCHAR(255)  NULL,
+  body                TEXT          NULL,
+  stanza                TEXT          NULL,
+  INDEX ofMucConversationLog_roomtime_idx (roomID, logTime),
+  INDEX ofMucConversationLog_time_idx (logTime),
+  INDEX ofMucConversationLog_msg_id (messageID)
+);
+
+# PubSub Tables
+
+CREATE TABLE ofPubsubNode (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  leaf                TINYINT       NOT NULL,
+  creationDate        CHAR(15)      NOT NULL,
+  modificationDate    CHAR(15)      NOT NULL,
+  parent              VARCHAR(100)  NULL,
+  deliverPayloads     TINYINT       NOT NULL,
+  maxPayloadSize      INTEGER       NULL,
+  persistItems        TINYINT       NULL,
+  maxItems            INTEGER       NULL,
+  notifyConfigChanges TINYINT       NOT NULL,
+  notifyDelete        TINYINT       NOT NULL,
+  notifyRetract       TINYINT       NOT NULL,
+  presenceBased       TINYINT       NOT NULL,
+  sendItemSubscribe   TINYINT       NOT NULL,
+  publisherModel      VARCHAR(15)   NOT NULL,
+  subscriptionEnabled TINYINT       NOT NULL,
+  configSubscription  TINYINT       NOT NULL,
+  accessModel         VARCHAR(10)   NOT NULL,
+  payloadType         VARCHAR(100)  NULL,
+  bodyXSLT            VARCHAR(100)  NULL,
+  dataformXSLT        VARCHAR(100)  NULL,
+  creator             VARCHAR(255) NOT NULL,
+  description         VARCHAR(255)  NULL,
+  language            VARCHAR(255)  NULL,
+  name                VARCHAR(50)   NULL,
+  replyPolicy         VARCHAR(15)   NULL,
+  associationPolicy   VARCHAR(15)   NULL,
+  maxLeafNodes        INTEGER       NULL,
+  PRIMARY KEY (serviceID, nodeID)
+);
+
+CREATE TABLE ofPubsubNodeJIDs (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  jid                 VARCHAR(255)  NOT NULL,
+  associationType     VARCHAR(20)   NOT NULL,
+  PRIMARY KEY (serviceID, nodeID, jid(70))
+);
+
+CREATE TABLE ofPubsubNodeGroups (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  rosterGroup         VARCHAR(100)   NOT NULL,
+  INDEX ofPubsubNodeGroups_idx (serviceID, nodeID)
+);
+
+CREATE TABLE ofPubsubAffiliation (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  jid                 VARCHAR(255) NOT NULL,
+  affiliation         VARCHAR(10)   NOT NULL,
+  PRIMARY KEY (serviceID, nodeID, jid(70))
+);
+
+CREATE TABLE ofPubsubItem (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  id                  VARCHAR(100)  NOT NULL,
+  jid                 VARCHAR(255)  NOT NULL,
+  creationDate        CHAR(15)      NOT NULL,
+  payload             MEDIUMTEXT    NULL,
+  PRIMARY KEY (serviceID, nodeID, id)
+);
+
+CREATE TABLE ofPubsubSubscription (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  id                  VARCHAR(100)  NOT NULL,
+  jid                 VARCHAR(255) NOT NULL,
+  owner               VARCHAR(255) NOT NULL,
+  state               VARCHAR(15)   NOT NULL,
+  deliver             TINYINT       NOT NULL,
+  digest              TINYINT       NOT NULL,
+  digest_frequency    INT           NOT NULL,
+  expire              CHAR(15)      NULL,
+  includeBody         TINYINT       NOT NULL,
+  showValues          VARCHAR(30)   NULL,
+  subscriptionType    VARCHAR(10)   NOT NULL,
+  subscriptionDepth   TINYINT       NOT NULL,
+  keyword             VARCHAR(200)  NULL,
+  PRIMARY KEY (serviceID, nodeID, id)
+);
+
+CREATE TABLE ofPubsubDefaultConf (
+  serviceID           VARCHAR(100)  NOT NULL,
+  leaf                TINYINT       NOT NULL,
+  deliverPayloads     TINYINT       NOT NULL,
+  maxPayloadSize      INTEGER       NOT NULL,
+  persistItems        TINYINT       NOT NULL,
+  maxItems            INTEGER       NOT NULL,
+  notifyConfigChanges TINYINT       NOT NULL,
+  notifyDelete        TINYINT       NOT NULL,
+  notifyRetract       TINYINT       NOT NULL,
+  presenceBased       TINYINT       NOT NULL,
+  sendItemSubscribe   TINYINT       NOT NULL,
+  publisherModel      VARCHAR(15)   NOT NULL,
+  subscriptionEnabled TINYINT       NOT NULL,
+  accessModel         VARCHAR(10)   NOT NULL,
+  language            VARCHAR(255)  NULL,
+  replyPolicy         VARCHAR(15)   NULL,
+  associationPolicy   VARCHAR(15)   NOT NULL,
+  maxLeafNodes        INTEGER       NOT NULL,
+  PRIMARY KEY (serviceID, leaf)
+);
+
+# Finally, insert default table values.
+
+INSERT INTO ofID (idType, id) VALUES (18, 1);
+INSERT INTO ofID (idType, id) VALUES (19, 1);
+INSERT INTO ofID (idType, id) VALUES (23, 1);
+INSERT INTO ofID (idType, id) VALUES (26, 2);
+INSERT INTO ofID (idType, id) VALUES (27, 1);
+
+# Entry for admin user
+INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modificationDate)
+    VALUES ('admin', 'admin', 'Administrator', 'admin@example.com', '0', '0');
+
+# Entry for default conference service
+INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
+
+# Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 38);

--- a/distribution/src/database/upgrade/1/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/1/openfire_mariadb.sql
@@ -1,0 +1,55 @@
+
+# jiveGroup: Recreate table from scratch
+DROP TABLE jiveGroup;
+CREATE TABLE jiveGroup (
+  groupName              VARCHAR(50)     NOT NULL,
+  description           VARCHAR(255),
+  PRIMARY KEY (groupName)
+);
+
+# jiveGroupProp: Recreate table from scratch
+DROP TABLE jiveGroupProp;
+CREATE TABLE jiveGroupProp (
+  groupName             VARCHAR(50)     NOT NULL,
+  name                  VARCHAR(100)    NOT NULL,
+  propValue             TEXT            NOT NULL,
+  PRIMARY KEY (groupName, name)
+);
+
+# jiveGroupUser: Recreate table from scratch
+DROP TABLE jiveGroupUser;
+CREATE TABLE jiveGroupUser (
+  groupName             VARCHAR(50)     NOT NULL,
+  username              VARCHAR(32)     NOT NULL,
+  administrator         TINYINT         NOT NULL,
+  PRIMARY KEY (groupName, username, administrator)
+);
+
+# mucRoom: Add new columns: "lockedDate" and "emptyDate". Rename column "invitationRequired" to "membersOnly". Delete columns: "lastActiveDate" and "inMemory".
+ALTER TABLE mucRoom ADD COLUMN lockedDate CHAR(15) NOT NULL AFTER description;
+ALTER TABLE mucRoom ADD COLUMN emptyDate CHAR(15) NULL AFTER lockedDate;
+ALTER TABLE mucRoom CHANGE invitationRequired membersOnly TINYINT NOT NULL;
+ALTER TABLE mucRoom DROP COLUMN lastActiveDate;
+ALTER TABLE mucRoom DROP COLUMN inMemory;
+
+
+# mucMember: Add new columns
+ALTER TABLE mucMember ADD COLUMN firstName VARCHAR(100) NULL;
+ALTER TABLE mucMember ADD COLUMN lastName  VARCHAR(100) NULL;
+ALTER TABLE mucMember ADD COLUMN url VARCHAR(100) NULL;
+ALTER TABLE mucMember ADD COLUMN email VARCHAR(100) NULL;
+ALTER TABLE mucMember ADD COLUMN faqentry VARCHAR(100) NULL;
+
+# mucConversationLog: Add new index
+ALTER TABLE mucConversationLog ADD INDEX mucLog_time_idx (time);
+
+# Deletes no longer needed entries
+DELETE FROM jiveID where idType = 3;
+DELETE FROM jiveID where idType = 4;
+
+# Add jiveVersion table
+CREATE TABLE jiveVersion (
+  majorVersion  INTEGER  NOT NULL,
+  minorVersion  INTEGER  NOT NULL
+);
+INSERT INTO jiveVersion (majorVersion, minorVersion) VALUES (2, 1);

--- a/distribution/src/database/upgrade/10/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/10/openfire_mariadb.sql
@@ -1,0 +1,8 @@
+
+CREATE TABLE jiveSASLAuthorized (
+  username            VARCHAR(64)   NOT NULL,
+  principal           TEXT          NOT NULL,
+  PRIMARY KEY (username, principal(200))
+);
+
+UPDATE jiveVersion set version=10 where name = 'openfire';

--- a/distribution/src/database/upgrade/11/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/11/openfire_mariadb.sql
@@ -1,0 +1,9 @@
+
+CREATE TABLE jivePresence (
+  username              VARCHAR(64)     NOT NULL,
+  offlinePresence       TEXT,
+  offlineDate           CHAR(15)     NOT NULL,
+  PRIMARY KEY (username)
+);
+
+UPDATE jiveVersion set version=11 where name = 'openfire';

--- a/distribution/src/database/upgrade/12/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/12/openfire_mariadb.sql
@@ -1,0 +1,4 @@
+
+ALTER TABLE mucConversationLog CHANGE time logTime CHAR(15) NOT NULL;
+
+UPDATE jiveVersion set version=12 where name = 'openfire';

--- a/distribution/src/database/upgrade/13/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/13/openfire_mariadb.sql
@@ -1,0 +1,16 @@
+
+ALTER TABLE pubsubItem CHANGE payload payload MEDIUMTEXT;
+
+ALTER TABLE jiveRemoteServerConf CHANGE domain xmppDomain VARCHAR(255) NOT NULL;
+
+ALTER TABLE jiveOffline CHANGE message stanza TEXT NOT NULL;
+
+ALTER TABLE jiveVCard CHANGE value vcard MEDIUMTEXT NOT NULL;
+
+ALTER TABLE jivePrivate CHANGE value privateData TEXT NOT NULL;
+
+ALTER TABLE jiveUser CHANGE password plainPassword VARCHAR(32);
+
+ALTER TABLE mucRoom CHANGE password roomPassword VARCHAR(50);
+
+UPDATE jiveVersion set version=13 where name = 'openfire';

--- a/distribution/src/database/upgrade/14/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/14/openfire_mariadb.sql
@@ -1,0 +1,7 @@
+# jiveRoster: Change jid column to varchar
+ALTER TABLE jiveRoster CHANGE COLUMN jid jid varchar(1024) not null;
+
+# jiveRoster: Add new index
+ALTER TABLE jiveRoster ADD INDEX jiveRoster_jid_idx (jid);
+
+UPDATE jiveVersion set version=14 where name = 'openfire';

--- a/distribution/src/database/upgrade/15/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/15/openfire_mariadb.sql
@@ -1,0 +1,12 @@
+# create jiveUserFlag table
+CREATE TABLE jiveUserFlag (
+  username              VARCHAR(64)     NOT NULL,
+  name                  VARCHAR(100)    NOT NULL,
+  startTime             CHAR(15),
+  endTime               CHAR(15),
+  PRIMARY KEY (username, name),
+  INDEX jiveUser_sTime_idx (startTime),
+  INDEX jiveUser_eTime_idx (endTime)
+);
+
+UPDATE jiveVersion set version=15 where name = 'openfire';

--- a/distribution/src/database/upgrade/16/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/16/openfire_mariadb.sql
@@ -1,0 +1,14 @@
+# create table jiveSecurityAuditLog
+CREATE TABLE jiveSecurityAuditLog (
+  msgID                 BIGINT          NOT NULL,
+  username              VARCHAR(64)     NOT NULL,
+  entryStamp            BIGINT          NOT NULL,
+  summary               VARCHAR(255)    NOT NULL,
+  node                  VARCHAR(255)    NOT NULL,
+  details               TEXT,
+  PRIMARY KEY (msgID),
+  INDEX jiveSecAuditLog_tstamp_idx (entryStamp),
+  INDEX jiveSecAuditLog_uname_idx (username)
+);
+
+UPDATE jiveVersion set version=16 where name = 'openfire';

--- a/distribution/src/database/upgrade/17/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/17/openfire_mariadb.sql
@@ -1,0 +1,116 @@
+# create table mucService
+CREATE TABLE mucService (
+  serviceID           BIGINT        NOT NULL,
+  subdomain           VARCHAR(255)  NOT NULL,
+  description         VARCHAR(255),
+  PRIMARY KEY (subdomain),
+  INDEX mucService_serviceid_idx (serviceID)
+);
+
+# create table mucServiceProp
+CREATE TABLE mucServiceProp (
+  serviceID           BIGINT        NOT NULL,
+  name                VARCHAR(100)  NOT NULL,
+  propValue           TEXT          NOT NULL,
+  PRIMARY KEY (serviceID, name)
+);
+
+# add new indexed column to mucRoom
+ALTER TABLE mucRoom ADD COLUMN serviceID BIGINT NOT NULL DEFAULT 1 FIRST;
+ALTER TABLE mucRoom ADD INDEX mucRoom_serviceid_idx (serviceID);
+
+# change mucRooms primary key to be referenced around serviceID
+ALTER TABLE mucRoom DROP PRIMARY KEY;
+ALTER TABLE mucRoom ADD PRIMARY KEY (serviceID,name);
+
+# add default entry for conference service and associated jiveID value
+INSERT INTO mucService (serviceID, subdomain) VALUES (1, 'conference');
+INSERT INTO jiveID (idType, id) VALUES (26, 1);
+
+# update conference name/desc if theres a custom one set
+UPDATE mucService SET mucService.subdomain = ( SELECT jiveProperty.propValue FROM jiveProperty WHERE jiveProperty.name = 'xmpp.muc.service' )
+  WHERE EXISTS ( SELECT jiveProperty.propValue FROM jiveProperty WHERE jiveProperty.name = 'xmpp.muc.service' );
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.service';
+
+UPDATE mucService SET mucService.description = ( SELECT jiveProperty.propValue FROM jiveProperty WHERE jiveProperty.name = 'muc.service-name' )
+  WHERE EXISTS ( SELECT jiveProperty.propValue FROM jiveProperty WHERE jiveProperty.name = 'muc.service-name' );
+DELETE FROM jiveProperty WHERE name = 'muc.service-name';
+
+# transfer all system properties to muc specific properties
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.canOccupantsChangeSubject',propValue FROM jiveProperty WHERE name = 'muc.room.canOccupantsChangeSubject';
+DELETE FROM jiveProperty WHERE name = 'muc.room.canOccupantsChangeSubject';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.maxUsers',propValue FROM jiveProperty WHERE name = 'muc.room.maxUsers';
+DELETE FROM jiveProperty WHERE name = 'muc.room.maxUsers';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.publicRoom',propValue FROM jiveProperty WHERE name = 'muc.room.publicRoom';
+DELETE FROM jiveProperty WHERE name = 'muc.room.publicRoom';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.persistent',propValue FROM jiveProperty WHERE name = 'muc.room.persistent';
+DELETE FROM jiveProperty WHERE name = 'muc.room.persistent';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.moderated',propValue FROM jiveProperty WHERE name = 'muc.room.moderated';
+DELETE FROM jiveProperty WHERE name = 'muc.room.moderated';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.membersOnly',propValue FROM jiveProperty WHERE name = 'muc.room.membersOnly';
+DELETE FROM jiveProperty WHERE name = 'muc.room.membersOnly';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.canOccupantsInvite',propValue FROM jiveProperty WHERE name = 'muc.room.canOccupantsInvite';
+DELETE FROM jiveProperty WHERE name = 'muc.room.canOccupantsInvite';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.canAnyoneDiscoverJID',propValue FROM jiveProperty WHERE name = 'muc.room.canAnyoneDiscoverJID';
+DELETE FROM jiveProperty WHERE name = 'muc.room.canAnyoneDiscoverJID';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.logEnabled',propValue FROM jiveProperty WHERE name = 'muc.room.logEnabled';
+DELETE FROM jiveProperty WHERE name = 'muc.room.logEnabled';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.loginRestrictedToNickname',propValue FROM jiveProperty WHERE name = 'muc.room.loginRestrictedToNickname';
+DELETE FROM jiveProperty WHERE name = 'muc.room.loginRestrictedToNickname';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.canChangeNickname',propValue FROM jiveProperty WHERE name = 'muc.room.canChangeNickname';
+DELETE FROM jiveProperty WHERE name = 'muc.room.canChangeNickname';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'room.registrationEnabled',propValue FROM jiveProperty WHERE name = 'muc.room.registrationEnabled';
+DELETE FROM jiveProperty WHERE name = 'muc.room.registrationEnabled';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'tasks.user.timeout',propValue FROM jiveProperty WHERE name = 'xmpp.muc.tasks.user.timeout';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.tasks.user.timeout';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'tasks.user.idle',propValue FROM jiveProperty WHERE name = 'xmpp.muc.tasks.user.idle';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.tasks.user.idle';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'tasks.log.timeout',propValue FROM jiveProperty WHERE name = 'xmpp.muc.tasks.log.timeout';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.tasks.log.timeout';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'tasks.log.batchsize',propValue FROM jiveProperty WHERE name = 'xmpp.muc.tasks.log.batchsize';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.tasks.log.batchsize';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'sysadmin.jid',propValue FROM jiveProperty WHERE name = 'xmpp.muc.sysadmin.jid';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.sysadmin.jid';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'discover.locked',propValue FROM jiveProperty WHERE name = 'xmpp.muc.discover.locked';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.discover.locked';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'create.anyone',propValue FROM jiveProperty WHERE name = 'xmpp.muc.create.anyone';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.create.anyone';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'create.jid',propValue FROM jiveProperty WHERE name = 'xmpp.muc.create.jid';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.create.jid';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'enabled',propValue FROM jiveProperty WHERE name = 'xmpp.muc.enabled';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.enabled';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'unload.empty_days',propValue FROM jiveProperty WHERE name = 'xmpp.muc.unload.empty_days';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.unload.empty_days';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'discover.locked',propValue FROM jiveProperty WHERE name = 'xmpp.muc.discover.locked';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.discover.locked';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'history.maxNumber',propValue FROM jiveProperty WHERE name = 'xmpp.muc.history.maxNumber';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.history.maxNumber';
+
+INSERT INTO mucServiceProp(serviceID,name,propValue) SELECT 1,'history.type',propValue FROM jiveProperty WHERE name = 'xmpp.muc.history.type';
+DELETE FROM jiveProperty WHERE name = 'xmpp.muc.history.type';
+
+
+UPDATE jiveVersion set version=17 where name = 'openfire';

--- a/distribution/src/database/upgrade/18/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/18/openfire_mariadb.sql
@@ -1,0 +1,5 @@
+# add isHidden column to mucService, with isHidden set to false by default
+ALTER TABLE mucService ADD COLUMN isHidden TINYINT NOT NULL DEFAULT 0;
+
+
+UPDATE jiveVersion set version=18 where name = 'openfire';

--- a/distribution/src/database/upgrade/19/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/19/openfire_mariadb.sql
@@ -1,0 +1,135 @@
+# Rename jiveUser to ofUser
+ALTER TABLE jiveUser DROP INDEX jiveUser_cDate_idx;
+RENAME TABLE jiveUser TO ofUser;
+ALTER TABLE ofUser ADD INDEX ofUser_cDate_idx (creationDate);
+
+# Rename jiveUserProp to ofUserProp
+RENAME TABLE jiveUserProp TO ofUserProp;
+
+# Rename jiveUserFlag to ofUserFlag
+ALTER TABLE jiveUserFlag DROP INDEX jiveUser_sTime_idx;
+ALTER TABLE jiveUserFlag DROP INDEX jiveUser_eTime_idx;
+RENAME TABLE jiveUserFlag TO ofUserFlag;
+ALTER TABLE ofUserFlag ADD INDEX ofUserFlag_sTime_idx (startTime);
+ALTER TABLE ofUserFlag ADD INDEX ofUserFlag_eTime_idx (endTime);
+
+# Rename jiveGroup to ofGroup
+RENAME TABLE jiveGroup TO ofGroup;
+
+# Rename jiveGroupProp to ofGroupProp
+RENAME TABLE jiveGroupProp TO ofGroupProp;
+
+# Rename jiveGroupUser to ofGroupUser
+RENAME TABLE jiveGroupUser TO ofGroupUser;
+
+# Rename jivePrivate to ofPrivate
+RENAME TABLE jivePrivate TO ofPrivate;
+
+# Rename jiveOffline to ofOffline
+RENAME TABLE jiveOffline TO ofOffline;
+
+# Rename jivePresence to ofPresence
+RENAME TABLE jivePresence TO ofPresence;
+
+# Make sure that the jid column of jiveRoster is a varchar instead of text
+ALTER TABLE jiveRoster CHANGE COLUMN jid jid VARCHAR(1024) NOT NULL;
+
+# Rename jiveRoster to ofRoster
+ALTER TABLE jiveRoster DROP INDEX jiveRoster_unameid_idx;
+ALTER TABLE jiveRoster DROP INDEX jiveRoster_jid_idx;
+RENAME TABLE jiveRoster TO ofRoster;
+ALTER TABLE ofRoster ADD INDEX ofRoster_unameid_idx (username);
+ALTER TABLE ofRoster ADD INDEX ofRoster_jid_idx (jid);
+
+# Rename jiveRosterGroups to ofRosterGroups
+ALTER TABLE jiveRosterGroups DROP INDEX jiveRosterGroup_rosterid_idx;
+RENAME TABLE jiveRosterGroups TO ofRosterGroups;
+ALTER TABLE ofRosterGroups ADD INDEX ofRosterGroup_rosterid_idx (rosterID);
+
+# Rename jiveVCard to ofVCard
+RENAME TABLE jiveVCard TO ofVCard;
+
+# Rename jiveID to ofID
+RENAME TABLE jiveID TO ofID;
+
+# Rename jiveProperty to ofProperty
+RENAME TABLE jiveProperty TO ofProperty;
+
+# Rename jiveVersion to ofVersion
+RENAME TABLE jiveVersion TO ofVersion;
+
+# Rename jiveExtComponentConf to ofExtComponentConf
+RENAME TABLE jiveExtComponentConf TO ofExtComponentConf;
+
+# Rename jiveRemoteServerConf to ofRemoteServerConf
+RENAME TABLE jiveRemoteServerConf TO ofRemoteServerConf;
+
+# Rename jivePrivacyList to ofPrivacyList
+ALTER TABLE jivePrivacyList DROP INDEX jivePList_default_idx;
+RENAME TABLE jivePrivacyList TO ofPrivacyList;
+ALTER TABLE ofPrivacyList ADD INDEX ofPrivacyList_default_idx (username, isDefault);
+
+# Rename jiveSASLAuthorized to ofSASLAuthorized
+RENAME TABLE jiveSASLAuthorized TO ofSASLAuthorized;
+
+# Rename jiveSecurityAuditLog to ofSecurityAuditLog
+ALTER TABLE jiveSecurityAuditLog DROP INDEX jiveSecAuditLog_tstamp_idx;
+ALTER TABLE jiveSecurityAuditLog DROP INDEX jiveSecAuditLog_uname_idx;
+RENAME TABLE jiveSecurityAuditLog TO ofSecurityAuditLog;
+ALTER TABLE ofSecurityAuditLog ADD INDEX ofSecurityAuditLog_tstamp_idx (entryStamp);
+ALTER TABLE ofSecurityAuditLog ADD INDEX ofSecurityAuditLog_uname_idx (username);
+
+# Rename mucService to ofMucService
+ALTER TABLE mucService DROP INDEX mucService_serviceid_idx;
+RENAME TABLE mucService TO ofMucService;
+ALTER TABLE ofMucService ADD INDEX ofMucService_serviceid_idx (serviceID);
+
+# Rename mucServiceProp to ofMucServiceProp
+RENAME TABLE mucServiceProp TO ofMucServiceProp;
+
+# Rename mucRoom to ofMucRoom
+ALTER TABLE mucRoom DROP INDEX mucRoom_roomid_idx;
+ALTER TABLE mucRoom DROP INDEX mucRoom_serviceid_idx;
+RENAME TABLE mucRoom TO ofMucRoom;
+ALTER TABLE ofMucRoom ADD INDEX ofMucRoom_roomid_idx (roomID);
+ALTER TABLE ofMucRoom ADD INDEX ofMucRoom_serviceid_idx (serviceID);
+
+# Rename mucRoomProp to ofMucRoomProp
+RENAME TABLE mucRoomProp TO ofMucRoomProp;
+
+# Rename mucAffiliation to ofMucAffiliation
+RENAME TABLE mucAffiliation TO ofMucAffiliation;
+
+# Rename mucMember to ofMucMember
+RENAME TABLE mucMember TO ofMucMember;
+
+# Rename mucConversationLog to ofMucConversationLog
+ALTER TABLE mucConversationLog DROP INDEX mucLog_time_idx;
+RENAME TABLE mucConversationLog TO ofMucConversationLog;
+ALTER TABLE ofMucConversationLog ADD INDEX ofMucConversationLog_time_idx (logTime);
+
+# Rename pubsubNode to ofPubsubNode
+RENAME TABLE pubsubNode TO ofPubsubNode;
+
+# Rename pubsubNodeJIDs to ofPubsubNodeJIDs
+RENAME TABLE pubsubNodeJIDs TO ofPubsubNodeJIDs;
+
+# Rename pubsubNodeGroups to ofPubsubNodeGroups
+ALTER TABLE pubsubNodeGroups DROP INDEX pubsubNodeGroups_idx;
+RENAME TABLE pubsubNodeGroups TO ofPubsubNodeGroups;
+ALTER TABLE ofPubsubNodeGroups ADD INDEX ofPubsubNodeGroups_idx (serviceID, nodeID);
+
+# Rename pubsubAffiliation to ofPubsubAffiliation
+RENAME TABLE pubsubAffiliation TO ofPubsubAffiliation;
+
+# Rename pubsubItem to ofPubsubItem
+RENAME TABLE pubsubItem TO ofPubsubItem;
+
+# Rename pubsubSubscription to ofPubsubSubscription
+RENAME TABLE pubsubSubscription TO ofPubsubSubscription;
+
+# Rename pubsubDefaultConf to ofPubsubDefaultConf
+RENAME TABLE pubsubDefaultConf TO ofPubsubDefaultConf;
+
+# Update version
+UPDATE ofVersion SET version = 19 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/2/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/2/openfire_mariadb.sql
@@ -1,0 +1,42 @@
+
+# Update jiveVersion to JM 2.2
+UPDATE jiveVersion SET majorVersion=2, minorVersion=2;
+
+# jiveExtComponentConf: Create new table
+CREATE TABLE jiveExtComponentConf (
+  subdomain             VARCHAR(255)    NOT NULL,
+  secret                VARCHAR(255),
+  permission            VARCHAR(10)     NOT NULL,
+  PRIMARY KEY (subdomain)
+);
+
+# jiveRemoteServerConf: Create new table
+CREATE TABLE jiveRemoteServerConf (
+  domain                VARCHAR(255)    NOT NULL,
+  remotePort            INTEGER,
+  permission            VARCHAR(10)     NOT NULL,
+  PRIMARY KEY (domain)
+);
+
+# mucRoomProp: Create new table
+CREATE TABLE mucRoomProp (
+  roomID                BIGINT          NOT NULL,
+  name                  VARCHAR(100)    NOT NULL,
+  propValue             TEXT            NOT NULL,
+  PRIMARY KEY (roomID, name)
+);
+
+# mucRoom: Add new columns: "useReservedNick", "canChangeNick" and "canRegister".
+ALTER TABLE mucRoom ADD COLUMN useReservedNick     TINYINT       NOT NULL;
+ALTER TABLE mucRoom ADD COLUMN canChangeNick       TINYINT       NOT NULL;
+ALTER TABLE mucRoom ADD COLUMN canRegister         TINYINT       NOT NULL;
+
+UPDATE mucRoom set useReservedNick=0, canChangeNick=1, canRegister=1;
+
+# jiveVCard: Recreate table from scratch
+DROP TABLE jiveVCard;
+CREATE TABLE jiveVCard (
+  username              VARCHAR(32)     NOT NULL,
+  value                 TEXT            NOT NULL,
+  PRIMARY KEY (username)
+);

--- a/distribution/src/database/upgrade/20/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/20/openfire_mariadb.sql
@@ -1,0 +1,5 @@
+# add wildcard column to ofExtComponentConf
+ALTER TABLE ofExtComponentConf ADD COLUMN wildcard TINYINT NOT NULL DEFAULT 0;
+
+# Update version
+UPDATE ofVersion SET version = 20 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/21/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/21/openfire_mariadb.sql
@@ -1,0 +1,3 @@
+# The database update has been implemented in org.jivesoftware.database.bugfix.OF33.java
+# Update version
+UPDATE ofVersion SET version = 21 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/22/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/22/openfire_mariadb.sql
@@ -1,0 +1,7 @@
+// add columns for SASL SCRAM-SHA-1
+ALTER TABLE ofUser ADD COLUMN storedKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN serverKey VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN salt VARCHAR(32);
+ALTER TABLE ofUser ADD COLUMN iterations INTEGER;
+
+UPDATE ofVersion SET version = 22 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/22/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/22/openfire_mariadb.sql
@@ -1,4 +1,4 @@
-// add columns for SASL SCRAM-SHA-1
+# add columns for SASL SCRAM-SHA-1
 ALTER TABLE ofUser ADD COLUMN storedKey VARCHAR(32);
 ALTER TABLE ofUser ADD COLUMN serverKey VARCHAR(32);
 ALTER TABLE ofUser ADD COLUMN salt VARCHAR(32);

--- a/distribution/src/database/upgrade/22/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/22/openfire_mysql.sql
@@ -1,4 +1,4 @@
-// add columns for SASL SCRAM-SHA-1
+# add columns for SASL SCRAM-SHA-1
 ALTER TABLE ofUser ADD COLUMN storedKey VARCHAR(32);
 ALTER TABLE ofUser ADD COLUMN serverKey VARCHAR(32);
 ALTER TABLE ofUser ADD COLUMN salt VARCHAR(32);

--- a/distribution/src/database/upgrade/23/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/23/openfire_mariadb.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ofMucRoom ADD COLUMN allowpm TINYINT NULL;
+UPDATE ofVersion SET version = 23 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/24/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/24/openfire_mariadb.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ofMucConversationLog ADD COLUMN stanza TEXT NULL;
+ALTER TABLE ofMucConversationLog ADD COLUMN messageID BIGINT NULL;
+UPDATE ofVersion SET version = 24 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/25/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/25/openfire_mariadb.sql
@@ -1,0 +1,7 @@
+
+set @exist := (select count(*) from information_schema.statistics where table_name = 'ofMucConversationLog' and index_name = 'ofMucConvLog_msg_id' and table_schema = database());
+set @sqlstmt := if( @exist > 0, 'select ''INFO: Index already exists.''', 'create index ofMucConvLog_msg_id on ofMucConversationLog (messageID)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+UPDATE ofVersion SET version = 25 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/26/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/26/openfire_mariadb.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ofProperty
+  ADD encrypted   INTEGER;
+
+UPDATE ofVersion SET version = 26 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/27/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/27/openfire_mariadb.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ofProperty
+  ADD iv   CHAR(24);
+
+UPDATE ofVersion SET version = 27 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/28/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/28/openfire_mariadb.sql
@@ -1,0 +1,3 @@
+# The database update has been implemented in org.jivesoftware.database.bugfix.OF1515.java
+# Update version
+UPDATE ofVersion SET version = 28 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/29/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/29/openfire_mariadb.sql
@@ -1,0 +1,5 @@
+# Only when the update in 28 succeeded, drop the table that was used as its source.
+DROP TABLE ofPrivate;
+
+# Update version
+UPDATE ofVersion SET version = 29 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/30/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/30/openfire_mariadb.sql
@@ -1,0 +1,3 @@
+INSERT INTO ofID (idType, id) VALUES (27, (SELECT coalesce(max(messageID), 1) FROM ofMucConversationLog) );
+
+UPDATE ofVersion SET version = 30 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/31/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/31/openfire_mariadb.sql
@@ -1,0 +1,13 @@
+# OF-2062: Allow for plenty of data to be stored.
+ALTER TABLE ofPubsubItem MODIFY payload LONGTEXT NULL;
+
+# OF-2061: Update the default configuration for leaf nodes of PEP services (those with a serviceID that contain the '@' symbol) to ensure that items are persisted.
+# provided that the maxPayloadSize still is at what Openfire used by default up to this point (5120).
+# OF-2062: Increase the maxPayloadSize in the default configuration for leaf nodes of PEP services (those with a serviceID that contain the '@' symbol,
+# which indicates that the serviceID matches a JID), provided that the maxPayloadSize still is at what Openfire used by default up to this point (5120).
+UPDATE ofPubsubDefaultConf SET persistItems = 1, maxPayloadSize = 10485760 WHERE serviceID LIKE '%@%' AND leaf = 1 AND maxPayloadSize = 5120;
+
+# OF-2061 & OF-262: Apply the same configuration change to all existing nodes that seem to use the default configuration.
+UPDATE ofPubsubNode SET persistItems = 1, maxPayloadSize = 10485760 WHERE serviceID LIKE '%@%' AND leaf = 1 AND maxPayloadSize = 5120;
+
+UPDATE ofVersion SET version = 31 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/32/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/32/openfire_mariadb.sql
@@ -1,0 +1,6 @@
+ALTER TABLE ofMucRoom ADD COLUMN fmucEnabled TINYINT NULL;
+ALTER TABLE ofMucRoom ADD COLUMN fmucOutboundNode VARCHAR(255) NULL;
+ALTER TABLE ofMucRoom ADD COLUMN fmucOutboundMode TINYINT NULL;
+ALTER TABLE ofMucRoom ADD COLUMN fmucInboundNodes VARCHAR(4000) NULL;
+
+UPDATE ofVersion SET version = 32 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/33/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/33/openfire_mariadb.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ofRoster ADD COLUMN stanza TEXT NULL;
+
+UPDATE ofVersion SET version = 33 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/34/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/34/openfire_mariadb.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ofMucConversationLog_roomtime_idx ON ofMucConversationLog (roomID, logTime);
+
+UPDATE ofVersion SET version = 34 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/35/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/35/openfire_mariadb.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ofMucRoom ADD COLUMN preserveHistOnDel TINYINT NOT NULL DEFAULT 1;
+
+UPDATE ofVersion SET version = 35 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/36/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/36/openfire_mariadb.sql
@@ -1,0 +1,12 @@
+ALTER TABLE ofMucRoom ADD COLUMN retireOnDeletion TINYINT NOT NULL DEFAULT 0;
+
+CREATE TABLE ofMucRoomRetiree (
+  serviceID           BIGINT        NOT NULL,
+  name                VARCHAR(50)   NOT NULL,
+  alternateJID        VARCHAR(2000),
+  reason              VARCHAR(1024),
+  retiredAt           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (serviceID,name)
+);
+
+UPDATE ofVersion SET version = 36 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/37/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/37/openfire_mariadb.sql
@@ -1,0 +1,3 @@
+DROP TABLE ofSASLAuthorized;
+
+UPDATE ofVersion SET version = 37 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/38/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/38/openfire_mariadb.sql
@@ -1,0 +1,28 @@
+-- This copies the subject-defining stanza as stored in the message archive into the room's table, replacing any text
+-- based (non-stanza) subject that was stored there.
+-- In rare occasions (see OF-3131) the room can have a subject, while the history does not. In those cases, this script
+-- leaves the (non-stanza) subject in the ofMucRoom table intact (this means that the column holds a mixture of plain
+-- text and XMPP data).
+-- Note that the stanzas in ofMucConversationLog typically do not contain a timestamp (although one is provided in a
+-- separate column). If the subject that gets migrated to ofMucRoom is used as-is, the time of subject change is likely
+-- lost (until the room's subject gets changed). This is deemed an acceptable loss.
+ALTER TABLE ofMucRoom MODIFY subject TEXT NULL;
+
+UPDATE ofMucRoom r
+JOIN (
+    SELECT l.roomID, l.stanza
+    FROM ofMucConversationLog l
+    JOIN (
+        SELECT roomID, MAX(logTime) AS maxTime
+        FROM ofMucConversationLog
+        WHERE subject IS NOT NULL
+        GROUP BY roomID
+    ) latest
+    ON l.roomID = latest.roomID
+    AND l.logTime = latest.maxTime
+) c
+ON r.roomID = c.roomID
+SET r.subject = c.stanza
+WHERE c.stanza IS NOT NULL;
+
+UPDATE ofVersion SET version = 38 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/4/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/4/openfire_mariadb.sql
@@ -1,0 +1,6 @@
+
+# Update jiveVersion to JM 2.4
+UPDATE jiveVersion SET majorVersion=2, minorVersion=4;
+
+# jiveGroupUser: Alter length of username column
+ALTER TABLE jiveGroupUser CHANGE username username varchar(100) NOT NULL;

--- a/distribution/src/database/upgrade/5/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/5/openfire_mariadb.sql
@@ -1,0 +1,13 @@
+
+# Update jiveVersion to Openfire 2.5
+UPDATE jiveVersion SET majorVersion=2, minorVersion=5;
+
+# jivePrivacyList: Create new table
+CREATE TABLE jivePrivacyList (
+  username              VARCHAR(32)     NOT NULL,
+  name                  VARCHAR(100)    NOT NULL,
+  isDefault             TINYINT         NOT NULL,
+  list                  TEXT            NOT NULL,
+  PRIMARY KEY (username, name),
+  INDEX jivePList_default_idx (username, isDefault)
+);

--- a/distribution/src/database/upgrade/6/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/6/openfire_mariadb.sql
@@ -1,0 +1,13 @@
+
+# Update the jiveVersion table to new definition.
+DROP TABLE jiveVersion;
+CREATE TABLE jiveVersion (
+  name     VARCHAR(50)  NOT NULL,
+  version  INTEGER  NOT NULL,
+  PRIMARY KEY (name)
+);
+INSERT INTO jiveVersion (name, version) VALUES ('openfire', 6);
+
+# Make password column accept null, add encrypted password column.
+ALTER TABLE jiveUser MODIFY password VARCHAR(32) NULL;
+ALTER TABLE jiveUser ADD COLUMN encryptedPassword VARCHAR(255) NULL AFTER password;

--- a/distribution/src/database/upgrade/7/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/7/openfire_mariadb.sql
@@ -1,0 +1,101 @@
+
+# Create PubSub Tables
+
+CREATE TABLE pubsubNode (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  leaf                TINYINT       NOT NULL,
+  creationDate        CHAR(15)      NOT NULL,
+  modificationDate    CHAR(15)      NOT NULL,
+  parent              VARCHAR(100)  NULL,
+  deliverPayloads     TINYINT       NOT NULL,
+  maxPayloadSize      INTEGER       NULL,
+  persistItems        TINYINT       NULL,
+  maxItems            INTEGER       NULL,
+  notifyConfigChanges TINYINT       NOT NULL,
+  notifyDelete        TINYINT       NOT NULL,
+  notifyRetract       TINYINT       NOT NULL,
+  presenceBased       TINYINT       NOT NULL,
+  sendItemSubscribe   TINYINT       NOT NULL,
+  publisherModel      VARCHAR(15)   NOT NULL,
+  subscriptionEnabled TINYINT       NOT NULL,
+  configSubscription  TINYINT       NOT NULL,
+  contacts            VARCHAR(4000) NULL,
+  rosterGroups        VARCHAR(4000) NULL,
+  accessModel         VARCHAR(10)   NOT NULL,
+  payloadType         VARCHAR(100)  NULL,
+  bodyXSLT            VARCHAR(100)  NULL,
+  dataformXSLT        VARCHAR(100)  NULL,
+  creator             VARCHAR(1024) NOT NULL,
+  description         VARCHAR(255)  NULL,
+  language            VARCHAR(255)  NULL,
+  name                VARCHAR(50)   NULL,
+  replyPolicy         VARCHAR(15)   NULL,
+  replyRooms          VARCHAR(4000) NULL,
+  replyTo             VARCHAR(1024) NULL,
+  associationPolicy   VARCHAR(15)   NULL,
+  associationTrusted  VARCHAR(4000) NULL,
+  maxLeafNodes        INTEGER       NULL,
+  PRIMARY KEY (serviceID, nodeID)
+);
+
+CREATE TABLE pubsubAffiliation (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  jid                 VARCHAR(1024) NOT NULL,
+  affiliation         VARCHAR(10)   NOT NULL,
+  PRIMARY KEY (serviceID, nodeID, jid(70))
+);
+
+CREATE TABLE pubsubItem (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  id                  VARCHAR(100)  NOT NULL,
+  jid                 VARCHAR(1024) NOT NULL,
+  creationDate        CHAR(15)      NOT NULL,
+  payload             TEXT          NULL,
+  PRIMARY KEY (serviceID, nodeID, id)
+);
+
+CREATE TABLE pubsubSubscription (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  id                  VARCHAR(100)  NOT NULL,
+  jid                 VARCHAR(1024) NOT NULL,
+  owner               VARCHAR(1024) NOT NULL,
+  state               VARCHAR(15)   NOT NULL,
+  deliver             TINYINT       NOT NULL,
+  digest              TINYINT       NOT NULL,
+  digest_frequency    TINYINT       NOT NULL,
+  expire              CHAR(15)      NULL,
+  includeBody         TINYINT       NOT NULL,
+  showValues          VARCHAR(30)   NOT NULL,
+  subscriptionType    VARCHAR(10)   NOT NULL,
+  subscriptionDepth   TINYINT       NOT NULL,
+  keyword             VARCHAR(200)  NULL,
+  PRIMARY KEY (serviceID, nodeID, id)
+);
+
+CREATE TABLE pubsubDefaultConf (
+  serviceID           VARCHAR(100)  NOT NULL,
+  leaf                TINYINT       NOT NULL,
+  deliverPayloads     TINYINT       NOT NULL,
+  maxPayloadSize      INTEGER       NOT NULL,
+  persistItems        TINYINT       NOT NULL,
+  maxItems            INTEGER       NOT NULL,
+  notifyConfigChanges TINYINT       NOT NULL,
+  notifyDelete        TINYINT       NOT NULL,
+  notifyRetract       TINYINT       NOT NULL,
+  presenceBased       TINYINT       NOT NULL,
+  sendItemSubscribe   TINYINT       NOT NULL,
+  publisherModel      VARCHAR(15)   NOT NULL,
+  subscriptionEnabled TINYINT       NOT NULL,
+  accessModel         VARCHAR(10)   NOT NULL,
+  language            VARCHAR(255)  NULL,
+  replyPolicy         VARCHAR(15)   NULL,
+  associationPolicy   VARCHAR(15)   NOT NULL,
+  maxLeafNodes        INTEGER       NOT NULL,
+  PRIMARY KEY (serviceID, leaf)
+);
+
+UPDATE jiveVersion set version=7 where name = 'openfire';

--- a/distribution/src/database/upgrade/8/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/8/openfire_mariadb.sql
@@ -1,0 +1,25 @@
+
+# Drop old columns of pubSubNode
+ALTER TABLE pubsubNode DROP COLUMN contacts;
+ALTER TABLE pubsubNode DROP COLUMN rosterGroups;
+ALTER TABLE pubsubNode DROP COLUMN replyRooms;
+ALTER TABLE pubsubNode DROP COLUMN replyTo;
+ALTER TABLE pubsubNode DROP COLUMN associationTrusted;
+
+# Add new pubsub tables
+CREATE TABLE pubsubNodeJIDs (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  jid                 VARCHAR(255)  NOT NULL,
+  associationType     VARCHAR(20)   NOT NULL,
+  PRIMARY KEY (serviceID, nodeID, jid(70))
+);
+
+CREATE TABLE pubsubNodeGroups (
+  serviceID           VARCHAR(100)  NOT NULL,
+  nodeID              VARCHAR(100)  NOT NULL,
+  rosterGroup         VARCHAR(100)   NOT NULL,
+  INDEX pubsubNodeGroups_idx (serviceID, nodeID)
+);
+
+UPDATE jiveVersion set version=8 where name = 'openfire';

--- a/distribution/src/database/upgrade/9/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/9/openfire_mariadb.sql
@@ -1,0 +1,18 @@
+
+# Increase size of username field
+ALTER TABLE jiveUser MODIFY username VARCHAR(64);
+ALTER TABLE jiveUserProp MODIFY username VARCHAR(64);
+
+ALTER TABLE jivePrivate DROP PRIMARY KEY;
+ALTER TABLE jivePrivate MODIFY username VARCHAR(64);
+ALTER TABLE jivePrivate ADD PRIMARY KEY (username, name, namespace(100));
+
+ALTER TABLE jiveOffline MODIFY username VARCHAR(64);
+ALTER TABLE jiveRoster MODIFY username VARCHAR(64);
+ALTER TABLE jiveVCard MODIFY username VARCHAR(64);
+ALTER TABLE jivePrivacyList MODIFY username VARCHAR(64);
+
+# Increase size of column digest_frequency in pubsubSubscription
+ALTER TABLE pubsubSubscription MODIFY digest_frequency INT NOT NULL;
+
+UPDATE jiveVersion set version=9 where name = 'openfire';

--- a/documentation/database.html
+++ b/documentation/database.html
@@ -27,7 +27,7 @@
         </p>
         <p>
             JDBC drivers are required for Openfire to communicate with your database. Suggested drivers for particular
-            databases are noted below where applicable. Openfire bundles JDBC drivers for MySQL, Oracle, PostgreSQL,
+            databases are noted below where applicable. Openfire bundles JDBC drivers for MySQL, MariaDB, Oracle, PostgreSQL,
             Microsoft SQL Server, Firebird, and HSQLDB.
         </p>
         <p>
@@ -45,6 +45,7 @@
         <nav>
             <ul>
                 <li><a href="#mysql">MySQL</a></li>
+                <li><a href="#mariadb">MariaDB</a></li>
                 <li><a href="#oracle">Oracle</a></li>
                 <li><a href="#sqlserver">Microsoft SQL Server</a></li>
                 <li><a href="#postgres">PostgreSQL</a></li>
@@ -123,7 +124,7 @@
                 the URL of the JDBC driver:
             </p>
             <ul style="list-style: none">
-                <li><code>?useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8</code></li>
+                <li><code>?useUnicode=true&amp;characterEncoding=UTF-8&amp;characterSetResults=UTF-8</code></li>
             </ul>
             <p>
                 You can edit the conf/openfire.xml file to add this value.
@@ -145,6 +146,100 @@
             </p>
             <ul>
                 <li><a href="https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html">MySQL Connector/J Configuration Properties </a></li>
+            </ul>
+
+        </section>
+
+    </section>
+
+    <section id="mariadb">
+
+        <h2>MariaDB</h2>
+
+        <section id="mariadb-jdbc-drivers">
+
+            <h3>JDBC Drivers</h3>
+
+            <p>
+                The JDBC driver for MariaDB is bundled with Openfire, so you do not need to download and install a separate driver.
+            </p>
+            <p>
+                In the Openfire setup tool, use the following values:
+            </p>
+            <ul style="list-style: none">
+                <li><span class="short-tab">driver:</span> <code>org.mariadb.jdbc.Driver</code></li>
+                <li><span class="short-tab">server:</span> <code>jdbc:mariadb://HOSTNAME/DATABASENAME</code></li>
+            </ul>
+            <p>
+                where HOSTNAME and DATABASENAME are the actual values for your server. In many cases
+                <code>localhost</code> is a suitable value for HOSTNAME when your database is running on the same
+                server as your webserver.
+            </p>
+
+        </section>
+
+        <section id="mariadb-setup-instructions">
+
+            <h3>Setup Instructions</h3>
+
+            <ol>
+                <li>
+                    Make sure that you are using a recent and supported MariaDB version.
+                </li>
+                <li>
+                    Create a database for the Openfire tables:
+
+                    <ul style="list-style: none">
+                        <li><code>mariadb-admin create DATABASENAME</code></li>
+                    </ul>
+
+                    (note: "DATABASENAME" can be something like 'openfire')
+                </li>
+
+                <li>
+                    Import the schema file from the <code>resources/database</code> directory of the installation folder:
+
+                    <ul style="list-style: none">
+                        <li>Unix/Linux: <code>cat openfire_mariadb.sql | mariadb DATABASENAME;</code></li>
+                        <li>Windows: <code>type openfire_mariadb.sql | mariadb DATABASENAME</code></li>
+                    </ul>
+                </li>
+
+                <li>Start the Openfire setup tool, and use the appropriate JDBC connection settings.</li>
+            </ol>
+
+        </section>
+
+        <section id="mariadb-character-encoding-issues">
+
+            <h3>Character Encoding Issues</h3>
+
+            <p>
+                To ensure proper Unicode support, enable character encoding by adding the following to the JDBC URL:
+            </p>
+            <ul style="list-style: none">
+                <li><code>?useUnicode=true&amp;characterEncoding=UTF-8&amp;characterSetResults=UTF-8</code></li>
+            </ul>
+            <p>
+                You can edit the conf/openfire.xml file to add this value.
+            </p>
+            <p>
+                Note: If the mechanism you use to configure a JDBC URL is XML-based, you will need to use the XML
+                character literal <code>&amp;amp;</code> to separate configuration parameters, as the ampersand is a
+                reserved character for XML.
+            </p>
+
+        </section>
+
+        <section id="mariadb-further-help">
+
+            <h3>Further Help</h3>
+
+            <p>
+                If you need help setting up MariaDB, refer to the following site:
+            </p>
+            <ul>
+                <li><a href="https://mariadb.com/kb/en/about-mariadb-connector-j/">MariaDB Connector/J documentation</a></li>
             </ul>
 
         </section>

--- a/documentation/database.html
+++ b/documentation/database.html
@@ -215,18 +215,8 @@
             <h3>Character Encoding Issues</h3>
 
             <p>
-                To ensure proper Unicode support, enable character encoding by adding the following to the JDBC URL:
-            </p>
-            <ul style="list-style: none">
-                <li><code>?useUnicode=true&amp;characterEncoding=UTF-8&amp;characterSetResults=UTF-8</code></li>
-            </ul>
-            <p>
-                You can edit the conf/openfire.xml file to add this value.
-            </p>
-            <p>
-                Note: If the mechanism you use to configure a JDBC URL is XML-based, you will need to use the XML
-                character literal <code>&amp;amp;</code> to separate configuration parameters, as the ampersand is a
-                reserved character for XML.
+                MariaDB Connector/J uses Unicode-capable defaults. If you need to override collation or other
+                connection properties, refer to the MariaDB Connector/J documentation for the supported URL options.
             </p>
 
         </section>

--- a/documentation/db-clustering-guide.html
+++ b/documentation/db-clustering-guide.html
@@ -156,6 +156,7 @@
         </p>
         <dl>
             <dt>MySQL</dt><dd><code>jdbc:mysql://HOSTNAME:3306/DATABASENAME</code></dd>
+            <dt>MariaDB</dt><dd><code>jdbc:mariadb://HOSTNAME:3306/DATABASENAME</code></dd>
             <dt>Microsoft SQL Server</dt><dd><code>jdbc:sqlserver://HOSTNAME:1433;databaseName=DATABASENAME;applicationName=Openfire</code></dd>
             <dt>PostgreSQL</dt><dd><code>jdbc:postgresql://HOSTNAME:5432/DATABASENAME</code></dd>
         </dl>
@@ -173,6 +174,7 @@
         </p>
         <dl>
             <dt>MySQL</dt><dd><code>jdbc:mysql://PRIMARYHOSTNAME:3306,SECONDARYHOST:3306/DATABASENAME?failOverReadOnly=false</code></dd>
+            <dt>MariaDB</dt><dd><code>jdbc:mariadb://PRIMARYHOSTNAME:3306,SECONDARYHOST:3306/DATABASENAME</code></dd>
             <dt>Microsoft SQL Server</dt><dd><code>jdbc:sqlserver://HOSTNAME:1433;databaseName=DATABASENAME;applicationName=Openfire;multiSubnetFailover=true</code></dd>
             <dt>PostgreSQL</dt><dd><code>jdbc:postgresql://PRIMARYHOSTNAME:5432,SECONDARYHOSTNAME:5432/DATABASENAME?targetServerType=primary</code></dd>
         </dl>
@@ -183,6 +185,7 @@
 
             <ul>
                 <li><a href="https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-multi-host-connections.html">MySQL Connector/J 8.0 Developer Guide: Multi-Host Connections</a></li>
+                <li><a href="https://mariadb.com/kb/en/failover-and-high-availability-with-mariadb-connector-j/">MariaDB Connector/J: Failover and High Availability</a></li>
                 <li><a href="https://learn.microsoft.com/en-us/sql/connect/jdbc/jdbc-driver-support-for-high-availability-disaster-recovery?view=sql-server-ver16">Microsoft SQL Server: JDBC driver support for High Availability, disaster recovery</a></li>
                 <li><a href="https://jdbc.postgresql.org/documentation/use/#connection-fail-over">PostgreSQL JDBC: Connection failover</a></li>
             </ul>

--- a/documentation/db-clustering-guide.html
+++ b/documentation/db-clustering-guide.html
@@ -174,7 +174,7 @@
         </p>
         <dl>
             <dt>MySQL</dt><dd><code>jdbc:mysql://PRIMARYHOSTNAME:3306,SECONDARYHOST:3306/DATABASENAME?failOverReadOnly=false</code></dd>
-            <dt>MariaDB</dt><dd><code>jdbc:mariadb://PRIMARYHOSTNAME:3306,SECONDARYHOST:3306/DATABASENAME</code></dd>
+            <dt>MariaDB</dt><dd><code>jdbc:mariadb:replication://PRIMARYHOSTNAME:3306,SECONDARYHOST:3306/DATABASENAME</code></dd>
             <dt>Microsoft SQL Server</dt><dd><code>jdbc:sqlserver://HOSTNAME:1433;databaseName=DATABASENAME;applicationName=Openfire;multiSubnetFailover=true</code></dd>
             <dt>PostgreSQL</dt><dd><code>jdbc:postgresql://PRIMARYHOSTNAME:5432,SECONDARYHOSTNAME:5432/DATABASENAME?targetServerType=primary</code></dd>
         </dl>

--- a/documentation/migration-blowfish-pbkdf2.html
+++ b/documentation/migration-blowfish-pbkdf2.html
@@ -173,6 +173,7 @@
                     <ul>
                         <li>PostgreSQL: <code>pg_dump openfire &gt; openfire_backup.sql</code></li>
                         <li>MySQL: <code>mysqldump openfire &gt; openfire_backup.sql</code></li>
+                        <li>MariaDB: <code>mariadb-dump openfire &gt; openfire_backup.sql</code></li>
                         <li>Embedded HSQLDB: <code>cp -r embedded-db/ embedded-db.backup/</code></li>
                     </ul>
                     <p>
@@ -293,6 +294,7 @@ cp /opt/openfire/conf/openfire.xml /opt/openfire/conf/openfire.xml.backup</pre>
                     <ul>
                         <li>PostgreSQL: <code>psql openfire &lt; openfire_backup.sql</code></li>
                         <li>MySQL: <code>mysql openfire &lt; openfire_backup.sql</code></li>
+                        <li>MariaDB: <code>mariadb openfire &lt; openfire_backup.sql</code></li>
                         <li>Embedded HSQLDB: <code>rm -rf embedded-db/ && cp -r embedded-db.backup/ embedded-db/</code></li>
                     </ul>
                 </li>
@@ -431,6 +433,7 @@ systemctl stop openfire  # On Node 3
                     <ul>
                         <li>PostgreSQL: <code>pg_dump openfire &gt; openfire_backup.sql</code></li>
                         <li>MySQL: <code>mysqldump openfire &gt; openfire_backup.sql</code></li>
+                        <li>MariaDB: <code>mariadb-dump openfire &gt; openfire_backup.sql</code></li>
                     </ul>
 
                     <p>Backup <code>security.xml</code> and <code>openfire.xml</code> on all nodes:</p>
@@ -680,6 +683,7 @@ systemctl start openfire  # On Node 3
                     <ul>
                         <li>PostgreSQL: <code>psql openfire &lt; openfire_backup.sql</code></li>
                         <li>MySQL: <code>mysql openfire &lt; openfire_backup.sql</code></li>
+                        <li>MariaDB: <code>mariadb openfire &lt; openfire_backup.sql</code></li>
                     </ul>
                 </li>
 

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -468,6 +468,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>3.5.8</version>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.11</version>

--- a/xmppserver/src/main/java/org/jivesoftware/database/DbConnectionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/DbConnectionManager.java
@@ -918,8 +918,13 @@ public class DbConnectionManager {
             databaseType = DatabaseType.sqlserver;
         }
 
-        // MySQL / MariaDB
-        else if (dbName.contains("mysql") || dbName.contains("maria")) {
+        // MariaDB properties (must be checked before MySQL, as MariaDB reports its product name as "MariaDB")
+        else if (dbName.contains("maria")) {
+            databaseType = DatabaseType.mariadb;
+        }
+
+        // MySQLproperties
+        else if (dbName.contains("mysql")) {
             databaseType = DatabaseType.mysql;
         }
 
@@ -1207,6 +1212,8 @@ public class DbConnectionManager {
         postgresql,
 
         mysql("rank"),
+
+        mariadb("rank"),
 
         hsqldb,
 


### PR DESCRIPTION
MariaDB was previously handled implicitly by mapping it to DatabaseType.mysql in DbConnectionManager.setMetaData() and sharing all MySQL SQL scripts. This commit gives MariaDB its own identity throughout the codebase.

This adds a copy of the Mysql install and upgrade script under the 'mariadb' name, ensuring that any existing MariaDB installation that was previously running under the Mysql type can continue to upgrade through any path.

Introduces two new CI jobs (mariadb-install and mariadb-upgrade) that mirror the structure of the existing mysql-install and mysql-upgrade jobs, giving MariaDB the same level of automated testing as other supported databases.

Update documentation to reflect MariaDB as a first-class database.