### PR TITLE
OF-3305: Abort Blowfish PBKDF2 migration when security.xml is not persistable

### DIFF
--- a/doc/adr/004-manual-blowfish-pbkdf2-migration.md
+++ b/doc/adr/004-manual-blowfish-pbkdf2-migration.md
@@ -255,6 +255,7 @@ The migration tool uses multiple `ClusterManager` methods to detect unsafe clust
 **Migration blocked when**:
 1. `clusteringEnabled && !clusteringStarted` — clustering configured but not yet running (race condition risk: other nodes might be starting simultaneously)
 2. `clusteringStarted && nodeCount > 1` — multiple nodes active in cluster
+3. `!isSecurityPropertiesPersistable()` — `conf/security.xml` cannot be loaded or written (missing, empty, corrupt, or not writable), so the freshly generated PBKDF2 salt and the `kdf=pbkdf2` flag could not be persisted and would be lost on the next restart, leaving the re-encrypted data unreadable (OF-3305)
 
 **Migration allowed when**:
 1. `!clusteringAvailable` — Hazelcast plugin not installed, clustering impossible

--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -2490,6 +2490,9 @@ security.blowfish.migration.error=Migration failed
 security.blowfish.migration.error.detail=Migration failed: {0}
 security.blowfish.migration.error.backups-required=You must confirm all backups before proceeding with migration.
 security.blowfish.migration.error.csrf=CSRF validation failed. Please refresh the page and try again.
+security.blowfish.migration.error.security-xml-not-writable=Migration blocked: conf/security.xml could not be loaded or is not writable. \
+        The new PBKDF2 salt and KDF setting must be saved there; without them the re-encrypted data could not be decrypted after a restart. \
+        Repair conf/security.xml (ensure it exists, is valid XML, and is writable by the Openfire process), then try again.
 security.blowfish.migration.help=For detailed migration instructions and documentation, see the
 security.blowfish.migration.help.link=Blowfish PBKDF2 Migration Guide
 security.blowfish.migration.detailed-guide-notice=A comprehensive migration guide with additional technical details is available in the Openfire documentation.

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/BlowfishMigrationServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/BlowfishMigrationServlet.java
@@ -22,6 +22,7 @@ import org.jivesoftware.util.Blowfish;
 import org.jivesoftware.util.CookieUtils;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.StringUtils;
+import org.jivesoftware.util.WebManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,6 +184,10 @@ public class BlowfishMigrationServlet extends HttpServlet {
             try {
                 // Perform migration
                 MigrationResult result = migrateBlowfishToPBKDF2();
+
+                final WebManager webManager = new WebManager();
+                webManager.init(request, response, request.getSession(), request.getServletContext());
+                webManager.logEvent("Migrated encrypted properties to more secure encryption standard", "Successfully migrated " + result.databaseCount() + " database properties and " + result.xmlCount() + " XML properties from SHA1 to PBKDF2.");
 
                 request.getSession().setAttribute("successMessage",
                         "security.blowfish.migration.success");

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/BlowfishMigrationServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/BlowfishMigrationServlet.java
@@ -169,6 +169,17 @@ public class BlowfishMigrationServlet extends HttpServlet {
                 return;
             }
 
+            // Block if security.xml cannot be persisted. The migration must store a new PBKDF2 salt
+            // and the kdf=pbkdf2 flag in conf/security.xml; if those writes are silently discarded
+            // (security.xml missing, empty, corrupt or not writable), the re-encrypted data becomes
+            // unrecoverable after a restart. Fail fast here, before any database changes. (OF-3305)
+            if (!JiveGlobals.isSecurityPropertiesPersistable()) {
+                request.getSession().setAttribute("errorMessage",
+                        "security.blowfish.migration.error.security-xml-not-writable");
+                response.sendRedirect("security-blowfish-migration.jsp");
+                return;
+            }
+
             try {
                 // Perform migration
                 MigrationResult result = migrateBlowfishToPBKDF2();
@@ -255,6 +266,16 @@ public class BlowfishMigrationServlet extends HttpServlet {
         if (!ENCRYPTION_ALGORITHM_BLOWFISH.equalsIgnoreCase(encryptionAlgorithm)) {
             throw new IllegalStateException("Encryption algorithm is " + encryptionAlgorithm +
                     ", not Blowfish. Migration only applies to Blowfish.");
+        }
+
+        // Defence in depth: refuse to proceed if security.xml cannot be persisted, so the PBKDF2
+        // salt and KDF flag this migration generates cannot be silently lost. doPost() and
+        // migrateXMLPropertiesFromSHA1ToPBKDF2() also check this; the check here keeps the method
+        // self-protecting regardless of how it is reached. (OF-3305)
+        if (!JiveGlobals.isSecurityPropertiesPersistable()) {
+            throw new IllegalStateException("Cannot migrate: conf/security.xml is not loaded or not writable, "
+                    + "so the new PBKDF2 salt and KDF setting cannot be persisted. "
+                    + "Repair conf/security.xml before migrating.");
         }
 
         Log.info("Starting Blowfish migration from SHA1 to PBKDF2...");
@@ -360,6 +381,13 @@ public class BlowfishMigrationServlet extends HttpServlet {
             // 8. Update security.xml to switch KDF to PBKDF2
             // This only updates the local node's security.xml
             // In clustered deployments, admin must manually sync to other nodes
+            //
+            // Known limitation (OF-3305): persistability was verified before the migration, but this
+            // KDF write happens after the database commit. If security.xml became unwritable in that
+            // narrow window (e.g. conf/ remounted read-only, or the disk filled), this save fails and
+            // is only logged. The salt was already persisted earlier (during setKey), so this state is
+            // recoverable by setting encrypt.blowfish.kdf=pbkdf2 in security.xml by hand. Surfacing this
+            // failure properly is tracked as a follow-up (make security-critical saves report failure).
             JiveGlobals.setBlowfishKdf(JiveGlobals.BLOWFISH_KDF_PBKDF2);
             Log.info("Updated security.xml: encrypt.blowfish.kdf=pbkdf2");
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1191,6 +1191,10 @@ public class JiveGlobals {
             byte[] saltBytes = new byte[32];
             new java.security.SecureRandom().nextBytes(saltBytes);
             salt = Base64.getEncoder().encodeToString(saltBytes);
+            // The setProperty result is intentionally not checked: a failed save is logged by
+            // XMLProperties, and the only caller that requires durability (the SHA1-to-PBKDF2 migration)
+            // gates on isSecurityPropertiesPersistable() up front. Do not rely on this save succeeding
+            // from a new call site without that guard. (OF-3305)
             securityProperties.setProperty(BLOWFISH_SALT, salt);
             Log.info("Generated new Blowfish salt for PBKDF2 key derivation");
         }
@@ -1226,6 +1230,9 @@ public class JiveGlobals {
             loadSecurityProperties();
         }
 
+        // The setProperty results below are intentionally not checked: failures are logged by
+        // XMLProperties, and the SHA1-to-PBKDF2 migration gates on isSecurityPropertiesPersistable()
+        // before reaching here. Do not rely on these saves from a new call site without that guard.
         if (BLOWFISH_KDF_PBKDF2.equalsIgnoreCase(kdf)) {
             securityProperties.setProperty(BLOWFISH_KDF, BLOWFISH_KDF_PBKDF2);
             Log.info("Blowfish KDF set to PBKDF2-HMAC-SHA512");
@@ -1236,6 +1243,27 @@ public class JiveGlobals {
 
         // Reinitialise the encryptor cache so new properties use the updated KDF immediately
         reinitialisePropertyEncryptor();
+    }
+
+    /**
+     * Determines whether the security configuration (conf/security.xml) can be persisted to disk.
+     *
+     * When security.xml cannot be loaded (it is missing, empty, corrupt or not writable), JiveGlobals
+     * falls back to a non-persisting, in-memory-only properties object. Any change written to it (such
+     * as the Blowfish PBKDF2 salt or KDF setting) is logged as an error and then silently lost on the
+     * next restart. Operations that depend on such state surviving a restart (notably the Blowfish
+     * SHA1-to-PBKDF2 migration) must verify this before making any irreversible change.
+     *
+     * This reflects the backing established when security.xml was loaded; it is not a live re-check of
+     * filesystem writability (the file-backed constructor verifies writability at load time).
+     *
+     * @return {@code true} if security properties are backed by a file, otherwise {@code false}
+     */
+    public static boolean isSecurityPropertiesPersistable() {
+        if (securityProperties == null) {
+            loadSecurityProperties();
+        }
+        return securityProperties != null && securityProperties.isPersistable();
     }
 
     /**
@@ -1267,6 +1295,17 @@ public class JiveGlobals {
         String currentKdf = getBlowfishKdf();
         if (BLOWFISH_KDF_PBKDF2.equalsIgnoreCase(currentKdf)) {
             throw new IllegalStateException("Cannot migrate: already using PBKDF2");
+        }
+
+        // Refuse to migrate if security.xml cannot be persisted. The migration derives the PBKDF2 key
+        // from a freshly generated salt and records that salt (and the kdf=pbkdf2 flag) in security.xml.
+        // If those writes are silently discarded (security.xml missing, empty, corrupt or not writable),
+        // the salt is lost on the next restart and the re-encrypted data becomes permanently unreadable.
+        // Fail fast here, before any key derivation or database change. (OF-3305)
+        if (!isSecurityPropertiesPersistable()) {
+            throw new IllegalStateException("Cannot migrate: conf/security.xml is not loaded or not writable, "
+                    + "so the new PBKDF2 salt and KDF setting cannot be persisted. "
+                    + "Repair conf/security.xml (ensure it exists, is valid XML, and is writable) before migrating.");
         }
 
         // 2. Get the master encryption key
@@ -1582,7 +1621,7 @@ public class JiveGlobals {
                     }
                 }
                 catch (IOException ioe) {
-                    Log.error("Unable to load default security properties from: {}{}{}", home, File.separator, getConfigName(), ioe);
+                    Log.error("Unable to load security properties from: {}", getSecurityConfigLocation(), ioe);
                     failedLoading = true;
                 }
             }

--- a/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/XMLProperties.java
@@ -174,6 +174,23 @@ public class XMLProperties {
     }
 
     /**
+     * Determines whether this instance is backed by a file and can therefore persist changes.
+     *
+     * Instances created from an input stream (see {@link #getNonPersistedInstance()}) are not backed
+     * by a file and silently discard any attempt to save (see {@link #saveProperties()}). Callers that
+     * must guarantee a change is durable should check this before writing.
+     *
+     * This reflects whether a backing file was established when the instance was constructed; it is not
+     * a live re-check of filesystem writability (the file-backed constructor verifies readability and
+     * writability at load time, falling back to a non-persisted instance otherwise).
+     *
+     * @return {@code true} if this instance is backed by a file, otherwise {@code false}
+     */
+    public boolean isPersistable() {
+        return file != null;
+    }
+
+    /**
      * Returns the value of the specified property.
      *
      * @param name the name of the property to get.

--- a/xmppserver/src/main/webapp/blowfish-migration.jsp
+++ b/xmppserver/src/main/webapp/blowfish-migration.jsp
@@ -13,6 +13,18 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   --%>
+<%--@elvariable id="isBlowfish" type="java.lang.Boolean"--%>
+<%--@elvariable id="needsMigration" type="java.lang.Boolean"--%>
+<%--@elvariable id="alreadyMigrated" type="java.lang.Boolean"--%>
+<%--@elvariable id="currentKdf" type="java.lang.String"--%>
+<%--@elvariable id="encryptionAlgorithm" type="java.lang.String"--%>
+<%--@elvariable id="encryptedPropertyCountDb" type="java.lang.Integer"--%>
+<%--@elvariable id="encryptedPropertyCountXml" type="java.lang.Integer"--%>
+<%--@elvariable id="clusteringAvailable" type="java.lang.Boolean"--%>
+<%--@elvariable id="clusteringEnabled" type="java.lang.Boolean"--%>
+<%--@elvariable id="clusteringStarted" type="java.lang.Boolean"--%>
+<%--@elvariable id="clusterNodeCount" type="java.lang.Integer"--%>
+<%--@elvariable id="csrf" type="java.lang.String"--%>
 
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp"%>
@@ -135,11 +147,11 @@
         <c:choose>
             <c:when test="${not empty errorParam}">
                 <fmt:message key="${errorMessage}">
-                    <fmt:param value="${errorParam}"/>
+                    <fmt:param><c:out value="${errorParam}"/></fmt:param>
                 </fmt:message>
             </c:when>
             <c:otherwise>
-                <fmt:message key="${errorMessage}"/>
+                <fmt:message><c:out value="${errorMessage}"/></fmt:message>
             </c:otherwise>
         </c:choose>
     </admin:infobox>
@@ -150,12 +162,12 @@
         <c:choose>
             <c:when test="${not empty successParamDb}">
                 <fmt:message key="${successMessage}">
-                    <fmt:param value="${successParamDb}"/>
-                    <fmt:param value="${successParamXml}"/>
+                    <fmt:param><fmt:formatNumber>${successParamDb}</fmt:formatNumber></fmt:param>
+                    <fmt:param><fmt:formatNumber>${successParamXml}</fmt:formatNumber></fmt:param>
                 </fmt:message>
             </c:when>
             <c:otherwise>
-                <fmt:message key="${successMessage}"/>
+                <fmt:message><c:out value="${successMessage}"/></fmt:message>
             </c:otherwise>
         </c:choose>
     </admin:infobox>
@@ -165,7 +177,7 @@
     <c:when test="${not isBlowfish}">
         <admin:infobox type="info">
             <fmt:message key="security.blowfish.migration.not-blowfish">
-                <fmt:param value="${encryptionAlgorithm}"/>
+                <fmt:param><c:out value="${encryptionAlgorithm}"/></fmt:param>
             </fmt:message>
         </admin:infobox>
     </c:when>
@@ -219,7 +231,7 @@
                 <%-- Block migration if multiple cluster nodes are running --%>
                 <admin:infobox type="error">
                     <fmt:message key="security.blowfish.migration.error.multi-node-active">
-                        <fmt:param value="${clusterNodeCount}"/>
+                        <fmt:param><fmt:formatNumber>${clusterNodeCount}</fmt:formatNumber></fmt:param>
                     </fmt:message>
                 </admin:infobox>
 
@@ -303,18 +315,18 @@
                     </tr>
                     <tr>
                         <td class="c1"><fmt:message key="security.blowfish.migration.status.encrypted-count-db"/></td>
-                        <td class="c2"><strong><c:out value="${encryptedPropertyCountDb}"/></strong></td>
+                        <td class="c2"><strong><fmt:formatNumber value="${encryptedPropertyCountDb}"/></strong></td>
                     </tr>
                     <tr>
                         <td class="c1"><fmt:message key="security.blowfish.migration.status.encrypted-count-xml"/></td>
-                        <td class="c2"><strong><c:out value="${encryptedPropertyCountXml}"/></strong></td>
+                        <td class="c2"><strong><fmt:formatNumber value="${encryptedPropertyCountXml}"/></strong></td>
                     </tr>
                 </tbody>
             </table>
         </div>
 
         <form action="security-blowfish-migration.jsp" method="post" onsubmit="return confirm('<fmt:message key="security.blowfish.migration.confirm"/>');">
-            <input type="hidden" name="csrf" value="${csrf}">
+            <input type="hidden" name="csrf" value="${admin:escapeHTMLTags(csrf)}">
             <input type="hidden" name="action" value="migrate">
 
             <div class="migration-checklist">

--- a/xmppserver/src/test/java/org/jivesoftware/admin/servlet/BlowfishMigrationServletTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/admin/servlet/BlowfishMigrationServletTest.java
@@ -37,6 +37,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -403,14 +404,16 @@ public class BlowfishMigrationServletTest {
     // ========== Clustering Tests ==========
 
     /**
-     * Test doPost() allows migration when clustering is not available.
-     * If the Hazelcast plugin isn't installed, clustering is impossible and migration is safe.
+     * Test doPost() does not block on clustering grounds when clustering is not available.
+     * If the Hazelcast plugin isn't installed, clustering is impossible and the clustering gate passes.
      *
      * This test verifies that when ClusterManager.isClusteringAvailable() returns false,
-     * the servlet does NOT block migration due to clustering concerns.
+     * the servlet does NOT block due to clustering concerns. (In the unit-test environment the
+     * migration then stops at the security.xml persistability gate, so this asserts only the
+     * clustering gate.)
      */
     @Test
-    public void testDoPost_ClusteringNotAvailable_AllowsMigration() throws Exception {
+    public void testDoPost_ClusteringNotAvailable_DoesNotBlockOnClustering() throws Exception {
         try (MockedStatic<ClusterManager> clusterManagerMock = mockStatic(ClusterManager.class)) {
             // Setup: Clustering plugin not installed
             clusterManagerMock.when(ClusterManager::isClusteringAvailable).thenReturn(false);
@@ -510,11 +513,12 @@ public class BlowfishMigrationServletTest {
     }
 
     /**
-     * Test doPost() allows migration when clustering is started with only one node.
-     * Single-node cluster is safe for migration.
+     * Test doPost() does not block on clustering grounds when clustering is started with only one node.
+     * A single-node cluster is safe for migration. (In the unit-test environment the migration then
+     * stops at the security.xml persistability gate, so this asserts only the clustering gate.)
      */
     @Test
-    public void testDoPost_ClusteringStartedWithSingleNode_AllowsMigration() throws Exception {
+    public void testDoPost_ClusteringStartedWithSingleNode_DoesNotBlockOnClustering() throws Exception {
         try (MockedStatic<ClusterManager> clusterManagerMock = mockStatic(ClusterManager.class)) {
             // Setup: Clustering active with only 1 node (this node only)
             clusterManagerMock.when(ClusterManager::isClusteringAvailable).thenReturn(true);
@@ -569,5 +573,64 @@ public class BlowfishMigrationServletTest {
             verify(request).setAttribute("clusterNodeCount", 0);
             verify(requestDispatcher).forward(request, response);
         }
+    }
+
+    // ========== security.xml persistability Tests (OF-3305) ==========
+
+    /**
+     * doPost() must block migration and report a clear error when security.xml cannot be persisted,
+     * before any database changes (OF-3305). In the unit-test environment there is no conf/security.xml,
+     * so security properties are a non-persisting dummy and the migration must not proceed.
+     */
+    @Test
+    public void should_blockMigrationAndReportError_when_securityXmlNotPersistable() throws Exception {
+        try (MockedStatic<ClusterManager> clusterManagerMock = mockStatic(ClusterManager.class)) {
+            // Clustering not available so the clustering gates pass and we reach the persistability gate
+            clusterManagerMock.when(ClusterManager::isClusteringAvailable).thenReturn(false);
+            clusterManagerMock.when(ClusterManager::isClusteringEnabled).thenReturn(false);
+            clusterManagerMock.when(ClusterManager::isClusteringStarted).thenReturn(false);
+
+            // Precondition: security.xml is not persistable in the test environment
+            assertFalse(JiveGlobals.isSecurityPropertiesPersistable(),
+                    "Test precondition: security.xml should not be persistable in the test environment");
+
+            // Valid CSRF and all backup confirmations so the earlier gates pass
+            String csrfToken = "valid-token";
+            when(request.getParameter("csrf")).thenReturn(csrfToken);
+            when(request.getCookies()).thenReturn(new Cookie[]{new Cookie("csrf", csrfToken)});
+            when(request.getParameter("action")).thenReturn("migrate");
+            when(request.getParameter("dbBackup")).thenReturn("true");
+            when(request.getParameter("securityBackup")).thenReturn("true");
+            when(request.getParameter("openfireBackup")).thenReturn("true");
+
+            // Execute
+            servlet.doPost(request, response);
+
+            // Verify: migration blocked with the dedicated error, no success, and a redirect
+            verify(session).setAttribute("errorMessage",
+                    "security.blowfish.migration.error.security-xml-not-writable");
+            verify(session, never()).setAttribute(eq("successMessage"), anyString());
+            verify(response).sendRedirect("security-blowfish-migration.jsp");
+        }
+    }
+
+    /**
+     * The migration API itself must refuse to run (throwing, before any database change) when
+     * security.xml is not persistable, so a salt/KDF that cannot be stored is never used to
+     * re-encrypt data (OF-3305).
+     */
+    @Test
+    public void should_throwWithSecurityXmlMessage_when_migratingWhileNotPersistable() {
+        // Precondition: security.xml is not persistable in the test environment
+        assertFalse(JiveGlobals.isSecurityPropertiesPersistable(),
+                "Test precondition: security.xml should not be persistable in the test environment");
+
+        // Ensure the migration preconditions pass (Blowfish algorithm by default; force SHA1 KDF)
+        JiveGlobals.setBlowfishKdf(JiveGlobals.BLOWFISH_KDF_SHA1);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                JiveGlobals::migrateXMLPropertiesFromSHA1ToPBKDF2);
+        assertTrue(ex.getMessage().toLowerCase().contains("security.xml"),
+                "Error should explain that security.xml cannot be persisted; was: " + ex.getMessage());
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/admin/servlet/BlowfishMigrationServletTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/admin/servlet/BlowfishMigrationServletTest.java
@@ -583,7 +583,7 @@ public class BlowfishMigrationServletTest {
      * so security properties are a non-persisting dummy and the migration must not proceed.
      */
     @Test
-    public void should_blockMigrationAndReportError_when_securityXmlNotPersistable() throws Exception {
+    public void testDoPost_SecurityXmlNotPersistable_BlocksMigration() throws Exception {
         try (MockedStatic<ClusterManager> clusterManagerMock = mockStatic(ClusterManager.class)) {
             // Clustering not available so the clustering gates pass and we reach the persistability gate
             clusterManagerMock.when(ClusterManager::isClusteringAvailable).thenReturn(false);
@@ -620,7 +620,7 @@ public class BlowfishMigrationServletTest {
      * re-encrypt data (OF-3305).
      */
     @Test
-    public void should_throwWithSecurityXmlMessage_when_migratingWhileNotPersistable() {
+    public void testMigrateXmlProperties_SecurityXmlNotPersistable_Throws() {
         // Precondition: security.xml is not persistable in the test environment
         assertFalse(JiveGlobals.isSecurityPropertiesPersistable(),
                 "Test precondition: security.xml should not be persistable in the test environment");

--- a/xmppserver/src/test/java/org/jivesoftware/util/XMLPropertiesTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/XMLPropertiesTest.java
@@ -579,7 +579,7 @@ public class XMLPropertiesTest {
      * security.xml before re-encrypting any data.
      */
     @Test
-    public void should_returnFalseFromIsPersistable_when_instanceIsNotFileBacked() throws Exception {
+    public void testIsPersistable_NotFileBacked() throws Exception {
         XMLProperties props = XMLProperties.getNonPersistedInstance();
 
         assertFalse(props.isPersistable(),
@@ -590,7 +590,7 @@ public class XMLPropertiesTest {
      * A file-backed instance can save changes and must report that it is persistable.
      */
     @Test
-    public void should_returnTrueFromIsPersistable_when_instanceIsFileBacked(@TempDir Path tempDir) throws Exception {
+    public void testIsPersistable_FileBacked(@TempDir Path tempDir) throws Exception {
         Path file = tempDir.resolve("security.xml");
         Files.writeString(file, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<security/>\n", StandardCharsets.UTF_8);
 

--- a/xmppserver/src/test/java/org/jivesoftware/util/XMLPropertiesTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/XMLPropertiesTest.java
@@ -20,9 +20,12 @@ import org.dom4j.Document;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Objects;
@@ -568,5 +571,32 @@ public class XMLPropertiesTest {
                 System.clearProperty("openfire.xmlproperties.encryption.autoupgrade");
             }
         }
+    }
+
+    /**
+     * A stream-backed (non-persisted) instance is not backed by a file, so it cannot save changes.
+     * The Blowfish SHA1-to-PBKDF2 migration guard (OF-3305) relies on this to detect an unwritable
+     * security.xml before re-encrypting any data.
+     */
+    @Test
+    public void should_returnFalseFromIsPersistable_when_instanceIsNotFileBacked() throws Exception {
+        XMLProperties props = XMLProperties.getNonPersistedInstance();
+
+        assertFalse(props.isPersistable(),
+                "A non-persisted (stream-backed) instance must report that it cannot be persisted");
+    }
+
+    /**
+     * A file-backed instance can save changes and must report that it is persistable.
+     */
+    @Test
+    public void should_returnTrueFromIsPersistable_when_instanceIsFileBacked(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("security.xml");
+        Files.writeString(file, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<security/>\n", StandardCharsets.UTF_8);
+
+        XMLProperties props = new XMLProperties(file);
+
+        assertTrue(props.isPersistable(),
+                "A file-backed instance must report that it can be persisted");
     }
 }


### PR DESCRIPTION
## Problem

The Blowfish SHA1 to PBKDF2 migration (OF-3075) re-encrypts the database properties
with a PBKDF2 key derived from a freshly generated salt, and stores that salt and the
`kdf=pbkdf2` flag in `conf/security.xml`.

When `conf/security.xml` cannot be loaded or written (it is missing, empty, corrupt,
or not writable), `JiveGlobals` falls back to a non-persisting, in-memory-only
`XMLProperties` instance. In that state:

- `getBlowfishSalt()` generates a salt and calls `setProperty()`, which cannot save
  (`IllegalStateException: No file specified`). The error is logged and the boolean
  result is ignored.
- The migration re-encrypts and commits the database properties regardless.
- `setBlowfishKdf()` likewise fails to persist, and the tool reports success.

After a restart, `security.xml` is still unusable, so the server defaults to the
`sha1` KDF with no salt and can no longer decrypt the PBKDF2-encrypted values. Among
those values are the certificate-store passwords (`*.keypass` / `*.trustpass`), which
Openfire stores as encrypted database properties. With them unreadable, the keystores
fail to load (`UnrecoverableKeyException: Password verification failed`), including the
`WEBADMIN` store used by the admin console, so the admin console cannot start its HTTPS
listener. On a server that reaches the admin console over HTTPS, this locks the
administrator out (in the original report there was no admin listener on either port,
and the server logged "admin console not started due to configuration settings"). The
randomly generated salt is unrecoverable, so the re-encrypted data can be recovered
only from a pre-migration database backup.

See OF-3305, ADR-004, ADR-005.

Follow-up to #3067 (OF-3075), which added this migration. Reported on the forums: https://discourse.igniterealtime.org/t/admin-gui-not-starting-after-migration-to-pbkdf2/96500

## Fix

Fail fast, before any irreversible change, if the security configuration cannot be
persisted:

- Add `XMLProperties.isPersistable()` (true only when backed by a file).
- Add `JiveGlobals.isSecurityPropertiesPersistable()`.
- `JiveGlobals.migrateXMLPropertiesFromSHA1ToPBKDF2()` throws `IllegalStateException`
  if security properties are not persistable, before deriving any key or touching the
  database. The servlet runs this before any database work and reports that no
  database changes were made.
- `BlowfishMigrationServlet.doPost()` adds a pre-flight check (after the CSRF, backup,
  and clustering gates) that blocks migration and shows a clear admin message
  (`security.blowfish.migration.error.security-xml-not-writable`).
- Correct the load-failure log message in `JiveGlobals.loadSecurityProperties()` to
  name `security.xml` rather than `openfire.xml`.

The check runs at the very start of the migration, before any key derivation or
database write, so an unwritable `security.xml` is reported to the administrator as a
clear, actionable error and the database is never modified.

## Testing

- `XMLPropertiesTest`: `isPersistable()` returns false for a non-persisted instance and
  true for a file-backed one.
- `BlowfishMigrationServletTest`: the migration throws with a `security.xml` message
  when not persistable; `doPost()` sets the new error key and redirects without
  attempting migration. Existing migration and clustering tests pass.
- Full `xmppserver` suite green via `mvn clean verify`: 1911 tests, 0 failures, 0 errors.


