### PR TITLE
OF-3122: Stop using Common Name based identities by default

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/CertificateManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/CertificateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,7 +117,7 @@ public class CertificateManager {
         if (serverCertMapping.isEmpty()) {
             Log.debug("CertificateManager: No server CertificateIdentityMapping's found. Loading default mappings");
             serverCertMapping.add(new SANCertificateIdentityMapping());
-            serverCertMapping.add(new CNCertificateIdentityMapping());   	
+            // serverCertMapping.add(new CNCertificateIdentityMapping()); // OF-3122: do not enable CN-based mapping by default.
         }
                 
         String clientCertMapList = JiveGlobals.getProperty("provider.clientCertIdentityMap.classList");
@@ -141,7 +141,7 @@ public class CertificateManager {
         if (clientCertMapping.isEmpty()) {
             Log.debug("CertificateManager: No client CertificateIdentityMapping's found. Loading default mappings");
             clientCertMapping.add(new SANCertificateIdentityMapping());
-            clientCertMapping.add(new CNCertificateIdentityMapping());
+            // clientCertMapping.add(new CNCertificateIdentityMapping()); // OF-3122: do not enable CN-based mapping by default.
         }
     }
 
@@ -149,9 +149,9 @@ public class CertificateManager {
     /**
      * Returns the identities of the remote client as defined in the specified certificate. The
      * identities are mapped by the classes in the "provider.clientCertIdentityMap.classList" property. 
-     * By default, the subjectDN of the certificate is used.
+     * By default, a SubjectAlternativeName of the certificate is used.
      *
-     * @param x509Certificate the certificate the holds the identities of the remote server.
+     * @param x509Certificate the certificate that holds the identities of the remote server.
      * @return the identities of the remote client as defined in the specified certificate.
      */
     public static List<String> getClientIdentities(X509Certificate x509Certificate) {
@@ -172,12 +172,9 @@ public class CertificateManager {
     /**
      * Returns the identities of the remote server as defined in the specified certificate. The
      * identities are mapped by the classes in the "provider.serverCertIdentityMap.classList" property.
-     * By default, the identities are defined in the subjectDN of the certificate and it can also be 
-     * defined in the subjectAltName extensions of type "xmpp". When the extension is being used then the
-     * identities defined in the extension are going to be returned. Otherwise, the value stored in
-     * the subjectDN is returned.
+     * By default, identities are derived from SubjectAlternativeName entries (xmppAddr, dnsSRV, DNSName, URI)
      *
-     * @param x509Certificate the certificate the holds the identities of the remote server.
+     * @param x509Certificate the certificate that holds the identities of the remote server.
      * @return the identities of the remote server as defined in the specified certificate.
      */
     public static List<String> getServerIdentities(X509Certificate x509Certificate) {

--- a/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
+++ b/xmppserver/src/test/java/org/jivesoftware/Fixtures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2018-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -322,21 +322,22 @@ public final class Fixtures {
      */
     public static final String expiredX509Certificate = """
         -----BEGIN CERTIFICATE-----
-        MIICsjCCAZoCCQDsFzeWUN/PbjANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDDBB0
-        ZXN0LnhtcHAuZG9tYWluMB4XDTIzMDYxNjEzMzE0OFoXDTIzMDYxNzEzMzE0OFow
-        GzEZMBcGA1UEAwwQdGVzdC54bXBwLmRvbWFpbjCCASIwDQYJKoZIhvcNAQEBBQAD
-        ggEPADCCAQoCggEBAKxaCt4vSjqzXwCfui+S0KjnQrxVagDKJOHbyhkxTbRROJYz
-        7SmdAUVHCcFlugOk7UhxTBZ7hHeC3DQTvqilwISRsgyOM8MSAXKV6lvWu2WDRI7s
-        LRg5o6r23Me/kiSMXGpzaWitxMOgZWxYJlLb7CfIJwN16F6UvKsX6npN5ETnvzkV
-        PZNgoWvy/TX2QlPJTiukX0a4FbyX6REkAgtI6WfLJm7lqtJZFw7KoX2g8GO+wk3v
-        akeuuA8OIrtRg5eP5K82a//sF1VoCh9vOryr4mT2BTa8L6x+bF27WMc8+QzXf0JL
-        s+Iy8J5dneQWEZPK13Eh5doE59EBx33fadT90CsCAwEAATANBgkqhkiG9w0BAQsF
-        AAOCAQEAQn05d+0QjKH5osqz7ZKm7wle/pF1KkOmCD9lfU1+Iu02Adz2nUx+WTaH
-        dtB8MtkLQFMcqz6oYquD0ruE3KUvj/A5fmir8wz0m9MG/i3QNrytWepv4vlrcmMr
-        yfZLwSrR3UNcNYk9W01/xjQVgH2JsF1B1nbn7eJt0mzr0arHp7VjtjdDJIfkZEEh
-        5ZpOERffIINoEptoKMCfjbcp2+PLZ1TjL6MxtrVs+TQmX4i9wL03uNgItbFqYeYP
-        RVeb9OaNj4NRMZB49D/jIaqmQWZi6u2ooOQv6AlyzeKInWm+aDmxCAX4IZAod18/
-        1hI2qIN8Xj9GUT7wldL368Dq1fUI5g==
+        MIIC2DCCAcCgAwIBAgIJAOwXN5ZQ389uMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV
+        BAMMEHRlc3QueG1wcC5kb21haW4wHhcNMjMwNjE2MTMzMTQ4WhcNMjMwNjE3MTMz
+        MTQ4WjAbMRkwFwYDVQQDDBB0ZXN0LnhtcHAuZG9tYWluMIIBIjANBgkqhkiG9w0B
+        AQEFAAOCAQ8AMIIBCgKCAQEArFoK3i9KOrNfAJ+6L5LQqOdCvFVqAMok4dvKGTFN
+        tFE4ljPtKZ0BRUcJwWW6A6TtSHFMFnuEd4LcNBO+qKXAhJGyDI4zwxIBcpXqW9a7
+        ZYNEjuwtGDmjqvbcx7+SJIxcanNpaK3Ew6BlbFgmUtvsJ8gnA3XoXpS8qxfqek3k
+        ROe/ORU9k2Cha/L9NfZCU8lOK6RfRrgVvJfpESQCC0jpZ8smbuWq0lkXDsqhfaDw
+        Y77CTe9qR664Dw4iu1GDl4/krzZr/+wXVWgKH286vKviZPYFNrwvrH5sXbtYxzz5
+        DNd/Qkuz4jLwnl2d5BYRk8rXcSHl2gTn0QHHfd9p1P3QKwIDAQABox8wHTAbBgNV
+        HREEFDASghB0ZXN0LnhtcHAuZG9tYWluMA0GCSqGSIb3DQEBCwUAA4IBAQAu6NEW
+        iUJZDPau4UPDk5fa5KKLmU4Km650Qkj2st9u+BsRYmhc67qCWOAW9Jf7UlDlzYQd
+        /nL+0vRB7MpnJu01K+R2tV1eBPi9tJCIlkaX09xzW2N4GgwpQ2D5Y/DguZwZoD8i
+        WgV6r35QBZbXytiv4x0hMiMHLM7W03Ppa5IVpBbnxqpoXJ5gzXW94jrRvhdRwCkW
+        abl6MCITbAYwDoCdInqMUwkcTK+7K418gnUpMXBFIN2+X/LnkPsytqwNyCfZCQXM
+        ZtYV+zjGqZq0nK6qVqw23wMbe1oMNfMI2U9xGkTQpm0jBhnV+jeBNkstYCleghSa
+        ymCjFlS9G9CZaABc
         -----END CERTIFICATE-----
         """;
 

--- a/xmppserver/src/test/java/org/jivesoftware/util/CertificateManagerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/CertificateManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,15 +83,17 @@ public class CertificateManagerTest
     }
 
     /**
-     * {@link CertificateManager#getServerIdentities(X509Certificate)} should return:
+     * {@link CertificateManager#getServerIdentities(X509Certificate)} should return
      * <ul>
-     *     <li>the Common Name</li>
+     *     <li>explicitly not the Common Name (default configuration of Openfire should not return CN-based identities, see OF-3122)</li>
      * </ul>
-     *
+     * <p>
      * when a certificate contains:
      * <ul>
      *     <li>no other identifiers than its CommonName</li>
      * </ul>
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3122">OF-3122</a>
      */
     @Test
     public void testServerIdentitiesCommonNameOnly() throws Exception
@@ -115,8 +117,7 @@ public class CertificateManagerTest
         final List<String> serverIdentities = CertificateManager.getServerIdentities( cert );
 
         // Verify result
-        assertEquals( 1, serverIdentities.size() );
-        assertEquals( subjectCommonName, serverIdentities.get( 0 ) );
+        assertEquals( 0, serverIdentities.size() );
     }
 
     /**


### PR DESCRIPTION
When dealing with certificates used for authentication (SASL EXTERNAL / mutual authentication) Openfire should no longer offer, by default, the functionality to obtain an identify from Common Name attributes.

Common Name usage was supposedly phased on in 2017 and CAB Forum compliant CAs do not allow users to arbitrarily pick Subject RDNs at all.

Furthermore, CAB Forum CAs always include a SAN as nothing is supposed to be using CommonName at all.

This commit removes this functionality from being enabled _by default_. It can be restored by adding the mapper disabled by this commit in the relevant properties:

- `provider.serverCertIdentityMap.classList` (for server-to-server / federation)
- `provider.clientCertIdentityMap.classList` (for client based mutual auth)