### PR TITLE
OF-3300: Harden against unrecognized error conditions

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1567,8 +1567,16 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                 PacketError.Condition.feature_not_implemented
             );
 
-            if (stanza.getError() != null && pingErrorsIndicatingClientConnectivity.contains(stanza.getError().getCondition())) {
-                return false;
+            final PacketError error = stanza.getError();
+            if (error != null) {
+                try {
+                    if (pingErrorsIndicatingClientConnectivity.contains(error.getCondition())) {
+                        return false;
+                    }
+                } catch (final IllegalArgumentException e) {
+                    // Condition not recognized. Log and proceed to check if it's a ping response.
+                    Log.debug("Received an error response with an unrecognized condition: {}. Treating as ping response.", stanza.toXML(), e);
+                }
             }
 
             final JID jid = PINGS_SENT.get(iq.getID());
@@ -1588,7 +1596,17 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
         );
 
         final PacketError error = stanza.getError();
-        return error != null && deliveryRelatedErrorConditions.contains(error.getCondition());
+        if (error == null) {
+            return false;
+        }
+
+        try {
+            return deliveryRelatedErrorConditions.contains(error.getCondition());
+        } catch (final IllegalArgumentException e) {
+            // Condition not recognized. Log and return false (not a delivery-related error we know about).
+            Log.debug("Received a stanza with an unrecognized error condition,: {}", stanza.toXML(), e);
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
The isDeliveryRelatedErrorResponse() method called error.getCondition() without exception handling. When an unrecognized error condition was encountered, it would throw an uncaught IllegalArgumentException.

Wrapped the calls to error.getCondition() in try-catch blocks that:
- Catch IllegalArgumentException when unrecognized conditions are encountered
- Log the error condition for debugging purposes
- Return false to gracefully handle unknown error types (appropriate behavior for unknown delivery-related errors)