### PR TITLE
OF-3252 & OF-3253: Upgrade various libraries

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1509,6 +1509,21 @@ system_property.ssl.certificates.expirycheck.notify-admins=Determines if the adm
 system_property.ssl.certificates.expirycheck.frequency=How often to check for (nearly) expired TLS certificates.
 system_property.ssl.certificates.expirycheck.warning-period=How long (in hours) before a TLS certificate will expire for a warning is to be sent out to admins.
 
+system_property.sms.smpp.connections.maxAmount=The maximum amount of SMPP connections that the SMS Service will maintain.
+system_property.sms.smpp.connections.idleMillis=Time after which idle MPPP connections used by the SMS Service are allowed to be evicted.
+system_property.sms.smpp.source.ton=The type-of-number value for the source of SMS messages.
+system_property.sms.smpp.source.npi=The number-plan-indicator value for the source of SMS messages.
+system_property.sms.smpp.source.address=The source address of SMS messages.
+system_property.sms.smpp.destination.ton=The type-of-number value for the destination of SMS messages.
+system_property.sms.smpp.destination.npi=The number-plan-indicator value for the destination of SMS messages.
+system_property.sms.smpp.host=The host name of your SMPP Server or SMSC, i.e. smsc.example.org.
+system_property.sms.smpp.port=The port on which the SMSC is listening.
+system_property.sms.smpp.systemId=The 'user name' to use when connecting to the SMSC.
+system_property.sms.smpp.password=The password that authenticates the systemId value when connecting to the SMSC.
+system_property.sms.smpp.systemType=An optional system type, which, if defined, will be used when connecting to the SMSC.
+system_property.sms.smpp.receive.ton=The type-of-number value for 'receiving' SMS messages.
+system_property.sms.smpp.receive.npi=The number-plan-indicator value for 'receiving' SMS messages.
+
 # Server properties Page
 
 server.properties.title=System Properties

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1510,7 +1510,7 @@ system_property.ssl.certificates.expirycheck.frequency=How often to check for (n
 system_property.ssl.certificates.expirycheck.warning-period=How long (in hours) before a TLS certificate will expire for a warning is to be sent out to admins.
 
 system_property.sms.smpp.connections.maxAmount=The maximum amount of SMPP connections that the SMS Service will maintain.
-system_property.sms.smpp.connections.idleMillis=Time after which idle MPPP connections used by the SMS Service are allowed to be evicted.
+system_property.sms.smpp.connections.idleMillis=Time after which idle SMPP connections used by the SMS Service are allowed to be evicted.
 system_property.sms.smpp.source.ton=The type-of-number value for the source of SMS messages.
 system_property.sms.smpp.source.npi=The number-plan-indicator value for the source of SMS messages.
 system_property.sms.smpp.source.address=The source address of SMS messages.

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1411,6 +1411,21 @@ system_property.ssl.certificates.expirycheck.notify-admins=Bepaalt of de beheerd
 system_property.ssl.certificates.expirycheck.frequency=Hoe vaak controleren op (bijna) verlopen TLS-certificaten.
 system_property.ssl.certificates.expirycheck.warning-period=Hoe lang (in uren) voordat een TLS-certificaat verloopt voor een waarschuwing naar beheerders wordt gestuurd.
 
+system_property.sms.smpp.connections.maxAmount=Het maximale aantal SMPP-verbindingen dat de SMS-service onderhoudt.
+system_property.sms.smpp.connections.idleMillis=Tijd waarna inactieve SMPP-verbindingen die door de SMS-service worden gebruikt, mogen worden verwijderd.
+system_property.sms.smpp.source.ton=De type-of-number-waarde voor de bron van SMS-berichten.
+system_property.sms.smpp.source.npi=De number-plan-indicator-waarde voor de bron van SMS-berichten.
+system_property.sms.smpp.source.address=Het bronadres van SMS-berichten.
+system_property.sms.smpp.destination.ton=De type-of-number-waarde voor de bestemming van SMS-berichten.
+system_property.sms.smpp.destination.npi=De number-plan-indicator-waarde voor de bestemming van SMS-berichten.
+system_property.sms.smpp.host=De hostnaam van uw SMPP-server of SMSC, bijv. smsc.example.org.
+system_property.sms.smpp.port=De poort waarop de SMSC luistert.
+system_property.sms.smpp.systemId=De 'gebruikersnaam' die wordt gebruikt bij het verbinden met de SMSC.
+system_property.sms.smpp.password=Het wachtwoord dat de systemId-waarde verifieert bij het verbinden met de SMSC.
+system_property.sms.smpp.systemType=Een optioneel systeemtype dat, indien opgegeven, wordt gebruikt bij het verbinden met de SMSC.
+system_property.sms.smpp.receive.ton=De type-of-number-waarde voor het 'ontvangen' van SMS-berichten.
+system_property.sms.smpp.receive.npi=De number-plan-indicator-waarde voor het 'ontvangen' van SMS-berichten.
+
 # Server properties Page
 
 server.properties.title=Systeemeigenschappen

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -408,7 +408,7 @@
         <dependency>
             <groupId>org.jsmpp</groupId>
             <artifactId>jsmpp</artifactId>
-            <version>2.3.10</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>opensymphony</groupId>

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -367,7 +367,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.9.0</version>
+            <version>2.14.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -378,7 +378,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
-            <version>2.9.0</version>
+            <version>2.13.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/DefaultConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,8 +103,8 @@ public class DefaultConnectionProvider implements ConnectionProvider {
         final ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(serverURL, username, password);
         final PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, null);
         poolableConnectionFactory.setValidationQuery(testSQL);
-        poolableConnectionFactory.setValidationQueryTimeout((int)testTimeout.toSeconds());
-        poolableConnectionFactory.setMaxConnLifetimeMillis(connectionTimeout.toMillis());
+        poolableConnectionFactory.setValidationQueryTimeout(testTimeout);
+        poolableConnectionFactory.setMaxConn(connectionTimeout);
 
         final GenericObjectPoolConfig<PoolableConnection> poolConfig = new GenericObjectPoolConfig<>();
         poolConfig.setTestOnBorrow(testBeforeUse);
@@ -115,9 +115,9 @@ public class DefaultConnectionProvider implements ConnectionProvider {
             poolConfig.setMaxIdle(minConnections);
         }
         poolConfig.setMaxTotal(maxConnections);
-        poolConfig.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRuns.toMillis());
-        poolConfig.setSoftMinEvictableIdleTimeMillis(minIdleTime.toMillis());
-        poolConfig.setMaxWaitMillis(maxWaitTime.toMillis());
+        poolConfig.setTimeBetweenEvictionRuns(timeBetweenEvictionRuns);
+        poolConfig.setSoftMinEvictableIdleDuration(minIdleTime);
+        poolConfig.setMaxWait(maxWaitTime);
         connectionPool = new GenericObjectPool<>(poolableConnectionFactory, poolConfig);
         poolableConnectionFactory.setPool(connectionPool);
         dataSource = new PoolingDataSource<>(connectionPool);
@@ -298,12 +298,20 @@ public class DefaultConnectionProvider implements ConnectionProvider {
         return testTimeout;
     }
 
+    /**
+     * @deprecated Replaced by {@link #getDurationBetweenEvictionRuns()}
+     */
+    @Deprecated
     public Duration getTimeBetweenEvictionRunsMillis() {
-        return Duration.ofMillis(connectionPool.getTimeBetweenEvictionRunsMillis());
+        return getDurationBetweenEvictionRuns();
+    }
+
+    public Duration getDurationBetweenEvictionRuns() {
+        return connectionPool.getDurationBetweenEvictionRuns();
     }
 
     public Duration getMinIdleTime() {
-        return Duration.ofMillis(connectionPool.getSoftMinEvictableIdleTimeMillis());
+        return connectionPool.getSoftMinEvictableIdleDuration();
     }
 
     public int getActiveConnections() {
@@ -323,15 +331,15 @@ public class DefaultConnectionProvider implements ConnectionProvider {
     }
 
     public Duration getMaxWaitTime() {
-        return Duration.ofMillis(connectionPool.getMaxWaitMillis());
+        return connectionPool.getMaxWaitDuration();
     }
 
     public Duration getMeanBorrowWaitTime() {
-        return Duration.ofMillis(connectionPool.getMeanBorrowWaitTimeMillis());
+        return connectionPool.getMeanBorrowWaitDuration();
     }
 
     public Duration getMaxBorrowWaitTime() {
-        return Duration.ofMillis(connectionPool.getMaxBorrowWaitTimeMillis());
+        return connectionPool.getMaxBorrowWaitDuration();
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/EmbeddedConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ public class EmbeddedConnectionProvider implements ConnectionProvider {
         serverURL = "jdbc:hsqldb:" + databaseDir.resolve("openfire");
         final ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(serverURL, "sa", "");
         final PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, null);
-        poolableConnectionFactory.setMaxConnLifetimeMillis(Duration.ofHours(12).toMillis());
+        poolableConnectionFactory.setMaxConn(Duration.ofHours(12));
 
         final GenericObjectPoolConfig<PoolableConnection> poolConfig = new GenericObjectPoolConfig<>();
         poolConfig.setMinIdle(3);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/WebSocketClientConnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans, 2023-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2023-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -224,7 +224,7 @@ public class WebSocketClientConnectionHandler
             readerPool.setMaxTotal(-1);
             readerPool.setBlockWhenExhausted(false);
             readerPool.setTestOnReturn(true);
-            readerPool.setTimeBetweenEvictionRunsMillis(Duration.ofMinutes(1).toMillis());
+            readerPool.setDurationBetweenEvictionRuns(Duration.ofMinutes(1));
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/SmsService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SmsService.java
@@ -288,7 +288,7 @@ public class SmsService
      * Checks if an exception in the chain of the provided throwable contains a 'command status' that can be
      * translated in a somewhat more helpful error message.
      *
-     * The list of error messages was taken from <a href="http://www.smssolutions.net/tutorials/smpp/smpperrorcodes/">http://www.smssolutions.net/tutorials/smpp/smpperrorcodes/</a>
+     * The list of error messages was taken from <a href="https://www.smssolutions.net/tutorials/smpp/smpperrorcodes/">https://www.smssolutions.net/tutorials/smpp/smpperrorcodes/</a>
      *
      * @param ex The exception in which to search for a command status.
      * @return a human-readable error message.

--- a/xmppserver/src/main/java/org/jivesoftware/util/SmsService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SmsService.java
@@ -73,7 +73,7 @@ public class SmsService
         .build();
 
     /**
-     * Time after which idle MPPP connections used by the SMS Service are allowed to be evicted.
+     * Time after which idle SMPP connections used by the SMS Service are allowed to be evicted.
      */
     public static final SystemProperty<Duration> SMPP_CONNECTIONS_IDLE = SystemProperty.Builder.ofType(Duration.class)
         .setKey("sms.smpp.connections.idleMillis")

--- a/xmppserver/src/main/java/org/jivesoftware/util/SmsService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SmsService.java
@@ -24,6 +24,7 @@ import org.jsmpp.bean.*;
 import org.jsmpp.extra.NegativeResponseException;
 import org.jsmpp.session.BindParameter;
 import org.jsmpp.session.SMPPSession;
+import org.jsmpp.session.SubmitSmResult;
 import org.jsmpp.util.AbsoluteTimeFormatter;
 import org.jsmpp.util.TimeFormatter;
 import org.slf4j.Logger;
@@ -427,14 +428,14 @@ public class SmsService
             final SMPPSession session = sessionPool.borrowObject();
             try
             {
-                final String messageId = session.submitShortMessage(
+                final SubmitSmResult result = session.submitShortMessage(
                     serviceType,
                     sourceTon, sourceNpi, sourceAddress,
                     destinationTon, destinationNpi, destinationAddress,
                     esm, protocolId, priorityFlag,
                     scheduleDeliveryTime, validityPeriod, registeredDelivery, replaceIfPresentFlag,
                     dataCoding, smDefaultMsgId, message );
-                Log.debug( "Message submitted, message_id is '{}'.", messageId );
+                Log.debug( "Message submitted, message_id is '{}'.", result.getMessageId() );
             }
             finally
             {

--- a/xmppserver/src/main/java/org/jivesoftware/util/SmsService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SmsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ import org.jsmpp.util.TimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 /**
@@ -59,7 +61,145 @@ public class SmsService
 {
     private static final Logger Log = LoggerFactory.getLogger( SmsService.class );
 
-    private static TimeFormatter timeFormatter = new AbsoluteTimeFormatter();
+    /**
+     * The maximum amount of SMPP connections that the SMS Service will maintain.
+     */
+    public static final SystemProperty<Integer> SMPP_CONNECTIONS_MAX_AMOUNT = SystemProperty.Builder.ofType(Integer.class)
+        .setKey("sms.smpp.connections.maxAmount")
+        .setDefaultValue(1)
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.connections.maxAmount"))
+        .build();
+
+    /**
+     * Time after which idle MPPP connections used by the SMS Service are allowed to be evicted.
+     */
+    public static final SystemProperty<Duration> SMPP_CONNECTIONS_IDLE = SystemProperty.Builder.ofType(Duration.class)
+        .setKey("sms.smpp.connections.idleMillis")
+        .setDefaultValue(Duration.ofMinutes(2))
+        .setDynamic(true)
+        .setChronoUnit(ChronoUnit.MILLIS)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.connections.idleMillis"))
+        .build();
+
+    /**
+     * The type-of-number value for the source of SMS messages.
+     */
+    public static final SystemProperty<TypeOfNumber> SMPP_SOURCE_TON = SystemProperty.Builder.ofType(TypeOfNumber.class)
+        .setKey("sms.smpp.source.ton")
+        .setDefaultValue(TypeOfNumber.UNKNOWN)
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.source.ton"))
+        .build();
+
+    /**
+     * The number-plan-indicator value for the source of SMS messages.
+     */
+    public static final SystemProperty<NumberingPlanIndicator> SMPP_SOURCE_NPI = SystemProperty.Builder.ofType(NumberingPlanIndicator.class)
+        .setKey("sms.smpp.source.npi")
+        .setDefaultValue(NumberingPlanIndicator.UNKNOWN)
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.source.npi"))
+        .build();
+
+    /**
+     * The source address of SMS messages.
+     */
+    public static final SystemProperty<String> SMPP_SOURCE_ADDRESS = SystemProperty.Builder.ofType(String.class)
+        .setKey("sms.smpp.source.address")
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.source.address"))
+        .build();
+
+    /**
+     * The type-of-number value for the destination of SMS messages.
+     */
+    public static final SystemProperty<TypeOfNumber> SMPP_DESTINATION_TON = SystemProperty.Builder.ofType(TypeOfNumber.class)
+        .setKey("sms.smpp.destination.ton")
+        .setDefaultValue(TypeOfNumber.UNKNOWN)
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.destination.ton"))
+        .build();
+
+    /**
+     * The number-plan-indicator value for the destination of SMS messages.
+     */
+    public static final SystemProperty<NumberingPlanIndicator> SMPP_DESTINATION_NPI = SystemProperty.Builder.ofType(NumberingPlanIndicator.class)
+        .setKey("sms.smpp.destination.npi")
+        .setDefaultValue(NumberingPlanIndicator.UNKNOWN)
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.destination.npi"))
+        .build();
+
+    /**
+     * The host name of your SMPP Server or SMSC, i.e. smsc.example.org.
+     */
+    public static final SystemProperty<String> SMPP_HOST = SystemProperty.Builder.ofType(String.class)
+        .setKey("sms.smpp.host")
+        .setDefaultValue("localhost")
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.host"))
+        .build();
+
+    /**
+     * The port on which the SMSC is listening.
+     */
+    public static final SystemProperty<Integer> SMPP_PORT = SystemProperty.Builder.ofType(Integer.class)
+        .setKey("sms.smpp.port")
+        .setDefaultValue(2775)
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.port"))
+        .build();
+
+    /**
+     * The 'user name' to use when connecting to the SMSC.
+     */
+    public static final SystemProperty<String> SMPP_SYSTEMID = SystemProperty.Builder.ofType(String.class)
+        .setKey("sms.smpp.systemId")
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.systemId"))
+        .build();
+
+    /**
+     * The password that authenticates the systemId value when connecting to the SMSC.
+     */
+    public static final SystemProperty<String> SMPP_PASSWORD = SystemProperty.Builder.ofType(String.class)
+        .setKey("sms.smpp.password")
+        .setEncrypted(true)
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.password"))
+        .build();
+
+    /**
+     * An optional system type, which, if defined, will be used when connecting to the SMSC.
+     */
+    public static final SystemProperty<String> SMPP_SYSTEMTYPE = SystemProperty.Builder.ofType(String.class)
+        .setKey("sms.smpp.systemType")
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.systemType"))
+        .build();
+
+    /**
+     * The type-of-number value for 'receiving' SMS messages.
+     */
+    public static final SystemProperty<TypeOfNumber> SMPP_RECEIVE_TON = SystemProperty.Builder.ofType(TypeOfNumber.class)
+        .setKey("sms.smpp.receive.ton")
+        .setDefaultValue(TypeOfNumber.UNKNOWN)
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.receive.ton"))
+        .build();
+
+    /**
+     * The number-plan-indicator value for 'receiving' SMS messages.
+     */
+    public static final SystemProperty<NumberingPlanIndicator> SMPP_RECEIVE_NPI = SystemProperty.Builder.ofType(NumberingPlanIndicator.class)
+        .setKey("sms.smpp.receive.npi")
+        .setDefaultValue(NumberingPlanIndicator.UNKNOWN)
+        .setDynamic(true)
+        .addListener(l -> SmsService.getInstance().sessionPool.processPropertyChange("sms.smpp.receive.npi"))
+        .build();
+
+    private static final TimeFormatter timeFormatter = new AbsoluteTimeFormatter();
 
     private static SmsService INSTANCE;
 
@@ -147,10 +287,10 @@ public class SmsService
      * Checks if an exception in the chain of the provided throwable contains a 'command status' that can be
      * translated in a somewhat more helpful error message.
      *
-     * The list of error messages was taken from http://www.smssolutions.net/tutorials/smpp/smpperrorcodes/
+     * The list of error messages was taken from <a href="http://www.smssolutions.net/tutorials/smpp/smpperrorcodes/">http://www.smssolutions.net/tutorials/smpp/smpperrorcodes/</a>
      *
      * @param ex The exception in which to search for a command status.
-     * @return a human readable error message.
+     * @return a human-readable error message.
      */
     public static String getDescriptiveMessage( Throwable ex )
     {
@@ -238,13 +378,13 @@ public class SmsService
         private final ObjectPool<SMPPSession> sessionPool;
 
         // Settings that apply to source of an SMS message.
-        private final TypeOfNumber sourceTon = JiveGlobals.getEnumProperty( "sms.smpp.source.ton", TypeOfNumber.class, TypeOfNumber.UNKNOWN );
-        private final NumberingPlanIndicator sourceNpi = JiveGlobals.getEnumProperty( "sms.smpp.source.npi", NumberingPlanIndicator.class, NumberingPlanIndicator.UNKNOWN );
-        private final String sourceAddress = JiveGlobals.getProperty( "sms.smpp.source.address" );
+        private final TypeOfNumber sourceTon = SMPP_SOURCE_TON.getValue();
+        private final NumberingPlanIndicator sourceNpi = SMPP_SOURCE_NPI.getValue();
+        private final String sourceAddress = SMPP_SOURCE_ADDRESS.getValue();
 
         // Settings that apply to destination of an SMS message.
-        private final TypeOfNumber destinationTon = JiveGlobals.getEnumProperty( "sms.smpp.destination.ton", TypeOfNumber.class, TypeOfNumber.UNKNOWN );
-        private final NumberingPlanIndicator destinationNpi = JiveGlobals.getEnumProperty( "sms.smpp.destination.npi", NumberingPlanIndicator.class, NumberingPlanIndicator.UNKNOWN );
+        private final TypeOfNumber destinationTon = SMPP_DESTINATION_TON.getValue();
+        private final NumberingPlanIndicator destinationNpi = SMPP_DESTINATION_NPI.getValue();
 
         private final String destinationAddress;
         private final byte[] message;
@@ -316,15 +456,15 @@ public class SmsService
         public SMPPSession create() throws Exception
         {
             // SMSC connection settings
-            final String host = JiveGlobals.getProperty( "sms.smpp.host", "localhost" );
-            final int port = JiveGlobals.getIntProperty( "sms.smpp.port", 2775 );
-            final String systemId = JiveGlobals.getProperty( "sms.smpp.systemId" );
-            final String password = JiveGlobals.getProperty( "sms.smpp.password" );
-            final String systemType = JiveGlobals.getProperty( "sms.smpp.systemType" );
+            final String host = SMPP_HOST.getValue();
+            final int port = SMPP_PORT.getValue();
+            final String systemId = SMPP_SYSTEMID.getValue();
+            final String password = SMPP_PASSWORD.getValue();
+            final String systemType = SMPP_SYSTEMTYPE.getValue();
 
-            // Settings that apply to 'receiving' SMS. Should not apply to this implementation, as we're not receiving anything..
-            final TypeOfNumber receiveTon = JiveGlobals.getEnumProperty( "sms.smpp.receive.ton", TypeOfNumber.class, TypeOfNumber.UNKNOWN );
-            final NumberingPlanIndicator receiveNpi = JiveGlobals.getEnumProperty( "sms.smpp.receive.npi", NumberingPlanIndicator.class, NumberingPlanIndicator.UNKNOWN );
+            // Settings that apply to 'receiving' SMS. Should not apply to this implementation, as we're not receiving anything.
+            final TypeOfNumber receiveTon = SMPP_RECEIVE_TON.getDefaultValue();
+            final NumberingPlanIndicator receiveNpi = SMPP_RECEIVE_NPI.getValue();
 
             Log.debug( "Creating a new sesssion (host: '{}', port: '{}', systemId: '{}'.", host, port, systemId );
             final SMPPSession session = new SMPPSession();
@@ -358,13 +498,13 @@ public class SmsService
     }
 
     /**
-     * Implementation of an Object pool that manages instances of SMPPSession. The intend of this pool is to have a
+     * Implementation of an Object pool that manages instances of SMPPSession. The intent of this pool is to have a
      * single session, that's allowed to be idle for at least two minutes before being closed.
      *
      * The pool reacts to Openfire property changes, clearing all (inactive) sessions when a property used to create
      * a session is modified. Note that sessions that are borrowed from the pool are not affected by such a change. When
      * a property change occurs while a session is borrowed, a warning is logged (the property change will be applied
-     * when that session is eventually rotated out of the pool by the eviction strategy.
+     * when that session is eventually rotated out of the pool by the eviction strategy).
      *
      * @author Guus der Kinderen, guus.der.kinderen@gmail.com
      */
@@ -375,13 +515,13 @@ public class SmsService
         SMPPSessionPool()
         {
             super( new SMPPSessionFactory() );
-            setMaxTotal( JiveGlobals.getIntProperty( "sms.smpp.connections.maxAmount", 1 ) );
+            setMaxTotal(SMPP_CONNECTIONS_MAX_AMOUNT.getValue());
             setNumTestsPerEvictionRun( getMaxTotal() );
 
-            setMinEvictableIdleTimeMillis( JiveGlobals.getLongProperty( "sms.smpp.connections.idleMillis", 1000 * 60 * 2 ) );
-            if ( getMinEvictableIdleTimeMillis() > 0 )
+            setMinEvictableIdleDuration(SMPP_CONNECTIONS_IDLE.getValue());
+            if ( !getMinEvictableIdleDuration().isNegative() && !getMinEvictableIdleDuration().isZero() )
             {
-                setTimeBetweenEvictionRunsMillis( getMinEvictableIdleTimeMillis() / 10 );
+                setDurationBetweenEvictionRuns( getMinEvictableIdleDuration().dividedBy(10) );
             }
 
             setTestOnBorrow( true );
@@ -413,16 +553,16 @@ public class SmsService
             // No need to clear the sessions for these properties:
             if ( propertyName.equals( "sms.smpp.connections.maxAmount" ) )
             {
-                setMaxTotal( JiveGlobals.getIntProperty( "sms.smpp.connections.maxAmount", 1 ) );
+                setMaxTotal(SMPP_CONNECTIONS_MAX_AMOUNT.getValue());
                 setNumTestsPerEvictionRun( getMaxTotal() );
             }
 
             if ( propertyName.equals( "sms.smpp.connections.idleMillis" ) )
             {
-                setMinEvictableIdleTimeMillis( JiveGlobals.getLongProperty( "sms.smpp.connections.idleMillis", 1000 * 60 * 2 ) );
-                if ( getMinEvictableIdleTimeMillis() > 0 )
+                setMinEvictableIdleDuration(SMPP_CONNECTIONS_IDLE.getValue());
+                if ( !getMinEvictableIdleDuration().isNegative() && !getMinEvictableIdleDuration().isZero() )
                 {
-                    setTimeBetweenEvictionRunsMillis( getMinEvictableIdleTimeMillis() / 10 );
+                    setDurationBetweenEvictionRuns( getMinEvictableIdleDuration().dividedBy(10) );
                 }
             }
         }

--- a/xmppserver/src/main/webapp/server-db.jsp
+++ b/xmppserver/src/main/webapp/server-db.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -192,7 +192,7 @@
             <fmt:message key="server.db.house_keeping_sleep" />
         </td>
         <td class="c2">
-            <%=StringUtils.getFullElapsedTime(defaultConnectionProvider.getTimeBetweenEvictionRunsMillis())%>
+            <%=StringUtils.getFullElapsedTime(defaultConnectionProvider.getDurationBetweenEvictionRuns())%>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
This PR updates the following libraries:
- Apache's commons-dbcp2 from 2.9.0 to 2.14.0
- Apache's commons-pool2 from 2.9.0 to 2.13.1
- org.jsmpp:jsmpp from 2.3.10 to 3.0.2

All of these are maintenance releases, each of them bringing about half a decade of changes - mostly minor ones.

There was enough overlap between the three for me to include them all in one PR.

This also replaces usage of the old `JiveGlobals` with `SystemProperty` where applied in the SMS service.