### PR TITLE
OF-2009: Encrypt default value of encrypted properties

### DIFF
--- a/xmppserver/src/main/webapp/system-properties.jsp
+++ b/xmppserver/src/main/webapp/system-properties.jsp
@@ -220,6 +220,9 @@
                         <c:when test="${!property.systemProperty}">
                             <span class="hidden">unknown</span>
                         </c:when>
+                        <c:when test="${property.hidden}">
+                            <span class="hidden">hidden</span>
+                        </c:when>
                         <c:when test="${property.defaultDisplayValue == null}">
                             <span class="hidden">none</span>
                         </c:when>


### PR DESCRIPTION
## Description

Currently, system properties that are marked as encrypted or sensitive have their configured values masked as *"hidden"* in the **Value** column of the System Properties page. However, their default values are still displayed in plain text in both the **Default** column and the property's edit form.

This can unintentionally expose sensitive default values such as passwords, API tokens, or encryption keys through the Admin Console.

This change updates the Admin Console UI to mask the default values of encrypted or sensitive properties, making their behavior consistent with the handling of configured values.

## Proposed Changes

### Admin Console

**Modified:** `system-properties.jsp`

* Added a check for `property.hidden` when rendering the **Default** column.
* When a property is marked as hidden, the default value is displayed as:

```html
<span class="hidden">hidden</span>
```

* This also masks the default value shown in the edit form, as the existing `doEdit()` JavaScript function reads the displayed value directly from the table row.

## Verification

### Automated Verification

* Successfully executed:

```bash
mvnw.cmd test -pl xmppserver -Dtest=SystemPropertyTest
```

* All tests completed successfully.

### Manual Verification

1. Open **Admin Console → Server → System Properties**.
2. Locate an encrypted or sensitive property.
3. Verify that the **Default** column displays *"hidden"* instead of the actual default value.
4. Open the property's edit dialog.
5. Verify that the **Default:** field also displays *"hidden"* rather than the underlying value.

### Build Verification

* Verified that JSPs compile successfully without errors.
* Confirmed that the System Properties page renders correctly after the change.

## Impact

* No architectural or behavioral changes.
* No configuration or API changes.
* UI-only change to prevent accidental disclosure of sensitive default values.
* Existing functionality remains unchanged.
