### PR TITLE
OF-3270: Fix setter for MUC's user-idle-task interval

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2254,7 +2254,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
     @Override
     public void setIdleUserTaskInterval(final @Nonnull Duration duration) {
         // Set the new property value
-        MUCPersistenceManager.setProperty(chatServiceName, "tasks.user.timeout", Long.toString(userIdleTaskInterval.toMillis()));
+        MUCPersistenceManager.setProperty(chatServiceName, "tasks.user.timeout", Long.toString(duration.toMillis()));
 
         rescheduleUserTimeoutTask();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Idle user timeout configuration now persists the actual interval supplied by callers, ensuring applied and saved timeout values match and preventing stale settings from being stored.

* **Chores**
  * Updated copyright year ranges in file headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->