### PR TITLE
CI / GitHub workflow: Cache Maven Wrapper artifacts

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -31,6 +31,13 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: ${{ matrix.distribution }}
           cache: maven
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Build with Maven while generating code coverage report # We install instead of package, because we want the result in the local mvn repo
         if: ${{ github.ref_name == 'main' }}
         run: ./mvnw -B install -Pcoverage --file pom.xml
@@ -139,6 +146,14 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
           cache: 'maven'
+
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('openfire-integration-tests/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
 
       - name: Run Integration Tests
         working-directory: openfire-integration-tests
@@ -424,6 +439,13 @@ jobs:
           java-version: 17
           distribution: zulu
           cache: maven
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Restore mvn repo artifacts from build job
         uses: actions/download-artifact@v8
         with:
@@ -462,6 +484,13 @@ jobs:
           java-version: 17
           distribution: zulu
           cache: maven
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Restore mvn repo artifacts from build job
         uses: actions/download-artifact@v8
         with:
@@ -507,6 +536,13 @@ jobs:
           java-version: 17
           distribution: zulu
           cache: maven
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Restore mvn repo artifacts from build job
         uses: actions/download-artifact@v8
         with:
@@ -546,6 +582,13 @@ jobs:
           java-version: 17
           distribution: zulu
           cache: maven
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Restore mvn repo artifacts from build job
         uses: actions/download-artifact@v8
         with:
@@ -586,6 +629,13 @@ jobs:
           java-version: 17
           distribution: zulu
           cache: maven
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Restore mvn repo artifacts from build job
         uses: actions/download-artifact@v8
         with:
@@ -623,6 +673,13 @@ jobs:
           java-version: 17
           distribution: zulu
           cache: maven
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Restore mvn repo artifacts from build job
         uses: actions/download-artifact@v8
         with:
@@ -663,6 +720,13 @@ jobs:
           java-version: 17
           distribution: zulu
           cache: maven
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Restore mvn repo artifacts from build job
         uses: actions/download-artifact@v8
         with:
@@ -702,6 +766,13 @@ jobs:
           java-version: 17
           distribution: zulu
           cache: maven
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Restore mvn repo artifacts from build job
         uses: actions/download-artifact@v8
         with:
@@ -744,6 +815,13 @@ jobs:
           java-version: 17
           distribution: zulu
           cache: maven
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Restore mvn repo artifacts from build job
         uses: actions/download-artifact@v8
         with:
@@ -783,6 +861,13 @@ jobs:
           java-version: 17
           distribution: zulu
           cache: maven
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Restore mvn repo artifacts from build job
         uses: actions/download-artifact@v8
         with:
@@ -832,6 +917,13 @@ jobs:
           server-id: igniterealtime
           server-username: IGNITE_REALTIME_MAVEN_USERNAME
           server-password: IGNITE_REALTIME_MAVEN_PASSWORD
+      - name: Cache Maven wrapper distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/wrapper
+          key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvn-wrapper-
       - name: Publish
         run: ./mvnw -B deploy -Pci -Dmaven.test.skip=true
         env:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -32,7 +32,7 @@ jobs:
           distribution: ${{ matrix.distribution }}
           cache: maven
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
@@ -148,7 +148,7 @@ jobs:
           cache: 'maven'
 
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('openfire-integration-tests/.mvn/wrapper/maven-wrapper.properties') }}
@@ -440,7 +440,7 @@ jobs:
           distribution: zulu
           cache: maven
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
@@ -485,7 +485,7 @@ jobs:
           distribution: zulu
           cache: maven
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
@@ -537,7 +537,7 @@ jobs:
           distribution: zulu
           cache: maven
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
@@ -583,7 +583,7 @@ jobs:
           distribution: zulu
           cache: maven
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
@@ -630,7 +630,7 @@ jobs:
           distribution: zulu
           cache: maven
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
@@ -674,7 +674,7 @@ jobs:
           distribution: zulu
           cache: maven
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
@@ -721,7 +721,7 @@ jobs:
           distribution: zulu
           cache: maven
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
@@ -767,7 +767,7 @@ jobs:
           distribution: zulu
           cache: maven
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
@@ -816,7 +816,7 @@ jobs:
           distribution: zulu
           cache: maven
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
@@ -862,7 +862,7 @@ jobs:
           distribution: zulu
           cache: maven
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties', 'build/ci/updater/.mvn/wrapper/maven-wrapper.properties') }}
@@ -918,7 +918,7 @@ jobs:
           server-username: IGNITE_REALTIME_MAVEN_USERNAME
           server-password: IGNITE_REALTIME_MAVEN_PASSWORD
       - name: Cache Maven wrapper distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/wrapper
           key: ${{ runner.os }}-mvn-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties') }}


### PR DESCRIPTION
Our GitHub workflow uses the 'maven' cache that's provided by the `actions/setup-java` action.

I was surprised to see the following build failure earlier today:

```
Run ./mvnw -B install --file pom.xml
  ./mvnw -B install --file pom.xml
  shell: /usr/bin/bash -e {0}
  env:
    CI: true
    REGISTRY: ghcr.io
    IMAGE_NAME: openfire
    JAVA_HOME: /opt/hostedtoolcache/Java_Zulu_jdk/25.0.3-9/x64
    JAVA_HOME_25_X64: /opt/hostedtoolcache/Java_Zulu_jdk/25.0.3-9/x64
Error: Exception in thread "main" java.io.IOException: Server returned HTTP response code: 429 for URL: https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1713)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1305)
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:223)
	at org.apache.maven.wrapper.DefaultDownloader.downloadInternal(DefaultDownloader.java:100)
	at org.apache.maven.wrapper.DefaultDownloader.download(DefaultDownloader.java:86)
	at org.apache.maven.wrapper.Installer.createDist(Installer.java:84)
	at org.apache.maven.wrapper.WrapperExecutor.execute(WrapperExecutor.java:160)
	at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:73)
Error: Process completed with exit code 1.
```

This shows that Maven is still being downloaded, instead of the wrapped version being cached/used.

Apparently, the 'maven' cache from the `actions/setup-java` action does not cache these artifacts. With the changes in this commit, they now should.