### PR TITLE
OF-3297: Refactor setup property migration handling

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/XMPPServer.java
@@ -26,7 +26,6 @@ import org.jivesoftware.openfire.admin.AdminManager;
 import org.jivesoftware.openfire.archive.ArchiveManager;
 import org.jivesoftware.openfire.audit.AuditManager;
 import org.jivesoftware.openfire.audit.spi.AuditManagerImpl;
-import org.jivesoftware.openfire.auth.AuthFactory;
 import org.jivesoftware.openfire.cluster.ClusterManager;
 import org.jivesoftware.openfire.cluster.ClusterMonitor;
 import org.jivesoftware.openfire.cluster.NodeID;
@@ -40,7 +39,6 @@ import org.jivesoftware.openfire.entitycaps.EntityCapabilitiesManager;
 import org.jivesoftware.openfire.filetransfer.DefaultFileTransferManager;
 import org.jivesoftware.openfire.filetransfer.FileTransferManager;
 import org.jivesoftware.openfire.filetransfer.proxy.FileTransferProxy;
-import org.jivesoftware.openfire.group.GroupManager;
 import org.jivesoftware.openfire.handler.*;
 import org.jivesoftware.openfire.keystore.CertificateStoreManager;
 import org.jivesoftware.openfire.keystore.IdentityStore;
@@ -57,7 +55,6 @@ import org.jivesoftware.openfire.roster.RosterItem;
 import org.jivesoftware.openfire.roster.RosterItemProvider;
 import org.jivesoftware.openfire.roster.RosterManager;
 import org.jivesoftware.openfire.sasl.AnonymousSaslServer;
-import org.jivesoftware.openfire.security.SecurityAuditManager;
 import org.jivesoftware.openfire.session.ConnectionSettings;
 import org.jivesoftware.openfire.session.RemoteSessionLocator;
 import org.jivesoftware.openfire.session.SoftwareServerVersionManager;
@@ -497,21 +494,6 @@ public class XMPPServer {
 
         // steps from setup-profile-settings.jsp
         if ("default".equals(JiveGlobals.getXMLProperty("autosetup.authprovider.mode", "default"))) {
-            JiveGlobals.setProperty(AuthFactory.AUTH_PROVIDER.getKey(), JiveGlobals.getXMLProperty(AuthFactory.AUTH_PROVIDER.getKey(),
-                AuthFactory.AUTH_PROVIDER.getDefaultValue().getName()));
-            JiveGlobals.setProperty(UserManager.USER_PROVIDER.getKey(), JiveGlobals.getXMLProperty(UserManager.USER_PROVIDER.getKey(),
-                UserManager.USER_PROVIDER.getDefaultValue().getName()));
-            JiveGlobals.setProperty(GroupManager.GROUP_PROVIDER.getKey(), JiveGlobals.getXMLProperty(GroupManager.GROUP_PROVIDER.getKey(),
-                GroupManager.GROUP_PROVIDER.getDefaultValue().getName()));
-            JiveGlobals.setProperty(VCardManager.VCARD_PROVIDER.getKey(), JiveGlobals.getXMLProperty(VCardManager.VCARD_PROVIDER.getKey(),
-                VCardManager.VCARD_PROVIDER.getDefaultValue().getName()));
-            JiveGlobals.setProperty(LockOutManager.LOCKOUT_PROVIDER.getKey(), JiveGlobals.getXMLProperty(LockOutManager.LOCKOUT_PROVIDER.getKey(),
-                LockOutManager.LOCKOUT_PROVIDER.getDefaultValue().getName()));
-            JiveGlobals.setProperty(SecurityAuditManager.AUDIT_PROVIDER.getKey(), JiveGlobals.getXMLProperty(SecurityAuditManager.AUDIT_PROVIDER.getKey(),
-                SecurityAuditManager.AUDIT_PROVIDER.getDefaultValue().getName()));
-            JiveGlobals.setProperty(AdminManager.ADMIN_PROVIDER.getKey(), JiveGlobals.getXMLProperty(AdminManager.ADMIN_PROVIDER.getKey(),
-                AdminManager.ADMIN_PROVIDER.getDefaultValue().getName()));
-
             // make configurable?
             JiveGlobals.setProperty("user.scramHashedPasswordOnly", "true");
         }

--- a/xmppserver/src/main/webapp/setup/setup-profile-settings.jsp
+++ b/xmppserver/src/main/webapp/setup/setup-profile-settings.jsp
@@ -1,6 +1,6 @@
 <%--
   -
-  - Copyright (C) 2006-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2006-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -18,13 +18,6 @@
 <%@ page import="org.jivesoftware.openfire.XMPPServer"%>
 <%@ page import="org.jivesoftware.util.JiveGlobals"%>
 <%@ page import="java.util.Map" %>
-<%@ page import="org.jivesoftware.openfire.admin.AdminManager" %>
-<%@ page import="org.jivesoftware.openfire.group.GroupManager" %>
-<%@ page import="org.jivesoftware.openfire.lockout.LockOutManager" %>
-<%@ page import="org.jivesoftware.openfire.security.SecurityAuditManager" %>
-<%@ page import="org.jivesoftware.openfire.user.UserManager" %>
-<%@ page import="org.jivesoftware.openfire.auth.AuthFactory" %>
-<%@ page import="org.jivesoftware.openfire.vcard.VCardManager" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -50,26 +43,11 @@
         String mode = request.getParameter("mode");
 
         if ("default".equals(mode)) {
-            // Set to default providers by deleting any existing values.
             @SuppressWarnings("unchecked")
             Map<String,String> xmppSettings = (Map<String,String>)session.getAttribute("xmppSettings");
             if (xmppSettings == null){
                 sessionFailure = true;
             } else {
-                xmppSettings.put(AuthFactory.AUTH_PROVIDER.getKey(), JiveGlobals.getXMLProperty(AuthFactory.AUTH_PROVIDER.getKey(),
-                    AuthFactory.AUTH_PROVIDER.getDefaultValue().getName()));
-                xmppSettings.put(UserManager.USER_PROVIDER.getKey(), JiveGlobals.getXMLProperty(UserManager.USER_PROVIDER.getKey(),
-                    UserManager.USER_PROVIDER.getDefaultValue().getName()));
-                xmppSettings.put(GroupManager.GROUP_PROVIDER.getKey(), JiveGlobals.getXMLProperty(GroupManager.GROUP_PROVIDER.getKey(),
-                    GroupManager.GROUP_PROVIDER.getDefaultValue().getName()));
-                xmppSettings.put(VCardManager.VCARD_PROVIDER.getKey(), JiveGlobals.getXMLProperty(VCardManager.VCARD_PROVIDER.getKey(),
-                    VCardManager.VCARD_PROVIDER.getDefaultValue().getName()));
-                xmppSettings.put(LockOutManager.LOCKOUT_PROVIDER.getKey(), JiveGlobals.getXMLProperty(LockOutManager.LOCKOUT_PROVIDER.getKey(),
-                    LockOutManager.LOCKOUT_PROVIDER.getDefaultValue().getName()));
-                xmppSettings.put(SecurityAuditManager.AUDIT_PROVIDER.getKey(), JiveGlobals.getXMLProperty(SecurityAuditManager.AUDIT_PROVIDER.getKey(),
-                    SecurityAuditManager.AUDIT_PROVIDER.getDefaultValue().getName()));
-                xmppSettings.put(AdminManager.ADMIN_PROVIDER.getKey(), JiveGlobals.getXMLProperty(AdminManager.ADMIN_PROVIDER.getKey(),
-                    AdminManager.ADMIN_PROVIDER.getDefaultValue().getName()));
                 if (requestedScramOnly) {
                     JiveGlobals.setProperty("user.scramHashedPasswordOnly", "true");
                 }


### PR DESCRIPTION
Remove redundant setup-time property assignment logic that duplicated migration behavior, causing loss of data.

Rely on existing SystemProperty migration/default mechanisms to avoid unintended overwrites.

Also clean up related setup-page code after removing duplicate logic.