### PR TITLE
Disable unit tests that give inconsistent results.

### DIFF
--- a/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalIncomingServerSessionTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/session/LocalIncomingServerSessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -78,6 +79,7 @@ import static org.mockito.Mockito.*;
  * @author Guus der Kinderen, guus@goodbytes.nl
  * @author Alex Gidman, alex.gidman@surevine.com
  */
+@Disabled("Despite many efforts, this test does not run consistently on GitHub's workflow, leading to a significant amount of intermittent failures. See OF-3269")
 @ExtendWith(MockitoExtension.class)
 public class LocalIncomingServerSessionTest
 {


### PR DESCRIPTION
These tests fail frequently in GitHub's CI workflow, while running fine locally. Disabling them to prevent build failures until we can find the cause. See OF-3269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled a test class on GitHub CI that was experiencing intermittent execution failures.
  * Updated copyright year in test file header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->