### PR TITLE
OF-2744: Enrich DOAP file with status and version for all XEPs

### DIFF
--- a/documentation/openfire.doap
+++ b/documentation/openfire.doap
@@ -48,6 +48,8 @@
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0004.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>2.13.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
@@ -61,108 +63,150 @@
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0012.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>2.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0013.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.3</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0016.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.7</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0030.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>2.5.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0033.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0045.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.35.3</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0048.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0049.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0050.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.3.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0054.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.3.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0055.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.3</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'Search' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0059.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0060.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.14</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0065.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.8.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0077.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>2.4</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0078.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>2.5</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'Non-SASL Authentication' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0082.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0086.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0090.html"/>
+                <xmpp:status>deprecated</xmpp:status>
+                <xmpp:version>1.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0091.html"/>
+                <xmpp:status>deprecated</xmpp:status>
+                <xmpp:version>1.4</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0092.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
@@ -176,238 +220,328 @@
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0096.html"/>
+                <xmpp:status>deprecated</xmpp:status>
+                <xmpp:version>1.3.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0106.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0114.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.6</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0115.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.6.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0124.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.11.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0126.html"/>
+                <xmpp:status>deprecated</xmpp:status>
+                <xmpp:version>1.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0128.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0129.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.3</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0133.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.3.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0136.html"/>
+                <xmpp:status>deprecated</xmpp:status>
+                <xmpp:version>1.3.1</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'Monitoring Service' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0138.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>2.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0142.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.3.1</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'Fastpath' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0153.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1.1</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'Avatar Resizer' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0156.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.4.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0157.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0160.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.0.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0163.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.2.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0175.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0178.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0182.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0191.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.3</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0198.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.5.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0199.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>2.0.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0202.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>2.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0203.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>2.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0206.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.4</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0215.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.0.0</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'External Service Discovery' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0220.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0227.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'User Import/Export' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0223.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0232.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.3</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0233.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.0.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0249.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0278.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.4.0</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'Jingle Nodes' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0280.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.0.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0289.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.2.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0313.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.6.1</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'Monitoring Service' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0321.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.1.1</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'GoJara' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0322.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.6.0</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'EXI' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0328.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.1</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'JID Validation' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0352.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.1</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0357.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.4.1</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'Push Notification' and 'Push Server' plugins</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0359.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.7.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0363.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.3.0</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'HTTP File Upload' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0368.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
@@ -420,16 +554,22 @@
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0410.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0411.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>1.1.0</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0431.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.2.0</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'Monitoring Service' plugin</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
@@ -459,12 +599,15 @@
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0483.html"/>
+                <xmpp:status>complete</xmpp:status>
+                <xmpp:version>0.2.0</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'Openfire Meetings, Galene and OrinAyo' plugins</xmpp:note>
             </xmpp:SupportedXep>
         </implements>
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0485.html"/>
+                <xmpp:status>complete</xmpp:status>
                 <xmpp:version>0.1.0</xmpp:version>
                 <xmpp:note xml:lang='en'>Provided by the 'PubSub Server Info' plugin</xmpp:note>
             </xmpp:SupportedXep>


### PR DESCRIPTION
## Description

This Pull Request enhances Openfire's DOAP (Description of a Project) file by adding version and implementation status metadata for all supported XMPP Extension Protocols (XEPs).

Previously, most XEP entries only referenced their specification URLs, without indicating the level of implementation support or the specification version implemented by Openfire. To improve interoperability with software directories and metadata consumers, this change aligns Openfire's DOAP data with the requirements of XEP-0453.

### Changes

* Added `<xmpp:status>` elements to indicate implementation completeness (for example, `complete` or `partial`).
* Added `<xmpp:version>` elements to specify the supported version of each XEP.
* Marked obsolete and superseded specifications as `deprecated`, including:

  * XEP-0090
  * XEP-0091
  * XEP-0096
  * XEP-0126
  * XEP-0136

### Benefits

These additions provide a more accurate representation of Openfire's XMPP feature support and enable software catalogs, aggregators, and directory services (such as the xmpp.org software listings) to correctly display compatibility information and implementation status.
