### PR TITLE
Cache conversations.apk in tests

### DIFF
--- a/.github/actions/conversationstest-action/action.yml
+++ b/.github/actions/conversationstest-action/action.yml
@@ -31,6 +31,12 @@ runs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
 
+    - name: Cache Conversations APK
+      uses: actions/cache@v5
+      with:
+        path: conversations.apk
+        key: conversations-apk-4217303 # Update this number at the same time as the version in run-tests.sh
+
     - name: Run Android emulator and tests
       uses: reactivecircus/android-emulator-runner@v2
       with:

--- a/.github/actions/conversationstest-action/run-tests.sh
+++ b/.github/actions/conversationstest-action/run-tests.sh
@@ -14,7 +14,15 @@ INCLUDE_TAGS="$1"
 # For now, when updating the version number here, update the cache key in conversationstest-action/action.yml
 if [ ! -f conversations.apk ]; then
   echo "Downloading Conversations APK..."
-  curl -fL --progress-bar -o conversations.apk https://f-droid.org/repo/eu.siacs.conversations_4217303.apk
+  curl -fL \
+    --progress-bar \
+    --retry 5 \
+    --retry-all-errors \
+    --retry-delay 2 \
+    --connect-timeout 15 \
+    --max-time 300 \
+    -o conversations.apk \
+    https://f-droid.org/repo/eu.siacs.conversations_4217303.apk
 else
   echo "Using cached Conversations APK."
 fi

--- a/.github/actions/conversationstest-action/run-tests.sh
+++ b/.github/actions/conversationstest-action/run-tests.sh
@@ -11,8 +11,13 @@ fi
 INCLUDE_TAGS="$1"
 
 # TODO: research F-Droid APIs to resolve the latest Conversations APK dynamically. v2.19.15 is 4217303 (x86_64) and 4217304 (arm64-v8a).
-echo "Downloading Conversations APK..."
-curl -fL --progress-bar -o conversations.apk https://f-droid.org/repo/eu.siacs.conversations_4217303.apk
+# For now, when updating the version number here, update the cache key in conversationstest-action/action.yml
+if [ ! -f conversations.apk ]; then
+  echo "Downloading Conversations APK..."
+  curl -fL --progress-bar -o conversations.apk https://f-droid.org/repo/eu.siacs.conversations_4217303.apk
+else
+  echo "Using cached Conversations APK."
+fi
 
 echo "Installing Conversations APK..."
 adb install -r conversations.apk


### PR DESCRIPTION
Sometimes f-droid has comms flakes. We also shouldn't burn their bandwidth unnecessarily.