### PR TITLE
OF-3256: Ensure that non-filtered metadata is included in plugin

### DIFF
--- a/plugins/openfire-plugin-assembly-descriptor/src/main/resources/assemblies/openfire-plugin-assembly.xml
+++ b/plugins/openfire-plugin-assembly-descriptor/src/main/resources/assemblies/openfire-plugin-assembly.xml
@@ -7,8 +7,23 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
 
-        <!-- metadata files (readme, icons, etc). -->
-        <fileSet>
+        <!--
+           metadata files (readme, icons, etc).
+            This includes 2 sections, one for the current project structure and one for legacy projects
+            This used to assume a 'src/java' directory, but that is not always the case. Default project
+            structure is now src/main/java. Some plugins have worked around this by placing the plugin.xml
+            and related collateral in the src directory. This section now supports both structures.
+        -->
+        <fileSet> <!-- Current project structure - plugin descriptors in the project root -->
+            <outputDirectory/>
+            <directory>${project.basedir}</directory>
+            <includes>
+                <include>*.gif</include>
+                <include>*.png</include>
+                <include>lib/**</include>
+            </includes>
+        </fileSet>
+        <fileSet> <!-- Cope with legacy & unusual project structures - plugin descriptors 2 folders above plugin source -->
             <outputDirectory/>
             <directory>${project.build.sourceDirectory}/../..</directory>
             <includes>


### PR DESCRIPTION
The plugin assembly pulls in files from the plugin source directory. It notably misses the plugin icons when they're in the location dictated by the Plugin Developers Guide.

For OF-2614, changes have been applied to get certain (filtered) metadata files from similar source directories. This commit applies a similar change for the unfiltered metadata files.