### PR TITLE
OF-2010 Specify port protocol for Media Proxy

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -3571,9 +3571,9 @@ mediaproxy.form.idletimeout = Session Idle Timeout (in seconds)
 mediaproxy.form.idletimeout.tip = This value is usually bigger than 15 seconds.
 mediaproxy.form.lifetime = Session Life Time (in seconds)
 mediaproxy.form.lifetime.tip = Life Time is the maximum time that a Session can live. After this time it is destroyed, even if it stills active.
-mediaproxy.form.minport = Port Range Min
-mediaproxy.form.maxport = Port Range Max
-mediaproxy.form.echoport = Echo Test Port
+mediaproxy.form.minport = UDP Port Range Min
+mediaproxy.form.maxport = UDP Port Range Max
+mediaproxy.form.echoport = UDP Echo Test Port
 
 mediaproxy.summary.label = Active Sessions Summary
 mediaproxy.summary.desc = Sessions are Media Proxy Channels that controls packet relaying. \


### PR DESCRIPTION
### Description

The Media Proxy service in Openfire opens UDP listeners, but the corresponding port configuration fields in the Admin Console do not explicitly indicate that these ports use the UDP protocol. This can cause confusion when configuring firewall or network rules.

This change updates the labels of the Media Proxy port configuration fields to clearly indicate that they are UDP ports.

### Changes

Updated the default English localization resource file (`openfire_i18n.properties`):

* `mediaproxy.form.minport`: `Port Range Min` → `UDP Port Range Min`
* `mediaproxy.form.maxport`: `Port Range Max` → `UDP Port Range Max`
* `mediaproxy.form.echoport`: `Echo Test Port` → `UDP Echo Test Port`

### Testing

* Verified that the project compiles successfully using `mvn compile`.
* Verified that the updated labels are displayed correctly on the Media Proxy settings page in the Admin Console.

### Notes

This is a UI text-only change. No functional behavior has been modified.

OF-2010
