### PR TITLE
OF-3037: Expose failed outbound S2S sessions in admin console with diagnostics

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1917,7 +1917,26 @@ server.session.label.close_connect=Close Connection
 server.session.connection.incoming=Incoming
 server.session.connection.outgoing=Outgoing
 server.session.connection.both=Both
+server.session.connection.failed=Failed
 server.session.summary.sessions_per_page=Sessions per page
+server.session.summary.failed_count=Failed S2S attempts
+server.session.summary.not_available=N/A
+server.session.failure.diagnostics.open=Diagnostics
+
+# Server Session failure details Page
+
+server.session.failure.title=Failed Remote Server Connection Diagnostics
+server.session.failure.info=Below are diagnostics for a failed server-to-server session attempt to {0}.
+server.session.failure.section.overview=Failure overview
+server.session.failure.section.initiator=Connection initiation diagnostics
+server.session.failure.last_attempt=Last attempt
+server.session.failure.reason=Failure reason
+server.session.failure.action.retry=Retry now
+server.session.failure.action.block=Block this domain
+server.session.failure.action.search=Search roster usage
+server.session.failure.search.results.title=Local users with roster contacts on this remote domain
+server.session.failure.search.results.none=No local users were found with roster contacts on this remote domain.
+server.session.failure.stub.initiator=Stub: initiation details are not yet wired to backend diagnostics APIs.
 
 # Server Session details Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1240,6 +1240,19 @@ public class SessionManager extends BasicModule implements ClusterEventListener
     public Collection<String> getOutgoingServers() {
         return routingTable.getServerHostnames();
     }
+
+    /**
+     * Returns remote domains for which the latest outgoing server-to-server connection establishment
+     * attempt failed.
+     *
+     * Entries are cleared when a subsequent outgoing attempt to the same remote domain succeeds.
+     *
+     * @return a collection of remote server domains.
+     */
+    public Collection<String> getFailedServers() {
+        return OutgoingSessionPromise.getInstance().getFailedServers();
+    }
+
     public Collection<DomainPair> getOutgoingDomainPairs() {
         return routingTable.getServerRoutes();
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/DefaultRosterItemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2021 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,8 @@ public class DefaultRosterItemProvider implements RosterItemProvider {
             "DELETE FROM ofRoster WHERE rosterID=?";
     private static final String LOAD_USERNAMES =
             "SELECT DISTINCT username from ofRoster WHERE jid=?";
+    private static final String LOAD_USERNAMES_BY_DOMAIN =
+            "SELECT DISTINCT username FROM ofRoster WHERE jid=? OR jid LIKE ?";
     private static final String COUNT_ROSTER_ITEMS =
             "SELECT COUNT(rosterID) FROM ofRoster WHERE username=?";
      private static final String LOAD_ROSTER =
@@ -201,6 +203,31 @@ public class DefaultRosterItemProvider implements RosterItemProvider {
             con = DbConnectionManager.getConnection();
             pstmt = con.prepareStatement(LOAD_USERNAMES);
             pstmt.setString(1, jid);
+            rs = pstmt.executeQuery();
+            while (rs.next()) {
+                answer.add(rs.getString(1));
+            }
+        }
+        catch (SQLException e) {
+            Log.error(LocaleUtils.getLocalizedString("admin.error"), e);
+        }
+        finally {
+            DbConnectionManager.closeConnection(rs, pstmt, con);
+        }
+        return answer.iterator();
+    }
+
+    @Override
+    public Iterator<String> getUsernamesByDomain(final String domain) {
+        final List<String> answer = new ArrayList<>();
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            con = DbConnectionManager.getConnection();
+            pstmt = con.prepareStatement(LOAD_USERNAMES_BY_DOMAIN);
+            pstmt.setString(1, domain);
+            pstmt.setString(2, "%@" + domain);
             rs = pstmt.executeQuery();
             while (rs.next()) {
                 answer.add(rs.getString(1));

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItemProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterItemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2009 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2009 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,21 @@ public interface RosterItemProvider {
     * @return an iterator on the usernames whose roster includes the specified JID.
     */
     Iterator<String> getUsernames(String jid);
+
+    /**
+     * Returns an iterator of usernames whose roster includes one or more entities that are on the
+     * specified remote domain.
+     *
+     * Implementations are encouraged to provide an optimized backend query. The default
+     * implementation indicates that this operation is not supported.
+     *
+     * @param domain the remote domain for which to find roster usage.
+     * @return an iterator of usernames whose roster contains at least one contact on the domain.
+     * @throws UnsupportedOperationException when this provider does not support domain-targeted lookups.
+     */
+    default Iterator<String> getUsernamesByDomain(final String domain) {
+        throw new UnsupportedOperationException("Domain-based roster lookup is not supported by this provider.");
+    }
 
     /**
     * Obtain a count of the number of roster items available for the given user.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,6 +172,55 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
             }
         }
         return roster;
+    }
+
+    /**
+     * Returns local usernames that have one or more roster items on the specified remote domain.
+     *
+     * This method prefers provider-level optimized lookup when available. When not available,
+     * it falls back to scanning rosters.
+     *
+     * @param domain a remote domain.
+     * @return usernames that have roster usage on the specified domain.
+     */
+    public Collection<String> getUsernamesWithRosterItemsOnDomain(final String domain)
+    {
+        final String normalizedDomain;
+        try {
+            normalizedDomain = domain == null || domain.trim().isEmpty() ? "" : new JID(null, domain.trim(), null).getDomain();
+        } catch (IllegalArgumentException e) {
+            return Collections.emptySet();
+        }
+        if (normalizedDomain.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        final Set<String> result = new TreeSet<>();
+        try {
+            final Iterator<String> usernames = provider.getUsernamesByDomain(normalizedDomain);
+            while (usernames.hasNext()) {
+                result.add(usernames.next());
+            }
+            return result;
+        } catch (UnsupportedOperationException e) {
+            Log.debug("Roster provider {} does not support domain-targeted lookup. Falling back to roster scan.", provider.getClass().getName());
+        }
+
+        // Compatibility fallback for custom providers that don't implement domain-targeted lookup.
+        for (final String username : UserManager.getInstance().getUsernames()) {
+            try {
+                final Roster roster = getRoster(username);
+                for (final RosterItem rosterItem : roster.getRosterItems()) {
+                    if (normalizedDomain.equalsIgnoreCase(rosterItem.getJid().getDomain())) {
+                        result.add(username);
+                        break;
+                    }
+                }
+            } catch (Exception ignored) {
+                // Skip users that cannot be inspected.
+            }
+        }
+        return result;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/FailedOutgoingServerSessionAttempt.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/FailedOutgoingServerSessionAttempt.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.server;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Basic diagnostics for a failed outgoing server-to-server connection attempt.
+ *
+ * Instances of this type are intended to be stored in a clustered cache, which requires that
+ * keys and values are serializable.
+ */
+public class FailedOutgoingServerSessionAttempt implements Serializable
+{
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final String localDomain;
+    private final String remoteDomain;
+    private final Instant when;
+    private final String errorType;
+    private final String errorMessage;
+
+    /**
+     * Constructs diagnostics for one failed outgoing S2S connection establishment attempt.
+     *
+     * @param localDomain the local domain from which the outgoing attempt was initiated.
+     * @param remoteDomain the remote peer domain that connection establishment targeted.
+     * @param when timestamp that indicates when the failure was observed.
+     * @param errorType fully qualified class name of the throwable that caused the failure, or null.
+     * @param errorMessage throwable message that describes the failure, or null.
+     */
+    public FailedOutgoingServerSessionAttempt(final String localDomain, final String remoteDomain, final Instant when, final String errorType, final String errorMessage)
+    {
+        this.localDomain = localDomain;
+        this.remoteDomain = remoteDomain;
+        this.when = when;
+        this.errorType = errorType;
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * @return the local domain from which the outgoing attempt was initiated.
+     */
+    public String getLocalDomain() {
+        return localDomain;
+    }
+
+    /**
+     * @return the remote domain for which connection establishment failed.
+     */
+    public String getRemoteDomain() {
+        return remoteDomain;
+    }
+
+    /**
+     * @return timestamp of when this failure was recorded.
+     */
+    public Instant getWhen() {
+        return when;
+    }
+
+    /**
+     * @return fully qualified class name of the exception that caused the failure, or null.
+     */
+    public String getErrorType() {
+        return errorType;
+    }
+
+    /**
+     * @return message associated with the exception that caused the failure, or null.
+     */
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    /**
+     * Creates diagnostics payload for a failed outgoing S2S connection attempt.
+     *
+     * @param localDomain the local domain from which the outgoing attempt was initiated.
+     * @param remoteDomain the remote domain that connection establishment targeted.
+     * @param cause the failure cause.
+     * @return a diagnostics payload representing the provided failure.
+     */
+    public static FailedOutgoingServerSessionAttempt from(final String localDomain, final String remoteDomain, final Throwable cause)
+    {
+        final String type = cause == null ? null : cause.getClass().getName();
+        final String message = cause == null ? null : Objects.toString(cause.getMessage(), null);
+        return new FailedOutgoingServerSessionAttempt(localDomain, remoteDomain, Instant.now(), type, message);
+    }
+}
+
+

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/server/OutgoingSessionPromise.java
@@ -97,6 +97,11 @@ public class OutgoingSessionPromise {
 
     private static final OutgoingSessionPromise instance = new OutgoingSessionPromise();
 
+    /**
+     * Name of the clustered cache that stores the latest failed outgoing S2S attempt per remote domain.
+     */
+    public static final String FAILED_S2S_ATTEMPTS_CACHE_NAME = "Routing Failed Servers Cache";
+
     private final Interner<DomainPair> interner = Interners.newWeakInterner();
 
     /**
@@ -113,6 +118,13 @@ public class OutgoingSessionPromise {
      */
     private Cache<DomainPair, NodeID> serversCache;
 
+    /**
+     * Cache that holds the most recent failed outgoing S2S connection attempt per remote domain.
+     *
+     * Key: remote server domain, Value: diagnostics payload for the latest failed attempt.
+     */
+    private Cache<String, FailedOutgoingServerSessionAttempt> failedServerAttemptsCache;
+
     private RoutingTable routingTable;
 
     private OutgoingSessionPromise() {
@@ -122,6 +134,7 @@ public class OutgoingSessionPromise {
 
     private void init() {
         serversCache = CacheFactory.createCache(RoutingTableImpl.S2S_CACHE_NAME);
+        failedServerAttemptsCache = CacheFactory.createCache(FAILED_S2S_ATTEMPTS_CACHE_NAME);
         routingTable = XMPPServer.getInstance().getRoutingTable();
 
         // Create a pool of threads that will process queued packets.
@@ -229,6 +242,52 @@ public class OutgoingSessionPromise {
         return processor != null && !processor.isDone();
     }
 
+    /**
+     * Returns domains for which the latest outgoing S2S connection establishment attempt failed.
+     *
+     * @return a snapshot of remote domains for which a failure is recorded.
+     */
+    public Collection<String> getFailedServers() {
+        return new HashSet<>(failedServerAttemptsCache.keySet());
+    }
+
+    /**
+     * Returns diagnostics for the latest failed outgoing S2S connection establishment attempt to a remote domain.
+     *
+     * @param remoteDomain The remote domain.
+     * @return diagnostics payload, if available.
+     */
+    public Optional<FailedOutgoingServerSessionAttempt> getFailedServerAttempt(@Nonnull final String remoteDomain) {
+        return Optional.ofNullable(failedServerAttemptsCache.get(remoteDomain));
+    }
+
+    /**
+     * Stores diagnostics for a failed connection establishment attempt.
+     *
+     * This overwrites any previous entry for the same remote domain, intentionally preserving only
+     * the latest known failure.
+     *
+     * @param domainPair the local/remote domain pair for the attempted connection.
+     * @param cause the failure cause.
+     */
+    private void recordFailedAttempt(@Nonnull final DomainPair domainPair, @Nonnull final Throwable cause)
+    {
+        failedServerAttemptsCache.put(domainPair.getRemote(), FailedOutgoingServerSessionAttempt.from(domainPair.getLocal(), domainPair.getRemote(), cause));
+    }
+
+    /**
+     * Removes the latest-failure diagnostics entry for a remote domain.
+     *
+     * This is invoked after a successful connection establishment to ensure stale failure data does
+     * not continue to be presented for an active peer.
+     *
+     * @param domainPair the local/remote domain pair for which failure state should be cleared.
+     */
+    private void clearFailedAttempt(@Nonnull final DomainPair domainPair)
+    {
+        failedServerAttemptsCache.remove(domainPair.getRemote());
+    }
+
     private class PacketsProcessor implements Runnable
     {
         private final Logger Log = LoggerFactory.getLogger( PacketsProcessor.class );
@@ -251,8 +310,10 @@ public class OutgoingSessionPromise {
             LocalOutgoingServerSession channel;
             try {
                 channel = establishConnection();
+                clearFailedAttempt(domainPair);
             } catch (Exception e) {
                 Log.debug("An exception occurred while trying to establish a connection for {}", domainPair, e);
+                recordFailedAttempt(domainPair, e);
                 channel = null;
             }
 

--- a/xmppserver/src/main/webapp/server-session-failure-details.jsp
+++ b/xmppserver/src/main/webapp/server-session-failure-details.jsp
@@ -1,0 +1,214 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%--
+  -
+  - Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+ --%>
+
+<%@ page import="org.jivesoftware.openfire.SessionManager,
+                 org.jivesoftware.openfire.server.OutgoingSessionPromise,
+                 org.jivesoftware.openfire.server.FailedOutgoingServerSessionAttempt,
+                 org.jivesoftware.util.JiveGlobals,
+                 org.jivesoftware.util.ParamUtils,
+                 org.jivesoftware.util.StringUtils,
+                 org.jivesoftware.util.CookieUtils,
+                 java.net.URLEncoder,
+                 java.nio.charset.StandardCharsets,
+                 java.util.*"
+    errorPage="error.jsp"
+%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
+<% webManager.init(request, response, session, application, out ); %>
+
+<%
+    final String domainName = ParamUtils.getParameter(request, "hostname");
+    final SessionManager sessionManager = webManager.getSessionManager();
+    final Set<String> failedServers = new HashSet<>(sessionManager.getFailedServers());
+
+    final Map<String, String> errors = new HashMap<>();
+    if (domainName == null || domainName.trim().isEmpty()) {
+        response.sendRedirect("server-session-summary.jsp");
+        return;
+    }
+
+    if (!failedServers.contains(domainName)) {
+        response.sendRedirect("server-session-details.jsp?hostname=" + java.net.URLEncoder.encode(domainName, java.nio.charset.StandardCharsets.UTF_8));
+        return;
+    }
+
+    final Optional<FailedOutgoingServerSessionAttempt> failedAttempt = OutgoingSessionPromise.getInstance().getFailedServerAttempt(domainName);
+
+    Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+    String csrfParam = ParamUtils.getParameter(request, "csrf");
+    String action = ParamUtils.getParameter(request, "action");
+    boolean showSearchResults = false;
+    final Set<String> matchingLocalUsers = new TreeSet<>();
+
+    if (action != null) {
+        if (csrfCookie == null || csrfParam == null || !csrfCookie.getValue().equals(csrfParam)) {
+            errors.put("csrf", "CSRF Failure!");
+        }
+
+        if (errors.isEmpty()) {
+            switch (action) {
+                case "retry":
+                    response.sendRedirect("server-connectiontest.jsp?server2server-testing-domain=" + URLEncoder.encode(domainName, StandardCharsets.UTF_8));
+                    return;
+                case "block":
+                    response.sendRedirect("connection-settings-socket-s2s.jsp?serverBlocked=true&domain=" + URLEncoder.encode(domainName, StandardCharsets.UTF_8));
+                    return;
+                case "search":
+                    showSearchResults = true;
+                    break;
+                default:
+                    errors.put("Unknown action", "unknown action");
+                    break;
+            }
+        }
+    }
+
+    if (showSearchResults) {
+        matchingLocalUsers.addAll(webManager.getRosterManager().getUsernamesWithRosterItemsOnDomain(domainName));
+    }
+
+    csrfParam = StringUtils.randomString(15);
+    CookieUtils.setCookie(request, response, "csrf", csrfParam, -1);
+
+    pageContext.setAttribute("errors", errors);
+%>
+
+<html>
+<head>
+    <title><fmt:message key="server.session.failure.title"/></title>
+    <meta name="pageID" content="server-session-summary"/>
+</head>
+<body>
+
+<p>
+    <fmt:message key="server.session.failure.info">
+        <fmt:param value="<b><%= StringUtils.escapeForXML(domainName) %></b>" />
+    </fmt:message>
+</p>
+
+<c:forEach var="err" items="${errors}">
+    <admin:infobox type="error">
+        <c:choose>
+            <c:when test="${err.key eq 'csrf'}"><fmt:message key="global.csrf.failed" /></c:when>
+            <c:otherwise>
+                <c:if test="${not empty err.value}">
+                    <fmt:message key="admin.error"/>: <c:out value="${err.value}"/>
+                </c:if>
+                (<c:out value="${err.key}"/>)
+            </c:otherwise>
+        </c:choose>
+    </admin:infobox>
+</c:forEach>
+
+<div class="jive-table">
+    <table>
+        <tr>
+            <th colspan="2"><fmt:message key="server.session.failure.section.overview"/></th>
+        </tr>
+        <tr>
+            <td class="c1"><fmt:message key="server.session.details.domainname"/></td>
+            <td><%= StringUtils.escapeHTMLTags(domainName) %></td>
+        </tr>
+        <tr>
+            <td class="c1"><fmt:message key="server.session.label.connection"/></td>
+            <td>
+                <img src="images/warning-16x16.gif" width="16" height="16" alt="<fmt:message key='server.session.connection.failed' />">
+                <fmt:message key="server.session.connection.failed"/>
+            </td>
+        </tr>
+        <tr>
+            <td class="c1"><fmt:message key="server.session.failure.last_attempt"/></td>
+            <td>
+                <% if (failedAttempt.isPresent() && failedAttempt.get().getWhen() != null) { %>
+                    <%= JiveGlobals.formatDateTime(Date.from(failedAttempt.get().getWhen())) %>
+                <% } else { %>
+                    <fmt:message key="server.session.summary.not_available"/>
+                <% } %>
+            </td>
+        </tr>
+        <tr>
+            <td class="c1"><fmt:message key="server.session.failure.reason"/></td>
+            <td>
+                <% if (failedAttempt.isPresent() && failedAttempt.get().getErrorMessage() != null && !failedAttempt.get().getErrorMessage().trim().isEmpty()) { %>
+                    <%= StringUtils.escapeHTMLTags(failedAttempt.get().getErrorMessage()) %>
+                <% } else if (failedAttempt.isPresent() && failedAttempt.get().getErrorType() != null) { %>
+                    <%= StringUtils.escapeHTMLTags(failedAttempt.get().getErrorType()) %>
+                <% } else { %>
+                    <fmt:message key="server.session.summary.not_available"/>
+                <% } %>
+            </td>
+        </tr>
+    </table>
+</div>
+
+<br/>
+
+<div class="jive-table">
+    <table>
+        <tr>
+            <th><fmt:message key="server.session.failure.section.initiator"/></th>
+        </tr>
+        <tr>
+            <td><fmt:message key="server.session.failure.stub.initiator"/></td>
+        </tr>
+    </table>
+</div>
+
+<br/>
+
+<div style="text-align: center;">
+    <form action="server-session-failure-details.jsp" style="display: inline;">
+        <input type="hidden" name="hostname" value="<%= StringUtils.escapeForXML(domainName) %>">
+        <input type="hidden" name="csrf" value="<%= csrfParam %>"/>
+        <input type="hidden" name="action" id="failure-action" value=""/>
+        <input type="submit" value="<fmt:message key="server.session.failure.action.retry"/>" onclick="document.getElementById('failure-action').value='retry';"/>
+        <input type="submit" value="<fmt:message key="server.session.failure.action.block"/>" onclick="document.getElementById('failure-action').value='block';"/>
+        <input type="submit" value="<fmt:message key="server.session.failure.action.search"/>" onclick="document.getElementById('failure-action').value='search';"/>
+        <input type="submit" value="<fmt:message key="session.details.back_button"/>" formaction="server-session-summary.jsp" onclick="document.getElementById('failure-action').value='';"/>
+    </form>
+</div>
+
+<% if (showSearchResults) { %>
+<br/>
+<div class="jive-table">
+    <table>
+        <tr>
+            <th><fmt:message key="server.session.failure.search.results.title"/></th>
+        </tr>
+        <% if (matchingLocalUsers.isEmpty()) { %>
+        <tr>
+            <td><fmt:message key="server.session.failure.search.results.none"/></td>
+        </tr>
+        <% } else { %>
+            <% for (final String username : matchingLocalUsers) { %>
+            <tr>
+                <td><a href="user-roster.jsp?username=<%= URLEncoder.encode(username, StandardCharsets.UTF_8) %>"><%= StringUtils.escapeHTMLTags(username) %></a></td>
+            </tr>
+            <% } %>
+        <% } %>
+    </table>
+</div>
+<% } %>
+
+</body>
+</html>
+
+
+

--- a/xmppserver/src/main/webapp/server-session-row.jspf
+++ b/xmppserver/src/main/webapp/server-session-row.jspf
@@ -14,8 +14,9 @@
  <%--
    - This page is meant to be included in other pages. It assumes 4 variables:
    -     * 'host', the name of the remote server
-   -     * 'inSession', an  IncomingServerSession object
-   -     * 'outSession', an OutgoingServerSession object
+   -     * 'inSessions', a collection of IncomingServerSession objects
+   -     * 'outSessions', a collection of OutgoingServerSession objects
+   -     * 'isFailedSession', true when no active session exists but a failed S2S attempt is known
    -     * 'count', an int representing the row number we're on.
  --%>
 
@@ -45,24 +46,41 @@
     }
     String isEncryptedAltText = isEncrypted ? String.join(", ", tlsProtocolNames) + " - " + String.join(", ", cipherSuiteNames): "";
 %>
+<%
+    final String detailsPage = isFailedSession ? "server-session-failure-details.jsp" : "server-session-details.jsp";
+%>
 <tr>
     <td style="width: 1%; white-space: nowrap"><%= count %></td>
     <td style="width: 47%; white-space: nowrap">
         <table>
             <tr>
             <td style="width: 1%; padding-right: 0.5em" ><img src="getFavicon?host=<%=URLEncoder.encode(host, StandardCharsets.UTF_8)%>" width="16" height="16" alt=""></td>
-            <td><a href="server-session-details.jsp?hostname=<%= URLEncoder.encode(host, StandardCharsets.UTF_8) %>" title="<fmt:message key='session.row.click' />"><%= StringUtils.escapeHTMLTags(host) %></a></td>
+            <td>
+                <a href="<%= detailsPage %>?hostname=<%= URLEncoder.encode(host, StandardCharsets.UTF_8) %>" title="<fmt:message key='session.row.click' />"><%= StringUtils.escapeHTMLTags(host) %></a>
+                <% if (isFailedSession) { %>
+                    <span style="color: #a94442; margin-left: 0.5em;">(<fmt:message key="server.session.connection.failed" />)</span>
+                <% } %>
+            </td>
             </tr>
         </table>
     </td>
-    <%  if (isEncrypted) { %>
+    <%  if (isFailedSession) { %>
+    <td style="width: 1%">
+        <img src="images/warning-16x16.gif" alt="<fmt:message key='server.session.connection.failed' />">
+    </td>
+    <%  } else if (isEncrypted) { %>
     <td style="width: 1%">
         <img src="images/lock.gif" alt="<%=isEncryptedAltText%>">
     </td>
      <% } else { %>
     <td style="width: 1%"><img src="images/blank.gif" width="1" height="1" alt=""></td>
      <% } %>
-    <% if (!inSessions.isEmpty() && outSessions.isEmpty()) { %>
+    <% if (isFailedSession) { %>
+        <td style="width: 1%">
+            <img src="images/warning-16x16.gif" width="16" height="16" title="<fmt:message key='server.session.connection.failed' />" alt="<fmt:message key='server.session.connection.failed' />">
+        </td>
+        <td><fmt:message key="server.session.connection.failed" /></td>
+    <% } else if (!inSessions.isEmpty() && outSessions.isEmpty()) { %>
         <td style="width: 1%">
             <img src="images/incoming_32x16.gif" width="32" height="16" title="<fmt:message key='server.session.connection.incoming' />" alt="<fmt:message key='server.session.connection.incoming' />">
         </td>
@@ -112,7 +130,9 @@
         final boolean hasIPv4 = hasInIPv4 || hasOutIPv4;
         final boolean hasIPv6 = hasInIPv6 || hasOutIPv6;
     %>
-    <% if (hasIPv4 && hasIPv6) { %>
+    <% if (isFailedSession) { %>
+    <td><fmt:message key="server.session.summary.not_available" /></td>
+    <% } else if (hasIPv4 && hasIPv6) { %>
     <td><fmt:message key="server.session.connection.both" /></td>
     <% } else if (hasIPv4) { %>
     <td><fmt:message key="global.ipv4" /></td>
@@ -172,16 +192,20 @@
     %>
 
     <td style="text-align: center;" nowrap>
-        <%= creationDateString %>
+        <%= isFailedSession ? org.jivesoftware.util.LocaleUtils.getLocalizedString("server.session.summary.not_available") : creationDateString %>
     </td>
     <td style="text-align: center;" nowrap>
-        <%= lastActivityString %>
+        <%= isFailedSession ? org.jivesoftware.util.LocaleUtils.getLocalizedString("server.session.summary.not_available") : lastActivityString %>
     </td>
 
     <td style="width: 1%; white-space: nowrap; text-align: center;">
+        <% if (isFailedSession) { %>
+        <a href="<%= detailsPage %>?hostname=<%= URLEncoder.encode(host, StandardCharsets.UTF_8) %>" title="<fmt:message key='server.session.failure.diagnostics.open' />"><fmt:message key="server.session.failure.diagnostics.open" /></a>
+        <% } else { %>
         <a href="server-session-summary.jsp?hostname=<%= URLEncoder.encode(host, StandardCharsets.UTF_8) %>&close=true&csrf=${csrf}"
          title="<fmt:message key="session.row.click_kill_session" />"
          onclick="return confirm('<fmt:message key="session.row.confirm_close" />');"
          ><img src="images/delete-16x16.gif" alt="Delete"></a>
+        <% } %>
     </td>
 </tr>

--- a/xmppserver/src/main/webapp/server-session-summary.jsp
+++ b/xmppserver/src/main/webapp/server-session-summary.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -89,9 +89,14 @@
     }
 
     // Get the session count
+    final Set<String> connectedDomainNames = new HashSet<>();
+    connectedDomainNames.addAll(sessionManager.getIncomingServers());
+    connectedDomainNames.addAll(sessionManager.getOutgoingServers());
+
     final Set<String> domainNames = new TreeSet<>();
-    domainNames.addAll(sessionManager.getIncomingServers());
-    domainNames.addAll(sessionManager.getOutgoingServers());
+    final Set<String> failedServers = new HashSet<>(sessionManager.getFailedServers());
+    domainNames.addAll(connectedDomainNames);
+    domainNames.addAll(failedServers);
     final int sessionCount = domainNames.size();
 
     // paginator vars
@@ -117,7 +122,10 @@
 <%  } %>
 
 <p>
-<fmt:message key="server.session.summary.active" />: <b><%= domainNames.size() %></b>
+<fmt:message key="server.session.summary.active" />: <b><%= connectedDomainNames.size() %></b>
+<% if (!failedServers.isEmpty()) { %>
+ - <fmt:message key="server.session.summary.failed_count" />: <b><%= failedServers.size() %></b>
+<% } %>
 
 <%  if (numPages > 1) { %>
 
@@ -197,7 +205,8 @@
             count++;
             List<IncomingServerSession> inSessions = sessionManager.getIncomingServerSessions(host);
             List<OutgoingServerSession> outSessions = sessionManager.getOutgoingServerSessions(host);
-            if (inSessions.isEmpty() && outSessions.isEmpty()) {
+            final boolean isFailedSession = failedServers.contains(host); // Potentially shows a functional _inbound_ session next to an erroneous _outbound_ session. Somewhat confusing, but better than not showing an error at all.
+            if (inSessions.isEmpty() && outSessions.isEmpty() && !isFailedSession) {
                 // If the connections were just closed then skip this host
                 continue;
             }


### PR DESCRIPTION
This change extends server session administration to include failed outbound S2S connection attempts alongside active sessions.

Failed domains are now shown in the server session overview with clear visual indication, and selecting one opens a dedicated diagnostics page (instead of normal session details) that supports quick retry and block workflows by redirecting to existing admin pages with the failed domain pre-populated.

Under the hood, `OutgoingSessionPromise` now records the latest failed attempt per remote domain in a new clustered cache using a serializable diagnostics payload, and clears that failure state after a successful reconnect. The diagnostics page also includes roster-domain usage search for impacted local users, backed by a new domain-targeted roster lookup API with an optimized implementation in `DefaultRosterItemProvider` (plus compatible fallback behavior for custom providers).