### PR TITLE
Fix S2S dialback not offered in post-TLS features when self-signed certs accepted

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientTrustManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientTrustManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,6 +173,8 @@ public class ClientTrustManager implements X509TrustManager {
 
         loadCRL();
 
+        final ConnectionListener connectionListener = XMPPServer.getInstance().getConnectionManager().getListener(ConnectionType.SOCKET_C2S, false);
+
         boolean verify = JiveGlobals.getBooleanProperty("xmpp.client.certificate.verify", true);
         if (verify) {
             int nSize = x509Certificates.length;
@@ -254,7 +256,7 @@ public class ClientTrustManager implements X509TrustManager {
                 }
             }
 
-            if (JiveGlobals.getBooleanProperty("xmpp.client.certificate.verify.validity", true)) {
+            if (connectionListener.verifyCertificateValidity()) {
                 // For every certificate in the chain, verify that the certificate
                 // is valid at the current time.
                 Date date = new Date();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientTrustManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientTrustManager.java
@@ -65,7 +65,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gaston Dombiak
  * @author Jay Kline
+ * @deprecated Replaced by org.jivesoftware.openfire.keystore.OpenfireX509TrustManager
  */
+@Deprecated(forRemoval = true, since = "5.1.0") // Remove in or after Openfire 5.2.0
 public class ClientTrustManager implements X509TrustManager {
 
     private static final Logger Log = LoggerFactory.getLogger(ClientTrustManager.class);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientTrustManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientTrustManager.java
@@ -48,6 +48,9 @@ import java.util.*;
 
 import javax.net.ssl.X509TrustManager;
 
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.spi.ConnectionListener;
+import org.jivesoftware.openfire.spi.ConnectionType;
 import org.jivesoftware.util.CertificateManager;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
@@ -335,7 +338,8 @@ public class ClientTrustManager implements X509TrustManager {
 
     @Override
     public X509Certificate[] getAcceptedIssuers() {
-        if (JiveGlobals.getBooleanProperty("xmpp.client.certificate.accept-selfsigned", false)) {
+        final ConnectionListener connectionListener = XMPPServer.getInstance().getConnectionManager().getListener(ConnectionType.SOCKET_C2S, false);
+        if (connectionListener.acceptSelfSignedCertificates()) {
             // Answer an empty list since we accept any issuer
             return new X509Certificate[0];
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerStanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,9 +134,10 @@ public class ServerStanzaHandler extends StanzaHandler {
 
     @Override
     void startTLS() throws Exception {
+        final boolean acceptSelfSignedCerts = connection.getConfiguration().isAcceptSelfSignedCertificates();
         boolean needed = JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true) &&
                 JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY, true) &&
-                !JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false);
+                !acceptSelfSignedCerts;
         //needed ? Connection.ClientAuth.needed : Connection.ClientAuth.wanted
         connection.startTLS(false, false);
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerTrustManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerTrustManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.jivesoftware.openfire.net;
 
-import org.jivesoftware.openfire.session.ConnectionSettings;
-import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.spi.ConnectionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +86,8 @@ public class ServerTrustManager implements X509TrustManager {
 
     @Override
     public X509Certificate[] getAcceptedIssuers() {
-        if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false)) {
+        final boolean acceptSelfSignedCertificates = XMPPServer.getInstance().getConnectionManager().getListener(ConnectionType.SOCKET_S2S, false).acceptSelfSignedCertificates();
+        if (acceptSelfSignedCertificates) {
             // Answer an empty list since we accept any issuer
             return new X509Certificate[0];
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerTrustManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ServerTrustManager.java
@@ -36,7 +36,9 @@ import java.util.Enumeration;
  * certificates or certificates of unknown issuers and manually accept them.
  *
  * @author Gaston Dombiak
+ * @deprecated Replaced by org.jivesoftware.openfire.keystore.OpenfireX509TrustManager
  */
+@Deprecated(forRemoval = true, since = "5.1.0") // Remove in or after Openfire 5.2.0
 public class ServerTrustManager implements X509TrustManager {
 
     private static final Logger Log = LoggerFactory.getLogger(ServerTrustManager.class);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/TLSStreamHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,8 +136,7 @@ public class TLSStreamHandler {
             // Only REQUIRE client authentication if we are fully verifying certificates
             if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY, true) &&
                     JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_CHAIN_VERIFY, true) &&
-                    !JiveGlobals
-                            .getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false))
+                    !configuration.isAcceptSelfSignedCertificates())
             {
                 tlsEngine.setNeedClientAuth(true);
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -135,7 +135,14 @@ public class ServerDialback {
      * certificate.
      */
     public static boolean isEnabledForSelfSigned() {
-        return JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false);
+        // Check the legacy property name first for backwards compatibility.
+        if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false)) {
+            return true;
+        }
+        // Also check the current property name written by ConnectionListener.setAcceptSelfSignedCertificates().
+        // The two names diverged when ConnectionListener introduced per-connection-type prefixed properties
+        // (OF-2273), but the readers in this class were not updated at that time.
+        return JiveGlobals.getBooleanProperty(ConnectionType.SOCKET_S2S.getPrefix() + "certificate.accept-selfsigned", false);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/ServerDialback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,29 +135,21 @@ public class ServerDialback {
      * certificate.
      */
     public static boolean isEnabledForSelfSigned() {
-        // Check the legacy property name first for backwards compatibility.
-        if (JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, false)) {
-            return true;
-        }
-        // Also check the current property name written by ConnectionListener.setAcceptSelfSignedCertificates().
-        // The two names diverged when ConnectionListener introduced per-connection-type prefixed properties
-        // (OF-2273), but the readers in this class were not updated at that time.
-        return JiveGlobals.getBooleanProperty(ConnectionType.SOCKET_S2S.getPrefix() + "certificate.accept-selfsigned", false);
+        // Allowance for self-signed certificates is based on the configuration for all server-to-server connections.
+        return XMPPServer.getInstance().getConnectionManager().getListener(ConnectionType.SOCKET_S2S, false).acceptSelfSignedCertificates();
     }
 
     /**
-     * Sets if server dialback can be used when the remote server presented a self-signed
-     * certificate. During TLS the remote server can present a self-signed certificate, if this
-     * setting is enabled then the self-signed certificate will be accepted and if SASL EXTERNAL
-     * is not offered then server dialback will be used for verifying the remote server.<p>
+     * This (unexpectedly/incorrectly) affected the configuration of all socket-s2s connections, not just those of
+     * Dialback connections. This is unlikely what is desired.
      *
-     * If self-signed certificates are accepted then server dialback over TLS is enabled.
-     *
-     * @param enabled if server dialback can be used when the remote server presented a self-signed
-     * certificate.
+     * @param enabled if server dialback can be used when the remote server presented a self-signed certificate.
+     * @deprecated Instead, set the connection listener property for socket-s2s connections in {@link org.jivesoftware.openfire.spi.ConnectionListener#setAcceptSelfSignedCertificates(boolean)}
      */
-    public static void setEnabledForSelfSigned(boolean enabled) {
-        JiveGlobals.setProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, Boolean.toString(enabled));
+    @Deprecated(forRemoval = true, since = "5.1.0")
+    public static void setEnabledForSelfSigned(boolean enabled)
+    {
+        XMPPServer.getInstance().getConnectionManager().getListener(ConnectionType.SOCKET_S2S, false).setAcceptSelfSignedCertificates(enabled);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -114,6 +114,10 @@ public final class ConnectionSettings {
         @Deprecated(forRemoval = true, since = "5.1.0")
         public static final String TLS_ACCEPT_SELFSIGNED_CERTS = "xmpp.server.certificate.accept-selfsigned";
 
+        /**
+         * @deprecated Redundant - setting this property does not seem to have a meaningful effect.
+         */
+        @Deprecated(forRemoval = true, since = "5.1.0") // Remove in or after Openfire 5.2.0
         public static final String TLS_CERTIFICATE_VERIFY = "xmpp.server.certificate.verify";
 
         /**
@@ -122,8 +126,18 @@ public final class ConnectionSettings {
         @Deprecated(forRemoval = true, since = "5.1.0")
         public static final String TLS_CERTIFICATE_VERIFY_VALIDITY = "xmpp.server.certificate.verify.validity";
 
+        /**
+         * @deprecated This property is unused.
+         */
+        @Deprecated(forRemoval = true, since = "5.1.0") // Remove in or after Openfire 5.2.0
         public static final String TLS_CERTIFICATE_ROOT_VERIFY = "xmpp.server.certificate.verify.root";
+
+        /**
+         * @deprecated Redundant - setting this property does not seem to have a meaningful effect.
+         */
+        @Deprecated(forRemoval = true, since = "5.1.0") // Remove in or after Openfire 5.2.0
         public static final String TLS_CERTIFICATE_CHAIN_VERIFY = "xmpp.server.certificate.verify.chain";
+
         public static final String TLS_ON_PLAIN_DETECTION_ALLOW_NONDIRECTTLS_FALLBACK = "xmpp.server.tls.on-plain-detection-allow-nondirecttls-fallback";
 
         /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -113,8 +113,15 @@ public final class ConnectionSettings {
          */
         @Deprecated(forRemoval = true, since = "5.1.0")
         public static final String TLS_ACCEPT_SELFSIGNED_CERTS = "xmpp.server.certificate.accept-selfsigned";
+
         public static final String TLS_CERTIFICATE_VERIFY = "xmpp.server.certificate.verify";
+
+        /**
+         * @deprecated Use {@link org.jivesoftware.openfire.spi.ConnectionListener#verifyCertificateValidity()} and {@link org.jivesoftware.openfire.spi.ConnectionListener#setVerifyCertificateValidity(boolean)} instead.
+         */
+        @Deprecated(forRemoval = true, since = "5.1.0")
         public static final String TLS_CERTIFICATE_VERIFY_VALIDITY = "xmpp.server.certificate.verify.validity";
+
         public static final String TLS_CERTIFICATE_ROOT_VERIFY = "xmpp.server.certificate.verify.root";
         public static final String TLS_CERTIFICATE_CHAIN_VERIFY = "xmpp.server.certificate.verify.chain";
         public static final String TLS_ON_PLAIN_DETECTION_ALLOW_NONDIRECTTLS_FALLBACK = "xmpp.server.tls.on-plain-detection-allow-nondirecttls-fallback";

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/ConnectionSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,6 +108,10 @@ public final class ConnectionSettings {
         public static final String DIALBACK_ENABLED = "xmpp.server.dialback.enabled";
         public static final String TLS_POLICY = "xmpp.server.tls.policy";
 
+        /**
+         * @deprecated Use {@link org.jivesoftware.openfire.spi.ConnectionListener#acceptSelfSignedCertificates()} and {@link org.jivesoftware.openfire.spi.ConnectionListener#setAcceptSelfSignedCertificates(boolean)} instead.
+         */
+        @Deprecated(forRemoval = true, since = "5.1.0")
         public static final String TLS_ACCEPT_SELFSIGNED_CERTS = "xmpp.server.certificate.accept-selfsigned";
         public static final String TLS_CERTIFICATE_VERIFY = "xmpp.server.certificate.verify";
         public static final String TLS_CERTIFICATE_VERIFY_VALIDITY = "xmpp.server.certificate.verify.validity";

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -723,6 +723,9 @@ public class ConnectionListener
             if (currentType == ConnectionType.SOCKET_S2S && JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, defaultValue)) {
                 return true;
             }
+            if (currentType.isClientOriented() && JiveGlobals.getBooleanProperty("xmpp.client.certificate.accept-selfsigned", defaultValue)) {
+                return true;
+            }
 
             // This checks the 'new' properties.
             final String propertyName = currentType.getPrefix() + "certificate.accept-selfsigned";
@@ -766,18 +769,30 @@ public class ConnectionListener
      */
     public boolean verifyCertificateValidity()
     {
-        // TODO these are new properties! Deprecate (migrate?) all existing 'verify / verify-validity properties' (Eg: org.jivesoftware.openfire.session.ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY_VALIDITY )
-        final String propertyName = type.getPrefix() + "certificate.verify.validity";
         final boolean defaultValue = true;
 
-        if ( type.getFallback() == null )
+        // Recursively check the old properties at every step in the fallback chain.
+        ConnectionType currentType = type;
+        while (currentType != null)
         {
-            return JiveGlobals.getBooleanProperty( propertyName, defaultValue );
+            // This checks the 'old' properties, that have been marked as deprecated in Openfire 5.1.0 (OF-3259)
+            if (currentType == ConnectionType.SOCKET_S2S && !JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_CERTIFICATE_VERIFY_VALIDITY, defaultValue)) {
+                return false;
+            }
+            if (currentType.isClientOriented() && !JiveGlobals.getBooleanProperty("xmpp.client.certificate.verify.validity", defaultValue)) {
+                return false;
+            }
+
+            // This checks the 'new' properties.
+            final String propertyName = currentType.getPrefix() + "certificate.verify.validity";
+            if (JiveGlobals.getProperty(propertyName) != null) {
+                return JiveGlobals.getBooleanProperty(propertyName, defaultValue);
+            }
+
+            // Recursively check the fallback properties.
+            currentType = currentType.getFallback();
         }
-        else
-        {
-            return JiveGlobals.getBooleanProperty( propertyName, getConnectionListener( type.getFallback() ).verifyCertificateValidity() );
-        }
+        return defaultValue;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -20,6 +20,7 @@ import org.jivesoftware.openfire.ConnectionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.keystore.CertificateStoreConfiguration;
 import org.jivesoftware.openfire.net.SocketConnection;
+import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -712,18 +713,27 @@ public class ConnectionListener
      */
     public boolean acceptSelfSignedCertificates()
     {
-        // TODO these are new properties! Deprecate (migrate?) all existing 'accept-selfsigned properties' (Eg: org.jivesoftware.openfire.session.ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS )
-        final String propertyName = type.getPrefix() + "certificate.accept-selfsigned";
         final boolean defaultValue = false;
 
-        if ( type.getFallback() == null )
+        // Recursively check the old properties at every step in the fallback chain.
+        ConnectionType currentType = type;
+        while (currentType != null)
         {
-            return JiveGlobals.getBooleanProperty( propertyName, defaultValue );
+            // This checks the 'old' properties, that have been marked as deprecated in Openfire 5.1.0 (OF-3259)
+            if (currentType == ConnectionType.SOCKET_S2S && JiveGlobals.getBooleanProperty(ConnectionSettings.Server.TLS_ACCEPT_SELFSIGNED_CERTS, defaultValue)) {
+                return true;
+            }
+
+            // This checks the 'new' properties.
+            final String propertyName = currentType.getPrefix() + "certificate.accept-selfsigned";
+            if (JiveGlobals.getProperty(propertyName) != null) {
+                return JiveGlobals.getBooleanProperty(propertyName, defaultValue);
+            }
+
+            // Recursively check the fallback properties.
+            currentType = currentType.getFallback();
         }
-        else
-        {
-            return JiveGlobals.getBooleanProperty( propertyName, getConnectionListener( type.getFallback() ).acceptSelfSignedCertificates() );
-        }
+        return defaultValue;
     }
 
     /**


### PR DESCRIPTION
ServerDialback.isEnabledForSelfSigned() reads the legacy property xmpp.server.certificate.accept-selfsigned (TLS_ACCEPT_SELFSIGNED_CERTS), but ConnectionListener.setAcceptSelfSignedCertificates() — which backs the Admin Console UI checkbox — writes to the per-connection-type prefixed property xmpp.socket.ssl.certificate.accept-selfsigned. These diverged when per-type prefixed properties were introduced but the readers in ServerDialback were not updated.

The consequence is that after a successful TLS handshake with a self-signed peer certificate, LocalIncomingServerSession.getAvailableStreamFeatures() calls isEnabledForSelfSigned(), gets false, and omits <db:dialback> from the post-TLS <stream:features>. The connecting server then finds no usable authentication mechanism and closes the connection. This causes all encrypted S2S connections to fail silently when the only option is dialback, even if the operator has enabled self-signed certificate acceptance via the UI.

Fix: check both property names in isEnabledForSelfSigned(), preserving full backwards compatibility with installations that have the legacy property set.