### PR TITLE
OF-3266: Fix wrong getter used in setAcceptSelfSignedCertificates

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/spi/ConnectionListener.java
@@ -733,7 +733,7 @@ public class ConnectionListener
      */
     public void setAcceptSelfSignedCertificates( boolean accept )
     {
-        final boolean oldValue = verifyCertificateValidity();
+        final boolean oldValue = acceptSelfSignedCertificates();
 
         // Always set the property explicitly even if it appears the equal to the old value (the old value might be a fallback value).
         JiveGlobals.setProperty( type.getPrefix() + "certificate.accept-selfsigned", Boolean.toString( accept ) );


### PR DESCRIPTION
Use acceptSelfSignedCertificates() instead of verifyCertificateValidity() to determine the previous value.

The old implementation compared unrelated settings, which could prevent required restarts or trigger unnecessary ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of self-signed certificate acceptance policy change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->