### PR TITLE
Inform dependabot to recursively look for pom.xml files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
   - package-ecosystem: "maven"
-    directory: "/"
+    # Specify to recursively search for pom.xml files
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Hoping this addresses the issue of dependabot missing dep updates based on [this doc](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files)