### PR TITLE
OF-1392 Add "No one can create a chat room"

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -736,6 +736,7 @@ muc.create.permission.user_removed=User/Group removed successfully.
 muc.create.permission.policy=Permission Policy
 muc.create.permission.anyone_created=Anyone can create a chat room.
 muc.create.permission.specific_created=Only specific users/groups can create a chat room.
+muc.create.permission.no_one_created=No one can create a chat room.
 muc.create.permission.allowed_users=Allowed Users/Groups
 muc.create.permission.add_jid=Add User (JID):
 muc.create.permission.add_group=Select Group (one or more):

--- a/xmppserver/src/main/webapp/muc-create-permission.jsp
+++ b/xmppserver/src/main/webapp/muc-create-permission.jsp
@@ -103,6 +103,8 @@
             webManager.logEvent("set MUC room creation to restricted for service "+mucname, null);
             response.sendRedirect("muc-create-permission.jsp?success=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
+        }else{
+            errors.put("openPerms", "openPerms");
         }
     }
 

--- a/xmppserver/src/main/webapp/muc-create-permission.jsp
+++ b/xmppserver/src/main/webapp/muc-create-permission.jsp
@@ -45,7 +45,7 @@
     boolean addsuccess = request.getParameter("addsuccess") != null;
     boolean deletesuccess = request.getParameter("deletesuccess") != null;
     boolean delete = ParamUtils.getBooleanParameter(request,"delete");
-    boolean openPerms = ParamUtils.getBooleanParameter(request,"openPerms");
+    String openPerms = ParamUtils.getParameter(request,"openPerms");
     String mucname = ParamUtils.getParameter(request,"mucname");
 
     if (!webManager.getMultiUserChatManager().isServiceRegistered(mucname)) {
@@ -73,22 +73,34 @@
     // Handle a save
     Map<String,String> errors = new HashMap<>();
     if (save) {
-        if (openPerms) {
+        if ("anyone".equals(openPerms)) {
             // Remove all users who have the ability to create rooms
             for (JID user : mucService.getUsersAllowedToCreate()) {
                 mucService.removeUserAllowedToCreate(user);
             }
             mucService.setRoomCreationRestricted(false);
             // Log the event
-            webManager.logEvent("set MUC room creation to restricted for service "+mucname, null);
+            webManager.logEvent("set MUC room creation to not restricted for service "+mucname, null);
             response.sendRedirect("muc-create-permission.jsp?success=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
-        else {
+        else if ("none".equals(openPerms)) {
+            // Remove all users who have the ability to create rooms
+            for (JID user : mucService.getUsersAllowedToCreate()) {
+                mucService.removeUserAllowedToCreate(user);
+            }
+            mucService.setRoomCreationRestricted(true);
+            mucService.setAllRegisteredUsersAllowedToCreate(false);
+            // Log the event
+            webManager.logEvent("set MUC room creation to restricted (none) for service "+mucname, null);
+            response.sendRedirect("muc-create-permission.jsp?success=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
+            return;
+        }
+        else if ("specific".equals(openPerms)) {
             mucService.setRoomCreationRestricted(true);
             mucService.setAllRegisteredUsersAllowedToCreate(allowAllRegisteredUsers);
             // Log the event
-            webManager.logEvent("set MUC room creation to not restricted for service "+mucname, null);
+            webManager.logEvent("set MUC room creation to restricted for service "+mucname, null);
             response.sendRedirect("muc-create-permission.jsp?success=true&mucname="+URLEncoder.encode(mucname, StandardCharsets.UTF_8));
             return;
         }
@@ -227,7 +239,7 @@
         <tbody>
             <tr>
                 <td style="width: 1%">
-                    <input type="radio" name="openPerms" value="true" id="rb01"
+                    <input type="radio" name="openPerms" value="anyone" id="rb01"
                      onchange="toggleAllowedUsers()"
                      <%= ((!mucService.isRoomCreationRestricted()) ? "checked" : "") %>>
                 </td>
@@ -237,12 +249,22 @@
             </tr>
             <tr>
                 <td style="width: 1%">
-                    <input type="radio" name="openPerms" value="false" id="restrictedPermissionsRadio"
+                    <input type="radio" name="openPerms" value="specific" id="restrictedPermissionsRadio"
                      onchange="toggleAllowedUsers()"
-                     <%= ((mucService.isRoomCreationRestricted()) ? "checked" : "") %>>
+                     <%= ((mucService.isRoomCreationRestricted() && (!mucService.getUsersAllowedToCreate().isEmpty() || mucService.isAllRegisteredUsersAllowedToCreate())) ? "checked" : "") %>>
                 </td>
                 <td>
                     <label for="restrictedPermissionsRadio"><fmt:message key="muc.create.permission.specific_created" /></label>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 1%">
+                    <input type="radio" name="openPerms" value="none" id="nonePermissionsRadio"
+                     onchange="toggleAllowedUsers()"
+                     <%= ((mucService.isRoomCreationRestricted() && mucService.getUsersAllowedToCreate().isEmpty() && !mucService.isAllRegisteredUsersAllowedToCreate()) ? "checked" : "") %>>
+                </td>
+                <td>
+                    <label for="nonePermissionsRadio"><fmt:message key="muc.create.permission.no_one_created" /></label>
                 </td>
             </tr>
         </tbody>
@@ -254,7 +276,7 @@
 
 <br>
 
-<div id="allowedUsersContainer" style="display: <%= (mucService.isRoomCreationRestricted() ? "block" : "none") %>">
+<div id="allowedUsersContainer" style="display: <%= (mucService.isRoomCreationRestricted() && (!mucService.getUsersAllowedToCreate().isEmpty() || mucService.isAllRegisteredUsersAllowedToCreate()) ? "block" : "none") %>">
 <!-- BEGIN 'Allowed Users' -->
 <form action="muc-create-permission.jsp?add" method="post">
     <input type="hidden" name="csrf" value="${csrf}">


### PR DESCRIPTION
## Summary

Currently, room creation permissions support only two policies:

* **Anyone** can create a chat room.
* **Only specific users/groups** can create a chat room.

To completely prevent room creation, administrators must select the *specific users/groups* option and add a placeholder account (for example, an admin user) to the allowed list. This workaround is unintuitive and requires unnecessary configuration.

This PR introduces a third policy:

> **No one can create a chat room**

This allows room creation to be completely disabled for regular users without requiring dummy users or groups. System administrators continue to bypass these restrictions and can always create rooms.

## Changes

### Internationalization

* Added the `muc.create.permission.no_one_created` translation key to `openfire_i18n.properties`.

### UI & Backend Logic

Updated `muc-create-permission.jsp` to support three room creation policies:

* `anyone`
* `specific`
* `none`

Additional changes:

* Added a new radio button option: **"No one can create a chat room."**
* Updated permission handling to support the new `none` state.
* Updated page initialization logic to correctly reflect the selected policy when loading the page.
* Added dynamic visibility handling for the **Allowed Users/Groups** section:

  * Hidden when `anyone` is selected.
  * Hidden when `none` is selected.
  * Displayed when `specific` is selected.
* Updated audit log messages to accurately describe policy changes for all supported modes.

## Verification

### UI Verification

* Navigated to **Group Chat → Room Creation Permissions**.
* Verified that the new **"No one can create a chat room"** option is displayed.
* Verified that selecting **"No one can create a chat room"** hides the **Allowed Users/Groups** section.
* Verified that selecting **"Only specific users/groups..."** immediately displays the **Allowed Users/Groups** section.
* Verified that the correct state is restored after saving and reloading the page.

### Functional Verification

* Verified that users without administrative privileges cannot create chat rooms when the **"No one can create a chat room"** policy is active.
* Verified that room creation remains restricted to configured users/groups when the **"Only specific users/groups..."** policy is active.
* Verified that system administrators can still create chat rooms regardless of the selected policy.
