### PR TITLE
Rename isStreamManagementNonza to isCsiNonza in CsiManager

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -271,9 +271,17 @@ public class CsiManager
      * @param fragment the XML to evaluate
      * @return true if the XML is recognized as a CSI nonza, otherwise false.
      */
-    public static boolean isStreamManagementNonza(@Nullable final Element fragment) {
+    public static boolean isCsiNonza(@Nullable final Element fragment) {
         return fragment != null
             && NAMESPACE.equals(fragment.getNamespaceURI())
             && Set.of("active", "inactive").contains(fragment.getName());
+    }
+
+    /**
+     * @deprecated Replaced by {@link #isCsiNonza(Element)}
+     */
+    @Deprecated(forRemoval = true, since = "5.1.0")
+    public static boolean isStreamManagementNonza(@Nullable final Element fragment) {
+        return isCsiNonza(fragment);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientStanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/ClientStanzaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public class ClientStanzaHandler extends StanzaHandler {
 
     @Override
     protected boolean processUnknowPacket(Element doc) {
-        if (CsiManager.isStreamManagementNonza(doc)) {
+        if (CsiManager.isCsiNonza(doc)) {
             Log.trace("Client is sending client state indication nonza.");
             ((LocalClientSession) session).getCsiManager().process(doc);
             return true;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/StreamManagementPacketRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/websocket/StreamManagementPacketRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Tom Evans, 2017-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2015 Tom Evans, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class StreamManagementPacketRouter extends SessionPacketRouter {
 
         if (StreamManager.NAMESPACE_V3.equals(wrappedElement.getNamespace().getStringValue())) {
             session.getStreamManager().process(wrappedElement);
-        } else if (CsiManager.isStreamManagementNonza(wrappedElement)) {
+        } else if (CsiManager.isCsiNonza(wrappedElement)) {
             session.getCsiManager().process(wrappedElement);
         } else {
             super.route(wrappedElement);


### PR DESCRIPTION
The old method name clearly is a copy/paste error. Deprecated old method name for removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal client state indication detection with clearer API naming conventions.
  * Deprecated legacy stream management detection method in favor of a more semantically accurate alternative.
  * Updated internal stream handling components to use the new detection method, ensuring consistent behavior across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->