### PR TITLE
OF-3274: Bump org.glassfish.jaxb:jaxb-runtime from 2.3.3 to 2.3.9

### DIFF
--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -427,7 +427,7 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.3</version>
+            <version>2.3.9</version>
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>


### PR DESCRIPTION
jaxb-runtime 4 is Jakarta JAXB (jakarta.xml.bind.), which is a package-rename break from javax.xml.bind.. so a direct upgrade to 4.0.x is not safe for the current code.

We should keep JAXB on the 2.3.x line for now (same javax namespace)