### PR TITLE
Fix test setup race condition and suppress log4j warnings

### DIFF
--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalIncomingServerSessionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalIncomingServerSessionTest.java
@@ -137,7 +137,6 @@ public class LocalIncomingServerSessionTest
     public void setUpEach() throws Exception {
         JiveGlobals.setProperty("xmpp.domain", Fixtures.XMPP_DOMAIN);
         final XMPPServer xmppServer = Fixtures.mockXMPPServer();
-        XMPPServer.setInstance(xmppServer);
 
         final File tmpDir = new File(System.getProperty("java.io.tmpdir"));
 
@@ -162,6 +161,9 @@ public class LocalIncomingServerSessionTest
         final SessionManager sessionManager = new SessionManager(); // This is the system under test. We do not want to use a mock for this test!
         sessionManager.initialize(xmppServer);
         doReturn(sessionManager).when(xmppServer).getSessionManager();
+
+        // Expose the singleton only after stubs are ready: lingering Netty threads from the prior test call getInstance() during cleanup, racing stub setup and corrupting Mockito's InvocationContainerImpl.
+        XMPPServer.setInstance(xmppServer);
 
         remoteInitiatingServerDummy = new RemoteInitiatingServerDummy(Fixtures.XMPP_DOMAIN);
     }

--- a/xmppserver/src/test/resources/log4j2-test-mvn.xml
+++ b/xmppserver/src/test/resources/log4j2-test-mvn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- log4j2 config file used when running under Maven -->
-<Configuration>
+<Configuration status="OFF">
     <Appenders>
         <File name="file" fileName="target/surefire-reports/test.log">
             <PatternLayout>


### PR DESCRIPTION
:pray: Please be the fix that ends this loop

The second commit is an annoyance during local test execution, but something I'll drop if folks don't like it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure and logging configuration to improve test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->