### PR TITLE
CI: Add action to run Maestro tests, along with simple tests

### DIFF
--- a/.github/actions/conversationstest-action/action.yml
+++ b/.github/actions/conversationstest-action/action.yml
@@ -1,0 +1,65 @@
+name: 'Run Conversations Maestro Tests'
+description: >
+  Runs the Maestro UI test suite for Conversations against an Openfire instance.
+  Requires Openfire running on the host with domain example.org and user jane/secret —
+  the Android emulator reaches the host at 10.0.2.2.
+
+inputs:
+  includeTags:
+    description: 'Comma-separated Maestro tag filter (--include-tags). Runs all flows if omitted.'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Java 17
+      uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: '17'
+
+    - name: Install Maestro CLI
+      shell: bash
+      run: |
+        curl -Ls "https://get.maestro.mobile.dev" | bash
+        echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+    - name: Enable KVM group perms
+      shell: bash
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
+    - name: Run Android emulator and tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 34
+        arch: x86_64
+        profile: Nexus 6
+        script: ${{ github.action_path }}/run-tests.sh ${{ inputs.includeTags }}
+
+    - name: Upload ADB logcat on failure
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: adb-logcat
+        path: adb_logcat.log
+        retention-days: 7
+
+    - name: Upload sidecar log on failure
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: sidecar-log
+        path: ${{ runner.temp }}/sidecar.log
+        retention-days: 7
+
+    - name: Upload maestro artifacts on failure
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: maestro-logs
+        path: ~/.maestro/tests
+        retention-days: 7
+        include-hidden-files: true

--- a/.github/actions/conversationstest-action/action.yml
+++ b/.github/actions/conversationstest-action/action.yml
@@ -6,8 +6,8 @@ description: >
 
 inputs:
   includeTags:
-    description: 'Comma-separated Maestro tag filter (--include-tags). Runs all flows if omitted.'
-    required: false
+    description: 'Comma-separated Maestro tag filter (--include-tags). Required: suites use incompatible Openfire configurations and must not be mixed.'
+    required: true
 
 runs:
   using: composite

--- a/.github/actions/conversationstest-action/run-tests.sh
+++ b/.github/actions/conversationstest-action/run-tests.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+if [ -z "${1:-}" ]; then
+  echo "Usage: run-tests.sh <tag>" >&2
+  echo "Available tags: demoboot, sasl2" >&2
+  exit 1
+fi
+INCLUDE_TAGS="$1"
+
+# TODO: research F-Droid APIs to resolve the latest Conversations APK dynamically. v2.19.15 is 4217303 (x86_64) and 4217304 (arm64-v8a).
+echo "Downloading Conversations APK..."
+curl -fL --progress-bar -o conversations.apk https://f-droid.org/repo/eu.siacs.conversations_4217303.apk
+
+echo "Installing Conversations APK..."
+adb install -r conversations.apk
+
+echo "Starting sidecar API..."
+"$SCRIPT_DIR/start-sidecar-api.sh"
+trap '"$SCRIPT_DIR/stop-sidecar-api.sh"' EXIT
+
+echo "Running Maestro tests (tags: $INCLUDE_TAGS)..."
+maestro test --include-tags "$INCLUDE_TAGS" "$REPO_ROOT/build/ci/conversations/flows/" \
+  || { RC=$?; adb logcat -d conversations:V '*:S' > adb_logcat.log 2>&1; exit $RC; }

--- a/.github/actions/conversationstest-action/run-tests.sh
+++ b/.github/actions/conversationstest-action/run-tests.sh
@@ -18,9 +18,9 @@ echo "Installing Conversations APK..."
 adb install -r conversations.apk
 
 echo "Starting sidecar API..."
-"$SCRIPT_DIR/start-sidecar-api.sh"
 trap '"$SCRIPT_DIR/stop-sidecar-api.sh"' EXIT
+"$SCRIPT_DIR/start-sidecar-api.sh"
 
 echo "Running Maestro tests (tags: $INCLUDE_TAGS)..."
 maestro test --include-tags "$INCLUDE_TAGS" "$REPO_ROOT/build/ci/conversations/flows/" \
-  || { RC=$?; adb logcat -d conversations:V '*:S' > adb_logcat.log 2>&1; exit $RC; }
+  || { RC=$?; adb logcat -d conversations:V '*:S' > adb_logcat.log 2>&1 || true; exit $RC; }

--- a/.github/actions/conversationstest-action/start-sidecar-api.sh
+++ b/.github/actions/conversationstest-action/start-sidecar-api.sh
@@ -7,7 +7,6 @@ SIDECAR_JAR="$WORK_DIR/maestro-logcat-sidecar-${SIDECAR_VERSION}.jar"
 SIDECAR_URL="https://github.com/Fishbowler/maestro-logcat-sidecar/releases/download/v${SIDECAR_VERSION}/maestro-logcat-sidecar-${SIDECAR_VERSION}.jar"
 PID_FILE="$WORK_DIR/.sidecar.pid"
 LOG_FILE="$WORK_DIR/sidecar.log"
-PORT="${PORT:-17777}"
 LOGCAT_TAGS="${LOGCAT_TAGS:-conversations:V *:S}"
 
 if [ ! -f "$SIDECAR_JAR" ]; then
@@ -15,13 +14,15 @@ if [ ! -f "$SIDECAR_JAR" ]; then
     curl -fsSL -o "$SIDECAR_JAR" "$SIDECAR_URL"
 fi
 
-LOGCAT_TAGS="$LOGCAT_TAGS" java -jar "$SIDECAR_JAR" >"$LOG_FILE" 2>&1 &
+LOGCAT_TAGS="$LOGCAT_TAGS" \
+  java -jar "$SIDECAR_JAR" >"$LOG_FILE" 2>&1 &
+
 SIDECAR_PID=$!
 echo "$SIDECAR_PID" >"$PID_FILE"
 
 for _ in $(seq 1 30); do
-    if curl -sf "http://localhost:${PORT}/health" >/dev/null 2>&1; then
-        echo "Sidecar ready on port ${PORT}"
+    if curl -sf "http://localhost:17777/health" >/dev/null 2>&1; then
+        echo "Sidecar ready on port 17777"
         exit 0
     fi
     sleep 0.5

--- a/.github/actions/conversationstest-action/start-sidecar-api.sh
+++ b/.github/actions/conversationstest-action/start-sidecar-api.sh
@@ -29,4 +29,6 @@ for _ in $(seq 1 30); do
 done
 
 echo "ERROR: sidecar did not become ready within 15 seconds. Check $LOG_FILE" >&2
+kill "$SIDECAR_PID" 2>/dev/null || true
+rm -f "$PID_FILE"
 exit 1

--- a/.github/actions/conversationstest-action/start-sidecar-api.sh
+++ b/.github/actions/conversationstest-action/start-sidecar-api.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SIDECAR_VERSION="${SIDECAR_VERSION:-1.0.0}" # A released version of maestro-logcat-sidecar
+WORK_DIR="${RUNNER_TEMP:-/tmp}" # Use GHA temp directory, else the OS temp directory
+SIDECAR_JAR="$WORK_DIR/maestro-logcat-sidecar-${SIDECAR_VERSION}.jar"
+SIDECAR_URL="https://github.com/Fishbowler/maestro-logcat-sidecar/releases/download/v${SIDECAR_VERSION}/maestro-logcat-sidecar-${SIDECAR_VERSION}.jar"
+PID_FILE="$WORK_DIR/.sidecar.pid"
+LOG_FILE="$WORK_DIR/sidecar.log"
+PORT="${PORT:-17777}"
+LOGCAT_TAGS="${LOGCAT_TAGS:-conversations:V *:S}"
+
+if [ ! -f "$SIDECAR_JAR" ]; then
+    echo "Downloading maestro-logcat-sidecar v${SIDECAR_VERSION}..."
+    curl -fsSL -o "$SIDECAR_JAR" "$SIDECAR_URL"
+fi
+
+LOGCAT_TAGS="$LOGCAT_TAGS" java -jar "$SIDECAR_JAR" >"$LOG_FILE" 2>&1 &
+SIDECAR_PID=$!
+echo "$SIDECAR_PID" >"$PID_FILE"
+
+for _ in $(seq 1 30); do
+    if curl -sf "http://localhost:${PORT}/health" >/dev/null 2>&1; then
+        echo "Sidecar ready on port ${PORT}"
+        exit 0
+    fi
+    sleep 0.5
+done
+
+echo "ERROR: sidecar did not become ready within 15 seconds. Check $LOG_FILE" >&2
+exit 1

--- a/.github/actions/conversationstest-action/stop-sidecar-api.sh
+++ b/.github/actions/conversationstest-action/stop-sidecar-api.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORK_DIR="${RUNNER_TEMP:-/tmp}"
+PID_FILE="$WORK_DIR/.sidecar.pid"
+
+if [ ! -f "$PID_FILE" ]; then
+    echo "No sidecar PID file found at $PID_FILE; nothing to stop." >&2
+    exit 0
+fi
+
+PID="$(cat "$PID_FILE")"
+kill "$PID" 2>/dev/null && echo "Sidecar (PID $PID) stopped." || echo "Process $PID was not running."
+rm -f "$PID_FILE"

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -314,6 +314,51 @@ jobs:
         if: ${{ always() && steps.startCIServer.conclusion == 'success' }} # TODO figure out if this is correct. The intent is to have the server stopped if it was successfully started, even if the tests fail. Failing tests should still cause the job to fail.
         uses: ./.github/actions/stopserver-action
 
+  conversations:
+    name: Execute Conversations e2e tests (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: demoboot
+            maestro-tags: demoboot
+          #- name: sasl2
+          #  maestro-tags: sasl2
+          #  config-file: build/ci/conversations/configs/sasl2.xml
+
+    steps:
+      - name: Checkout local actions and test flows # Do this _before_ untarring the distribution, as the checkout will empty the directory prior to the checkout!
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+            build/ci/conversations
+      - name: Download distribution artifact from build job.
+        uses: actions/download-artifact@v8
+        with:
+          name: Openfire Distribution Java 17 zulu on ${{ runner.os }}
+          path: .
+      - name: untar distribution # sharing artifacts that consist of many files can be slow. Share one file instead.
+        run: tar -xf distribution-artifact.tar
+      - name: Patch Openfire config for ${{ matrix.name }}
+        if: ${{ matrix.config-file != '' }}
+        run: cp ${{ matrix.config-file }} ./distribution/target/distribution-base/conf/openfire-demoboot.xml
+      - name: Start CI server from distribution
+        id: startCIServer
+        uses: ./.github/actions/startserver-action
+        with:
+          logLevel: debug
+      - name: Run Conversations tests (${{ matrix.name }})
+        uses: ./.github/actions/conversationstest-action
+        with:
+          includeTags: ${{ matrix.maestro-tags }}
+      - name: Stop CI server
+        if: ${{ always() && steps.startCIServer.conclusion == 'success' }}
+        uses: ./.github/actions/stopserver-action
+
+
   should-do-database-tests:
     name: Check if database install/upgrade tests should be run
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -324,6 +324,7 @@ jobs:
         include:
           - name: demoboot
             maestro-tags: demoboot
+            config-file: '' # Use default demoboot config
           #- name: sasl2
           #  maestro-tags: sasl2
           #  config-file: build/ci/conversations/configs/sasl2.xml

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ CLAUDE.md
 
 # Ignore developer docs (for now)
 docs
+
+conversations.apk

--- a/build/ci/conversations/configs/sasl2.xml
+++ b/build/ci/conversations/configs/sasl2.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jive>
+  <adminConsole>
+      <port>9090</port>
+      <securePort>9091</securePort>
+  </adminConsole>
+  <connectionProvider>
+    <className>org.jivesoftware.database.EmbeddedConnectionProvider</className>
+  </connectionProvider>
+  <autosetup>
+      <run>true</run>
+      <locale>en</locale>
+      <xmpp>
+          <auth>
+              <anonymous>true</anonymous>
+          </auth>
+          <domain>example.org</domain>
+          <fqdn>example.org</fqdn>
+      </xmpp>
+      <database>
+          <mode>embedded</mode>
+      </database>
+      <admin>
+          <email>admin@example.com</email>
+          <password>admin</password>
+      </admin>
+      <users>
+          <user1>
+              <username>john</username>
+              <password>secret</password>
+              <name>John Doe</name>
+              <email>john.doe@example.com</email>
+              <roster>
+                  <item1>
+                      <jid>jane@example.org</jid>
+                      <nickname>Jane</nickname>
+                  </item1>
+                  <item2>
+                      <jid>juan@example.org</jid>
+                      <nickname>Juan</nickname>
+                  </item2>
+              </roster>
+          </user1>
+          <user2>
+              <username>jane</username>
+              <password>secret</password>
+              <name>Jane Doe</name>
+              <email>jane.doe@example.com</email>
+              <roster>
+                  <item1>
+                      <jid>john@example.org</jid>
+                      <nickname>John</nickname>
+                  </item1>
+                  <item2>
+                      <jid>juan@example.org</jid>
+                      <nickname>Juan</nickname>
+                  </item2>
+              </roster>
+          </user2>
+          <user3>
+              <username>juan</username>
+              <password>secret</password>
+              <name>Juan Doe</name>
+              <email>juan.doe@example.com</email>
+              <roster>
+                  <item1>
+                      <jid>john@example.org</jid>
+                      <nickname>John</nickname>
+                  </item1>
+                  <item2>
+                      <jid>jane@example.org</jid>
+                      <nickname>Jane</nickname>
+                  </item2>
+              </roster>
+          </user3>
+      </users>
+  </autosetup>
+  <properties>
+    <!-- TODO: Add SASL2-enabling system properties here. -->
+    <!-- These are likely defined in the SASL2 plugin or as xmpp.auth.* core properties. -->
+  </properties>
+</jive>

--- a/build/ci/conversations/flows/README.md
+++ b/build/ci/conversations/flows/README.md
@@ -31,7 +31,7 @@ Build the distribution and start the server.
 
 The `demoboot` flows need no extra configuration beyond launching Openfire with `-demoboot`.
 For flows with a specific config, copy the matching file from `build/ci/conversations/configs/`
-into your distribution's `conf/` directory as `openfire.xml` before starting demoboot mode.
+into your distribution's `conf/` directory as `openfire-demoboot.xml` before starting demoboot mode.
 
 ### 2. Start an Android emulator
 
@@ -74,7 +74,7 @@ directly (e.g. for flow authoring), start and stop the sidecar yourself:
 
 `start-sidecar-api.sh` downloads the sidecar JAR from GitHub Releases (if not already
 cached), starts it in the background, and polls `GET /health` until it responds.
-Logs are written to `/tmp/sidecar.log`.
+Logs are written to `/tmp/sidecar.log` (or `$RUNNER_TEMP/sidecar.log` in GitHub Actions).
 
 To pin a specific sidecar version:
 ```bash
@@ -96,8 +96,7 @@ for the full API reference.
 
 | Variable | Default | Effect |
 |----------|---------|--------|
-| `PORT` | `17777` | HTTP port the sidecar listens on |
-| `LOGCAT_TAGS` | `Conversations:* *:S` | Tags passed to `adb logcat`. Space-separated. |
+| `LOGCAT_TAGS` | `conversations:V *:S` | Tags passed to `adb logcat`. Space-separated. |
 | `SIDECAR_VERSION` | `1.0.0` | Which release of maestro-logcat-sidecar to download |
 
 The `LOGCAT_TAGS` default filters to Conversations output only — override to capture additional tags if needed.

--- a/build/ci/conversations/flows/README.md
+++ b/build/ci/conversations/flows/README.md
@@ -1,0 +1,118 @@
+# Conversations Maestro Test Harness
+
+Maestro UI test flows for the [Conversations](https://conversations.im) XMPP client, 
+asserting against Android logcat output via the
+[maestro-logcat-sidecar](https://github.com/Fishbowler/maestro-logcat-sidecar) 
+(a Java process that hosts an HTTP API, and fetches logs from a running Android device 
+or emulator).
+
+## Prerequisites
+
+- **`adb` on PATH** from the Android SDK platform-tools. The sidecar API requires it, but 
+doesn't provide it. Maestro uses its own internal `dadb` library so doesn't provide it either.
+
+  ```bash
+  export PATH="$ANDROID_HOME/platform-tools:$PATH"
+  ```
+
+- **Java** on PATH (required to run the sidecar JAR). You probably had this for Openfire anyway.
+
+- **Maestro CLI** installed:
+
+  ```bash
+  curl -fsSL "https://get.maestro.mobile.dev" | bash
+  ```
+
+## Running locally
+
+### 1. Start Openfire
+
+Build the distribution and start the server.
+
+The `demoboot` flows need no extra configuration beyond launching Openfire with `-demoboot`.
+For flows with a specific config, copy the matching file from `build/ci/conversations/configs/`
+into your distribution's `conf/` directory as `openfire.xml` before starting demoboot mode.
+
+### 2. Start an Android emulator
+
+Launch an emulator with API 34 and x86_64 architecture. With Maestro installed, you can create or
+launch one with the following:
+
+```bash
+maestro start-device --platform=android --os-version=34
+```
+
+Or you can start one via Android Studio's AVD Manager. Wait until it is fully booted before
+continuing.
+
+### 3. Run the tests
+
+From the repo root, pass a tag to select which suite to run:
+
+```bash
+.github/actions/conversationstest-action/run-tests.sh demoboot
+```
+
+All tests that don't require a specific config should be tagged `demoboot`.
+A tag is required - the suites use incompatible Openfire configurations and must not be mixed.
+
+The script downloads and installs the Conversations APK, starts the sidecar,
+runs the selected Maestro flows, then stops the sidecar.
+
+## Sidecar: manual start/stop
+
+`run-tests.sh` manages the sidecar lifecycle automatically. If you need to run Maestro
+directly (e.g. for flow authoring), start and stop the sidecar yourself:
+
+```bash
+# Before your test run (from the repo root)
+.github/actions/conversationstest-action/start-sidecar-api.sh
+
+# After your test run
+.github/actions/conversationstest-action/stop-sidecar-api.sh
+```
+
+`start-sidecar-api.sh` downloads the sidecar JAR from GitHub Releases (if not already
+cached), starts it in the background, and polls `GET /health` until it responds.
+Logs are written to `/tmp/sidecar.log`.
+
+To pin a specific sidecar version:
+```bash
+SIDECAR_VERSION=1.2.0 .github/actions/conversationstest-action/start-sidecar-api.sh
+```
+
+## API reference
+
+See the [maestro-logcat-sidecar docs](https://github.com/Fishbowler/maestro-logcat-sidecar/blob/main/README.md)
+for the full API reference.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/session/start` | Clears the logcat buffer. |
+| `GET`  | `/assert?pattern=<regex>` | Snapshot scan. Returns `200` with matched lines, or `404` if none match. |
+| `GET`  | `/health` | Liveness probe. Always returns `200 {"status":"ok"}`. |
+
+## Configuration
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `PORT` | `17777` | HTTP port the sidecar listens on |
+| `LOGCAT_TAGS` | `Conversations:* *:S` | Tags passed to `adb logcat`. Space-separated. |
+| `SIDECAR_VERSION` | `1.0.0` | Which release of maestro-logcat-sidecar to download |
+
+The `LOGCAT_TAGS` default filters to Conversations output only — override to capture additional tags if needed.
+
+## Writing regex patterns
+
+Use `checkForLogs.js` in a flow:
+
+```yaml
+- runScript:
+    file: scripts/checkForLogs.js
+    env:
+      PATTERN: 'SMACK.*connected'
+```
+
+The above returns `HTTP/200` if a log line containing "SMACK" followed later by "connected" exists.
+
+The matched lines are available in subsequent steps as `${checkForLogs.output.matchedLines}`.

--- a/build/ci/conversations/flows/sasl2.yaml
+++ b/build/ci/conversations/flows/sasl2.yaml
@@ -1,0 +1,53 @@
+appId: eu.siacs.conversations
+tags:
+    - sasl2
+onFlowStart:
+    - runScript: scripts/checkHealth.js
+---
+
+- runScript: scripts/startSession.js
+
+- launchApp:
+    clearState: true
+
+- assertVisible: "I already have an account"
+
+- runScript: 
+    file: scripts/checkForLogs.js
+    env:
+        PATTERN: initializing database.*
+
+- tapOn: "I already have an account"
+- tapOn: "More options"
+- tapOn: "Settings"
+- tapOn: "Connection"
+- tapOn: "Show extended connection settings when setting up an account"
+- tapOn: "Navigate up"
+- tapOn: "Navigate up"
+
+- tapOn: "XMPP address"
+- inputText: "jane@example.org"
+- tapOn: "Password"
+- inputText: "secret"
+- tapOn: "Hostname"
+- inputText: "10.0.2.2"
+- tapOn: "Next"
+
+- assertVisible: "Accept Unknown Certificate?"
+- tapOn: "Always"
+
+- assertVisible: "Publish avatar"
+- tapOn: "Skip"
+
+- runFlow:
+    when: 
+      visible: "Battery optimizations enabled"
+    commands: 
+      - tapOn: "Next"
+      - assertVisible: "Let app always run in background?"
+      - tapOn: "Allow"
+
+- runScript: 
+    file: scripts/checkForLogs.js
+    env:
+        PATTERN: .*SASL 2.0 authorization identifier was jane@example.org

--- a/build/ci/conversations/flows/scripts/checkForLogs.js
+++ b/build/ci/conversations/flows/scripts/checkForLogs.js
@@ -1,0 +1,10 @@
+const pattern = PATTERN;
+if (!pattern) throw new Error('PATTERN env var is required');
+
+const res = http.get('http://localhost:17777/assert?pattern=' + encodeURIComponent(pattern));
+if (res.status === 404) throw new Error('Expected log line not found: ' + pattern);
+if (!res.ok) throw new Error('Sidecar error: ' + res.status);
+
+const body = JSON.parse(res.body);
+output.matchedLines = body.lines;
+body.lines.forEach(function(line) { console.log(line); });

--- a/build/ci/conversations/flows/scripts/checkForLogs.js
+++ b/build/ci/conversations/flows/scripts/checkForLogs.js
@@ -1,4 +1,4 @@
-const pattern = PATTERN;
+const pattern = typeof PATTERN !== 'undefined' ? PATTERN : undefined;
 if (!pattern) throw new Error('PATTERN env var is required');
 
 const res = http.get('http://localhost:17777/assert?pattern=' + encodeURIComponent(pattern));

--- a/build/ci/conversations/flows/scripts/checkHealth.js
+++ b/build/ci/conversations/flows/scripts/checkHealth.js
@@ -1,0 +1,23 @@
+const MAX_ATTEMPTS = 3;
+const DELAY_MS = 500;
+
+function sleep(ms) {
+    const end = Date.now() + ms;
+    while (Date.now() < end) { /* busy-wait */ }
+}
+
+let healthy = false;
+let lastError = 'Health check failed after ' + MAX_ATTEMPTS + ' attempts';
+
+for (let i = 0; i < MAX_ATTEMPTS; i++) {
+    if (i > 0) sleep(DELAY_MS);
+    try {
+        const res = http.get('http://localhost:17777/health');
+        if (res.ok) { healthy = true; break; }
+        lastError = 'Health check returned HTTP ' + res.status;
+    } catch (e) {
+        lastError = 'Health check request failed: ' + (e.message || String(e));
+    }
+}
+
+if (!healthy) throw new Error(lastError);

--- a/build/ci/conversations/flows/scripts/startSession.js
+++ b/build/ci/conversations/flows/scripts/startSession.js
@@ -1,0 +1,7 @@
+const res = http.post('http://localhost:17777/session/start', {body: ''})
+if (!res.ok) throw new Error('Failed to start session: HTTP ' + res.status);
+
+const body = JSON.parse(res.body);
+if (body.status !== 'started') throw new Error('Unexpected session start response: ' + res.body);
+
+output.timestamp = body.timestamp;

--- a/build/ci/conversations/flows/simple.yaml
+++ b/build/ci/conversations/flows/simple.yaml
@@ -1,0 +1,50 @@
+appId: eu.siacs.conversations
+tags:
+    - demoboot
+onFlowStart:
+    - runScript: scripts/checkHealth.js
+---
+
+- runScript: scripts/startSession.js
+
+- launchApp:
+    clearState: true
+
+- assertVisible: "I already have an account"
+
+- runScript: 
+    file: scripts/checkForLogs.js
+    env:
+        PATTERN: initializing database.*
+
+- tapOn: "I already have an account"
+- tapOn: "More options"
+- tapOn: "Settings"
+- tapOn: "Connection"
+- tapOn: "Show extended connection settings when setting up an account"
+- tapOn: "Navigate up"
+- tapOn: "Navigate up"
+
+- tapOn: "XMPP address"
+- inputText: "jane@example.org"
+- tapOn: "Password"
+- inputText: "secret"
+- tapOn: "Hostname"
+- inputText: "10.0.2.2"
+- tapOn: "Next"
+
+- assertVisible: "Accept Unknown Certificate?"
+- tapOn: "Always"
+
+- assertVisible: "Publish avatar"
+- tapOn: "Skip"
+
+- runFlow:
+    when: 
+      visible: "Battery optimizations enabled"
+    commands: 
+      - tapOn: "Next"
+      - assertVisible: "Let app always run in background?"
+      - tapOn: "Allow"
+
+- assertVisible: "Once you start a new conversation.*"


### PR DESCRIPTION
This PR:
- Adds an action that will download a Conversations APK, launch an emulator, install the app and run tests using Maestro
- Adds some tests to run
- Adds an additional test job to Openfire CI to run the action

There's the beginnings of some `sasl2` stuff here, as that was the trigger for writing this, but it's not enabled here.