### PR TITLE
OF-3285, OF-3286, OF-3287 & OF-3288: Group manager improvements

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -671,6 +671,9 @@ public class GroupManager {
         // Get all nested groups, removing any cyclic dependency.
         final Set<Group> groups = getSharedGroups( group );
 
+        // Also evict members/admins of the group itself (OF-3287)
+        groups.add(group);
+
         // Evict cached information for affected users.
         synchronized (groupMetaLock) {
             groups.forEach(g -> {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. 2016-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software. 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.concurrent.locks.Lock;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import org.apache.commons.lang3.StringUtils;
@@ -47,17 +48,18 @@ import javax.annotation.Nullable;
  */
 public class GroupManager {
 
+    private static GroupManager INSTANCE;
+
     public static final SystemProperty<Class> GROUP_PROVIDER = SystemProperty.Builder.ofType(Class.class)
         .setKey("provider.group.className")
         .setBaseClass(GroupProvider.class)
         .setDefaultValue(DefaultGroupProvider.class)
-        .addListener(GroupManager::initProvider)
+        .addListener(clazz -> { if (INSTANCE != null) { INSTANCE.initProvider(clazz); }})
         .setDynamic(true)
         .build();
 
     private static final Logger Log = LoggerFactory.getLogger(GroupManager.class);
 
-    private static GroupManager INSTANCE;
 
     private static final Interner<JID> userBasedMutex = Interners.newWeakInterner();
     private static final Interner<PagedGroupNameKey> pagedGroupNameKeyInterner = Interners.newWeakInterner();
@@ -82,21 +84,78 @@ public class GroupManager {
         return INSTANCE;
     }
 
+    /**
+     * Replaces the singleton instance of GroupManager.
+     *
+     * This method is intended for use in unit tests, where a pre-configured instance (for example, one constructed with
+     * mock dependencies via {@link #GroupManager(GroupProvider, Cache, Cache)}) needs to be installed as the singleton.
+     * Tests should restore the original instance (or set it to {@code null}) in their teardown to avoid state leaking
+     * between tests.
+     *
+     * @param instance the GroupManager instance to install as the singleton, or {@code null} to clear the current
+     *                 instance so that the next call to {@link #getInstance()} creates a fresh one.
+     */
+    @VisibleForTesting
+    static synchronized void setInstance(GroupManager instance) {
+        INSTANCE = instance;
+    }
+
     private final Cache<String, CacheableOptional<Group>> groupCache;
+
+    /**
+     * A cache for meta-data around groups: count, group names, groups associated with a particular user.
+     */
     private final Cache<String, Serializable> groupMetaCache;
-    private static GroupProvider provider;
 
-    private GroupManager() {
-        // Initialize caches.
-        groupCache = CacheFactory.createCache("Group"); // TODO determine if this works in a cluster (should this be a local cache?)
+    private GroupProvider provider;
 
-        // A cache for meta-data around groups: count, group names, groups associated with
-        // a particular user
-        groupMetaCache = CacheFactory.createCache("Group Metadata Cache"); // TODO determine if this works in a cluster (should this be a local cache?)
+    private GroupManager()
+    {
+        groupCache = createGroupCache();
+        groupMetaCache = createGroupMetaCache();
 
         initProvider(GROUP_PROVIDER.getValue());
 
-        UserEventDispatcher.addListener(new UserEventListener() {
+        registerListeners();
+    }
+
+    /**
+     * Constructs a GroupManager with explicit dependencies, intended for use in unit tests.
+     *
+     * This constructor allows tests to supply lightweight or mock implementations of the provider and caches without
+     * triggering the full Openfire infrastructure (such as {@link CacheFactory} or
+     * {@link org.jivesoftware.openfire.event.UserEventDispatcher}). Listener registration is intentionally omitted; if
+     * listener behaviour needs to be tested, call {@link #registerListeners()} explicitly after construction.
+     *
+     * This constructor does not install the instance as the singleton. Use {@link #setInstance(GroupManager)} for that
+     * if required.
+     *
+     * @param provider       the group provider to use; must not be {@code null}.
+     * @param groupCache     the cache to use for individual group lookups; must not be {@code null}.
+     * @param groupMetaCache the cache to use for group metadata (counts, name lists, per-user group lists); must not be {@code null}.
+     */
+    @VisibleForTesting
+    GroupManager(GroupProvider provider, Cache<String, CacheableOptional<Group>> groupCache, Cache<String, Serializable> groupMetaCache)
+    {
+        this.provider = provider;
+        this.groupCache = groupCache;
+        this.groupMetaCache = groupMetaCache;
+        // deliberately skip listener registration
+    }
+
+    /**
+     * Registers event listeners required for this manager to maintain consistent state.
+     *
+     * Specifically, this registers a {@link UserEventListener} with {@link org.jivesoftware.openfire.event.UserEventDispatcher}
+     * so that group membership is cleaned up when a user is deleted from the system.
+     *
+     * This method is called automatically by the standard no-arg constructor. It is extracted as a protected method so
+     * that subclasses or test fixtures can override it to suppress registration (avoiding side effects during testing)
+     * or substitute alternative listener behaviour.
+     */
+    protected void registerListeners()
+    {
+        registerUserEventListener(new UserEventListener() {
             @Override
             public void userCreated(User user, Map<String, Object> params) {
                 // ignore
@@ -114,7 +173,7 @@ public class GroupManager {
         });
     }
 
-    private static void initProvider(final Class<? extends GroupProvider> clazz) {
+    private void initProvider(final Class<? extends GroupProvider> clazz) {
         if (provider == null || !clazz.equals(provider.getClass())) {
             try {
                 provider = clazz.getDeclaredConstructor().newInstance();
@@ -123,6 +182,81 @@ public class GroupManager {
                 provider = new DefaultGroupProvider();
             }
         }
+    }
+
+    /**
+     * Replaces the group provider used by this manager.
+     *
+     * This method is intended for use in unit tests, allowing a mock or stub {@link GroupProvider} to be injected after
+     * construction. It should not be used in production code; provider configuration is handled via the
+     * {@link #GROUP_PROVIDER} system property.
+     *
+     * @param provider the group provider to use; must not be {@code null}.
+     */
+    @VisibleForTesting
+    void setProvider(GroupProvider provider) {
+        this.provider = provider;
+    }
+
+    /**
+     * Creates the cache used to store individual {@link Group} instances, keyed by group name.
+     *
+     * The default implementation delegates to {@link CacheFactory}, which requires the Openfire cache infrastructure to
+     * be initialised. Subclasses may override this method to return a simpler cache implementation (for example, one
+     * backed by a {@link java.util.concurrent.ConcurrentHashMap}) to avoid that dependency in unit tests.
+     *
+     * @return a new, empty cache for group instances; never {@code null}.
+     */
+    protected Cache<String, CacheableOptional<Group>> createGroupCache() {
+        return CacheFactory.createCache("Group"); // TODO determine if this works in a cluster (should this be a local cache?)
+    }
+
+    /**
+     * Creates the cache used to store group metadata, including total group counts, group name lists (full and
+     * paginated), and per-user group membership lists.
+     *
+     * The default implementation delegates to {@link CacheFactory}, which requires the Openfire cache infrastructure to
+     * be initialised. Subclasses may override this method to return a simpler cache implementation (for example, one
+     * backed by a {@link java.util.concurrent.ConcurrentHashMap}) to avoid that dependency in unit tests.
+     *
+     * @return a new, empty cache for group metadata; never {@code null}.
+     */
+    @VisibleForTesting
+    protected Cache<String, Serializable> createGroupMetaCache() {
+        return CacheFactory.createCache("Group Metadata Cache"); // TODO determine if this works in a cluster (should this be a local cache?)
+    }
+
+    /**
+     * Dispatches a group event via {@link GroupEventDispatcher}.
+     *
+     * All event dispatching within this class is routed through this method rather than calling
+     * {@link GroupEventDispatcher#dispatchEvent} directly. This allows subclasses or test fixtures to override this
+     * method to capture, suppress, or verify dispatched events without requiring a fully initialised event dispatch
+     * infrastructure.
+     *
+     * @param group  the group to which the event relates; must not be {@code null}.
+     * @param type   the type of event being dispatched; must not be {@code null}.
+     * @param params additional parameters describing the event; must not be {@code null},
+     *               but may be empty.
+     */
+    protected void dispatchGroupEvent(Group group, GroupEventDispatcher.EventType type, Map<String, ?> params)
+    {
+        GroupEventDispatcher.dispatchEvent(group, type, params);
+    }
+
+    /**
+     * Registers a listener for user events via {@link UserEventDispatcher}.
+     *
+     * All listener registration within this class is routed through this method rather than calling
+     * {@link UserEventDispatcher#addListener} directly. This allows subclasses or test fixtures to override this method
+     * to suppress registration (to prevent side effects during testing) or to track which listeners have been
+     * registered.
+     *
+     * @param listener the listener to register; must not be {@code null}.
+     */
+    protected void registerUserEventListener(UserEventListener listener)
+    {
+        UserEventDispatcher.addListener(listener);
     }
 
     /**
@@ -649,7 +783,7 @@ public class GroupManager {
         groupCache.put(group.getName(), CacheableOptional.of(group));
 
         // Fire event.
-        GroupEventDispatcher.dispatchEvent(group, GroupEventDispatcher.EventType.group_created, Collections.emptyMap());
+        dispatchGroupEvent(group, GroupEventDispatcher.EventType.group_created, Collections.emptyMap());
     }
 
     /**
@@ -663,7 +797,7 @@ public class GroupManager {
     public void deleteGroupPreProcess(@Nonnull final Group group)
     {
         // Fire event.
-        GroupEventDispatcher.dispatchEvent(group, GroupEventDispatcher.EventType.group_deleting, Collections.emptyMap());
+        dispatchGroupEvent(group, GroupEventDispatcher.EventType.group_deleting, Collections.emptyMap());
     }
 
     /**
@@ -713,9 +847,9 @@ public class GroupManager {
         params.put("admin", admin.toString());
         if (wasMember) {
             params.put("member", admin.toString());
-            GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.member_removed, params);
+            dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.member_removed, params);
         }
-        GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.admin_added, params);
+        dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.admin_added, params);
     }
 
     /**
@@ -744,7 +878,7 @@ public class GroupManager {
         final Map<String, String> params = new HashMap<>();
         params.put("admin", admin.toString());
 
-        GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.admin_removed, params);
+        dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.admin_removed, params);
     }
 
     /**
@@ -775,9 +909,9 @@ public class GroupManager {
         params.put("member", member.toString());
         if (wasAdmin) {
             params.put("admin", member.toString());
-            GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.admin_removed, params);
+            dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.admin_removed, params);
         }
-        GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.member_added, params);
+        dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.member_added, params);
     }
 
     /**
@@ -806,7 +940,7 @@ public class GroupManager {
         final Map<String, String> params = new HashMap<>();
         params.put("member", member.toString());
 
-        GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.member_removed, params);
+        dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.member_removed, params);
     }
 
     /**
@@ -844,7 +978,7 @@ public class GroupManager {
         params.put("originalValue", originalName);
         params.put("originalJID", new GroupJID(originalName));
 
-        GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, params);
+        dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, params);
     }
 
     /**
@@ -873,7 +1007,7 @@ public class GroupManager {
         params.put("type", "descriptionModified");
         params.put("originalValue", originalDescription);
 
-        GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, params);
+        dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, params);
     }
 
     /**
@@ -903,7 +1037,7 @@ public class GroupManager {
         params.put("propertyKey", key);
         params.put("type", "propertyAdded");
 
-        GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, params);
+        dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, params);
     }
 
     /**
@@ -935,7 +1069,7 @@ public class GroupManager {
         params.put("type", "propertyModified");
         params.put("originalValue", originalValue);
 
-        GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, params);
+        dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, params);
     }
 
     /**
@@ -967,7 +1101,7 @@ public class GroupManager {
         params.put("type", "propertyDeleted");
         params.put("originalValue", originalValue);
 
-        GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, params);
+        dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, params);
     }
 
     /**
@@ -993,14 +1127,14 @@ public class GroupManager {
 
         // Make sure that 'shared roster' changes are processed.
         for (final Map.Entry<String, String> entry : originalProperties.entrySet()) {
-            GroupManager.getInstance().propertyChangePostProcess(group, entry.getKey(), entry.getValue());
+            propertyChangePostProcess(updatedGroup, entry.getKey(), entry.getValue());
         }
 
         // Fire event.
         final Map<String, Object> event = new HashMap<>();
         event.put("type", "propertyDeleted");
         event.put("propertyKey", "*");
-        GroupEventDispatcher.dispatchEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, event);
+        dispatchGroupEvent(updatedGroup, GroupEventDispatcher.EventType.group_modified, event);
     }
 
     // A generic method to process the effect of property changes to contact list sharing. Re-used by all property change post-processing methods.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -21,8 +21,6 @@ import java.util.*;
 import java.util.concurrent.locks.Lock;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Interner;
-import com.google.common.collect.Interners;
 import org.apache.commons.lang3.StringUtils;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.event.GroupEventDispatcher;
@@ -39,6 +37,7 @@ import org.xmpp.packet.JID;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * Manages groups.
@@ -60,17 +59,12 @@ public class GroupManager {
 
     private static final Logger Log = LoggerFactory.getLogger(GroupManager.class);
 
-
-    private static final Interner<JID> userBasedMutex = Interners.newWeakInterner();
-    private static final Interner<PagedGroupNameKey> pagedGroupNameKeyInterner = Interners.newWeakInterner();
-
     private static final String GROUP_COUNT_KEY = "GROUP_COUNT";
     private static final String GROUP_NAMES_KEY = "GROUP_NAMES";
     private static final String USER_GROUPS_KEY = "USER_GROUPS";
 
-    private static final Object GROUP_COUNT_LOCK = new Object();
-    private static final Object GROUP_NAMES_LOCK = new Object();
-    private static final Object USER_GROUPS_LOCK = new Object();
+    // Mutex for metadata cache access
+    private final Object groupMetaLock = new Object();
 
     /**
      * Returns a singleton instance of GroupManager.
@@ -105,6 +99,7 @@ public class GroupManager {
     /**
      * A cache for meta-data around groups: count, group names, groups associated with a particular user.
      */
+    @GuardedBy("groupMetaLock")
     private final Cache<String, Serializable> groupMetaCache;
 
     private GroupProvider provider;
@@ -407,17 +402,15 @@ public class GroupManager {
      * @return the total number of groups.
      */
     public int getGroupCount() {
+        synchronized (groupMetaLock)
+        {
             Integer count = getGroupCountFromCache();
-        if (count == null) {
-            synchronized(GROUP_COUNT_LOCK) {
-                count = getGroupCountFromCache();
-                if (count == null) {
-                    count = provider.getGroupCount();
-                    saveGroupCountInCache(count);
-                }
+            if (count == null) {
+                count = provider.getGroupCount();
+                saveGroupCountInCache(count);
             }
+            return count;
         }
-        return count;
     }
 
     /**
@@ -431,17 +424,15 @@ public class GroupManager {
      * @return an unmodifiable Collection of all groups.
      */
     public Collection<Group> getGroups() {
-        HashSet<String> groupNames = getGroupNamesFromCache();
-        if (groupNames == null) {
-            synchronized(GROUP_NAMES_LOCK) {
-                groupNames = getGroupNamesFromCache();
-                if (groupNames == null) {
-                    groupNames = new HashSet<>(provider.getGroupNames());
-                    saveGroupNamesInCache(groupNames);
-                }
+        synchronized (groupMetaLock)
+        {
+            HashSet<String> groupNames = getGroupNamesFromCache();
+            if (groupNames == null) {
+                groupNames = new HashSet<>(provider.getGroupNames());
+                saveGroupNamesInCache(groupNames);
             }
+            return new GroupCollection(groupNames);
         }
-        return new GroupCollection(groupNames);
     }
 
     /**
@@ -542,18 +533,15 @@ public class GroupManager {
      * @return an Iterator for all groups in the specified range.
      */
     public Collection<Group> getGroups(int startIndex, int numResults) {
-        HashSet<String> groupNames = getPagedGroupNamesFromCache(startIndex, numResults);
-        if (groupNames == null) {
-            // synchronizing on interned string isn't great, but this value is deemed sufficiently unique for this to be safe here.
-            synchronized (pagedGroupNameKeyInterner.intern(getPagedGroupNameKey(startIndex, numResults))) {
-                groupNames = getPagedGroupNamesFromCache(startIndex, numResults);
-                if (groupNames == null) {
-                    groupNames = new HashSet<>(provider.getGroupNames(startIndex, numResults));
-                    savePagedGroupNamesFromCache(groupNames, startIndex, numResults);
-                }
+        synchronized (groupMetaLock)
+        {
+            HashSet<String> groupNames = getPagedGroupNamesFromCache(startIndex, numResults);
+            if (groupNames == null) {
+                groupNames = new HashSet<>(provider.getGroupNames(startIndex, numResults));
+                savePagedGroupNamesFromCache(groupNames, startIndex, numResults);
             }
+            return new GroupCollection(groupNames);
         }
-        return new GroupCollection(groupNames);
     }
 
     /**
@@ -573,17 +561,15 @@ public class GroupManager {
      * @return all groups that an entity belongs to.
      */
     public Collection<Group> getGroups(JID user) {
-        HashSet<String> groupNames = getUserGroupsFromCache(user);
-        if (groupNames == null) {
-            synchronized (userBasedMutex.intern(user)) {
-                groupNames = getUserGroupsFromCache(user);
-                if (groupNames == null) {
-                    groupNames = new HashSet<>(provider.getGroupNames(user));
-                    saveUserGroupsInCache(user, groupNames);
-                }
+        synchronized (groupMetaLock)
+        {
+            HashSet<String> groupNames = getUserGroupsFromCache(user);
+            if (groupNames == null) {
+                groupNames = new HashSet<>(provider.getGroupNames(user));
+                saveUserGroupsInCache(user, groupNames);
             }
+            return new GroupCollection(groupNames);
         }
-        return new GroupCollection(groupNames);
     }
 
     /**
@@ -653,9 +639,7 @@ public class GroupManager {
 
     private void evictCachedUserForGroup(JID user) {
         if (user != null) {
-
-            // remove cache for getGroups
-            synchronized (USER_GROUPS_LOCK) {
+            synchronized(groupMetaLock) {
                 clearUserGroupsCache(user);
             }
         }
@@ -688,14 +672,16 @@ public class GroupManager {
         final Set<Group> groups = getSharedGroups( group );
 
         // Evict cached information for affected users.
-        groups.forEach( g -> {
-            g.getAdmins().forEach( jid -> evictCachedUserForGroup( jid.asBareJID()) );
-            g.getMembers().forEach( jid -> evictCachedUserForGroup( jid.asBareJID()) );
-        });
+        synchronized (groupMetaLock) {
+            groups.forEach(g -> {
+                g.getAdmins().forEach(jid -> clearUserGroupsCache(jid.asBareJID()));
+                g.getMembers().forEach(jid -> clearUserGroupsCache(jid.asBareJID()));
+            });
 
-        // If any of the groups is shared with everybody, evict all cached groups.
-        if ( groups.stream().anyMatch( g -> g.getSharedWith() == SharedGroupVisibility.everybody)) {
-            evictCachedUserSharedGroups();
+            // If any of the groups is shared with everybody, evict all cached groups.
+            if ( groups.stream().anyMatch( g -> g.getSharedWith() == SharedGroupVisibility.everybody)) {
+                evictCachedUserSharedGroups();
+            }
         }
     }
 
@@ -748,12 +734,24 @@ public class GroupManager {
         return result;
     }
 
+    /**
+     * Evicts all paginated group-name cache entries.
+     *
+     * Caller must hold {@code groupMetaLock}.
+     */
+    @GuardedBy("groupMetaLock")
     private void evictCachedPaginatedGroupNames() {
         groupMetaCache.keySet().stream()
             .filter(key -> key.startsWith(GROUP_NAMES_KEY))
             .forEach(groupMetaCache::remove);
     }
 
+    /**
+     * Evicts all user-to-group cache entries.
+     *
+     * Caller must hold {@code groupMetaLock}.
+     */
+    @GuardedBy("groupMetaLock")
     private void evictCachedUserSharedGroups() {
         groupMetaCache.keySet().stream()
             .filter(key -> key.startsWith(USER_GROUPS_KEY))
@@ -776,10 +774,13 @@ public class GroupManager {
         }
 
         // Update caches.
-        clearGroupNameCache();
-        clearGroupCountCache();
+        synchronized (groupMetaLock)
+        {
+            clearGroupNameCache();
+            clearGroupCountCache();
+            evictCachedPaginatedGroupNames();
+        }
         evictCachedUsersForGroup(group);
-        evictCachedPaginatedGroupNames();
 
         groupCache.put(group.getName(), CacheableOptional.of(group));
 
@@ -814,10 +815,13 @@ public class GroupManager {
     {
         // Add a no-hit to the cache.
         groupCache.put(group.getName(), CacheableOptional.of(null));
-        clearGroupNameCache();
-        clearGroupCountCache();
+        synchronized (groupMetaLock)
+        {
+            clearGroupNameCache();
+            clearGroupCountCache();
+            evictCachedPaginatedGroupNames();
+        }
         evictCachedUsersForGroup(group);
-        evictCachedPaginatedGroupNames();
     }
 
     /**
@@ -960,9 +964,12 @@ public class GroupManager {
         if (originalName != null) {
             groupCache.remove(originalName);
         }
-        clearGroupNameCache();
+        synchronized (groupMetaLock)
+        {
+            clearGroupNameCache();
+            evictCachedPaginatedGroupNames();
+        }
         evictCachedUsersForGroup(group);
-        evictCachedPaginatedGroupNames();
 
         final Group updatedGroup;
         try {
@@ -1143,13 +1150,19 @@ public class GroupManager {
     {
         switch (key) {
             case Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY: {
-                clearGroupNameCache();
+                synchronized (groupMetaLock)
+                {
+                    clearGroupNameCache();
+                }
 
                 // Check to see if the definition of people to which the shared group is shared has changed
                 final String newValue = group.getProperties().get(Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY);
                 if (!StringUtils.equals(originalValue, newValue)) {
                     if ("everybody".equals(originalValue) || "everybody".equals(newValue)) {
-                        evictCachedUserSharedGroups();
+                        synchronized (groupMetaLock)
+                        {
+                            evictCachedUserSharedGroups();
+                        }
                     }
                 }
                 break;
@@ -1179,17 +1192,31 @@ public class GroupManager {
 
     /*
         For reasons currently unclear, this class stores a number of different objects in the groupMetaCache. To
-        better encapsulate this, all access to the groupMetaCache is via these methods
+        better encapsulate this, all access to the groupMetaCache is via these methods.
+
+        Thread-safety contract: callers of the methods below must already hold groupMetaLock.
+     */
+    /**
+     * Caller must hold {@code groupMetaLock}.
      */
     @SuppressWarnings("unchecked")
+    @GuardedBy("groupMetaLock")
     private HashSet<String> getGroupNamesFromCache() {
-        return (HashSet<String>)groupMetaCache.get(GROUP_NAMES_KEY);
+        return (HashSet<String>) groupMetaCache.get(GROUP_NAMES_KEY);
     }
 
+    /**
+     * Caller must hold {@code groupMetaLock}.
+     */
+    @GuardedBy("groupMetaLock")
     private void clearGroupNameCache() {
         groupMetaCache.remove(GROUP_NAMES_KEY);
     }
 
+    /**
+     * Caller must hold {@code groupMetaLock}.
+     */
+    @GuardedBy("groupMetaLock")
     private void saveGroupNamesInCache(final HashSet<String> groupNames) {
         groupMetaCache.put(GROUP_NAMES_KEY, groupNames);
     }
@@ -1228,37 +1255,68 @@ public class GroupManager {
         }
     }
 
+    /**
+     * Caller must hold {@code groupMetaLock}.
+     */
     @SuppressWarnings("unchecked")
+    @GuardedBy("groupMetaLock")
     private HashSet<String> getPagedGroupNamesFromCache(final int startIndex, final int numResults) {
-        return (HashSet<String>)groupMetaCache.get(getPagedGroupNameKey(startIndex, numResults).toString());
+        return (HashSet<String>) groupMetaCache.get(getPagedGroupNameKey(startIndex, numResults).toString());
     }
 
+    /**
+     * Caller must hold {@code groupMetaLock}.
+     */
+    @GuardedBy("groupMetaLock")
     private void savePagedGroupNamesFromCache(final HashSet<String> groupNames, final int startIndex, final int numResults) {
         groupMetaCache.put(getPagedGroupNameKey(startIndex, numResults).toString(), groupNames);
-
     }
 
+    /**
+     * Caller must hold {@code groupMetaLock}.
+     */
+    @GuardedBy("groupMetaLock")
     private Integer getGroupCountFromCache() {
         return (Integer)groupMetaCache.get(GROUP_COUNT_KEY);
     }
 
+    /**
+     * Caller must hold {@code groupMetaLock}.
+     */
+    @GuardedBy("groupMetaLock")
     private void saveGroupCountInCache(final int count) {
         groupMetaCache.put(GROUP_COUNT_KEY, count);
     }
 
+    /**
+     * Caller must hold {@code groupMetaLock}.
+     */
+    @GuardedBy("groupMetaLock")
     private void clearGroupCountCache() {
         groupMetaCache.remove(GROUP_COUNT_KEY);
     }
 
+    /**
+     * Caller must hold {@code groupMetaLock}.
+     */
     @SuppressWarnings("unchecked")
+    @GuardedBy("groupMetaLock")
     private HashSet<String> getUserGroupsFromCache(final JID user) {
-        return (HashSet<String>)groupMetaCache.get(getUserGroupsKey(user));
+        return (HashSet<String>) groupMetaCache.get(getUserGroupsKey(user));
     }
 
+    /**
+     * Caller must hold {@code groupMetaLock}.
+     */
+    @GuardedBy("groupMetaLock")
     private void clearUserGroupsCache(final JID user) {
         groupMetaCache.remove(getUserGroupsKey(user));
     }
 
+    /**
+     * Caller must hold {@code groupMetaLock}.
+     */
+    @GuardedBy("groupMetaLock")
     private void saveUserGroupsInCache(final JID user, final HashSet<String> groupNames) {
         groupMetaCache.put(getUserGroupsKey(user), groupNames);
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -711,6 +711,7 @@ public class GroupManager {
     private Set<Group> getSharedGroups(@Nonnull final Group group) {
         final HashSet<Group> result = new HashSet<>();
         if (provider.isSharingSupported()) {
+            // Note: the option 'users of the same group' is persisted as 'usersOfGroups' with a list of groups that is limited to the own group-name.
             if (group.getSharedWith() == SharedGroupVisibility.usersOfGroups) {
                 final Set<String> groupNames = new HashSet<>(group.getSharedWithUsersInGroupNames());
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -738,12 +738,12 @@ public class GroupManager {
     }
 
     /**
-     * Evicts all paginated group-name cache entries.
+     * Evicts all group-name cache entries, both paginated and the non-paginated one.
      *
      * Caller must hold {@code groupMetaLock}.
      */
     @GuardedBy("groupMetaLock")
-    private void evictCachedPaginatedGroupNames() {
+    private void evictCachedGroupNames() {
         groupMetaCache.keySet().stream()
             .filter(key -> key.startsWith(GROUP_NAMES_KEY))
             .forEach(groupMetaCache::remove);
@@ -779,9 +779,8 @@ public class GroupManager {
         // Update caches.
         synchronized (groupMetaLock)
         {
-            clearGroupNameCache();
             clearGroupCountCache();
-            evictCachedPaginatedGroupNames();
+            evictCachedGroupNames();
         }
         evictCachedUsersForGroup(group);
 
@@ -820,9 +819,8 @@ public class GroupManager {
         groupCache.put(group.getName(), CacheableOptional.of(null));
         synchronized (groupMetaLock)
         {
-            clearGroupNameCache();
             clearGroupCountCache();
-            evictCachedPaginatedGroupNames();
+            evictCachedGroupNames();
         }
         evictCachedUsersForGroup(group);
     }
@@ -969,8 +967,7 @@ public class GroupManager {
         }
         synchronized (groupMetaLock)
         {
-            clearGroupNameCache();
-            evictCachedPaginatedGroupNames();
+            evictCachedGroupNames();
         }
         evictCachedUsersForGroup(group);
 
@@ -1155,7 +1152,7 @@ public class GroupManager {
             case Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY: {
                 synchronized (groupMetaLock)
                 {
-                    clearGroupNameCache();
+                    evictCachedGroupNames();
                 }
 
                 // Check to see if the definition of people to which the shared group is shared has changed
@@ -1206,14 +1203,6 @@ public class GroupManager {
     @GuardedBy("groupMetaLock")
     private HashSet<String> getGroupNamesFromCache() {
         return (HashSet<String>) groupMetaCache.get(GROUP_NAMES_KEY);
-    }
-
-    /**
-     * Caller must hold {@code groupMetaLock}.
-     */
-    @GuardedBy("groupMetaLock")
-    private void clearGroupNameCache() {
-        groupMetaCache.remove(GROUP_NAMES_KEY);
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -755,7 +755,7 @@ public class GroupManager {
 
     private void evictCachedUserSharedGroups() {
         groupMetaCache.keySet().stream()
-            .filter(key -> key.startsWith(GROUP_NAMES_KEY))
+            .filter(key -> key.startsWith(USER_GROUPS_KEY))
             .forEach(groupMetaCache::remove);
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/GroupManager.java
@@ -102,7 +102,7 @@ public class GroupManager {
     @GuardedBy("groupMetaLock")
     private final Cache<String, Serializable> groupMetaCache;
 
-    private GroupProvider provider;
+    private volatile GroupProvider provider;
 
     private GroupManager()
     {
@@ -168,7 +168,7 @@ public class GroupManager {
         });
     }
 
-    private void initProvider(final Class<? extends GroupProvider> clazz) {
+    private synchronized void initProvider(final Class<? extends GroupProvider> clazz) {
         if (provider == null || !clazz.equals(provider.getClass())) {
             try {
                 provider = clazz.getDeclaredConstructor().newInstance();

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/AbstractGroupProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/AbstractGroupProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xmpp.packet.JID;
 
-import java.lang.reflect.Field;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -111,14 +110,8 @@ public class AbstractGroupProviderTest extends DBTestCase {
     public void tearDown() throws Exception {
         super.tearDown();
 
-        // Reset static fields after use (to not confuse other test classes).
         // TODO: this ideally goes in a static @AfterClass method, but that's not supported in JUnit 3.
-        for (String fieldName : Arrays.asList("INSTANCE", "provider")) {
-            Field field = GroupManager.class.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            field.set(null, null);
-            field.setAccessible(false);
-        }
+        GroupManager.setInstance(null);
 
         Fixtures.clearExistingProperties();
     }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/DefaultGroupProviderTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/DefaultGroupProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,12 +111,7 @@ public class DefaultGroupProviderTest extends DBTestCase
 
         // Reset static fields after use (to not confuse other test classes).
         // TODO: this ideally goes in a static @AfterClass method, but that's not supported in JUnit 3.
-        for (String fieldName : Arrays.asList("INSTANCE", "provider")) {
-            final Field field = GroupManager.class.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            field.set(null, null);
-            field.setAccessible(false);
-        }
+        GroupManager.setInstance(null);
 
         final Field field = GroupEventDispatcher.class.getDeclaredField("listeners");
         field.setAccessible(true);

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerConcurrencyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerConcurrencyTest.java
@@ -1,0 +1,641 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.group;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.util.CacheableOptional;
+import org.jivesoftware.util.PersistableMap;
+import org.jivesoftware.util.cache.Cache;
+import org.jivesoftware.util.cache.CacheFactory;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.xmpp.packet.JID;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for concurrency issues in {@link GroupManager}'s locking strategy.
+ */
+@ExtendWith(MockitoExtension.class)
+public class GroupManagerConcurrencyTest
+{
+    private static Cache<String, CacheableOptional<Group>> groupCache;
+    private static Cache<String, Serializable> groupMetaCache;
+
+    private GroupManager groupManager;
+    private ControllableGroupProvider provider;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception
+    {
+        Fixtures.reconfigureOpenfireHome();
+        Fixtures.disableDatabasePersistence();
+        groupCache = CacheFactory.createCache("Group");
+        groupMetaCache = CacheFactory.createCache("Group Metadata Cache");
+    }
+
+    @BeforeEach
+    public void setUp()
+    {
+        Arrays.stream(CacheFactory.getAllCaches()).forEach(Map::clear);
+        provider = new ControllableGroupProvider();
+        groupManager = new GroupManager(provider, groupCache, groupMetaCache);
+        GroupManager.setInstance(groupManager);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        groupManager.getGroups().forEach(group -> {
+            try { groupManager.deleteGroup(group); }
+            catch (GroupNotFoundException e) { throw new RuntimeException(e); }
+        });
+        GroupManager.setInstance(null);
+        Arrays.stream(CacheFactory.getAllCaches()).forEach(Map::clear);
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        Arrays.stream(CacheFactory.getAllCaches()).forEach(Map::clear);
+        GroupManager.setInstance(null);
+    }
+
+    /**
+     * Verifies that the cached group count stays correct when a group is created concurrently with a
+     * {@code getGroupCount()} call whose provider query is artificially delayed to open the race window.
+     */
+    @Test
+    public void testGroupCountNotStaleDespiteConcurrentGroupCreation() throws Exception
+    {
+        // Setup test fixture.
+        groupManager.createGroup("initial-group-1");
+        groupManager.createGroup("initial-group-2");
+        groupMetaCache.clear(); // force a fresh provider hit on the next call
+
+        // The hook fires AFTER the provider has computed the count (= 2) but BEFORE GroupManager writes that value into
+        // the cache. This is the exact moment Thread-B must intervene.
+        final CountDownLatch providerCallDone = new CountDownLatch(1);
+        final CountDownLatch allowCacheWrite  = new CountDownLatch(1);
+        provider.onGetGroupCount(() -> {
+            providerCallDone.countDown(); // "I have the answer, about to return"
+            try {
+                if (!allowCacheWrite.await(1, TimeUnit.MINUTES)) {
+                    throw new InterruptedException("Provider call took too long");
+                }
+            }
+            catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        });
+
+        // Thread-A: slow getGroupCount() – will write count=2 to cache after the latch
+        final Thread threadA = new Thread(() -> groupManager.getGroupCount());
+        threadA.start();
+
+        assertTrue(providerCallDone.await(5, TimeUnit.SECONDS), "Thread-A did not reach the provider");
+
+        // Thread-B: run mutation concurrently on a separate thread.
+        final Thread threadB = new Thread(() -> {
+            try {
+                groupManager.createGroup("new-group-added-during-race");
+            } catch (GroupAlreadyExistsException | GroupNameInvalidException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        threadB.start();
+
+        // Give Thread-B a chance to complete first.
+        threadB.join(1_000);
+
+        // Let Thread-A write the (possibly stale) count into the cache
+        allowCacheWrite.countDown();
+        threadA.join(5_000);
+        threadB.join(5_000);
+        assertFalse(threadA.isAlive(), "Thread-A did not finish");
+        assertFalse(threadB.isAlive(), "Thread-B did not finish");
+
+        // Execute system under test.
+        final int cachedCount   = groupManager.getGroupCount(); // hits the cache written by Thread-A
+        final int providerCount = provider.getGroupCount();
+
+        // Verify result.
+        assertEquals(providerCount, cachedCount,"Cached group count (" + cachedCount + ") is stale; provider reports " + providerCount + " groups.");
+    }
+
+    /**
+     * Verifies that {@code getGroupCount()} and {@code getGroups().size()} always agree under concurrent writes.
+     */
+    @Test
+    public void testGroupCountAndGroupNamesAreConsistentUnderConcurrentWrite() throws Exception
+    {
+        // Setup test fixture.
+        groupManager.createGroup("seed-group-1");
+        groupManager.createGroup("seed-group-2");
+        groupManager.createGroup("seed-group-3");
+        groupMetaCache.clear();
+
+        // Hook fires AFTER the provider has built the complete 3-name list, but BEFORE GroupManager stores it in the cache.
+        final CountDownLatch namesComputedByProvider = new CountDownLatch(1);
+        final CountDownLatch allowNamesWrite         = new CountDownLatch(1);
+        provider.onGetGroupNames(() -> {
+            namesComputedByProvider.countDown();
+            try {
+                if (!allowNamesWrite.await(1, TimeUnit.MINUTES)) {
+                    throw new InterruptedException("Provider call took too long");
+                }
+            }
+            catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        });
+
+        // Thread-A: slow getGroups() – will write 3 names to cache after the latch
+        final Thread threadA = new Thread(() -> groupManager.getGroups());
+        threadA.start();
+
+        assertTrue(namesComputedByProvider.await(5, TimeUnit.SECONDS), "Thread-A did not reach the provider");
+
+        // Thread-B: add a fourth group on a separate thread.
+        final Thread threadB = new Thread(() -> {
+            try {
+                groupManager.createGroup("interloper-group");
+            } catch (GroupAlreadyExistsException | GroupNameInvalidException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        threadB.start();
+
+        // Try to let Thread-B complete first.
+        threadB.join(1_000);
+
+        // Thread-A resumes, writes stale 3-name list into GROUP_NAMES cache.
+        allowNamesWrite.countDown();
+        threadA.join(5_000);
+        threadB.join(5_000);
+        assertFalse(threadA.isAlive(), "Thread-A did not finish");
+        assertFalse(threadB.isAlive(), "Thread-B did not finish");
+
+        // Execute system under test.
+        final int cachedNamesCount = groupManager.getGroups().size();
+        final int cachedGroupCount = groupManager.getGroupCount();
+
+        // Verify results – the two cache paths must agree.
+        assertEquals(cachedGroupCount, cachedNamesCount, "getGroupCount() returned " + cachedGroupCount + " but getGroups().size() returned " + cachedNamesCount);
+    }
+
+    /**
+     * Verifies that the per-user group-membership cache is not reinstated with stale data after
+     * {@code memberRemovedPostProcess()} has already evicted it.
+     */
+    @Test
+    public void testPerUserGroupCacheNotStaleDespiteConcurrentMemberRemoval() throws Exception
+    {
+        // Setup test fixture: one group containing a single user
+        final JID user = new JID("alice", "example.org", null);
+        groupManager.createGroup("membership-group");
+        provider.addMember("membership-group", user, false);
+        groupMetaCache.clear();
+
+        // Verify the user really is a member before we start the race
+        assertFalse(groupManager.getGroups(user).isEmpty(), "Pre-condition: user must be in at least one group");
+        groupMetaCache.clear(); // evict so the next call actually queries the provider
+
+        // Hook fires AFTER the provider has computed the membership list (user IS a member) but BEFORE GroupManager writes that list into the per-user cache.
+        final CountDownLatch membershipComputedByProvider = new CountDownLatch(1);
+        final CountDownLatch allowMembershipWrite         = new CountDownLatch(1);
+        provider.onGetGroupNamesForUser(() -> {
+            membershipComputedByProvider.countDown();
+            try {
+                if (!allowMembershipWrite.await(1, TimeUnit.MINUTES)) {
+                    throw new InterruptedException("Provider call took too long");
+                }
+            }
+            catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        });
+
+        // Thread-A: slow getGroups(user) – will write [membership-group] to cache after latch
+        final Thread threadA = new Thread(() -> groupManager.getGroups(user));
+        threadA.start();
+
+        assertTrue(membershipComputedByProvider.await(5, TimeUnit.SECONDS), "Thread-A did not reach the provider");
+
+        // Thread-B: remove user from the provider, then notify GroupManager.
+        final Thread threadB = new Thread(() -> {
+            try {
+                provider.deleteMember("membership-group", user);
+                final Group groupAfterRemoval = provider.getGroup("membership-group");
+                groupManager.memberRemovedPostProcess(groupAfterRemoval, user);
+            } catch (GroupNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        threadB.start();
+
+        // Attempt to let Thread-B complete first.
+        threadB.join(1_000);
+
+        // Thread-A resumes and writes stale membership-group.
+        allowMembershipWrite.countDown();
+        threadA.join(5_000);
+        threadB.join(5_000);
+        assertFalse(threadA.isAlive(), "Thread-A did not finish");
+        assertFalse(threadB.isAlive(), "Thread-B did not finish");
+
+        // Execute system under test: query again; must return empty because the user was removed.
+        final Collection<Group> afterRemoval = groupManager.getGroups(user);
+
+        // Verify result.
+        assertTrue(afterRemoval.isEmpty(), "After removing user from all groups, getGroups(user) still returned " + afterRemoval.size() + " group(s).");
+    }
+
+    /**
+     * Verifies that paginated group-name cache entries are not written back with stale data after
+     * {@code evictCachedPaginatedGroupNames()} has already cleared them.
+     */
+    @Test
+    public void testPaginatedGroupNamesCacheNotStaleDespiteConcurrentEviction() throws Exception
+    {
+        // Setup test fixture
+        for (int i = 0; i < 4; i++) {
+            groupManager.createGroup("page-group-" + i);
+        }
+        groupMetaCache.clear();
+
+        // Hook fires AFTER the provider computed the 4-group page, BEFORE GroupManager writes it to the cache.
+        final CountDownLatch pageComputedByProvider = new CountDownLatch(1);
+        final CountDownLatch allowPageWrite         = new CountDownLatch(1);
+        provider.onGetGroupNamesPage(() -> {
+            pageComputedByProvider.countDown();
+            try {
+                if (!allowPageWrite.await(1, TimeUnit.MINUTES)) {
+                    throw new InterruptedException("Provider call took too long");
+                }
+            }
+            catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        });
+
+        // Thread-A: slow getGroups(0, 10) – will write 4-name page to cache after latch
+        final Thread threadA = new Thread(() -> groupManager.getGroups(0, 10));
+        threadA.start();
+
+        assertTrue(pageComputedByProvider.await(5, TimeUnit.SECONDS), "Thread-A did not reach the provider");
+
+        // Thread-B: create a new group concurrently.
+        final Thread threadB = new Thread(() -> {
+            try {
+                groupManager.createGroup("fifth-group");
+            } catch (GroupAlreadyExistsException | GroupNameInvalidException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        threadB.start();
+
+        // Try to let Thread-B complete first to force stale-page reinstatement.
+        threadB.join(1_000);
+
+        // Thread-A resumes and writes the stale 4-group page into the now-empty cache slot.
+        allowPageWrite.countDown();
+        threadA.join(5_000);
+        threadB.join(5_000);
+        assertFalse(threadA.isAlive(), "Thread-A did not finish");
+        assertFalse(threadB.isAlive(), "Thread-B did not finish");
+
+        // Execute system under test.
+        final Collection<Group> cachedPage   = groupManager.getGroups(0, 10);
+        final int               providerSize = provider.getGroupCount();
+
+        // Verify result.
+        assertEquals(providerSize, cachedPage.size(), "getGroups(0,10) returned " + cachedPage.size() + " groups, but the provider holds " + providerSize + ".");
+    }
+
+    /**
+     * Verifies that {@link GroupManager} throws no exception and leaves the caches in a coherent state when many
+     * threads perform mixed group operations simultaneously.
+     */
+    @Test
+    public void stressTestNoConcurrentExceptionsAndCacheRemainsCoherent() throws Exception
+    {
+        // Setup test fixture.
+        final int threadCount = 17;
+        final Duration duration = Duration.ofSeconds(2);
+        final int groupCount = 5;
+        final JID testUser = new JID("stress-user", "example.org", null);
+
+        for (int i = 0; i < groupCount; i++) {
+            groupManager.createGroup("stress-seed-" + i);
+            provider.addMember("stress-seed-" + i, testUser, false);
+        }
+
+        final AtomicInteger exceptionCount = new AtomicInteger(0);
+        final AtomicReference<Throwable> firstError = new AtomicReference<>();
+        final AtomicInteger nextGroupId = new AtomicInteger(100);
+
+        final CountDownLatch startGate = new CountDownLatch(1);
+        final CountDownLatch stopGate  = new CountDownLatch(threadCount);
+
+        // Execute system under test
+        for (int t = 0; t < threadCount; t++)
+        {
+            final int threadIndex = t;
+            final Thread thread = new Thread(() -> {
+                try {
+                    startGate.await();
+                    final Instant deadline = Instant.now().plus(duration);
+                    while (Instant.now().isBefore(deadline))
+                    {
+                        try {
+                            switch (threadIndex % 4) {
+                                case 0 -> {
+                                    final int c = groupManager.getGroupCount();
+                                    assertTrue(c >= 0, "Group count must be non-negative");
+                                }
+                                case 1 -> {
+                                    final Collection<Group> groups = groupManager.getGroups();
+                                    assertNotNull(groups);
+                                }
+                                case 2 -> {
+                                    final Collection<Group> userGroups = groupManager.getGroups(testUser);
+                                    assertNotNull(userGroups);
+                                }
+                                case 3 -> {
+                                    // Create a unique transient group, then immediately delete it.
+                                    final String name = "stress-transient-" + nextGroupId.getAndIncrement();
+                                    final Group created = groupManager.createGroup(name);
+                                    groupManager.deleteGroup(created);
+                                }
+                            }
+                        } catch (Throwable e) {
+                            exceptionCount.incrementAndGet();
+                            firstError.compareAndSet(null, e);
+                        }
+                    }
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    stopGate.countDown();
+                }
+            });
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        startGate.countDown();
+        assertTrue(stopGate.await(Duration.ofSeconds(5).plus(duration).toMillis(), TimeUnit.MILLISECONDS), "Not all threads finished in time");
+
+        // Verify result.
+        if (firstError.get() != null) {
+            fail("At least " + exceptionCount.get()
+                + " exception(s) were thrown during concurrent group operations. "
+                + "First error: " + firstError.get().getMessage(),
+                firstError.get());
+        }
+
+        // final cache coherence – count and names-list must agree
+        final int finalCount = groupManager.getGroupCount();
+        final int finalNamesSize = groupManager.getGroups().size();
+        assertEquals(finalCount, finalNamesSize, "After the stress test, getGroupCount() (" + finalCount + ") != getGroups().size() (" + finalNamesSize + ").");
+    }
+
+    /**
+     * A thread-safe, in-memory {@link GroupProvider} that accepts optional {@link Runnable} hooks executed at the end
+     * of specific provider calls.
+     *
+     * A hook fires <em>after</em> the provider has computed its result but <em>before</em> it returns to GroupManager.
+     * This is the exact window in which an intervening modification by Thread-B can leave Thread-A's about-to-be-cached
+     * value stale.
+     *
+     * Each hook is a one-shot: it must be set afresh for each test.
+     */
+    static class ControllableGroupProvider implements GroupProvider
+    {
+        private final ConcurrentHashMap<String, String>   descriptions = new ConcurrentHashMap<>();
+        private final ConcurrentHashMap<String, Set<JID>> members      = new ConcurrentHashMap<>();
+        private final ConcurrentHashMap<String, Set<JID>> admins       = new ConcurrentHashMap<>();
+
+        private volatile Runnable onGetGroupCountHook;
+        private volatile Runnable onGetGroupNamesHook;
+        private volatile Runnable onGetGroupNamesForUserHook;
+        private volatile Runnable onGetGroupNamesPageHook;
+
+        void onGetGroupCount(Runnable hook)        { onGetGroupCountHook        = hook; }
+        void onGetGroupNames(Runnable hook)        { onGetGroupNamesHook        = hook; }
+        void onGetGroupNamesForUser(Runnable hook) { onGetGroupNamesForUserHook = hook; }
+        void onGetGroupNamesPage(Runnable hook)    { onGetGroupNamesPageHook    = hook; }
+
+        @Override
+        public Group createGroup(String name) throws GroupAlreadyExistsException
+        {
+            if (descriptions.putIfAbsent(name, "") != null) {
+                throw new GroupAlreadyExistsException();
+            }
+            members.put(name, ConcurrentHashMap.newKeySet());
+            admins.put(name,  ConcurrentHashMap.newKeySet());
+            return buildGroup(name);
+        }
+
+        @Override
+        public void deleteGroup(String name) throws GroupNotFoundException
+        {
+            if (descriptions.remove(name) == null) {
+                throw new GroupNotFoundException();
+            }
+            members.remove(name);
+            admins.remove(name);
+        }
+
+        @Override
+        public Group getGroup(String name) throws GroupNotFoundException
+        {
+            if (!descriptions.containsKey(name)) {
+                throw new GroupNotFoundException();
+            }
+            return buildGroup(name);
+        }
+
+        private Group buildGroup(String name)
+        {
+            return new Group(
+                name,
+                descriptions.getOrDefault(name, ""),
+                new ArrayList<>(members.getOrDefault(name, Collections.emptySet())),
+                new ArrayList<>(admins.getOrDefault(name,  Collections.emptySet())));
+        }
+
+        @Override
+        public void setName(String oldName, String newName) throws GroupAlreadyExistsException, GroupNameInvalidException, GroupNotFoundException
+        {
+            if (!descriptions.containsKey(oldName)) {
+                throw new GroupNotFoundException();
+            }
+            if ( descriptions.containsKey(newName)) {
+                throw new GroupAlreadyExistsException();
+            }
+            descriptions.put(newName, descriptions.remove(oldName));
+            members.put(newName, members.remove(oldName));
+            admins.put(newName,  admins.remove(oldName));
+        }
+
+        @Override
+        public void setDescription(String name, String description) throws GroupNotFoundException
+        {
+            if (!descriptions.containsKey(name)) {
+                throw new GroupNotFoundException();
+            }
+            descriptions.put(name, description);
+        }
+
+        @Override
+        public int getGroupCount()
+        {
+            final int count = descriptions.size();
+
+            if (onGetGroupCountHook != null) {
+                // Hook fires AFTER computing the count, BEFORE returning to GroupManager.
+                onGetGroupCountHook.run();
+                onGetGroupCountHook = null;
+            }
+
+            return count;
+        }
+
+        @Override
+        public Collection<String> getGroupNames()
+        {
+            final List<String> names = new ArrayList<>(descriptions.keySet());
+
+            if (onGetGroupNamesHook != null) {
+                try {
+                    // Hook fires AFTER computing the list, BEFORE returning to GroupManager.
+                    onGetGroupNamesHook.run();
+                } finally {
+                    onGetGroupNamesHook = null;
+                }
+            }
+
+            return names;
+        }
+
+        @Override
+        public Collection<String> getGroupNames(int startIndex, int numResults)
+        {
+            final List<String> page = descriptions.keySet().stream()
+                .skip(startIndex)
+                .limit(numResults)
+                .collect(Collectors.toList());
+
+            if (onGetGroupNamesPageHook != null) {
+                try {
+                    // Hook fires AFTER computing the page, BEFORE returning to GroupManager.
+                    onGetGroupNamesPageHook.run();
+                } finally {
+                    onGetGroupNamesPageHook = null;
+                }
+            }
+
+            return page;
+        }
+
+        @Override
+        public Collection<String> getGroupNames(JID user)
+        {
+            final JID bare = user.asBareJID();
+            final Set<String> result = new HashSet<>();
+            members.forEach((group, jids) -> { if (jids.contains(bare)) result.add(group); });
+            admins.forEach( (group, jids) -> { if (jids.contains(bare)) result.add(group); });
+
+            if (onGetGroupNamesForUserHook != null) {
+                try {
+                    // Hook fires AFTER computing the membership set, BEFORE returning to GroupManager.
+                    onGetGroupNamesForUserHook.run();
+                } finally {
+                    onGetGroupNamesForUserHook = null;
+                }
+            }
+
+            return result;
+        }
+
+        @Override
+        public void addMember(String groupName, JID user, boolean administrator) throws GroupNotFoundException
+        {
+            if (!descriptions.containsKey(groupName)) {
+                throw new GroupNotFoundException();
+            }
+
+            final ConcurrentMap<String, Set<JID>> users = administrator ? admins : members;
+            users
+                .computeIfAbsent(groupName, k -> ConcurrentHashMap.newKeySet())
+                .add(user.asBareJID());
+        }
+
+        @Override
+        public void updateMember(String groupName, JID user, boolean administrator) throws GroupNotFoundException
+        {
+            if (!descriptions.containsKey(groupName)) {
+                throw new GroupNotFoundException();
+            }
+
+            final JID bare = user.asBareJID();
+            if (administrator) {
+                members.getOrDefault(groupName, Collections.emptySet()).remove(bare);
+                admins.computeIfAbsent(groupName, k -> ConcurrentHashMap.newKeySet()).add(bare);
+            } else {
+                admins.getOrDefault(groupName, Collections.emptySet()).remove(bare);
+                members.computeIfAbsent(groupName, k -> ConcurrentHashMap.newKeySet()).add(bare);
+            }
+        }
+
+        @Override
+        public void deleteMember(String groupName, JID user)
+        {
+            final JID bare = user.asBareJID();
+            members.getOrDefault(groupName, Collections.emptySet()).remove(bare);
+            admins.getOrDefault( groupName, Collections.emptySet()).remove(bare);
+        }
+
+        @Override public boolean            isReadOnly()                           { return false; }
+        @Override public boolean            isSharingSupported()                   { return false; }
+        @Override public Collection<String> getSharedGroupNames()                  { return Collections.emptyList(); }
+        @Override public Collection<String> getSharedGroupNames(JID user)          { return Collections.emptyList(); }
+        @Override public Collection<String> getPublicSharedGroupNames()            { return Collections.emptyList(); }
+        @Override public Collection<String> getVisibleGroupNames(String userGroup) { return Collections.emptyList(); }
+        @Override public Collection<String> search(String query)                   { return Collections.emptyList(); }
+        @Override public Collection<String> search(String q, int s, int n)         { return Collections.emptyList(); }
+        @Override public Collection<String> search(String key, String value)       { return Collections.emptyList(); }
+        @Override public boolean            isSearchSupported()                    { return false; }
+
+        @Override
+        public PersistableMap<String, String> loadProperties(Group group)
+        {
+            return new PersistableMap<>() {
+                @Override
+                public String put(String key, String value, boolean persist) {
+                    // Tests do not exercise persistent property storage; delegate to the backing HashMap so in-memory
+                    // writes (e.g. shareWithNobody) succeed without a real database.
+                    return super.put(key, value);
+                }
+            };
+        }
+    }
+}
+
+
+

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
@@ -450,6 +450,62 @@ public class GroupManagerNoMockTest extends DBTestCase
     }
 
     /**
+     * Verifies that when a group's sharing target list removes a group, users of that removed group
+     * immediately stop seeing the shared group.
+     */
+    @Test
+    public void testSharedGroupsQueryReflectsCurrentStateAfterSharingTargetListRemoval() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+
+        final Group groupB = groupManager.createGroup("Test Group B");
+        groupB.shareWithEverybody("Users in Test Group B");
+
+        final Group groupC = groupManager.createGroup("Test Group C");
+
+        final Group groupA = groupManager.createGroup("Test Group A");
+        groupA.shareWithUsersInGroups(List.of("Test Group B", "Test Group C"), "Users in Test Group A");
+
+        // Verify pre-condition.
+        assertTrue(groupManager.getVisibleGroups(groupC).stream().anyMatch(g -> "Test Group A".equals(g.getName())),
+            "Pre-condition: members of 'Test Group C' should see 'Test Group A' before 'Test Group C' is removed from the sharing target list.");
+
+        // Execute system under test.
+        groupA.shareWithUsersInGroups(List.of("Test Group B"), "Users in Test Group A");
+
+        // Verify result.
+        assertFalse(groupManager.getVisibleGroups(groupC).stream().anyMatch(g -> "Test Group A".equals(g.getName())),
+            "After 'Test Group C' is removed from the sharing target list, members of 'Test Group C' should no longer see 'Test Group A'.");
+    }
+
+    /**
+     * Verifies that toggling sharing with everybody is immediately reflected in per-user shared-group results.
+     */
+    @Test
+    public void testSharingChangeToAndFromEverybodyUpdatesUserSharedGroups() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+        final Group groupA = groupManager.createGroup("Test Group A");
+
+        // Execute system under test.
+        final Collection<Group> beforeChange = groupManager.getSharedGroups("jane");
+        groupA.shareWithEverybody("Users in Test Group A");
+        final Collection<Group> afterEnable = groupManager.getSharedGroups("jane");
+        groupA.shareWithNobody();
+        final Collection<Group> afterDisable = groupManager.getSharedGroups("jane");
+
+        // Verify result.
+        assertFalse(beforeChange.stream().anyMatch(g -> "Test Group A".equals(g.getName())),
+            "Pre-condition: before sharing is enabled, users should not see 'Test Group A' in shared-group results.");
+        assertTrue(afterEnable.stream().anyMatch(g -> "Test Group A".equals(g.getName())),
+            "After sharing with everybody is enabled, users should immediately see 'Test Group A' in shared-group results.");
+        assertFalse(afterDisable.stream().anyMatch(g -> "Test Group A".equals(g.getName())),
+            "After sharing with everybody is disabled, users should immediately stop seeing 'Test Group A' in shared-group results.");
+    }
+
+    /**
      * Verifies that when a group's sharing target list is updated, users that are newly in scope
      * see that group in shared-group results.
      *

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2022-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -87,7 +88,7 @@ public class GroupManagerNoMockTest extends DBTestCase
         // Initialize Openfire's cache framework.
         CacheFactory.initialize();
 
-        // Mock the XMPPServer implementation that's used internally.
+        // Mock the XMPPServer implementation that is used internally.
         Fixtures.clearExistingProperties();
         XMPPServer.setInstance(Fixtures.mockXMPPServer());
 
@@ -110,12 +111,7 @@ public class GroupManagerNoMockTest extends DBTestCase
 
         // Reset static fields after use (to not confuse other test classes).
         // TODO: this ideally goes in a static @AfterClass method, but that's not supported in JUnit 3.
-        for (String fieldName : Arrays.asList("INSTANCE", "provider")) {
-            final Field field = GroupManager.class.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            field.set(null, null);
-            field.setAccessible(false);
-        }
+        GroupManager.setInstance(null);
 
         final Field field = GroupEventDispatcher.class.getDeclaredField("listeners");
         field.setAccessible(true);
@@ -133,10 +129,10 @@ public class GroupManagerNoMockTest extends DBTestCase
     }
 
     /**
-     * Asserts that a simple test group that is created by the provider can be retrieved again in good order.
+     * Verifies that a newly created group can be retrieved with its configured description, members, and administrators.
      */
     @Test
-    public void testCreateGroup() throws Exception
+    public void testCreatedGroupCanBeRetrievedWithConfiguredData() throws Exception
     {
         // Setup test fixture.
         final GroupManager groupManager = GroupManager.getInstance();
@@ -149,68 +145,82 @@ public class GroupManagerNoMockTest extends DBTestCase
         group.getMembers().add(new JID("jack@example.org"));
         group.getAdmins().add(new JID("jane@example.org"));
 
-        // Verify results.
+        // Verify result.
         final Group result = provider.getGroup("Test Group");
-        assertNotNull(result);
-        assertEquals("Test Group", result.getName());
-        assertEquals("This is test group.", result.getDescription());
-        assertEquals(2, result.getMembers().size());
-        assertTrue(result.getMembers().contains(new JID("john@example.org")));
-        assertTrue(result.getMembers().contains(new JID("jack@example.org")));
-        assertEquals(1, result.getAdmins().size());
-        assertTrue(result.getAdmins().contains(new JID("jane@example.org")));
-        assertEquals(3, result.getAll().size());
-        assertTrue(result.getAll().contains(new JID("john@example.org")));
-        assertTrue(result.getAll().contains(new JID("jack@example.org")));
-        assertTrue(result.getAll().contains(new JID("jane@example.org")));
+        assertNotNull(result, "Group should be retrievable after creation.");
+        assertEquals("Test Group", result.getName(), "Group name should match the configured value.");
+        assertEquals("This is test group.", result.getDescription(), "Group description should match the configured value.");
+        assertEquals(2, result.getMembers().size(), "Group should have exactly two members.");
+        assertTrue(result.getMembers().contains(new JID("john@example.org")), "Members should include john@example.org.");
+        assertTrue(result.getMembers().contains(new JID("jack@example.org")), "Members should include jack@example.org.");
+        assertEquals(1, result.getAdmins().size(), "Group should have exactly one administrator.");
+        assertTrue(result.getAdmins().contains(new JID("jane@example.org")), "Administrators should include jane@example.org.");
+        assertEquals(3, result.getAll().size(), "getAll() should return all members and administrators.");
+        assertTrue(result.getAll().contains(new JID("john@example.org")), "getAll() should include john@example.org.");
+        assertTrue(result.getAll().contains(new JID("jack@example.org")), "getAll() should include jack@example.org.");
+        assertTrue(result.getAll().contains(new JID("jane@example.org")), "getAll() should include jane@example.org.");
     }
 
     /**
-     * Asserts that a with no name cannot be created
+     * Verifies that creating a group with an empty name is rejected.
      */
     @Test
-    public void testCreateGroupWithEmptyNameThrows() throws Exception
+    public void testCreatingGroupWithEmptyNameFails() throws Exception
     {
+        // Setup test fixture.
         final String GROUP_NAME = "";
         final GroupManager groupManager = GroupManager.getInstance();
-        assertThrows(GroupNameInvalidException.class, ()-> groupManager.createGroup(GROUP_NAME));
+
+        // Execute system under test and verify result.
+        assertThrows(GroupNameInvalidException.class, () -> groupManager.createGroup(GROUP_NAME), "Creating a group with an empty name should be rejected.");
     }
 
     /**
-     * Asserts that two groups with the same name cannot be created
+     * Verifies that creating a second group with the same name is rejected.
      */
     @Test
-    public void testCreateGroupWithDuplicateNameThrows() throws Exception
+    public void testCreatingGroupWithDuplicateNameFails() throws Exception
     {
+        // Setup test fixture.
         final String GROUP_NAME = "Test Group A";
         final GroupManager groupManager = GroupManager.getInstance();
+
+        // Execute system under test.
         groupManager.createGroup(GROUP_NAME);
-        assertThrows(GroupAlreadyExistsException.class, ()-> groupManager.createGroup(GROUP_NAME));
+
+        // Verify result.
+        assertThrows(GroupAlreadyExistsException.class, () -> groupManager.createGroup(GROUP_NAME), "Creating a second group with the same name should be rejected.");
     }
 
     /**
-     * Asserts that a group can be created, removed and recreated again, with the same name.
+     * Verifies that a deleted group name can be reused for a new group.
      */
     @Test
-    public void testRecreateGroup() throws Exception
+    public void testDeletedGroupNameCanBeReused() throws Exception
     {
+        // Setup test fixture.
         final String GROUP_NAME = "Test Group A";
         final GroupManager groupManager = GroupManager.getInstance();
+
+        // Execute system under test.
         final Group group = groupManager.createGroup(GROUP_NAME);
         groupManager.deleteGroup(group);
-        groupManager.createGroup(GROUP_NAME);
+        final Group recreatedGroup = groupManager.createGroup(GROUP_NAME);
+
+        // Verify result.
+        assertNotNull(recreatedGroup, "Group should be successfully recreated with the same name.");
     }
 
     /**
-     * Reproduces an issue where adding a member to a group that does not exist would cause the group to be added
-     * to a cache, making it appear that this group exists.
+     * Verifies that mutating a stale reference to a deleted group does not make that group
+     * appear to exist again.
      *
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-2426">Group cache can contain ghost entries</a>
      */
     @Test
-    public void testAddMemberToDeletedGroup() throws Exception
+    public void testDeletedGroupRemainsUnavailableAfterStaleReferenceMutation() throws Exception
     {
-        // Setup test fixture
+        // Setup test fixture.
         final String GROUP_NAME = "Test Group A";
         final GroupManager groupManager = GroupManager.getInstance();
         final Group group = groupManager.createGroup(GROUP_NAME);
@@ -219,12 +229,12 @@ public class GroupManagerNoMockTest extends DBTestCase
         // Execute system under test.
         group.getMembers().add(new JID("test@example.org"));
 
-        // Verify results.
-        assertThrows(GroupNotFoundException.class, ()-> groupManager.getGroup(GROUP_NAME));
+        // Verify result.
+        assertThrows(GroupNotFoundException.class, () -> groupManager.getGroup(GROUP_NAME), "Deleted group should remain unavailable even after mutation of a stale reference.");
     }
 
     /**
-     * Verifies that a group can be retrieved based on the name that it was created with.
+     * Verifies that a group can be retrieved by the name it was created with.
      */
     @Test
     public void testGetGroupByName() throws Exception
@@ -237,13 +247,12 @@ public class GroupManagerNoMockTest extends DBTestCase
         final Group result = groupManager.getGroup("test");
 
         // Verify result.
-        assertNotNull(result);
-        assertEquals("test", result.getName());
+        assertNotNull(result, "Group should be retrievable by name.");
+        assertEquals("test", result.getName(), "Retrieved group name should match the requested name.");
     }
 
     /**
-     * Verifies that a {@link GroupManager#getGroupCount()} returns the correct count of groups when no groups
-     * are present.
+     * Verifies that {@link GroupManager#getGroupCount()} returns zero when no groups are present.
      */
     @Test
     public void testGroupCountEmpty() throws Exception
@@ -255,12 +264,11 @@ public class GroupManagerNoMockTest extends DBTestCase
         final int result = groupManager.getGroupCount();
 
         // Verify result.
-        assertEquals(0, result);
+        assertEquals(0, result, "Group count should be zero when no groups exist.");
     }
 
     /**
-     * Verifies that a {@link GroupManager#getGroupCount()} returns the correct count of groups when one group
-     * is present.
+     * Verifies that {@link GroupManager#getGroupCount()} returns one when one group is present.
      */
     @Test
     public void testGroupCountOne() throws Exception
@@ -273,12 +281,11 @@ public class GroupManagerNoMockTest extends DBTestCase
         final int result = groupManager.getGroupCount();
 
         // Verify result.
-        assertEquals(1, result);
+        assertEquals(1, result, "Group count should be one when exactly one group exists.");
     }
 
     /**
-     * Verifies that a {@link GroupManager#getGroupCount()} returns the correct count of groups when multiple
-     * groups are present.
+     * Verifies that {@link GroupManager#getGroupCount()} returns the expected count when multiple groups are present.
      */
     @Test
     public void testGroupCountMultiple() throws Exception
@@ -292,23 +299,50 @@ public class GroupManagerNoMockTest extends DBTestCase
         final int result = groupManager.getGroupCount();
 
         // Verify result.
-        assertEquals(2, result);
+        assertEquals(2, result, "Group count should match the number of created groups.");
     }
 
     /**
-     * Verifies that {@link GroupManager#deleteGroup(Group)} deletes a shared group, such that it cannot be retrieved
+     * Verifies that deleting a shared group removes it from shared-group results.
      */
     @Test
-    public void testDeleteGroupShared() throws Exception {
+    public void testDeletedSharedGroupIsNoLongerReturned() throws Exception
+    {
+        // Setup test fixture.
         final JID needle = new JID("jane@example.org");
         final GroupManager groupManager = GroupManager.getInstance();
         final Group groupA = groupManager.createGroup("Test Group A");
         groupA.shareWithEverybody("Users in group A");
         groupManager.createGroup("Test Group B");
 
+        // Execute system under test.
         groupManager.deleteGroup(groupA);
         final Collection<Group> result = groupManager.getSharedGroups(needle.getNode());
 
-        assertEquals(0, result.size());
+        // Verify result.
+        assertEquals(0, result.size(), "Deleted shared group should not appear in shared-group results.");
+    }
+
+    /**
+     * Verifies that paginated group listings include newly created groups, even when the same page
+     * has been requested before the new group was added.
+     */
+    @Test
+    public void testPaginatedGroupListingReflectsNewGroupAfterPriorQuery() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+        groupManager.createGroup("Test Group A");
+
+        // Execute system under test (warm the cache with an initial page query).
+        final Collection<Group> firstPage = groupManager.getGroups(0, 10);
+        assertEquals(1, firstPage.size(), "Pre-condition: exactly one group should be present initially.");
+
+        // Execute system under test (create a new group).
+        groupManager.createGroup("Test Group B");
+        final Collection<Group> updatedPage = groupManager.getGroups(0, 10);
+
+        // Verify result.
+        assertEquals(2, updatedPage.size(), "Paginated query should include the newly created group.");
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
@@ -403,6 +403,53 @@ public class GroupManagerNoMockTest extends DBTestCase
     }
 
     /**
+     * Verifies that enabling sharing with users in the same group is immediately reflected in the shared-group
+     * results of those users.
+     */
+    @Test
+    public void testSharingEnabledForUsersInSameGroupIsImmediatelyReflected() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+        final JID jane = new JID("jane", XMPPServer.getInstance().getServerInfo().getXMPPDomain(), null);
+        final Group groupA = groupManager.createGroup("Test Group A");
+        groupA.getMembers().add(jane);
+
+        // Execute system under test (warm with pre-change result).
+        final Collection<Group> beforeChange = groupManager.getSharedGroups("jane");
+        groupA.shareWithUsersInSameGroup("Users in Test Group A");
+        final Collection<Group> afterChange = groupManager.getSharedGroups("jane");
+
+        // Verify result.
+        assertFalse(beforeChange.stream().anyMatch(g -> "Test Group A".equals(g.getName())), "Pre-condition: before sharing is enabled, users should not see 'Test Group A' in shared-group results.");
+        assertTrue(afterChange.stream().anyMatch(g -> "Test Group A".equals(g.getName())), "After sharing with users in the same group is enabled, users should immediately see 'Test Group A'.");
+    }
+
+    /**
+     * Verifies that disabling sharing with users in the same group is immediately reflected in the shared-group
+     * results of those users.
+     */
+    @Test
+    public void testSharingDisabledForUsersInSameGroupIsImmediatelyReflected() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+        final JID jane = new JID("jane", XMPPServer.getInstance().getServerInfo().getXMPPDomain(), null);
+        final Group groupA = groupManager.createGroup("Test Group A");
+        groupA.getMembers().add(jane);
+        groupA.shareWithUsersInSameGroup("Users in Test Group A");
+
+        // Execute system under test (warm with pre-change result).
+        final Collection<Group> beforeChange = groupManager.getSharedGroups("jane");
+        groupA.shareWithNobody();
+        final Collection<Group> afterChange = groupManager.getSharedGroups("jane");
+
+        // Verify result.
+        assertTrue(beforeChange.stream().anyMatch(g -> "Test Group A".equals(g.getName())), "Pre-condition: before sharing is disabled, users should see 'Test Group A' in shared-group results.");
+        assertFalse(afterChange.stream().anyMatch(g -> "Test Group A".equals(g.getName())), "After sharing is disabled, users should immediately stop seeing 'Test Group A'.");
+    }
+
+    /**
      * Verifies that when a group's sharing target list is updated, users that are newly in scope
      * see that group in shared-group results.
      *

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerNoMockTest.java
@@ -345,4 +345,92 @@ public class GroupManagerNoMockTest extends DBTestCase
         // Verify result.
         assertEquals(2, updatedPage.size(), "Paginated query should include the newly created group.");
     }
+
+    /**
+     * Verifies that changing a group to be shared with everybody makes that group visible to
+     * users outside of that group.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3285">OF-3285: Changes to group sharing visibility are not immediately reflected in users' contact lists</a>
+     */
+    @Test
+    public void testSharingChangeToEverybodyUpdatesVisibleGroups() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+        final Group groupA = groupManager.createGroup("Test Group A");
+        final Group groupB = groupManager.createGroup("Test Group B");
+
+        // Verify pre-condition.
+        assertFalse(groupManager.getVisibleGroups(groupB).stream().anyMatch(g -> "Test Group A".equals(g.getName())),
+            "Pre-condition: 'Test Group A' should not be visible to 'Test Group B' before it is shared with everybody.");
+
+        // Execute system under test.
+        groupA.shareWithEverybody("Test Group A");
+
+        // Verify result.
+        assertTrue(groupManager.getVisibleGroups(groupB).stream().anyMatch(g -> "Test Group A".equals(g.getName())),
+            "After sharing with everybody, 'Test Group A' should be visible to users outside that group.");
+    }
+
+    /**
+     * Verifies that changing a group from shared-with-everybody to not shared removes that group
+     * from visibility results for users outside of that group.
+     *
+     * This test covers the reverse direction compared to
+     * {@link #testSharingChangeToEverybodyUpdatesVisibleGroups()}.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3285">OF-3285: Changes to group sharing visibility are not immediately reflected in users' contact lists</a>
+     */
+    @Test
+    public void testSharingChangeFromEverybodyUpdatesVisibleGroups() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+        final Group groupA = groupManager.createGroup("Test Group A");
+        groupA.shareWithEverybody("Test Group A");
+        final Group groupB = groupManager.createGroup("Test Group B");
+
+        // Verify pre-condition.
+        assertTrue(groupManager.getVisibleGroups(groupB).stream().anyMatch(g -> "Test Group A".equals(g.getName())),
+            "Pre-condition: 'Test Group A' should be visible to 'Test Group B' while it is shared with everybody.");
+
+        // Execute system under test.
+        groupA.shareWithNobody();
+
+        // Verify result.
+        assertFalse(groupManager.getVisibleGroups(groupB).stream().anyMatch(g -> "Test Group A".equals(g.getName())),
+            "After sharing is disabled, 'Test Group A' should no longer be visible to users outside that group.");
+    }
+
+    /**
+     * Verifies that when a group's sharing target list is updated, users that are newly in scope
+     * see that group in shared-group results.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3285">OF-3285: Changes to group sharing visibility are not immediately reflected in users' contact lists</a>
+     */
+    @Test
+    public void testSharedGroupsQueryReflectsCurrentStateAfterSharingTargetListChange() throws Exception
+    {
+        // Setup test fixture.
+        final GroupManager groupManager = GroupManager.getInstance();
+
+        final Group groupB = groupManager.createGroup("Test Group B");
+        groupB.shareWithEverybody("Users in Test Group B");
+
+        final Group groupC = groupManager.createGroup("Test Group C");
+
+        final Group groupA = groupManager.createGroup("Test Group A");
+        groupA.shareWithUsersInGroups(List.of("Test Group B"), "Users in Test Group A");
+
+        // Verify pre-condition.
+        assertFalse(groupManager.getVisibleGroups(groupC).stream().anyMatch(g -> "Test Group A".equals(g.getName())),
+            "Pre-condition: members of 'Test Group C' should not see 'Test Group A' before that group is shared with users in 'Test Group C'.");
+
+        // Execute system under test.
+        groupA.shareWithUsersInGroups(List.of("Test Group B", "Test Group C"), "Users in Test Group A");
+
+        // Verify result.
+        assertTrue(groupManager.getVisibleGroups(groupC).stream().anyMatch(g -> "Test Group A".equals(g.getName())),
+            "After the sharing target list is updated, members of 'Test Group C' should see 'Test Group A'.");
+    }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
@@ -553,4 +553,339 @@ public class GroupManagerTest
         assertNull(groupMetaCache.get(userGroupsKey), "Per-user group-membership cache entry should be invalidated after sharing target list changes when one target is shared with everybody.");
         assertNotNull(groupMetaCache.get(paginatedKey), "Paginated group-names cache entry should NOT be invalidated by a sharing target list change.");
     }
+
+    /**
+     * Verifies that deleteGroupPostProcess evicts the per-user group-membership cache entries for members of a
+     * NON-SHARED group. This test exposes the bug where evictCachedUsersForGroup only processes groups returned by
+     * getSharedGroups(), which returns empty for non-shared groups, leaving members with stale cache entries.
+     *
+     * This is a regression test for the issue where members of deleted non-shared groups retain stale
+     * cached membership information in their per-user group cache.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3287">Issue: Group members' user cache not evicted for non-shared groups</a>
+     */
+    @Test
+    public void deleteGroupPostProcessEvictsPerUserCacheForNonSharedGroupMembers() throws Exception
+    {
+        // Setup test fixture: a non-shared group with members and admins
+        final String groupName = "test-group-non-shared";
+        final JID member1 = new JID("member1@example.org");
+        final JID member2 = new JID("member2@example.org");
+        final JID admin1 = new JID("admin1@example.org");
+
+        final Group groupToDelete = mock(Group.class);
+        when(groupToDelete.getName()).thenReturn(groupName);
+        when(groupToDelete.getSharedWith()).thenReturn(SharedGroupVisibility.nobody);
+        when(groupToDelete.getMembers()).thenReturn(new HashSet<>(Arrays.asList(member1, member2)));
+        when(groupToDelete.getAdmins()).thenReturn(new HashSet<>(List.of(admin1)));
+
+        // Pre-populate per-user group-membership cache for all members
+        final String member1CacheKey = "USER_GROUPS" + member1.toBareJID();
+        final String member2CacheKey = "USER_GROUPS" + member2.toBareJID();
+        final String admin1CacheKey = "USER_GROUPS" + admin1.toBareJID();
+        final HashSet<String> member1Groups = new HashSet<>(Arrays.asList(groupName, "other-group"));
+        final HashSet<String> member2Groups = new HashSet<>(List.of(groupName));
+        final HashSet<String> admin1Groups = new HashSet<>(List.of(groupName));
+
+        groupMetaCache.put(member1CacheKey, member1Groups);
+        groupMetaCache.put(member2CacheKey, member2Groups);
+        groupMetaCache.put(admin1CacheKey, admin1Groups);
+
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                // Suppress event dispatch; not the focus of this test.
+            }
+        };
+
+        // Verify precondition: cache entries exist before deletion
+        assertNotNull(groupMetaCache.get(member1CacheKey), "Precondition: member1 should have cached groups before deletion.");
+        assertNotNull(groupMetaCache.get(member2CacheKey), "Precondition: member2 should have cached groups before deletion.");
+        assertNotNull(groupMetaCache.get(admin1CacheKey), "Precondition: admin1 should have cached groups before deletion.");
+
+        // Execute system under test: delete a non-shared group
+        manager.deleteGroupPostProcess(groupToDelete);
+
+        // Verify result: per-user group-membership cache entries must be evicted for all members/admins
+        assertNull(groupMetaCache.get(member1CacheKey), "REGRESSION: member1's per-user group-membership cache should be evicted after group deletion.");
+        assertNull(groupMetaCache.get(member2CacheKey), "REGRESSION: member2's per-user group-membership cache should be evicted after group deletion.");
+        assertNull(groupMetaCache.get(admin1CacheKey), "REGRESSION: admin1's per-user group-membership cache should be evicted after group deletion.");
+    }
+
+    /**
+     * Verifies that renameGroupPostProcess evicts the per-user group-membership cache entries for members of a
+     * NON-SHARED group. This test exposes the same bug as deleteGroupPostProcess: evictCachedUsersForGroup only
+     * processes groups returned by getSharedGroups(), which returns empty for non-shared groups, leaving members
+     * with stale cache entries.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3287">Issue: Group members' user cache not evicted for non-shared groups</a>
+     */
+    @Test
+    public void renameGroupPostProcessEvictsPerUserCacheForNonSharedGroupMembers() throws Exception
+    {
+        // Setup test fixture: a non-shared group with members
+        final String oldGroupName = "old-group-name";
+        final String newGroupName = "new-group-name";
+        final JID member1 = new JID("member1@example.org");
+        final JID admin1 = new JID("admin1@example.org");
+
+        final Group renamedGroup = mock(Group.class);
+        when(renamedGroup.getName()).thenReturn(newGroupName);
+        when(renamedGroup.getSharedWith()).thenReturn(SharedGroupVisibility.nobody);
+        when(renamedGroup.getMembers()).thenReturn(new HashSet<>(List.of(member1)));
+        when(renamedGroup.getAdmins()).thenReturn(new HashSet<>(List.of(admin1)));
+
+        // Pre-populate per-user group-membership cache with old group name
+        final String memberCacheKey = "USER_GROUPS" + member1.toBareJID();
+        final HashSet<String> memberGroups = new HashSet<>(Arrays.asList(oldGroupName, "other-group"));
+        groupMetaCache.put(memberCacheKey, memberGroups);
+
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                // Suppress event dispatch; not the focus of this test.
+            }
+        };
+
+        // Verify precondition: cache entry exists before rename
+        assertNotNull(groupMetaCache.get(memberCacheKey), "Precondition: member should have cached groups before rename.");
+
+        // Execute system under test: rename a non-shared group
+        // NOTE: This test intentionally does not invoke the full renameGroup flow to avoid XMPPServer dependency.
+        // We test the core cache-eviction behavior directly.
+        manager.deleteGroupPostProcess(renamedGroup);
+
+        // Verify result: per-user group-membership cache entries must be evicted
+        assertNull(groupMetaCache.get(memberCacheKey), "REGRESSION: member's per-user group-membership cache should be evicted after group rename.");
+    }
+
+    /**
+     * Verifies that createGroupPostProcess evicts the per-user group-membership cache entries for members of a newly
+     * created NON-SHARED group. This is a precautionary test to ensure consistency in cache handling across all group
+     * lifecycle operations.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3287">Issue: Group members' user cache not evicted for non-shared groups</a>
+     */
+    @Test
+    public void createGroupPostProcessEvictsPerUserCacheForNewNonSharedGroupMembers() throws Exception
+    {
+        // Setup test fixture: a newly created non-shared group with members
+        final String groupName = "new-group";
+        final JID member1 = new JID("member1@example.org");
+
+        final Group newGroup = mock(Group.class);
+        when(newGroup.getName()).thenReturn(groupName);
+        when(newGroup.getSharedWith()).thenReturn(SharedGroupVisibility.nobody);
+        when(newGroup.getMembers()).thenReturn(new HashSet<>(List.of(member1)));
+        when(newGroup.getAdmins()).thenReturn(new HashSet<>());
+
+        // Pre-populate per-user group-membership cache (simulating a cached result from before the group existed)
+        final String memberCacheKey = "USER_GROUPS" + member1.toBareJID();
+        final HashSet<String> memberGroups = new HashSet<>(List.of("other-group"));
+        groupMetaCache.put(memberCacheKey, memberGroups);
+
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                // Suppress event dispatch; not the focus of this test.
+            }
+        };
+
+        // Verify precondition: cache entry exists before creation
+        assertNotNull(groupMetaCache.get(memberCacheKey), "Precondition: member should have cached groups before new group is created.");
+
+        // Execute system under test: create a new non-shared group
+        manager.createGroupPostProcess(newGroup);
+
+        // Verify result: per-user group-membership cache entries must be evicted to pick up the new group
+        assertNull(groupMetaCache.get(memberCacheKey), "REGRESSION: member's per-user group-membership cache should be evicted after new group creation.");
+    }
+
+    /**
+     * Verifies that changing a group's membership list properly evicts the affected users' per-user group-membership
+     * caches. This test validates the propertyModifiedPostProcess behavior for SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY
+     * changes on non-shared groups.
+     *
+     * This ensures that when a group's sharing configuration changes, all affected users get fresh cache entries.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3287">Issue: Group members' user cache not evicted for non-shared groups</a>
+     */
+    @Test
+    public void groupMembershipChangeEvictsAffectedUsersCache() throws Exception
+    {
+        // Setup test fixture: a group with members whose membership list is changing
+        final String groupName = "test-group";
+        final String targetGroupName = "target-group";
+        final JID member1 = new JID("member1@example.org");
+        final JID member2 = new JID("member2@example.org");
+
+        final Group group = mock(Group.class);
+        when(group.getName()).thenReturn(groupName);
+        when(group.getSharedWith()).thenReturn(SharedGroupVisibility.usersOfGroups);
+        when(group.getSharedWithUsersInGroupNames()).thenReturn(List.of(targetGroupName));
+        when(group.getMembers()).thenReturn(new HashSet<>(Arrays.asList(member1, member2)));
+        when(group.getAdmins()).thenReturn(new HashSet<>());
+
+        // Target group also needs to be mocked
+        final Group targetGroup = mock(Group.class);
+        when(targetGroup.getMembers()).thenReturn(new HashSet<>());
+        when(targetGroup.getAdmins()).thenReturn(new HashSet<>());
+
+        // Group properties indicate the shared group list changed
+        final PersistableMap<String, String> props = new PersistableMap<>() {
+            @Override
+            public String put(final String key, final String value, final boolean persist) {
+                return super.put(key, value);
+            }
+        };
+        props.put(Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY, targetGroupName);
+        when(group.getProperties()).thenReturn(props);
+
+        // The getGroup call during postProcess must resolve the group
+        doReturn(group).when(groupProvider).getGroup(groupName);
+        doThrow(new GroupNotFoundException()).when(groupProvider).getGroup("old-target-group");
+        when(groupProvider.isSharingSupported()).thenReturn(true);
+
+        // Cache the target group
+        groupCache.put(targetGroupName, CacheableOptional.of(targetGroup));
+
+        // Pre-populate per-user group-membership cache for members
+        final String member1CacheKey = "USER_GROUPS" + member1.toBareJID();
+        final String member2CacheKey = "USER_GROUPS" + member2.toBareJID();
+        groupMetaCache.put(member1CacheKey, new HashSet<>(Arrays.asList(groupName, "other-group")));
+        groupMetaCache.put(member2CacheKey, new HashSet<>(List.of(groupName)));
+
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                // Suppress event dispatch; not the focus of this test.
+            }
+        };
+
+        // Verify precondition: cache entries exist before the modification
+        assertNotNull(groupMetaCache.get(member1CacheKey), "Precondition: member1 should have cached groups before modification.");
+        assertNotNull(groupMetaCache.get(member2CacheKey), "Precondition: member2 should have cached groups before modification.");
+
+        // Execute system under test: change the group's shared-with list
+        manager.propertyModifiedPostProcess(group, Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY, "old-target-group");
+
+        // Verify result: per-user group-membership cache entries must be evicted for all members
+        assertNull(groupMetaCache.get(member1CacheKey), "REGRESSION: member1's per-user group-membership cache should be evicted after group sharing change.");
+        assertNull(groupMetaCache.get(member2CacheKey), "REGRESSION: member2's per-user group-membership cache should be evicted after group sharing change.");
+    }
+
+    /**
+     * Verifies that per-user group-membership cache eviction works correctly for shared groups (where getSharedGroups()
+     * DOES return some groups). This is a positive test case to ensure that the eviction mechanism works for shared
+     * groups and serves as a baseline for comparison with the non-shared group failure case.
+     *
+     * This test validates that members of groups that ARE shared INTO generate proper cache evictions.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3287">Issue: Group members' user cache not evicted for non-shared groups</a>
+     */
+    @Test
+    public void deleteSharedGroupProperlyEvictsSharedIntoGroupMembers() throws Exception
+    {
+        // Setup test fixture: Group A is shared into Group B, and Group B has members
+        final String groupAName = "group-a-shared";
+        final String groupBName = "group-b";
+        final JID groupBMember = new JID("member@example.org");
+
+        // Group A: the one being deleted (shared with users of Group B)
+        final Group groupA = mock(Group.class);
+        when(groupA.getName()).thenReturn(groupAName);
+        when(groupA.getSharedWith()).thenReturn(SharedGroupVisibility.usersOfGroups);
+        when(groupA.getSharedWithUsersInGroupNames()).thenReturn(List.of(groupBName));
+
+        // Group B: a target group that Group A is shared with
+        final Group groupB = mock(Group.class);
+        when(groupB.getMembers()).thenReturn(new HashSet<>(List.of(groupBMember)));
+        when(groupB.getAdmins()).thenReturn(new HashSet<>());
+
+        groupCache.put(groupBName, CacheableOptional.of(groupB));
+
+        when(groupProvider.isSharingSupported()).thenReturn(true);
+
+        // Pre-populate per-user group-membership cache for Group B's member
+        final String memberCacheKey = "USER_GROUPS" + groupBMember.toBareJID();
+        groupMetaCache.put(memberCacheKey, new HashSet<>(Arrays.asList(groupAName, groupBName)));
+
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                // Suppress event dispatch; not the focus of this test.
+            }
+        };
+
+        // Verify precondition: cache entry exists
+        assertNotNull(groupMetaCache.get(memberCacheKey), "Precondition: member should have cached groups before deletion.");
+
+        // Execute system under test: delete the shared group
+        manager.deleteGroupPostProcess(groupA);
+
+        // Verify result: the member's cache IS evicted because Group B (shared-with) is included in evictCachedUsersForGroup
+        assertNull(groupMetaCache.get(memberCacheKey), "Group B member's per-user group-membership cache SHOULD be evicted because Group A is shared with Group B.");
+    }
+
+    /**
+     * Verifies that per-user group-membership cache eviction correctly handles the case where a group is shared with
+     * multiple target groups. This tests that all members of all target groups get their caches evicted.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3287">Issue: Group members' user cache not evicted for non-shared groups</a>
+     */
+    @Test
+    public void deleteGroupSharedWithMultipleTargetsEvictsAllTargetMembers() throws Exception
+    {
+        // Setup test fixture: Group A is shared with Groups B and C
+        final String groupAName = "group-a";
+        final String groupBName = "group-b";
+        final String groupCName = "group-c";
+        final JID memberB = new JID("memberb@example.org");
+        final JID memberC = new JID("memberc@example.org");
+
+        // Group A: being deleted, shared with B and C
+        final Group groupA = mock(Group.class);
+        when(groupA.getName()).thenReturn(groupAName);
+        when(groupA.getSharedWith()).thenReturn(SharedGroupVisibility.usersOfGroups);
+        when(groupA.getSharedWithUsersInGroupNames()).thenReturn(Arrays.asList(groupBName, groupCName));
+
+        // Group B: a target group, with a member
+        final Group groupB = mock(Group.class);
+        when(groupB.getMembers()).thenReturn(new HashSet<>(List.of(memberB)));
+        when(groupB.getAdmins()).thenReturn(new HashSet<>());
+
+        // Group C: another target group, with a member
+        final Group groupC = mock(Group.class);
+        when(groupC.getMembers()).thenReturn(new HashSet<>(List.of(memberC)));
+        when(groupC.getAdmins()).thenReturn(new HashSet<>());
+
+        groupCache.put(groupBName, CacheableOptional.of(groupB));
+        groupCache.put(groupCName, CacheableOptional.of(groupC));
+
+        when(groupProvider.isSharingSupported()).thenReturn(true);
+
+        // Pre-populate caches for both members
+        final String memberBCacheKey = "USER_GROUPS" + memberB.toBareJID();
+        final String memberCCacheKey = "USER_GROUPS" + memberC.toBareJID();
+        groupMetaCache.put(memberBCacheKey, new HashSet<>(List.of(groupBName)));
+        groupMetaCache.put(memberCCacheKey, new HashSet<>(List.of(groupCName)));
+
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                // Suppress event dispatch; not the focus of this test.
+            }
+        };
+
+        // Verify precondition: both cache entries exist before deletion
+        assertNotNull(groupMetaCache.get(memberBCacheKey), "Precondition: member B should have cached groups before deletion.");
+        assertNotNull(groupMetaCache.get(memberCCacheKey), "Precondition: member C should have cached groups before deletion.");
+
+        // Execute system under test: delete group A which is shared with B and C
+        manager.deleteGroupPostProcess(groupA);
+
+        // Verify result: both target group members have their caches evicted because they are in the shared-with groups
+        assertNull(groupMetaCache.get(memberBCacheKey), "Member of Group B should have cache evicted after Group A deletion.");
+        assertNull(groupMetaCache.get(memberCCacheKey), "Member of Group C should have cache evicted after Group A deletion.");
+    }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package org.jivesoftware.openfire.group;
 
 import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.event.GroupEventDispatcher;
 import org.jivesoftware.util.CacheableOptional;
-import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.PersistableMap;
 import org.jivesoftware.util.cache.Cache;
 import org.jivesoftware.util.cache.CacheFactory;
@@ -27,246 +27,354 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.xmpp.packet.JID;
 
-import java.lang.reflect.Field;
+import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class GroupManagerTest {
-
+public class GroupManagerTest
+{
     private static final String GROUP_NAME = "test-group-name";
     private static Cache<String, CacheableOptional<Group>> groupCache;
+    private static Cache<String, Serializable> groupMetaCache;
+
     @Mock
     GroupProvider groupProvider;
+
     private GroupManager groupManager;
+
     @Mock
     private Group cachedGroup;
+
     @Mock
     private Group unCachedGroup;
 
     @BeforeAll
-    public static void beforeClass() throws Exception {
+    public static void beforeClass() throws Exception
+    {
         Fixtures.reconfigureOpenfireHome();
         Fixtures.disableDatabasePersistence();
         groupCache = CacheFactory.createCache("Group");
+        groupMetaCache = CacheFactory.createCache("Group Metadata Cache");
         groupCache.clear();
-        JiveGlobals.setProperty("provider.group.className", TestGroupProvider.class.getName());
+        groupMetaCache.clear();
     }
 
     @BeforeEach
-    public void setUp() {
-        // Ensure that Openfire caches are reset before each test to avoid tests to affect each-other.
+    public void setUp()
+    {
+        // Reset shared caches before each test, then build GroupManager directly with test dependencies.
         Arrays.stream(CacheFactory.getAllCaches()).forEach(Map::clear);
-
-        TestGroupProvider.mockGroupProvider = groupProvider;
-        groupManager = GroupManager.getInstance();
+        groupManager = new GroupManager(groupProvider, groupCache, groupMetaCache);
     }
 
     @AfterAll
-    public static void afterClass() throws Exception {
-
-        // Reset static fields after use (to not confuse other test classes).
-        for (String fieldName : Arrays.asList("INSTANCE", "provider")) {
-            Field field = GroupManager.class.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            field.set(null, null);
-            field.setAccessible(false);
-        }
-
+    public static void afterClass()
+    {
         groupCache.clear();
-    }
-
-    @Test
-    public void willUseACacheHit() throws Exception {
-
-        groupCache.put(GROUP_NAME, CacheableOptional.of(cachedGroup));
-
-        final Group returnedGroup = groupManager.getGroup(GROUP_NAME, false);
-
-        assertThat(returnedGroup, is(cachedGroup));
-        verifyNoMoreInteractions(groupProvider);
-    }
-
-    @Test
-    public void willUseACacheMiss() {
-
-        groupCache.put(GROUP_NAME, CacheableOptional.of(null));
-
-        assertThrows(GroupNotFoundException.class, () -> groupManager.getGroup(GROUP_NAME, false));
-        verifyNoMoreInteractions(groupProvider);
-    }
-
-    @Test
-    public void willCacheAHitIfNotAlreadyCached() throws Exception {
-
-        doReturn(unCachedGroup).when(groupProvider).getGroup(GROUP_NAME);
-
-        final Group returnedGroup = groupManager.getGroup(GROUP_NAME, false);
-
-        assertThat(returnedGroup, is(unCachedGroup));
-        verify(groupProvider).getGroup(GROUP_NAME);
-        assertThat(groupCache.get(GROUP_NAME), is(CacheableOptional.of(unCachedGroup)));
-    }
-
-    @Test
-    public void willCacheAMissIfNotAlreadyCached() throws Exception {
-
-        doThrow(new GroupNotFoundException()).when(groupProvider).getGroup(GROUP_NAME);
-
-        assertThrows(GroupNotFoundException.class, () -> groupManager.getGroup(GROUP_NAME, false));
-        verify(groupProvider).getGroup(GROUP_NAME);
-        assertThat(groupCache.get(GROUP_NAME), is(CacheableOptional.of(null)));
-    }
-
-    @Test
-    public void aForceLookupHitWillIgnoreTheExistingCache() throws Exception {
-        groupCache.put(GROUP_NAME, CacheableOptional.of(cachedGroup));
-        doReturn(unCachedGroup).when(groupProvider).getGroup(GROUP_NAME);
-
-        final Group returnedGroup = groupManager.getGroup(GROUP_NAME, true);
-
-        assertThat(returnedGroup, is(unCachedGroup));
-        verify(groupProvider).getGroup(GROUP_NAME);
-        assertThat(groupCache.get(GROUP_NAME), is(CacheableOptional.of(unCachedGroup)));
-    }
-
-    @Test
-    public void aForceLookupMissWillIgnoreTheExistingCache() throws Exception {
-        groupCache.put(GROUP_NAME, CacheableOptional.of(cachedGroup));
-        doThrow(new GroupNotFoundException()).when(groupProvider).getGroup(GROUP_NAME);
-
-        assertThrows(GroupNotFoundException.class, () -> groupManager.getGroup(GROUP_NAME, true));
-        verify(groupProvider).getGroup(GROUP_NAME);
-        assertThat(groupCache.get(GROUP_NAME), is(CacheableOptional.of(null)));
+        groupMetaCache.clear();
     }
 
     /**
-     * As the GroupManager creates the instance of the GroupProvider, use this class to delegate calls
-     * to the mock.
+     * Unit-level test (not behavioral): Verifies internal caching behavior of GroupManager when a group is found
+     * in the cache. This test is implementation-focused and validates that the provider is not called when a cache hit occurs.
      */
-    public static class TestGroupProvider implements GroupProvider {
+    @Test
+    public void willUseACacheHit() throws Exception
+    {
+        // Setup test fixture.
+        groupCache.put(GROUP_NAME, CacheableOptional.of(cachedGroup));
 
-        private static GroupProvider mockGroupProvider;
+        // Execute system under test.
+        final Group returnedGroup = groupManager.getGroup(GROUP_NAME, false);
 
-        @Override
-        public Group createGroup(final String name) throws GroupAlreadyExistsException, GroupNameInvalidException {
-            return mockGroupProvider.createGroup(name);
-        }
+        // Verify result.
+        assertThat("Cache hit should return the cached group without consulting the provider.", returnedGroup, is(cachedGroup));
+        verifyNoMoreInteractions(groupProvider);
+    }
 
-        @Override
-        public void deleteGroup(final String name) throws GroupNotFoundException {
-            mockGroupProvider.deleteGroup(name);
-        }
+    /**
+     * Unit-level test (not behavioral): Verifies internal caching behavior of GroupManager when a negative cache entry
+     * (group-not-found) is found in the cache. This test is implementation-focused and validates that the provider is not called.
+     */
+    @Test
+    public void willUseACacheMiss()
+    {
+        // Setup test fixture.
+        groupCache.put(GROUP_NAME, CacheableOptional.of(null));
 
-        @Override
-        public Group getGroup(final String name) throws GroupNotFoundException {
-            return mockGroupProvider.getGroup(name);
-        }
+        // Execute system under test and verify result.
+        assertThrows(GroupNotFoundException.class, () -> groupManager.getGroup(GROUP_NAME, false), "Cache miss should throw GroupNotFoundException without consulting the provider.");
+        verifyNoMoreInteractions(groupProvider);
+    }
 
-        @Override
-        public void setName(final String oldName, final String newName) throws GroupAlreadyExistsException, GroupNameInvalidException, GroupNotFoundException {
-            mockGroupProvider.setName(oldName, newName);
-        }
+    /**
+     * Unit-level test (not behavioral): Verifies internal caching behavior of GroupManager when a group is looked up
+     * but not yet cached. This test is implementation-focused and validates that the result from the provider is cached.
+     */
+    @Test
+    public void willCacheAHitIfNotAlreadyCached() throws Exception
+    {
+        // Setup test fixture.
+        doReturn(unCachedGroup).when(groupProvider).getGroup(GROUP_NAME);
 
-        @Override
-        public void setDescription(final String name, final String description) throws GroupNotFoundException {
-            mockGroupProvider.setDescription(name, description);
-        }
+        // Execute system under test.
+        final Group returnedGroup = groupManager.getGroup(GROUP_NAME, false);
 
-        @Override
-        public int getGroupCount() {
-            return mockGroupProvider.getGroupCount();
-        }
+        // Verify result.
+        assertThat("Uncached group should be returned from the provider.", returnedGroup, is(unCachedGroup));
+        verify(groupProvider).getGroup(GROUP_NAME);
+        assertThat("Provider result should be cached for future lookups.", groupCache.get(GROUP_NAME), is(CacheableOptional.of(unCachedGroup)));
+    }
 
-        @Override
-        public Collection<String> getGroupNames() {
-            return mockGroupProvider.getGroupNames();
-        }
+    /**
+     * Unit-level test (not behavioral): Verifies internal caching behavior of GroupManager when a group is not found
+     * by the provider. This test is implementation-focused and validates that negative results (group-not-found) are
+     * cached to avoid repeated failed lookups.
+     */
+    @Test
+    public void willCacheAMissIfNotAlreadyCached() throws Exception
+    {
+        // Setup test fixture.
+        doThrow(new GroupNotFoundException()).when(groupProvider).getGroup(GROUP_NAME);
 
-        @Override
-        public boolean isSharingSupported() {
-            return mockGroupProvider.isSharingSupported();
-        }
+        // Execute system under test and verify result.
+        assertThrows(GroupNotFoundException.class, () -> groupManager.getGroup(GROUP_NAME, false), "Uncached miss should throw GroupNotFoundException from the provider.");
+        verify(groupProvider).getGroup(GROUP_NAME);
+        assertThat("Cache miss should be cached to avoid repeated provider lookups.", groupCache.get(GROUP_NAME), is(CacheableOptional.of(null)));
+    }
 
-        @Override
-        public Collection<String> getSharedGroupNames() {
-            return mockGroupProvider.getSharedGroupNames();
-        }
+    /**
+     * Unit-level test (not behavioral): Verifies internal caching behavior of GroupManager when force-refresh is
+     * requested. This test is implementation-focused and validates that the cache is bypassed and the provider is
+     * consulted even if an entry exists in the cache.
+     */
+    @Test
+    public void aForceLookupHitWillIgnoreTheExistingCache() throws Exception
+    {
+        // Setup test fixture.
+        groupCache.put(GROUP_NAME, CacheableOptional.of(cachedGroup));
+        doReturn(unCachedGroup).when(groupProvider).getGroup(GROUP_NAME);
 
-        @Override
-        public Collection<String> getSharedGroupNames(final JID user) {
-            return mockGroupProvider.getSharedGroupNames(user);
-        }
+        // Execute system under test.
+        final Group returnedGroup = groupManager.getGroup(GROUP_NAME, true);
 
-        @Override
-        public Collection<String> getPublicSharedGroupNames() {
-            return mockGroupProvider.getPublicSharedGroupNames();
-        }
+        // Verify result.
+        assertThat("Force-refresh should bypass cache and return fresh result from provider.", returnedGroup, is(unCachedGroup));
+        verify(groupProvider).getGroup(GROUP_NAME);
+        assertThat("Cache should be updated with the fresh lookup result.", groupCache.get(GROUP_NAME), is(CacheableOptional.of(unCachedGroup)));
+    }
 
-        @Override
-        public Collection<String> getVisibleGroupNames(final String userGroup) {
-            return mockGroupProvider.getVisibleGroupNames(userGroup);
-        }
+    /**
+     * Unit-level test (not behavioral): Verifies internal caching behavior of GroupManager when force-refresh is
+     * requested and the group is not found. This test is implementation-focused and validates that the cache bypass
+     * applies even when the provider fails to find the group.
+     */
+    @Test
+    public void aForceLookupMissWillIgnoreTheExistingCache() throws Exception
+    {
+        // Setup test fixture.
+        groupCache.put(GROUP_NAME, CacheableOptional.of(cachedGroup));
+        doThrow(new GroupNotFoundException()).when(groupProvider).getGroup(GROUP_NAME);
 
-        @Override
-        public Collection<String> getGroupNames(final int startIndex, final int numResults) {
-            return mockGroupProvider.getGroupNames(startIndex, numResults);
-        }
+        // Execute system under test and verify result.
+        assertThrows(GroupNotFoundException.class, () -> groupManager.getGroup(GROUP_NAME, true), "Force-refresh should bypass cache and consult provider even if cached entry exists.");
+        verify(groupProvider).getGroup(GROUP_NAME);
+        assertThat("Cache should be updated with the fresh lookup failure.", groupCache.get(GROUP_NAME), is(CacheableOptional.of(null)));
+    }
 
-        @Override
-        public Collection<String> getGroupNames(final JID user) {
-            return mockGroupProvider.getGroupNames(user);
-        }
+    /**
+     * Unit-level test (not behavioral): Verifies internal caching behavior after group creation.
+     * This test validates that createGroupPostProcess places newly created groups into the cache.
+     */
+    @Test
+    public void createGroupPostProcessCachesGroup()
+    {
+        // Setup test fixture.
+        final Group groupToCache = mock(Group.class);
+        when(groupToCache.getName()).thenReturn("new-group");
+        when(groupToCache.getSharedWith()).thenReturn(SharedGroupVisibility.nobody);
+        when(groupToCache.getAdmins()).thenReturn(new HashSet<>());
+        when(groupToCache.getMembers()).thenReturn(new HashSet<>());
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache);
 
-        @Override
-        public void addMember(final String groupName, final JID user, final boolean administrator) throws GroupNotFoundException {
-            mockGroupProvider.addMember(groupName, user, administrator);
-        }
+        // Execute system under test.
+        manager.createGroupPostProcess(groupToCache);
 
-        @Override
-        public void updateMember(final String groupName, final JID user, final boolean administrator) throws GroupNotFoundException {
-            mockGroupProvider.updateMember(groupName, user, administrator);
-        }
+        // Verify result.
+        assertNotNull(groupCache.get("new-group"), "Group should be cached in group cache after creation.");
+    }
 
-        @Override
-        public void deleteMember(final String groupName, final JID user) {
-            mockGroupProvider.deleteMember(groupName, user);
-        }
+    /**
+     * Verifies that createGroupPostProcess dispatches a group_created event.
+     */
+    @Test
+    public void createGroupPostProcessDispatchesCreatedEvent()
+    {
+        // Setup test fixture.
+        final Group groupToCreate = mock(Group.class);
+        when(groupToCreate.getName()).thenReturn("new-group");
+        when(groupToCreate.getSharedWith()).thenReturn(SharedGroupVisibility.nobody);
+        when(groupToCreate.getAdmins()).thenReturn(new HashSet<>());
+        when(groupToCreate.getMembers()).thenReturn(new HashSet<>());
+        final GroupEventDispatcher.EventType[] capturedEventType = new GroupEventDispatcher.EventType[1];
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                capturedEventType[0] = type;
+            }
+        };
 
-        @Override
-        public boolean isReadOnly() {
-            return mockGroupProvider.isReadOnly();
-        }
+        // Execute system under test.
+        manager.createGroupPostProcess(groupToCreate);
 
-        @Override
-        public Collection<String> search(final String query) {
-            return mockGroupProvider.search(query);
-        }
+        // Verify result.
+        assertEquals(GroupEventDispatcher.EventType.group_created, capturedEventType[0], "createGroupPostProcess should dispatch group_created event.");
+    }
 
-        @Override
-        public Collection<String> search(final String query, final int startIndex, final int numResults) {
-            return mockGroupProvider.search(query, startIndex, numResults);
-        }
+    /**
+     * Verifies that deleteGroupPreProcess dispatches a group_deleting event.
+     */
+    @Test
+    public void deleteGroupPreProcessDispatchesDeletingEvent()
+    {
+        // Setup test fixture.
+        final GroupEventDispatcher.EventType[] capturedEventType = new GroupEventDispatcher.EventType[1];
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                capturedEventType[0] = type;
+            }
+        };
 
-        @Override
-        public Collection<String> search(final String key, final String value) {
-            return mockGroupProvider.search(key, value);
-        }
+        // Execute system under test.
+        manager.deleteGroupPreProcess(cachedGroup);
 
-        @Override
-        public boolean isSearchSupported() {
-            return mockGroupProvider.isSearchSupported();
-        }
+        // Verify result.
+        assertEquals(GroupEventDispatcher.EventType.group_deleting, capturedEventType[0], "deleteGroupPreProcess should dispatch group_deleting event.");
+    }
 
-        @Override
-        public PersistableMap<String, String> loadProperties(final Group group) {
-            return mockGroupProvider.loadProperties(group);
-        }
+    /**
+     * Verifies that adminAddedPostProcess dispatches an admin_added event.
+     */
+    @Test
+    public void adminAddedPostProcessDispatchesAdminAddedEvent() throws GroupNotFoundException
+    {
+        // Setup test fixture.
+        final JID adminJid = new JID("admin@example.org");
+        when(cachedGroup.getName()).thenReturn("test-group");
+        doReturn(cachedGroup).when(groupProvider).getGroup("test-group");
+        groupCache.put("test-group", CacheableOptional.of(cachedGroup));
+        final GroupEventDispatcher.EventType[] capturedEventType = new GroupEventDispatcher.EventType[1];
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                capturedEventType[0] = type;
+            }
+        };
+
+        // Execute system under test.
+        manager.adminAddedPostProcess(cachedGroup, adminJid, false);
+
+        // Verify result.
+        assertEquals(GroupEventDispatcher.EventType.admin_added, capturedEventType[0], "adminAddedPostProcess should dispatch admin_added event.");
+    }
+
+    /**
+     * Verifies that memberAddedPostProcess dispatches a member_added event.
+     */
+    @Test
+    public void memberAddedPostProcessDispatchesMemberAddedEvent() throws GroupNotFoundException
+    {
+        // Setup test fixture.
+        final JID memberJid = new JID("member@example.org");
+        when(cachedGroup.getName()).thenReturn("test-group");
+        doReturn(cachedGroup).when(groupProvider).getGroup("test-group");
+        groupCache.put("test-group", CacheableOptional.of(cachedGroup));
+        final GroupEventDispatcher.EventType[] capturedEventType = new GroupEventDispatcher.EventType[1];
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                capturedEventType[0] = type;
+            }
+        };
+
+        // Execute system under test.
+        manager.memberAddedPostProcess(cachedGroup, memberJid, false);
+
+        // Verify result.
+        assertEquals(GroupEventDispatcher.EventType.member_added, capturedEventType[0], "memberAddedPostProcess should dispatch member_added event.");
+    }
+
+    /**
+     * Verifies that propertyAddedPostProcess dispatches a group_modified event.
+     */
+    @Test
+    public void propertyAddedPostProcessDispatchesModifiedEvent() throws GroupNotFoundException
+    {
+        // Setup test fixture.
+        when(cachedGroup.getName()).thenReturn("test-group");
+        doReturn(cachedGroup).when(groupProvider).getGroup("test-group");
+        groupCache.put("test-group", CacheableOptional.of(cachedGroup));
+        final GroupEventDispatcher.EventType[] capturedEventType = new GroupEventDispatcher.EventType[1];
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                capturedEventType[0] = type;
+            }
+        };
+
+        // Execute system under test.
+        manager.propertyAddedPostProcess(cachedGroup, "prop-key");
+
+        // Verify result.
+        assertEquals(GroupEventDispatcher.EventType.group_modified, capturedEventType[0], "propertyAddedPostProcess should dispatch group_modified event.");
+    }
+
+    /**
+     * Unit-level test (not behavioral): Verifies internal cache-eviction behavior when a group is created. This test
+     * validates that createGroupPostProcess evicts all paginated group-name cache entries (keys prefixed with
+     * GROUP_NAMES_KEY) from groupMetaCache, while leaving unrelated entries (such as per-user group-membership entries)
+     * untouched. This test is implementation-focused and necessary to ensure cache correctness but does not represent
+     * user-visible behavior.
+     */
+    @Test
+    public void createGroupPostProcessEvictsPaginatedGroupNamesCacheEntries()
+    {
+        // Setup test fixture: a group that is not shared with anybody.
+        final String groupName = "new-group";
+        when(cachedGroup.getName()).thenReturn(groupName);
+        when(cachedGroup.getSharedWith()).thenReturn(SharedGroupVisibility.nobody);
+        when(cachedGroup.getAdmins()).thenReturn(new HashSet<>());
+        when(cachedGroup.getMembers()).thenReturn(new HashSet<>());
+
+        // Pre-populate groupMetaCache with:
+        //   - a paginated GROUP_NAMES entry  → must be evicted by evictCachedPaginatedGroupNames()
+        //   - a USER_GROUPS entry            → must NOT be evicted (different responsibility)
+        final String paginatedKey = "GROUP_NAMES0,10";
+        final String userGroupsKey = "USER_GROUPSjane@example.org";
+        groupMetaCache.put(paginatedKey,  new HashSet<String>());
+        groupMetaCache.put(userGroupsKey, new HashSet<String>());
+
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                // Suppress event dispatch; not the focus of this test.
+            }
+        };
+
+        // Execute system under test: createGroupPostProcess calls evictCachedPaginatedGroupNames().
+        manager.createGroupPostProcess(cachedGroup);
+
+        // Verify result.
+        assertNull(groupMetaCache.get(paginatedKey), "Paginated GROUP_NAMES cache entry should be evicted after group creation.");
+        assertNotNull(groupMetaCache.get(userGroupsKey), "USER_GROUPS cache entry should NOT be evicted by evictCachedPaginatedGroupNames().");
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
@@ -435,7 +435,7 @@ public class GroupManagerTest
 
         // Verify result.
         assertNull(groupMetaCache.get(userGroupsKey), "USER_GROUPS cache entry should be evicted when group sharing changes to 'everybody'.");
-        assertNotNull(groupMetaCache.get(paginatedKey), "Paginated GROUP_NAMES cache entry should NOT be evicted by evictCachedUserSharedGroups().");
+        assertNull(groupMetaCache.get(paginatedKey), "Paginated GROUP_NAMES cache entry should be evicted by evictCachedUserSharedGroups().");
     }
 
     /**
@@ -487,7 +487,7 @@ public class GroupManagerTest
 
         // Verify result: USER_GROUPS must be evicted; paginated GROUP_NAMES must be left intact.
         assertNull(groupMetaCache.get(userGroupsKey), "USER_GROUPS cache entry should be evicted when group sharing changes from 'everybody'.");
-        assertNotNull(groupMetaCache.get(paginatedKey), "Paginated GROUP_NAMES cache entry should NOT be evicted by evictCachedUserSharedGroups().");
+        assertNull(groupMetaCache.get(paginatedKey), "Paginated GROUP_NAMES cache entry should be evicted by evictCachedUserSharedGroups().");
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
@@ -377,4 +377,180 @@ public class GroupManagerTest
         assertNull(groupMetaCache.get(paginatedKey), "Paginated GROUP_NAMES cache entry should be evicted after group creation.");
         assertNotNull(groupMetaCache.get(userGroupsKey), "USER_GROUPS cache entry should NOT be evicted by evictCachedPaginatedGroupNames().");
     }
+
+    /**
+     * Unit-level test (not behavioral): Verifies internal cache-eviction behavior when a group's sharing mode changes
+     * to "everybody". This test validates that propertyModifiedPostProcess evicts all per-user group-membership cache
+     * entries (keys prefixed with USER_GROUPS_KEY) from groupMetaCache, while leaving unrelated entries (such as
+     * paginated group-name entries) untouched. This test is implementation-focused and necessary to ensure cache
+     * correctness but does not represent user-visible behavior.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3285">OF-3285: Changes to group sharing visibility are not immediately reflected in users' contact lists</a>
+     */
+    @Test
+    public void sharingChangeToEverybodyEvictsUserGroupsCacheEntries() throws Exception
+    {
+        // Setup test fixture: a group whose sharing is about to change to "everybody".
+        final String groupName = "test-shared-group";
+        when(cachedGroup.getName()).thenReturn(groupName);
+
+        // The group's properties must return "everybody" so that propertyChangePostProcess
+        // triggers the eviction path.
+        final PersistableMap<String, String> props = new PersistableMap<>() {
+            @Override
+            public String put(final String key, final String value, final boolean persist) {
+                return super.put(key, value);
+            }
+        };
+        props.put(Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY, "everybody");
+        when(cachedGroup.getProperties()).thenReturn(props);
+
+        // The force-lookup inside propertyModifiedPostProcess must resolve the group.
+        doReturn(cachedGroup).when(groupProvider).getGroup(groupName);
+
+        // Pre-populate groupMetaCache with:
+        //   - a USER_GROUPS entry  → must be evicted by evictCachedUserSharedGroups()
+        //   - a paginated GROUP_NAMES entry → must NOT be evicted (different responsibility)
+        final String userGroupsKey   = "USER_GROUPSjane@example.org";
+        final String paginatedKey    = "GROUP_NAMES0,10";
+        groupMetaCache.put(userGroupsKey, new HashSet<String>());
+        groupMetaCache.put(paginatedKey,  new HashSet<String>());
+
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                // Suppress event dispatch; not the focus of this test.
+            }
+        };
+
+        // Execute system under test: change sharing from "nobody" → "everybody".
+        manager.propertyModifiedPostProcess(cachedGroup, Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY, "nobody");
+
+        // Verify result.
+        assertNull(groupMetaCache.get(userGroupsKey), "USER_GROUPS cache entry should be evicted when group sharing changes to 'everybody'.");
+        assertNotNull(groupMetaCache.get(paginatedKey), "Paginated GROUP_NAMES cache entry should NOT be evicted by evictCachedUserSharedGroups().");
+    }
+
+    /**
+     * Unit-level test (not behavioral): Verifies internal cache-eviction behavior when a group's sharing mode changes
+     * FROM "everybody" to another mode. This test validates that propertyModifiedPostProcess evicts all per-user
+     * group-membership cache entries (keys prefixed with USER_GROUPS_KEY) from groupMetaCache, while leaving unrelated
+     * entries (such as paginated group-name entries) untouched. This test is implementation-focused and necessary to
+     * ensure cache correctness but does not represent user-visible behavior. This test covers the reverse direction of
+     * the sharing-visibility change: the condition that triggers evictCachedUserSharedGroups() fires when the original
+     * value is "everybody", regardless of the new value.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3285">OF-3285: Changes to group sharing visibility are not immediately reflected in users' contact lists</a>
+     */
+    @Test
+    public void sharingChangeFromEverybodyEvictsUserGroupsCacheEntries() throws Exception
+    {
+        // Setup test fixture: a group whose sharing is about to change FROM "everybody" to "nobody".
+        final String groupName = "test-shared-group";
+        when(cachedGroup.getName()).thenReturn(groupName);
+
+        // The group's properties must return "nobody" as the new value so that propertyChangePostProcess can read it when evaluating the change.
+        final PersistableMap<String, String> props = new PersistableMap<>() {
+            @Override
+            public String put(final String key, final String value, final boolean persist) {
+                return super.put(key, value);
+            }
+        };
+        props.put(Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY, "nobody");
+        when(cachedGroup.getProperties()).thenReturn(props);
+
+        // The force-lookup inside propertyModifiedPostProcess must resolve the group.
+        doReturn(cachedGroup).when(groupProvider).getGroup(groupName);
+
+        // Pre-populate groupMetaCache with a USER_GROUPS entry (to be evicted) and a paginated GROUP_NAMES entry (must survive, as it is a different cache responsibility).
+        final String userGroupsKey = "USER_GROUPSjane@example.org";
+        final String paginatedKey  = "GROUP_NAMES0,10";
+        groupMetaCache.put(userGroupsKey, new HashSet<String>());
+        groupMetaCache.put(paginatedKey,  new HashSet<String>());
+
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                // Suppress event dispatch; not the focus of this test.
+            }
+        };
+
+        // Execute system under test: simulate a sharing-mode change FROM "everybody" to "nobody".
+        manager.propertyModifiedPostProcess(cachedGroup, Group.SHARED_ROSTER_SHOW_IN_ROSTER_PROPERTY_KEY, "everybody");
+
+        // Verify result: USER_GROUPS must be evicted; paginated GROUP_NAMES must be left intact.
+        assertNull(groupMetaCache.get(userGroupsKey), "USER_GROUPS cache entry should be evicted when group sharing changes from 'everybody'.");
+        assertNotNull(groupMetaCache.get(paginatedKey), "Paginated GROUP_NAMES cache entry should NOT be evicted by evictCachedUserSharedGroups().");
+    }
+
+    /**
+     * Unit-level test (not behavioral): Verifies internal cache-eviction behavior when a group's sharing target list
+     * is modified AND one of the target groups is itself shared with everybody. This test validates that
+     * propertyModifiedPostProcess evicts all per-user group-membership cache entries (keys prefixed with USER_GROUPS_KEY)
+     * from groupMetaCache. This is a complex scenario combining multiple cache-eviction conditions. This test is
+     * implementation-focused and necessary to ensure cache correctness but does not represent user-visible behavior.
+     *
+     * Without this invalidation, a user's cached group memberships would be stale after the sharing configuration change,
+     * causing their contact list to not reflect the updated sharing state until the cache naturally expires.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3285">OF-3285: Changes to group sharing visibility are not immediately reflected in users' contact lists</a>
+     */
+    @Test
+    public void sharingTargetListChangeWithEverybodyGroupInvalidatesPerUserGroupMembershipCache() throws Exception
+    {
+        // Setup test fixture: Group B is shared with everybody and has no members or admins.
+        final String groupAName = "group-a";
+        final String groupBName = "group-b";
+
+        final Group groupB = mock(Group.class);
+        when(groupB.getSharedWith()).thenReturn(SharedGroupVisibility.everybody);
+        when(groupB.getAdmins()).thenReturn(new HashSet<>());
+        when(groupB.getMembers()).thenReturn(new HashSet<>());
+        groupCache.put(groupBName, CacheableOptional.of(groupB));
+
+        // Group A is shared with users of Group B.
+        when(cachedGroup.getName()).thenReturn(groupAName);
+        when(cachedGroup.getSharedWith()).thenReturn(SharedGroupVisibility.usersOfGroups);
+        when(cachedGroup.getSharedWithUsersInGroupNames()).thenReturn(List.of(groupBName));
+
+        // Group A's properties return the new group-list value; this differs from the originalValue passed to
+        // propertyModifiedPostProcess below, ensuring the cache-invalidation branch is entered.
+        final PersistableMap<String, String> props = new PersistableMap<>() {
+            @Override
+            public String put(final String key, final String value, final boolean persist) {
+                return super.put(key, value);
+            }
+        };
+        props.put(Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY, groupBName);
+        when(cachedGroup.getProperties()).thenReturn(props);
+
+        // The reload of the group after the property change must resolve Group A.
+        doReturn(cachedGroup).when(groupProvider).getGroup(groupAName);
+        doThrow(new GroupNotFoundException()).when(groupProvider).getGroup(argThat(arg -> !arg.equals(groupAName) && !arg.equals(groupBName)));
+
+        // Sharing must be supported so that the shared-group target list is traversed.
+        when(groupProvider.isSharingSupported()).thenReturn(true);
+
+        // Pre-populate the cache with a per-user group-membership entry (to be invalidated) and a paginated
+        // group-names entry (must survive, as it covers a different concern).
+        final String userGroupsKey = "USER_GROUPSjane@example.org";
+        final String paginatedKey  = "GROUP_NAMES0,10";
+        groupMetaCache.put(userGroupsKey, new HashSet<String>());
+        groupMetaCache.put(paginatedKey,  new HashSet<String>());
+
+        final GroupManager manager = new GroupManager(groupProvider, groupCache, groupMetaCache) {
+            @Override
+            protected void dispatchGroupEvent(final Group group, final GroupEventDispatcher.EventType type, final Map<String, ?> params) {
+                // Suppress event dispatch; not the focus of this test.
+            }
+        };
+
+        // Execute system under test: change Group A's list of groups it is shared with.
+        manager.propertyModifiedPostProcess(cachedGroup, Group.SHARED_ROSTER_GROUP_LIST_PROPERTY_KEY, "old-group");
+
+        // Verify result: per-user group-membership cache entries must be invalidated so that subsequent lookups return
+        // fresh data; paginated group-names cache entries are unrelated and must be left intact.
+        assertNull(groupMetaCache.get(userGroupsKey), "Per-user group-membership cache entry should be invalidated after sharing target list changes when one target is shared with everybody.");
+        assertNotNull(groupMetaCache.get(paginatedKey), "Paginated group-names cache entry should NOT be invalidated by a sharing target list change.");
+    }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupManagerTest.java
@@ -16,6 +16,7 @@
 package org.jivesoftware.openfire.group;
 
 import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.event.GroupEventDispatcher;
 import org.jivesoftware.util.CacheableOptional;
 import org.jivesoftware.util.PersistableMap;
@@ -59,6 +60,10 @@ public class GroupManagerTest
     @BeforeAll
     public static void beforeClass() throws Exception
     {
+        // Install a functional XMPPServer fixture used by post-process paths (for example, GroupJID construction).
+        Fixtures.clearExistingProperties();
+        XMPPServer.setInstance(Fixtures.mockXMPPServer());
+
         Fixtures.reconfigureOpenfireHome();
         Fixtures.disableDatabasePersistence();
         groupCache = CacheFactory.createCache("Group");
@@ -80,6 +85,8 @@ public class GroupManagerTest
     {
         groupCache.clear();
         groupMetaCache.clear();
+
+        Fixtures.clearExistingProperties();
     }
 
     /**
@@ -618,10 +625,13 @@ public class GroupManagerTest
      * processes groups returned by getSharedGroups(), which returns empty for non-shared groups, leaving members
      * with stale cache entries.
      *
+     * The test exercises the full rename post-processing flow, including forced refresh of the renamed group and
+     * cache updates for old/new group names.
+     *
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3287">Issue: Group members' user cache not evicted for non-shared groups</a>
      */
     @Test
-    public void renameGroupPostProcessEvictsPerUserCacheForNonSharedGroupMembers() throws Exception
+    public void renameGroupPostProcessEvictsPerUserCacheAndRefreshesGroupCacheForNonSharedGroupMembers() throws Exception
     {
         // Setup test fixture: a non-shared group with members
         final String oldGroupName = "old-group-name";
@@ -634,6 +644,11 @@ public class GroupManagerTest
         when(renamedGroup.getSharedWith()).thenReturn(SharedGroupVisibility.nobody);
         when(renamedGroup.getMembers()).thenReturn(new HashSet<>(List.of(member1)));
         when(renamedGroup.getAdmins()).thenReturn(new HashSet<>(List.of(admin1)));
+        doReturn(renamedGroup).when(groupProvider).getGroup(newGroupName);
+
+        // Simulate stale cache entries before rename: old-name entry should be removed and new-name entry refreshed.
+        groupCache.put(oldGroupName, CacheableOptional.of(cachedGroup));
+        groupCache.put(newGroupName, CacheableOptional.of(cachedGroup));
 
         // Pre-populate per-user group-membership cache with old group name
         final String memberCacheKey = "USER_GROUPS" + member1.toBareJID();
@@ -649,14 +664,17 @@ public class GroupManagerTest
 
         // Verify precondition: cache entry exists before rename
         assertNotNull(groupMetaCache.get(memberCacheKey), "Precondition: member should have cached groups before rename.");
+        assertNotNull(groupCache.get(oldGroupName), "Precondition: old group-name cache entry should exist before rename.");
 
         // Execute system under test: rename a non-shared group
-        // NOTE: This test intentionally does not invoke the full renameGroup flow to avoid XMPPServer dependency.
-        // We test the core cache-eviction behavior directly.
-        manager.deleteGroupPostProcess(renamedGroup);
+        // Exercise full rename post-processing, including cache refresh and event parameter construction.
+        manager.renameGroupPostProcess(renamedGroup, oldGroupName);
 
-        // Verify result: per-user group-membership cache entries must be evicted
+        // Verify result: per-user group-membership cache entries must be evicted and group cache entries refreshed.
         assertNull(groupMetaCache.get(memberCacheKey), "REGRESSION: member's per-user group-membership cache should be evicted after group rename.");
+        assertNull(groupCache.get(oldGroupName), "Old group-name cache entry should be removed after rename.");
+        assertThat("Renamed group should be force-refreshed into cache under its new name.", groupCache.get(newGroupName), is(CacheableOptional.of(renamedGroup)));
+        verify(groupProvider).getGroup(newGroupName);
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import org.jivesoftware.Fixtures;
 import org.jivesoftware.openfire.event.GroupEventDispatcher;
 import org.jivesoftware.openfire.event.GroupEventListener;
 import org.jivesoftware.util.CacheableOptional;
-import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.PersistableMap;
 import org.jivesoftware.util.cache.Cache;
 import org.jivesoftware.util.cache.CacheFactory;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.xmpp.packet.JID;
 
-import java.lang.reflect.Field;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -45,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class GroupTest
 {
     private static Cache<String, CacheableOptional<Group>> groupCache;
+    private static Cache<String, java.io.Serializable> groupMetaCache;
 
     private GroupManager groupManager;
 
@@ -53,51 +52,42 @@ public class GroupTest
         Fixtures.reconfigureOpenfireHome();
         Fixtures.disableDatabasePersistence();
         groupCache = CacheFactory.createCache("Group");
+        groupMetaCache = CacheFactory.createCache("Group Metadata Cache");
         groupCache.clear();
-        JiveGlobals.setProperty("provider.group.className", GroupTest.TestGroupProvider.class.getName());
+        groupMetaCache.clear();
     }
 
     @BeforeEach
     public void setUp() {
-        // Ensure that Openfire caches are reset before each test to avoid tests to affect each-other.
+        // Reset shared caches before each test, then install a test-owned GroupManager instance.
         Arrays.stream(CacheFactory.getAllCaches()).forEach(Map::clear);
-        groupManager = GroupManager.getInstance();
+
+        groupManager = new GroupManager(new TestGroupProvider(), groupCache, groupMetaCache);
+        // Group instances resolve their manager via GroupManager.getInstance(), so keep the test instance active.
+        GroupManager.setInstance(groupManager);
     }
 
     @AfterEach
     public void tearDown() {
-        // Teardown fixture by removing any groups that have been created.
-        GroupManager.getInstance().getGroups().forEach(group -> {
+        // Remove any groups created during the test to leave the singleton-backed state clean.
+        groupManager.getGroups().forEach(group -> {
             try {
-                GroupManager.getInstance().deleteGroup(group);
+                groupManager.deleteGroup(group);
             } catch (GroupNotFoundException e) {
                 throw new RuntimeException(e);
             }
         });
 
+        GroupManager.setInstance(null);
         groupCache.clear();
+        groupMetaCache.clear();
     }
 
     @AfterAll
-    public static void afterClass() throws Exception {
-
-        // Reset static fields after use (to not confuse other test classes).
-        for (String fieldName : Arrays.asList("INSTANCE", "provider")) {
-            Field field = GroupManager.class.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            field.set(null, null);
-            field.setAccessible(false);
-        }
-
-        GroupManager.getInstance().getGroups().forEach(group -> {
-            try {
-                GroupManager.getInstance().deleteGroup(group);
-            } catch (GroupNotFoundException e) {
-                throw new RuntimeException(e);
-            }
-        });
-
+    public static void afterClass() {
         groupCache.clear();
+        groupMetaCache.clear();
+        GroupManager.setInstance(null);
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/group/GroupTest.java
@@ -307,6 +307,28 @@ public class GroupTest
     }
 
     /**
+     * Verifies that the corresponding event listener has been invoked after a group has been modified.
+     */
+    @Test
+    public void testEventListenerInvokedGroupModified() throws Exception
+    {
+        // Setup test fixture.
+        final String groupName = "unit-test-group-group-modified";
+        final String newDescription = "This is a changed description";
+        final Group group = groupManager.createGroup(groupName);
+        final RecordingGroupEventListener listener = new RecordingGroupEventListener();
+        GroupEventDispatcher.addListener(listener);
+
+        // Execute system under test.
+        group.setDescription(newDescription);
+
+        // Verify results.
+        assertEquals(groupName, listener.lastGroupModified);
+        assertEquals("descriptionModified", listener.lastParams.get("type"));
+        assertNull(listener.lastParams.get("originalValue"));
+    }
+
+    /**
      * Verifies that the group contained in the Group cache contains an admin user after it has been added to the group.
      */
     @Test
@@ -492,7 +514,7 @@ public class GroupTest
 
         // Verify results.
         List<String> sharedWithGroups = group.getSharedWithUsersInGroupNames();
-        assertEquals( sharedWithGroups.size(), 2);
+        assertEquals(2, sharedWithGroups.size());
         assertTrue(sharedWithGroups.contains(groupName));
         assertTrue(sharedWithGroups.contains(groupNameSharedWith));
     }
@@ -518,10 +540,80 @@ public class GroupTest
 
         // Verify results.
         List<String> sharedWithGroups = group.getSharedWithUsersInGroupNames();
-        assertEquals( sharedWithGroups.size(), 3);
+        assertEquals(3, sharedWithGroups.size());
         assertTrue(sharedWithGroups.contains(groupName));
         assertTrue(sharedWithGroups.contains(groupNameSharedWith1));
         assertTrue(sharedWithGroups.contains(groupNameSharedWith2));
+    }
+
+    /**
+     * Verifies that Group.setDescription() updates the group description.
+     */
+    @Test
+    public void testSetGroupDescription() throws Exception
+    {
+        // Setup test fixture.
+        final String groupName = "unit-test-group-set-description";
+        final String originalDescription = null;
+        final String newDescription = "This is a new description";
+        final Group group = groupManager.createGroup(groupName);
+
+        // Verify initial state
+        assertEquals(originalDescription, group.getDescription());
+
+        // Execute system under test.
+        group.setDescription(newDescription);
+
+        // Verify results.
+        assertEquals(newDescription, group.getDescription());
+    }
+
+    /**
+     * Verifies that Group.setName() doesn't change the name when the group is read-only.
+     */
+    @Test
+    public void testSetGroupNameReadOnly() throws Exception
+    {
+        // Setup test fixture.
+        final String groupName = "unit-test-group-readonly";
+        final String newName = "unit-test-group-new-readonly";
+
+        // Make the provider read-only by using a mock
+        final GroupProvider readOnlyProvider = new TestGroupProviderReadOnly();
+        readOnlyProvider.createGroup(groupName);
+        groupManager = new GroupManager(readOnlyProvider, groupCache, groupMetaCache);
+        GroupManager.setInstance(groupManager);
+        final Group readOnlyGroup = readOnlyProvider.getGroup(groupName);
+
+        // Execute system under test.
+        readOnlyGroup.setName(newName);
+
+        // Verify results - name should not change
+        assertEquals(groupName, readOnlyGroup.getName());
+    }
+
+    /**
+     * Verifies that Group.setDescription() doesn't change the description when the group is read-only.
+     */
+    @Test
+    public void testSetGroupDescriptionReadOnly() throws Exception
+    {
+        // Setup test fixture - use a read-only provider.
+        final String groupName = "unit-test-group-readonly-desc";
+        final String newDescription = "new description";
+
+        // Make the provider read-only by using a mock
+        final GroupProvider readOnlyProvider = new TestGroupProviderReadOnly();
+        readOnlyProvider.createGroup(groupName);
+        groupManager = new GroupManager(readOnlyProvider, groupCache, groupMetaCache);
+        GroupManager.setInstance(groupManager);
+        final Group readOnlyGroup = readOnlyProvider.getGroup(groupName);
+
+        // Execute system under test - try to change description
+        readOnlyGroup.setDescription(newDescription);
+
+        // Verify results - description should not change (remains null since read-only prevents updates)
+        assertNull(readOnlyGroup.getDescription());
     }
 
     /**
@@ -639,7 +731,7 @@ public class GroupTest
             if (!descriptionsByGroupName.containsKey(oldName)) {
                 throw new GroupNotFoundException();
             }
-            if (!descriptionsByGroupName.containsKey(newName)) {
+            if (descriptionsByGroupName.containsKey(newName)) {
                 throw new GroupAlreadyExistsException();
             }
 
@@ -783,6 +875,16 @@ public class GroupTest
                     throw new UnsupportedOperationException();
                 }
             };
+        }
+    }
+
+    /**
+     * A read-only test implementation of GroupProvider for testing read-only scenarios.
+     */
+    public static class TestGroupProviderReadOnly extends TestGroupProvider {
+        @Override
+        public boolean isReadOnly() {
+            return true;
         }
     }
 }


### PR DESCRIPTION
This is a significant refactoring of `GroupManager`, the entity responsible for managing collections of users (which is used primarily for roster / contact list sharing, and to a lesser extend to grant permissions to certain functionality to a collection of users, rather than individuals).

Much of the refactoring facilitates the creation of unit tests for Group and GroupManager. That refactoring should be functionally insignificant.

Three bugs (which prevent some changes to become visible immediately) are fixed (OF-3285, OF-3287 & OF-3288). Additionally, concurrency improvements have been applied (OF-3286), which should improve consistency/correctness (possibly at the cost of some performance).