### PR TITLE
OF-31: Preserve conference service context in room creation flow

### DIFF
--- a/xmppserver/src/main/webapp/muc-room-create.jsp
+++ b/xmppserver/src/main/webapp/muc-room-create.jsp
@@ -16,7 +16,11 @@
   - limitations under the License.
 
 --%>
-
+<%@ page import="java.util.function.BiFunction" %>
+<%@ page import="java.util.regex.Pattern" %>
+<%@ page import="java.util.regex.Matcher" %>
+<%@ page import="static java.nio.charset.StandardCharsets.UTF_8" %>
+<%@ page import="java.net.URLEncoder,java.net.URLDecoder" %>
 <%
     // OF-31: To select the current conference service automatically on room creation,
     // we extract the active service context from the HTTP Referer header. This allows us
@@ -27,87 +31,75 @@
     // The extraction is done here in the redirector page (muc-room-create.jsp), but the
     // validation is kept inside muc-room-edit-form.jsp to preserve clean separation of
     // concerns and fallback behaviors.
+
     String referrer = request.getHeader("Referer");
     String serviceParam = "";
+
+    BiFunction<String, String, String> extractParam = (url, key) -> {
+        Matcher m = Pattern
+            .compile("(?:[?&])" + Pattern.quote(key) + "=([^&#]*)")
+            .matcher(url);
+
+        return m.find() ? m.group(1) : null;
+    };
+
     if (referrer != null) {
-    if (referrer.contains("mucname=")) {
-        int idx = referrer.indexOf("mucname=");
-        int endIdx = referrer.indexOf("&", idx);
-        if (endIdx == -1) {
-            endIdx = referrer.indexOf("#", idx);
-        }
+        String val;
 
-        String val = endIdx != -1
-            ? referrer.substring(idx + 8, endIdx)
-            : referrer.substring(idx + 8);
-
-        try {
-            String decodedVal = java.net.URLDecoder.decode(
-                val,
-                java.nio.charset.StandardCharsets.UTF_8.name()
-            );
-            String encodedVal = java.net.URLEncoder.encode(
-                decodedVal,
-                java.nio.charset.StandardCharsets.UTF_8.name()
-            );
-            serviceParam = "&mucName=" + encodedVal;
-        } catch (Exception e) {
-            // Ignore parsing errors and let validation handle fallbacks
-        }
-    } else if (referrer.contains("mucName=")) {
-        int idx = referrer.indexOf("mucName=");
-        int endIdx = referrer.indexOf("&", idx);
-        if (endIdx == -1) {
-            endIdx = referrer.indexOf("#", idx);
-        }
-
-        String val = endIdx != -1
-            ? referrer.substring(idx + 8, endIdx)
-            : referrer.substring(idx + 8);
-
-        try {
-            String decodedVal = java.net.URLDecoder.decode(
-                val,
-                java.nio.charset.StandardCharsets.UTF_8.name()
-            );
-            String encodedVal = java.net.URLEncoder.encode(
-                decodedVal,
-                java.nio.charset.StandardCharsets.UTF_8.name()
-            );
-            serviceParam = "&mucName=" + encodedVal;
-        } catch (Exception e) {
-            // Ignore parsing errors and let validation handle fallbacks
-        }
-    } else if (referrer.contains("roomJID=")) {
-        int idx = referrer.indexOf("roomJID=");
-        int endIdx = referrer.indexOf("&", idx);
-        if (endIdx == -1) {
-            endIdx = referrer.indexOf("#", idx);
-        }
-
-        String val = endIdx != -1
-            ? referrer.substring(idx + 8, endIdx)
-            : referrer.substring(idx + 8);
-
-        try {
-            val = java.net.URLDecoder.decode(
-                val,
-                java.nio.charset.StandardCharsets.UTF_8.name()
-            );
-
-            org.xmpp.packet.JID jid = new org.xmpp.packet.JID(val);
-
-            serviceParam = "&mucName=" +
-                java.net.URLEncoder.encode(
-                    jid.getDomain(),
-                    java.nio.charset.StandardCharsets.UTF_8.name()
+        if ((val = extractParam.apply(referrer, "mucname")) != null) {
+            try {
+                String decodedVal = URLDecoder.decode(
+                    val,
+                    UTF_8.name()
                 );
-        } catch (Exception e) {
-            // Ignore parsing errors and let validation handle fallbacks
+
+                String encodedVal = URLEncoder.encode(
+                    decodedVal,
+                    UTF_8.name()
+                );
+
+                serviceParam = "&mucName=" + encodedVal;
+            } catch (Exception e) {
+                // Ignore parsing errors and let validation handle fallbacks
+            }
+        } else if ((val = extractParam.apply(referrer, "mucName")) != null) {
+            try {
+                String decodedVal = URLDecoder.decode(
+                    val,
+                    UTF_8.name()
+                );
+
+                String encodedVal = URLEncoder.encode(
+                    decodedVal,
+                    UTF_8.name()
+                );
+
+                serviceParam = "&mucName=" + encodedVal;
+            } catch (Exception e) {
+                // Ignore parsing errors and let validation handle fallbacks
+            }
+        } else if ((val = extractParam.apply(referrer, "roomJID")) != null) {
+            try {
+                val = URLDecoder.decode(
+                    val,
+                    UTF_8.name()
+                );
+
+                org.xmpp.packet.JID jid = new org.xmpp.packet.JID(val);
+
+                serviceParam = "&mucName=" +
+                    URLEncoder.encode(
+                        jid.getDomain(),
+                        UTF_8.name()
+                    );
+            } catch (Exception e) {
+                // Ignore parsing errors and let validation handle fallbacks
+            }
         }
     }
-}
-    // Redirect to muc-room-edit-form and set that a room will be created, forwarding the active service parameter if found
-    response.sendRedirect("muc-room-edit-form.jsp?create=true" + serviceParam);
+
+    response.sendRedirect(
+        "muc-room-edit-form.jsp?create=true" + serviceParam
+    );
 %>
 

--- a/xmppserver/src/main/webapp/muc-room-create.jsp
+++ b/xmppserver/src/main/webapp/muc-room-create.jsp
@@ -30,39 +30,83 @@
     String referrer = request.getHeader("Referer");
     String serviceParam = "";
     if (referrer != null) {
-        if (referrer.contains("mucname=")) {
-            int idx = referrer.indexOf("mucname=");
-            int endIdx = referrer.indexOf("&", idx);
-            if (endIdx == -1) {
-                endIdx = referrer.indexOf("#", idx);
-            }
-            String val = endIdx != -1 ? referrer.substring(idx + 8, endIdx) : referrer.substring(idx + 8);
-            serviceParam = "&mucName=" + val;
-        } else if (referrer.contains("mucName=")) {
-            int idx = referrer.indexOf("mucName=");
-            int endIdx = referrer.indexOf("&", idx);
-            if (endIdx == -1) {
-                endIdx = referrer.indexOf("#", idx);
-            }
-            String val = endIdx != -1 ? referrer.substring(idx + 8, endIdx) : referrer.substring(idx + 8);
-            serviceParam = "&mucName=" + val;
-        } else if (referrer.contains("roomJID=")) {
-            int idx = referrer.indexOf("roomJID=");
-            int endIdx = referrer.indexOf("&", idx);
-            if (endIdx == -1) {
-                endIdx = referrer.indexOf("#", idx);
-            }
-            String val = endIdx != -1 ? referrer.substring(idx + 8, endIdx) : referrer.substring(idx + 8);
-            try {
-                val = java.net.URLDecoder.decode(val, java.nio.charset.StandardCharsets.UTF_8.name());
-                // roomJID is like room@service.domain. Extract the domain part.
-                org.xmpp.packet.JID jid = new org.xmpp.packet.JID(val);
-                serviceParam = "&mucName=" + java.net.URLEncoder.encode(jid.getDomain(), java.nio.charset.StandardCharsets.UTF_8.name());
-            } catch (Exception e) {
-                // Ignore parsing errors and let validation handle fallbacks
-            }
+    if (referrer.contains("mucname=")) {
+        int idx = referrer.indexOf("mucname=");
+        int endIdx = referrer.indexOf("&", idx);
+        if (endIdx == -1) {
+            endIdx = referrer.indexOf("#", idx);
+        }
+
+        String val = endIdx != -1
+            ? referrer.substring(idx + 8, endIdx)
+            : referrer.substring(idx + 8);
+
+        try {
+            String decodedVal = java.net.URLDecoder.decode(
+                val,
+                java.nio.charset.StandardCharsets.UTF_8.name()
+            );
+            String encodedVal = java.net.URLEncoder.encode(
+                decodedVal,
+                java.nio.charset.StandardCharsets.UTF_8.name()
+            );
+            serviceParam = "&mucName=" + encodedVal;
+        } catch (Exception e) {
+            // Ignore parsing errors and let validation handle fallbacks
+        }
+    } else if (referrer.contains("mucName=")) {
+        int idx = referrer.indexOf("mucName=");
+        int endIdx = referrer.indexOf("&", idx);
+        if (endIdx == -1) {
+            endIdx = referrer.indexOf("#", idx);
+        }
+
+        String val = endIdx != -1
+            ? referrer.substring(idx + 8, endIdx)
+            : referrer.substring(idx + 8);
+
+        try {
+            String decodedVal = java.net.URLDecoder.decode(
+                val,
+                java.nio.charset.StandardCharsets.UTF_8.name()
+            );
+            String encodedVal = java.net.URLEncoder.encode(
+                decodedVal,
+                java.nio.charset.StandardCharsets.UTF_8.name()
+            );
+            serviceParam = "&mucName=" + encodedVal;
+        } catch (Exception e) {
+            // Ignore parsing errors and let validation handle fallbacks
+        }
+    } else if (referrer.contains("roomJID=")) {
+        int idx = referrer.indexOf("roomJID=");
+        int endIdx = referrer.indexOf("&", idx);
+        if (endIdx == -1) {
+            endIdx = referrer.indexOf("#", idx);
+        }
+
+        String val = endIdx != -1
+            ? referrer.substring(idx + 8, endIdx)
+            : referrer.substring(idx + 8);
+
+        try {
+            val = java.net.URLDecoder.decode(
+                val,
+                java.nio.charset.StandardCharsets.UTF_8.name()
+            );
+
+            org.xmpp.packet.JID jid = new org.xmpp.packet.JID(val);
+
+            serviceParam = "&mucName=" +
+                java.net.URLEncoder.encode(
+                    jid.getDomain(),
+                    java.nio.charset.StandardCharsets.UTF_8.name()
+                );
+        } catch (Exception e) {
+            // Ignore parsing errors and let validation handle fallbacks
         }
     }
+}
     // Redirect to muc-room-edit-form and set that a room will be created, forwarding the active service parameter if found
     response.sendRedirect("muc-room-edit-form.jsp?create=true" + serviceParam);
 %>

--- a/xmppserver/src/main/webapp/muc-room-create.jsp
+++ b/xmppserver/src/main/webapp/muc-room-create.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2018 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -18,6 +18,52 @@
 --%>
 
 <%
-    // Redirect to muc-room-edit-form and set that a room will be created
-    response.sendRedirect("muc-room-edit-form.jsp?create=true");
+    // OF-31: To select the current conference service automatically on room creation,
+    // we extract the active service context from the HTTP Referer header. This allows us
+    // to preserve context from top-level sidebar navigation links (which are statically
+    // defined in admin-sidebar.xml and do not support dynamic parameters) without having
+    // to introduce session state or perform intrusive layout changes.
+    //
+    // The extraction is done here in the redirector page (muc-room-create.jsp), but the
+    // validation is kept inside muc-room-edit-form.jsp to preserve clean separation of
+    // concerns and fallback behaviors.
+    String referrer = request.getHeader("Referer");
+    String serviceParam = "";
+    if (referrer != null) {
+        if (referrer.contains("mucname=")) {
+            int idx = referrer.indexOf("mucname=");
+            int endIdx = referrer.indexOf("&", idx);
+            if (endIdx == -1) {
+                endIdx = referrer.indexOf("#", idx);
+            }
+            String val = endIdx != -1 ? referrer.substring(idx + 8, endIdx) : referrer.substring(idx + 8);
+            serviceParam = "&mucName=" + val;
+        } else if (referrer.contains("mucName=")) {
+            int idx = referrer.indexOf("mucName=");
+            int endIdx = referrer.indexOf("&", idx);
+            if (endIdx == -1) {
+                endIdx = referrer.indexOf("#", idx);
+            }
+            String val = endIdx != -1 ? referrer.substring(idx + 8, endIdx) : referrer.substring(idx + 8);
+            serviceParam = "&mucName=" + val;
+        } else if (referrer.contains("roomJID=")) {
+            int idx = referrer.indexOf("roomJID=");
+            int endIdx = referrer.indexOf("&", idx);
+            if (endIdx == -1) {
+                endIdx = referrer.indexOf("#", idx);
+            }
+            String val = endIdx != -1 ? referrer.substring(idx + 8, endIdx) : referrer.substring(idx + 8);
+            try {
+                val = java.net.URLDecoder.decode(val, java.nio.charset.StandardCharsets.UTF_8.name());
+                // roomJID is like room@service.domain. Extract the domain part.
+                org.xmpp.packet.JID jid = new org.xmpp.packet.JID(val);
+                serviceParam = "&mucName=" + java.net.URLEncoder.encode(jid.getDomain(), java.nio.charset.StandardCharsets.UTF_8.name());
+            } catch (Exception e) {
+                // Ignore parsing errors and let validation handle fallbacks
+            }
+        }
+    }
+    // Redirect to muc-room-edit-form and set that a room will be created, forwarding the active service parameter if found
+    response.sendRedirect("muc-room-edit-form.jsp?create=true" + serviceParam);
 %>
+

--- a/xmppserver/src/main/webapp/muc-room-edit-form.jsp
+++ b/xmppserver/src/main/webapp/muc-room-edit-form.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%--
   -
-  - Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+  - Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -54,6 +54,9 @@
     boolean clearchatsuccess = ParamUtils.getBooleanParameter(request,"clearchatsuccess");
     String roomName = ParamUtils.getParameter(request,"roomName");
     String mucName = ParamUtils.getParameter(request,"mucName");
+    if (mucName == null) {
+        mucName = ParamUtils.getParameter(request,"mucname");
+    }
     String roomJIDStr = ParamUtils.getParameter(request,"roomJID");
     JID roomJID = null;
     if (roomName != null && mucName != null) {
@@ -306,11 +309,32 @@
     }
     else {
         if (create) {
-            // Before a selection for a service has been made (which is part of the room creation process in cases where
-            // more than one service exists) it's impossible to predict what service-specific configuration to use. To prevent
-            // having the user to go through a second step, we'll use the first available service. Given that having more than one
-            // service is a very uncommon scenario, this is an acceptable shortcut.
-            final String serviceName = webManager.getMultiUserChatManager().getMultiUserChatServices().iterator().next().getServiceName();
+            // OF-31: Retrieve and validate the candidate service context parameter (mucName).
+            // Fall back to the alphabetically first service if missing, invalid, or does not exist.
+            // This ensures backwards compatibility and graceful fallback when accessed directly.
+            String resolvedServiceName = null;
+            if (mucName != null) {
+                if (webManager.getMultiUserChatManager().isServiceRegistered(mucName)) {
+                    resolvedServiceName = mucName;
+                } else {
+                    try {
+                        org.jivesoftware.openfire.muc.MultiUserChatService service = webManager.getMultiUserChatManager().getMultiUserChatService(new JID(null, mucName, null));
+                        if (service != null) {
+                            resolvedServiceName = service.getServiceName();
+                        }
+                    } catch (Exception e) {
+                        // ignore
+                    }
+                }
+            }
+            if (resolvedServiceName == null) {
+                resolvedServiceName = webManager.getMultiUserChatManager().getMultiUserChatServices().iterator().next().getServiceName();
+            }
+            final String serviceName = resolvedServiceName;
+            org.jivesoftware.openfire.muc.MultiUserChatService resolvedService = webManager.getMultiUserChatManager().getMultiUserChatService(serviceName);
+            if (resolvedService != null) {
+                mucName = resolvedService.getServiceDomain();
+            }
             maxUsers = MUCPersistenceManager.getProperty(serviceName, "room.maxUsers", "30");
             broadcastModerator = MUCPersistenceManager.getBooleanProperty(serviceName, "room.broadcastModerator", true);
             broadcastParticipant = MUCPersistenceManager.getBooleanProperty(serviceName, "room.broadcastParticipant", true);


### PR DESCRIPTION
## Summary

Fixes OF-31 by preserving the current conference service context when creating a new MUC room.

Previously, when an administrator navigated to **Create New Room** from a service-specific MUC administration page, the room creation form defaulted to the alphabetically first conference service because the selected service context was lost during navigation.

This change derives the active conference service from the originating request and forwards it through the room creation flow, allowing the room creation form to preselect the correct service and load the appropriate service-specific defaults.

## Root Cause

The **Create New Room** sidebar entry is a top-level navigation item generated from a static URL. As a result, service-specific request parameters (`mucname`, `mucName`, or `roomJID`) were not carried to the room creation flow.

When `muc-room-edit-form.jsp` was opened without service context, it defaulted to the first available conference service.

## Changes

* Updated `muc-room-create.jsp` to derive the active conference service from the originating request and forward it to the room creation form.
* Updated `muc-room-edit-form.jsp` to:

  * Support both `mucName` and `mucname` parameters.
  * Resolve the target conference service from the provided context.
  * Fall back to the existing default behavior when no valid service can be determined.

## Backward Compatibility

No behavior changes occur when service context is unavailable.

The room creation form continues to default to the first available conference service in the following cases:

* No service context is provided.
* The originating request cannot be resolved.
* The resolved service is invalid or no longer exists.

## Testing

Verified with multiple conference services configured:

1. Open a service-specific MUC administration page (e.g. `conference2`).
2. Click **Create New Room**.
3. Confirm that:

   * The selected conference service defaults to `conference2`.
   * Service-specific room defaults are loaded correctly.
4. Verify that room creation succeeds under the selected service.
5. Verify that navigation from non-service-specific pages continues to use the existing default service selection behavior.
