### PR TITLE
OF-3264: IpUtils should ignore scope/zone suffix for IPv6 values

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/IpUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/IpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2024-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class IpUtils
             return isAddressInAnyOf(Ipv4.of(address), addressesAndRanges);
         }
         if (isValidIpv6(address)) {
-            return isAddressInAnyOf(Ipv6.of(address), addressesAndRanges);
+            return isAddressInAnyOf(Ipv6.of(stripIpv6ZoneId(address)), addressesAndRanges);
         }
         throw new IllegalArgumentException("Unrecognized address type: " + address);
     }
@@ -258,6 +258,10 @@ public class IpUtils
     /**
      * Checks if the provided value is a representation of an IPv6 address.
      *
+     * An optional zone/scope ID suffix (e.g. {@code %eth0} or {@code %1} as appended by
+     * {@link java.net.InetAddress#getHostAddress()}) is silently stripped before the check so that
+     * scoped link-local addresses such as {@code fe80::1%eth0} are recognised as valid.
+     *
      * @param value the value to check
      * @return true if the provided value is an IPv6 address, otherwise false.
      */
@@ -267,11 +271,27 @@ public class IpUtils
             return false;
         }
         try {
-            Ipv6.parse(value);
+            Ipv6.parse(stripIpv6ZoneId(value));
         } catch (IllegalArgumentException e) {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Strips the IPv6 zone/scope ID suffix from an address string if one is present.
+     *
+     * For example, {@code "fe80::1%eth0"} becomes {@code "fe80::1"}. Strings that contain no {@code '%'} character are
+     * returned unchanged. This handles the suffix that {@link java.net.InetAddress#getHostAddress()} appends for scoped
+     * IPv6 addresses.
+     *
+     * @param address the address string to normalise; must not be {@code null}
+     * @return the address string with any zone/scope ID removed
+     */
+    private static String stripIpv6ZoneId(@Nonnull final String address)
+    {
+        final int zoneIndex = address.indexOf('%');
+        return zoneIndex >= 0 ? address.substring(0, zoneIndex) : address;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/util/IpUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/IpUtils.java
@@ -114,7 +114,7 @@ public class IpUtils
      */
     public static boolean isAddressInAnyOf(final @Nonnull Ipv6 address, final @Nonnull Set<String> addressesAndRanges)
     {
-        final Set<Ipv6> addresses = addressesAndRanges.stream().filter(IpUtils::isValidIpv6).map(Ipv6::of).collect(Collectors.toSet());
+        final Set<Ipv6> addresses = addressesAndRanges.stream().filter(IpUtils::isValidIpv6).map(IpUtils::stripIpv6ZoneId).map(Ipv6::of).collect(Collectors.toSet());
         final Set<Ipv6Range> ranges = addressesAndRanges.stream().filter(IpUtils::isValidIpv6Range).map(Ipv6Range::parse).collect(Collectors.toSet());
         return isAddressInAnyOf(address, addresses, ranges);
     }

--- a/xmppserver/src/test/java/org/jivesoftware/util/IpUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/IpUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2024-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2028,5 +2028,43 @@ public class IpUtilsTest
 
         // Verify results.
         assertTrue(result);
+    }
+
+    /**
+     * Asserts that {@link IpUtils#isAddressInAnyOf(String, Set)} correctly handles an IPv6 address string that contains
+     * a zone/scope ID suffix (e.g. "fe80::1%eth0"), as produced by {@link java.net.InetAddress#getHostAddress()}.
+     * The zone ID must be stripped before matching so that no {@link IllegalArgumentException} is thrown and the
+     * address is still resolved against the configured ranges.
+     */
+    @Test
+    public void testIsAddressInAnyOfStringScopedIpv6MatchesTrueWhenInRange()
+    {
+        // Setup test fixture.
+        final String scopedAddress = "2001:db8::1%eth0";
+        final Set<String> ranges = Set.of("2001:db8::/32");
+
+        // Execute system under test.
+        final boolean result = IpUtils.isAddressInAnyOf(scopedAddress, ranges);
+
+        // Verify results.
+        assertTrue(result, "A scoped IPv6 address (with %zone suffix) must match when the bare address is inside a configured range.");
+    }
+
+    /**
+     * Asserts that {@link IpUtils#isAddressInAnyOf(String, Set)} correctly handles an IPv6 address string that contains
+     * a zone/scope ID suffix when the bare address is NOT in any configured range.
+     */
+    @Test
+    public void testIsAddressInAnyOfStringScopedIpv6ReturnsFalseWhenOutOfRange()
+    {
+        // Setup test fixture.
+        final String scopedAddress = "fe80::1%eth0";
+        final Set<String> ranges = Set.of("2001:db8::/32");
+
+        // Execute system under test.
+        final boolean result = IpUtils.isAddressInAnyOf(scopedAddress, ranges);
+
+        // Verify results.
+        assertFalse(result, "A scoped IPv6 address (with %zone suffix) must not match when the bare address is outside all configured ranges.");
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/util/IpUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/IpUtilsTest.java
@@ -147,6 +147,42 @@ public class IpUtilsTest
     }
 
     /**
+     * Asserts that {@link IpUtils#isAddressInAnyOf(Ipv6, Set)} supports scoped IPv6 configured addresses by
+     * stripping the zone/scope ID before conversion and matching.
+     */
+    @Test
+    public void testIsAddressInAnyOfIpv6NonSplitAddressMatchScopedConfiguredAddress()
+    {
+        // Setup test fixture.
+        final Ipv6 needle = Ipv6.of("fe80::1");
+        final Set<String> addressesAndRanges = Set.of("fe80::1%eth0", "2001:db8::/32");
+
+        // Execute system under test.
+        final boolean result = assertDoesNotThrow(() -> IpUtils.isAddressInAnyOf(needle, addressesAndRanges));
+
+        // Verify results.
+        assertTrue(result);
+    }
+
+    /**
+     * Asserts that {@link IpUtils#isAddressInAnyOf(Ipv6, Set)} does not throw when scoped IPv6 configured addresses
+     * are present and still returns false when no entry matches.
+     */
+    @Test
+    public void testIsAddressInAnyOfIpv6NonSplitNoMatchScopedConfiguredAddress()
+    {
+        // Setup test fixture.
+        final Ipv6 needle = Ipv6.of("fe80::2");
+        final Set<String> addressesAndRanges = Set.of("fe80::1%eth0", "2001:db8::/32");
+
+        // Execute system under test.
+        final boolean result = assertDoesNotThrow(() -> IpUtils.isAddressInAnyOf(needle, addressesAndRanges));
+
+        // Verify results.
+        assertFalse(result);
+    }
+
+    /**
      * Asserts that {@link IpUtils#isAddressInAnyOf(Ipv6, Set, Set)} correctly find the provided address in non-empty
      * sets of addresses and ranges, when one of the ranges contains the provided address.
      */
@@ -2066,5 +2102,23 @@ public class IpUtilsTest
 
         // Verify results.
         assertFalse(result, "A scoped IPv6 address (with %zone suffix) must not match when the bare address is outside all configured ranges.");
+    }
+
+    /**
+     * Asserts that {@link IpUtils#isAddressInAnyOf(String, Set)} supports scoped IPv6 literals in
+     * configured addresses by stripping zone/scope IDs before exact-address matching.
+     */
+    @Test
+    public void testIsAddressInAnyOfStringScopedIpv6MatchesScopedConfiguredAddress()
+    {
+        // Setup test fixture.
+        final String scopedNeedle = "fe80::1%wlan0";
+        final Set<String> addressesAndRanges = Set.of("fe80::1%eth0", "2001:db8::/32");
+
+        // Execute system under test.
+        final boolean result = assertDoesNotThrow(() -> IpUtils.isAddressInAnyOf(scopedNeedle, addressesAndRanges));
+
+        // Verify results.
+        assertTrue(result, "Scoped IPv6 literals should match by bare address even when zone IDs differ.");
     }
 }


### PR DESCRIPTION
IpUtils should successfully parse a value like `fe80::1%eth0` as an IPv6 address.