### PR TITLE
OF-3255: Fix Content-Type response header for GIF images

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginIconServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/container/PluginIconServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2020 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class PluginIconServlet extends HttpServlet {
                 if ( icon.toExternalForm().toLowerCase().endsWith( ".png" )) {
                     response.setContentType("image/png");
                 }
-                else if (icon.toExternalForm().toLowerCase().endsWith( ".png" )) {
+                else if (icon.toExternalForm().toLowerCase().endsWith( ".gif" )) {
                     response.setContentType("image/gif");
                 }
                 try (InputStream in = icon.openStream()) {


### PR DESCRIPTION
Fixes an obvious copy/paste issue in PluginIconServlet. This is what populates the icons on the plugin pages of the admin console.