### PR TITLE
OF-3236: Fix malformed link markup in upgrade guide.

### DIFF
--- a/documentation/upgrade-guide.html
+++ b/documentation/upgrade-guide.html
@@ -91,7 +91,7 @@
                     <li><code>/etc/sysconfig/openfire</code> can now be used to 'tweak' things, like paths and such. See the file for more information.</li>
                     <li>The entire directory tree is owned by daemon now. We ditched the need for a new user and are sticking with a standard unix system account. The RPM will take care of owning everything as you install it.</li>
                     <li>Beyond having <code>/etc/init.d/openfire</code> to stop and start openfire, it has chkconfig compatible tags in it and is automatically added via the rpm so that openfire should start up as your server starts up.</li>
-                    <li>The <code>/etc/init.d/openfire</code> should not be used directly but called with a SystemD wrapper via <code>systemctl</code> command. The init script is diffuclt to maintain and eventually it will be replaced with the SystemD unit. See the <a hre="https://igniterealtime.atlassian.net/browse/OF-3070">issue ticket</a> for details</li>
+                    <li>The <code>/etc/init.d/openfire</code> should not be used directly but called with a SystemD wrapper via <code>systemctl</code> command. The init script is difficult to maintain and eventually it will be replaced with the SystemD unit. See the <a href="https://igniterealtime.atlassian.net/browse/OF-3070">issue ticket</a> for details</li>
                     <li>The RPM will no longer overwrite: <code>conf/openfire.xml</code>, <code>resources/security/keystore</code> or <code>resources/security/truststore</code>.</li>
                 </ul>
 


### PR DESCRIPTION
## Summary
Fixes a malformed anchor tag and minor typos in the upgrade guide documentation.

## Changes
- Replaced incorrect `hre` attribute with `href` in `documentation/upgrade-guide.html`, making the issue ticket link clickable.
- Corrected spelling errors (e.g., "diffuclt" → "difficult") in the "Things to note" section.
