### PR TITLE
CI: bump actions/setup-java to v5

### DIFF
--- a/.github/actions/connectivitytests-action/action.yml
+++ b/.github/actions/connectivitytests-action/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 17
         distribution: zulu

--- a/.github/actions/startserver-action/action.yml
+++ b/.github/actions/startserver-action/action.yml
@@ -27,7 +27,7 @@ runs:
       env:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
     - name: Set up Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 17
         distribution: zulu


### PR DESCRIPTION
Node.js 20 actions are deprecated. actions/setup-java@v4 uses node 20, v5 uses node 24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to use the latest Java setup action version for improved compatibility and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->