### PR TITLE
OF-2710: Replace two group-member queries with one in DefaultGroupPro…

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/group/DefaultGroupProvider.java
@@ -57,10 +57,8 @@ public class DefaultGroupProvider extends AbstractGroupProvider {
     private static final String DELETE_GROUP =
         "DELETE FROM ofGroup WHERE groupName=?";
     private static final String GROUP_COUNT = "SELECT count(*) FROM ofGroup";
-     private static final String LOAD_ADMINS =
-        "SELECT username FROM ofGroupUser WHERE administrator=1 AND groupName=? ORDER BY username";
-    private static final String LOAD_MEMBERS =
-        "SELECT username FROM ofGroupUser WHERE administrator=0 AND groupName=? ORDER BY username";
+    private static final String LOAD_MEMBERS_AND_ADMINS =
+        "SELECT username, administrator FROM ofGroupUser WHERE groupName=? ORDER BY username";
     private static final String LOAD_GROUP =
         "SELECT description FROM ofGroup WHERE groupName=?";
     private static final String REMOVE_USER =
@@ -105,9 +103,9 @@ public class DefaultGroupProvider extends AbstractGroupProvider {
             DbConnectionManager.closeConnection(pstmt, con);
         }
 
-        // TODO Replace these two database queries with one. OF-2710
-        Collection<JID> members = getMembers(name, false);
-        Collection<JID> administrators = getMembers(name, true);
+        List<JID> members = new ArrayList<>();
+        List<JID> administrators = new ArrayList<>();
+        loadMembersAndAdmins(name, members, administrators);
 
         return new Group(name, "", members, administrators);
     }
@@ -137,9 +135,9 @@ public class DefaultGroupProvider extends AbstractGroupProvider {
             DbConnectionManager.closeConnection(rs, pstmt, con);
         }
 
-        // TODO Replace these two database queries with one. OF-2710
-        Collection<JID> members = getMembers(name, false);
-        Collection<JID> administrators = getMembers(name, true);
+        List<JID> members = new ArrayList<>();
+        List<JID> administrators = new ArrayList<>();
+        loadMembersAndAdmins(name, members, administrators);
 
         return new Group(name, description, members, administrators);
     }
@@ -507,23 +505,18 @@ public class DefaultGroupProvider extends AbstractGroupProvider {
         return true;
     }
 
-    private Collection<JID> getMembers(String groupName, boolean adminsOnly) {
-        List<JID> members = new ArrayList<>();
+    private void loadMembersAndAdmins(String groupName, Collection<JID> members, Collection<JID> administrators) {
         Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
         try {
             con = DbConnectionManager.getConnection();
-            if (adminsOnly) {
-                pstmt = con.prepareStatement(LOAD_ADMINS);
-            }
-            else {
-                pstmt = con.prepareStatement(LOAD_MEMBERS);
-            }
+            pstmt = con.prepareStatement(LOAD_MEMBERS_AND_ADMINS);
             pstmt.setString(1, groupName);
             rs = pstmt.executeQuery();
             while (rs.next()) {
                 String user = rs.getString(1);
+                boolean isAdmin = rs.getInt(2) == 1;
                 JID userJID = null;
                 if (user.indexOf('@') == -1) {
                     // Create JID of local user if JID does not match a component's JID
@@ -541,7 +534,14 @@ public class DefaultGroupProvider extends AbstractGroupProvider {
                     Log.warn("Group '{}' has a member that is persisted using its full JID, instead of a bare JID: '{}'. This is unexpected, and possibly a data consistency error. Groups should only contain bare JIDs.", groupName, userJID);
                     userJID = userJID.asBareJID();
                 }
-                members.add(userJID);
+
+                if (userJID != null) {
+                    if (isAdmin) {
+                        administrators.add(userJID);
+                    } else {
+                        members.add(userJID);
+                    }
+                }
             }
         }
         catch (SQLException e) {
@@ -550,6 +550,5 @@ public class DefaultGroupProvider extends AbstractGroupProvider {
         finally {
             DbConnectionManager.closeConnection(rs, pstmt, con);
         }
-        return members;
     }
 }


### PR DESCRIPTION
## Description

`DefaultGroupProvider` currently performs two database queries when loading a group's users:

- One query to retrieve regular members.
- One query to retrieve administrators.

As both user types are stored in the same table (`ofGroupUser`) and differ only by the value of the `administrator` column, the data can be retrieved using a single query and categorized in memory.

This PR optimizes group loading by replacing the two queries with a single query that retrieves both members and administrators.

### Changes

- Added a new query constant, `LOAD_MEMBERS_AND_ADMINS`, that retrieves both `username` and `administrator` values from `ofGroupUser`.
- Removed the separate `LOAD_MEMBERS` and `LOAD_ADMINS` query constants.
- Replaced the `getMembers(String, boolean)` helper method with `loadMembersAndAdmins(String, Collection<JID>, Collection<JID>)`.
- Updated group-loading logic to populate member and administrator collections from a single result set.
- Updated `createGroup` and `getGroup` to use the new helper method.

### Benefits

- Reduces the number of database queries required to load group membership data from **two to one**.
- Lowers database workload and query overhead.
- Preserves existing behavior and APIs.
- Requires no schema or architectural changes.

## Testing

### Compilation

```bash
mvn compile