### PR TITLE
OF-3306, OF-3307, OF-3309, OF-3310: Fix PubSub subscription uniqueness semantics

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -659,6 +659,7 @@ index.update.info=Server version {0} is now available. Click {1}here{2} to downl
         {3}change log{4} for more information.
 index.plugin.load-warning=One or more plugins failed to load. Please click {0}here{1} to review the status of all installed plugins.
 index.blowfish-migration.warning=<strong>Security Notice:</strong> Your server is using legacy SHA1 key derivation for encrypted properties. {0}Migrate to PBKDF2{1} for improved security.
+index.pubsub-subscription-maintenance.warning=Redundant publish-subscribe subscription data was found in the database, which can increase memory use. {0}Review and clean up the subscription data{1}.
 index.cs_blog=Ignite Realtime News
 index.cs_blog.unavailable=The Ignite Realtime feed is currently unavailable.
 
@@ -3003,7 +3004,6 @@ pubsub.service.summary.title=PubSub Service Configuration
 pubsub.service.summary.updated=Service configuration updated successfully
 pubsub.service.summary.info=Use the form below to update service settings.
 
-
 pubsub.service.form.serviceEnabled=Service Enabled
 
 pubsub.service.form.multipleSubscriptionsEnabled=Multiple Subscriptions Enabled
@@ -3029,6 +3029,36 @@ pubsub.form.not_valid="{0}" is not a valid {1}.
 pubsub.form.already_in_list={0} "{1}" already in list.
 pubsub.form.action=Action
 
+# Pub Sub Subscription Maintenance page
+
+pubsub.subscription.maintenance.title=PubSub Subscription Maintenance
+pubsub.subscription.maintenance.info=Some installations accumulate redundant rows in the pubsub subscription table: multiple stored subscriptions that are identical apart from an internally generated identifier. These serve no purpose, consume memory, and in extreme cases can exhaust the server's memory when loaded. This page reports how many such rows exist and lets you remove them.
+pubsub.subscription.maintenance.analysis-failed=The subscription data could not be analyzed: {0}
+pubsub.subscription.maintenance.status.title=Subscription Data
+pubsub.subscription.maintenance.status.total-rows=Total stored subscription rows
+pubsub.subscription.maintenance.status.distinct=Distinct subscriptions (rows kept after cleanup)
+pubsub.subscription.maintenance.status.removable=Redundant rows (would be removed)
+pubsub.subscription.maintenance.status.protected-services=Protected services (excluded from cleanup)
+pubsub.subscription.maintenance.warning.title=Warning
+pubsub.subscription.maintenance.warning.irreversible=Removing redundant rows cannot be undone. Make sure you understand the effect before continuing.
+pubsub.subscription.maintenance.warning.backup=Take a full database backup before starting.
+pubsub.subscription.maintenance.warning.quiescent=Run this when the server is not under heavy load. Performing the cleanup while subscriptions are actively being created or cancelled is not recommended.
+pubsub.subscription.maintenance.warning.cluster=This server is part of a cluster. Run the cleanup on a single active node only.
+pubsub.subscription.maintenance.checklist.title=Before you continue
+pubsub.subscription.maintenance.checklist.db-backup=I have taken a full backup of the database.
+pubsub.subscription.maintenance.button.cleanup=Remove redundant rows
+pubsub.subscription.maintenance.confirm=This will permanently delete redundant subscription rows from the database. Continue?
+pubsub.subscription.maintenance.nothing-to-do=No redundant subscription rows were found. No cleanup is needed.
+pubsub.subscription.maintenance.progress.title=Cleanup in progress
+pubsub.subscription.maintenance.progress.detail=Removed {0} of {1} redundant rows.
+pubsub.subscription.maintenance.progress.completed=Cleanup finished. Removed {0} redundant row(s).
+pubsub.subscription.maintenance.progress.failed=The cleanup did not finish successfully. Check the server logs for details. Any rows already removed have been deleted; the operation can be safely run again.
+pubsub.subscription.maintenance.started=The cleanup has started. Progress is shown below.
+pubsub.subscription.maintenance.already-running=A cleanup is already running. Progress is shown below.
+pubsub.subscription.maintenance.error.csrf=Your session could not be verified. Please reload the page and try again.
+pubsub.subscription.maintenance.error.backup-required=You must confirm that a database backup has been taken before starting the cleanup.
+pubsub.subscription.maintenance.error.cluster-enabled-not-started=Clustering is enabled but has not finished starting. Wait until clustering is fully started, or run the cleanup with clustering disabled, to avoid conflicts between nodes.
+pubsub.subscription.maintenance.error.multi-node-active=The cleanup cannot run while {0} cluster nodes are active. Stop all but one node first.
 
 # Plugins Admin Page
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -633,6 +633,7 @@ index.available_users_sessions=Beschikbare Gebruiker Sessies
 index.update.alert=Update information
 index.update.info=Openfire {0} is nu niet beschikbaar. Voor meer informatie, klik {1}hier{2} om de {3}change log{4} te downloaden of in te zien.
 index.plugin.load-warning=Een of meerdere plugins kunnen niet geladen worden. Klik {0}hier{1} om de status van de geïnstalleerde plugins te zien.
+index.pubsub-subscription-maintenance.warning=Er zijn overbodige publish-subscribe-abonnementsgegevens in de database aangetroffen, die het geheugengebruik kunnen verhogen. {0}Bekijk en schoon de abonnementsgegevens op{1}.
 index.cs_blog=Ignite Realtime Nieuws
 index.cs_blog.unavailable=De feed van Ignite Realtime is momenteel niet beschikbaar.
 
@@ -2692,6 +2693,36 @@ pubsub.form.not_valid="{0}" is geen valide {1}.
 pubsub.form.already_in_list={0} "{1}" staat al op lijst.
 pubsub.form.action=Actie
 
+# Pub Sub Subscription Maintenance page
+
+pubsub.subscription.maintenance.title=Onderhoud PubSub-abonnementen
+pubsub.subscription.maintenance.info=Bij sommige installaties verzamelen zich overbodige rijen in de tabel met pubsub-abonnementen: meerdere opgeslagen abonnementen die identiek zijn, op een intern gegenereerde identificatie na. Deze dienen geen doel, gebruiken geheugen en kunnen in extreme gevallen het geheugen van de server uitputten wanneer ze worden geladen. Deze pagina laat zien hoeveel van zulke rijen er zijn en stelt u in staat ze te verwijderen.
+pubsub.subscription.maintenance.analysis-failed=De abonnementsgegevens konden niet worden geanalyseerd: {0}
+pubsub.subscription.maintenance.status.title=Abonnementsgegevens
+pubsub.subscription.maintenance.status.total-rows=Totaal aantal opgeslagen abonnementsrijen
+pubsub.subscription.maintenance.status.distinct=Unieke abonnementen (rijen die behouden blijven na opschonen)
+pubsub.subscription.maintenance.status.removable=Overbodige rijen (worden verwijderd)
+pubsub.subscription.maintenance.status.protected-services=Beschermde services (uitgesloten van opschonen)
+pubsub.subscription.maintenance.warning.title=Waarschuwing
+pubsub.subscription.maintenance.warning.irreversible=Het verwijderen van overbodige rijen kan niet ongedaan worden gemaakt. Zorg dat u het effect begrijpt voordat u doorgaat.
+pubsub.subscription.maintenance.warning.backup=Maak een volledige back-up van de database voordat u begint.
+pubsub.subscription.maintenance.warning.quiescent=Voer dit uit wanneer de server niet zwaar wordt belast. Het opschonen uitvoeren terwijl er actief abonnementen worden aangemaakt of opgezegd, wordt afgeraden.
+pubsub.subscription.maintenance.warning.cluster=Deze server maakt deel uit van een cluster. Voer het opschonen uit op slechts één actieve node.
+pubsub.subscription.maintenance.checklist.title=Voordat u doorgaat
+pubsub.subscription.maintenance.checklist.db-backup=Ik heb een volledige back-up van de database gemaakt.
+pubsub.subscription.maintenance.button.cleanup=Overbodige rijen verwijderen
+pubsub.subscription.maintenance.confirm=Hiermee worden overbodige abonnementsrijen definitief uit de database verwijderd. Doorgaan?
+pubsub.subscription.maintenance.nothing-to-do=Er zijn geen overbodige abonnementsrijen gevonden. Opschonen is niet nodig.
+pubsub.subscription.maintenance.progress.title=Bezig met opschonen
+pubsub.subscription.maintenance.progress.detail={0} van {1} overbodige rijen verwijderd.
+pubsub.subscription.maintenance.progress.completed=Opschonen voltooid. {0} overbodige rij(en) verwijderd.
+pubsub.subscription.maintenance.progress.failed=Het opschonen is niet succesvol voltooid. Raadpleeg de serverlogboeken voor details. Reeds verwijderde rijen zijn verwijderd; de bewerking kan veilig opnieuw worden uitgevoerd.
+pubsub.subscription.maintenance.started=Het opschonen is gestart. De voortgang wordt hieronder weergegeven.
+pubsub.subscription.maintenance.already-running=Er wordt al een opschoonbewerking uitgevoerd. De voortgang wordt hieronder weergegeven.
+pubsub.subscription.maintenance.error.csrf=Uw sessie kon niet worden geverifieerd. Herlaad de pagina en probeer het opnieuw.
+pubsub.subscription.maintenance.error.backup-required=U moet bevestigen dat er een back-up van de database is gemaakt voordat u het opschonen start.
+pubsub.subscription.maintenance.error.cluster-enabled-not-started=Clustering is ingeschakeld maar nog niet volledig gestart. Wacht tot clustering volledig is gestart, of voer het opschonen uit met clustering uitgeschakeld, om conflicten tussen nodes te voorkomen.
+pubsub.subscription.maintenance.error.multi-node-active=Het opschonen kan niet worden uitgevoerd terwijl er {0} clusternodes actief zijn. Stop eerst alle nodes op één na.
 
 # Plugins Admin Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/PubSubSubscriptionMaintenanceServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/PubSubSubscriptionMaintenanceServlet.java
@@ -189,8 +189,8 @@ public class PubSubSubscriptionMaintenanceServlet extends HttpServlet {
             // Launch the background cleanup. startCleanup() returns immediately; the page polls for progress.
             final PubSubSubscriptionMaintenance m = PubSubSubscriptionMaintenance.getInstance();
             if (m == null) {
-                request.setAttribute("analysisAvailable", false);
-                request.setAttribute("analysisError", "The pubsub service is not running.");
+                request.getSession().setAttribute("analysisAvailable", false);
+                request.getSession().setAttribute("analysisError", "The pubsub service is not running.");
             } else {
                 final boolean started = m.startCleanup();
                 if (started) {

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/PubSubSubscriptionMaintenanceServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/PubSubSubscriptionMaintenanceServlet.java
@@ -23,6 +23,7 @@ import org.jivesoftware.openfire.pubsub.PubSubSubscriptionMaintenance;
 import org.jivesoftware.util.CookieUtils;
 import org.jivesoftware.util.StringUtils;
 import org.jivesoftware.util.WebManager;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -353,44 +354,13 @@ public class PubSubSubscriptionMaintenanceServlet extends HttpServlet {
         response.setContentType("application/json; charset=UTF-8");
         response.setHeader("Cache-Control", "no-store");
 
-        final String error = progress.getError();
-        final StringBuilder json = new StringBuilder();
-        json.append('{')
-            .append("\"phase\":\"").append(progress.getPhase().name()).append("\",")
-            .append("\"percent\":").append(progress.getPercentComplete()).append(',')
-            .append("\"removed\":").append(progress.getRemoved()).append(',')
-            .append("\"total\":").append(progress.getTotalToRemove()).append(',')
-            .append("\"error\":").append(error == null ? "null" : ('"' + jsonEscape(error) + '"'))
-            .append('}');
-        response.getWriter().write(json.toString());
-    }
+        final JSONObject json = new JSONObject();
+        json.put("phase", progress.getPhase().name());
+        json.put("percent", progress.getPercentComplete());
+        json.put("removed", progress.getRemoved());
+        json.put("total", progress.getTotalToRemove());
+        json.put("error", progress.getError());
 
-    /**
-     * Minimal JSON string escaping for the error message: escapes backslash, double-quote and control characters so the
-     * progress JSON remains well-formed regardless of the message content.
-     *
-     * @param value the raw string.
-     * @return the escaped string (without surrounding quotes).
-     */
-    private static String jsonEscape(String value) {
-        final StringBuilder sb = new StringBuilder(value.length() + 16);
-        for (int i = 0; i < value.length(); i++) {
-            final char c = value.charAt(i);
-            switch (c) {
-                case '"'  -> sb.append("\\\"");
-                case '\\' -> sb.append("\\\\");
-                case '\n' -> sb.append("\\n");
-                case '\r' -> sb.append("\\r");
-                case '\t' -> sb.append("\\t");
-                default -> {
-                    if (c < 0x20) {
-                        sb.append(String.format("\\u%04x", (int) c));
-                    } else {
-                        sb.append(c);
-                    }
-                }
-            }
-        }
-        return sb.toString();
+        response.getWriter().write(json.toString());
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/PubSubSubscriptionMaintenanceServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/PubSubSubscriptionMaintenanceServlet.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.admin.servlet;
+
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.cluster.ClusterManager;
+import org.jivesoftware.openfire.pubsub.PubSubModule;
+import org.jivesoftware.openfire.pubsub.PubSubSubscriptionMaintenance;
+import org.jivesoftware.util.CookieUtils;
+import org.jivesoftware.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Servlet for cleaning up redundant rows in the {@code ofPubsubSubscription} table.
+ *
+ * Some installations have accumulated very large numbers of redundant subscription rows (rows that share the same node,
+ * subscription JID, owner and subscription type, differing only by their generated subscription ID). On services that
+ * do not permit multiple subscriptions for the same subscription JID - most notably PEP services - such rows carry no
+ * functional value and, in extreme cases, exhaust the Java heap when loaded into memory (OF-3306).
+ *
+ * This servlet provides an admin-console UI to analyze the extent of the redundancy and to launch a cleanup. The
+ * cleanup runs on a background thread (it may delete millions of rows over several minutes); the page polls a small
+ * JSON progress endpoint to render a live progress bar.
+ *
+ * The structure deliberately follows {@link BlowfishMigrationServlet}: a servlet bound to one URL forwards to a
+ * separate view JSP (a different filename, to avoid a forward loop), CSRF is carried in a cookie and validated on POST,
+ * a destructive action is gated behind explicit backup confirmation, the operation is blocked in unsafe clustering
+ * states, and POST-Redirect-GET is used with messages parked in the session.
+ *
+ * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3306">OF-3306</a>
+ */
+@WebServlet(value = "/pubsub-subscription-maintenance.jsp")
+public class PubSubSubscriptionMaintenanceServlet extends HttpServlet {
+
+    /**
+     * Logger for this class.
+     */
+    private static final Logger Log = LoggerFactory.getLogger(PubSubSubscriptionMaintenanceServlet.class);
+
+    /**
+     * Request parameter naming the action to perform.
+     */
+    private static final String PARAM_ACTION = "action";
+
+    /**
+     * Request parameter for the database-backup confirmation checkbox.
+     */
+    private static final String PARAM_DB_BACKUP = "dbBackup";
+
+    /**
+     * Action value: start a cleanup.
+     */
+    private static final String ACTION_CLEANUP = "cleanup";
+
+    /**
+     * Action value: return the current progress as JSON (polled by the page).
+     */
+    private static final String ACTION_PROGRESS = "progress";
+
+    /**
+     * The maintenance instance, held statically so that a running cleanup and its progress survive page reloads for the
+     * lifetime of the JVM. A one-shot maintenance job needs no longer lifetime than this.
+     *
+     * Guarded by {@link #maintenanceLock} for creation; the instance's own progress state is thread-safe.
+     */
+    private static volatile PubSubSubscriptionMaintenance maintenance;
+
+    /**
+     * Lock guarding lazy creation of {@link #maintenance}.
+     */
+    private static final Object maintenanceLock = new Object();
+
+    /**
+     * Cached answer to "is a cleanup worth recommending?", read by the index page. Updated only by a background
+     * refresh (never on the calling thread), so reading it is always O(1) and never touches the database.
+     */
+    private static final AtomicBoolean cleanupAdvisableCache = new AtomicBoolean(false);
+
+    /**
+     * Epoch-millis timestamp of the last completed background refresh of {@link #cleanupAdvisableCache}, or 0 if it has
+     * never run. Used to decide when the cache is stale.
+     */
+    private static final AtomicLong cleanupAdvisableCheckedAt = new AtomicLong(0L);
+
+    /**
+     * Guards against launching more than one background refresh at a time.
+     */
+    private static final AtomicBoolean cleanupAdvisableRefreshing = new AtomicBoolean(false);
+
+    /**
+     * How long a cached advisability result is considered fresh. After this, the next read triggers a background
+     * refresh (but still returns the cached value immediately).
+     */
+    private static final long CLEANUP_ADVISABLE_TTL_MILLIS = Duration.ofHours(1).toMillis();
+
+    /**
+     * Returns whether a cleanup is worth recommending, for display as an advisory on the admin index page.
+     *
+     * This is deliberately non-blocking and never queries the database on the calling thread: it returns the most
+     * recently cached result immediately. If that result is missing or stale, it schedules a one-off background refresh
+     * (a full {@link PubSubSubscriptionMaintenance#analyze()} can take many seconds on a very large table, which must
+     * never delay rendering of the index page). Consequently the first index view after startup returns {@code false}
+     * (no alert) and the alert may only appear on a later view, once the background check has completed - the same
+     * best-effort, page-load-friendly approach the index page uses for its DNS warning.
+     *
+     * @return the cached advisability flag; {@code false} until the first background check has completed.
+     */
+    public static boolean isCleanupAdvisable() {
+        final PubSubSubscriptionMaintenance m = maintenance;
+        // While a cleanup is actively running, the row count is changing under us. Do not analyze (it would compete
+        // with the delete and could report a misleading interim value); just return the current cached value. Once the
+        // run finishes, the cache is marked stale below so the next read re-evaluates promptly.
+        if (m != null && m.getProgress().getPhase() == PubSubSubscriptionMaintenance.Phase.RUNNING) {
+            cleanupAdvisableCheckedAt.set(0L); // ensure a refresh happens right after the run completes
+            return cleanupAdvisableCache.get();
+        }
+
+        final long checkedAt = cleanupAdvisableCheckedAt.get();
+        final boolean stale = checkedAt == 0L || (System.currentTimeMillis() - checkedAt) > CLEANUP_ADVISABLE_TTL_MILLIS;
+        if (stale && cleanupAdvisableRefreshing.compareAndSet(false, true)) {
+            final Thread refresh = new Thread(() -> {
+                try {
+                    final PubSubSubscriptionMaintenance.Analysis analysis = getMaintenance().analyze();
+                    cleanupAdvisableCache.set(analysis.isCleanupRecommended());
+                } catch (Exception e) {
+                    // On failure, leave the previous cached value in place and log; the next read will retry.
+                    Log.debug("Background check for redundant pubsub subscription rows failed; will retry later.", e);
+                } finally {
+                    cleanupAdvisableCheckedAt.set(System.currentTimeMillis());
+                    cleanupAdvisableRefreshing.set(false);
+                }
+            }, "pubsub-subscription-cleanup-advisability-check");
+            refresh.setDaemon(true);
+            refresh.start();
+        }
+        return cleanupAdvisableCache.get();
+    }
+
+    /**
+     * Returns the shared maintenance instance, creating it on first use with the current set of multiple-subscription
+     * services excluded.
+     *
+     * The exclusion set is computed here, in trusted server-side code that can inspect the live services, rather than
+     * in the maintenance class (which only sees the database). See {@link #collectMultipleSubscriptionServiceIds()}.
+     *
+     * @return the shared maintenance instance.
+     */
+    private static PubSubSubscriptionMaintenance getMaintenance() {
+        PubSubSubscriptionMaintenance result = maintenance;
+        if (result == null) {
+            synchronized (maintenanceLock) {
+                result = maintenance;
+                if (result == null) {
+                    result = new PubSubSubscriptionMaintenance(collectMultipleSubscriptionServiceIds());
+                    maintenance = result;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Determines the IDs of pubsub services that permit multiple subscriptions for the same subscription JID, and whose
+     * rows must therefore never be treated as redundant by the cleanup.
+     *
+     * Whether multiple subscriptions are permitted is a service-wide setting. PEP services always return false, so they
+     * are never excluded (and are the dominant source of the redundancy this cleanup targets). The main pubsub service
+     * is governed by the {@code xmpp.pubsub.multiple-subscriptions} property; when it permits multiple subscriptions,
+     * its service ID is excluded.
+     *
+     * Note: this intentionally errs toward excluding (protecting) a service when in doubt. If additional pubsub
+     * services that permit multiple subscriptions are introduced, add their IDs here so their data is protected.
+     *
+     * @return the set of service IDs to exclude from cleanup; never null, possibly empty.
+     */
+    private static Set<String> collectMultipleSubscriptionServiceIds() {
+        final Set<String> excluded = new LinkedHashSet<>();
+        try {
+            final PubSubModule pubSubModule = XMPPServer.getInstance().getPubSubModule();
+            if (pubSubModule != null && pubSubModule.isMultipleSubscriptionsEnabled()) {
+                excluded.add(pubSubModule.getServiceID());
+            }
+        } catch (Exception e) {
+            // The main pubsub service is a singleton that is normally available whenever the admin console is running,
+            // so this is not expected. If it cannot be inspected, its ID is not added, which means its rows would be
+            // treated as eligible for cleanup; log loudly so an operator can verify before proceeding.
+            Log.warn("Unable to determine whether the main pubsub service permits multiple subscriptions; its rows " +
+                "will be treated as eligible for cleanup. Verify this is correct for this deployment before proceeding.", e);
+        }
+        return excluded;
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+
+        // The progress endpoint returns JSON for the page's polling; it is not a normal page view.
+        if (ACTION_PROGRESS.equals(request.getParameter(PARAM_ACTION))) {
+            writeProgressJson(response);
+            return;
+        }
+
+        final PubSubSubscriptionMaintenance m = getMaintenance();
+
+        // Read-only analysis for the status table. This can take a few seconds on a very large table, but does not
+        // modify data. Failures are surfaced to the page rather than thrown.
+        try {
+            final PubSubSubscriptionMaintenance.Analysis analysis = m.analyze();
+            request.setAttribute("totalRows", analysis.getTotalRows());
+            request.setAttribute("distinctSubscriptions", analysis.getDistinctSubscriptions());
+            request.setAttribute("removableRows", analysis.getRemovableRows());
+            request.setAttribute("cleanupRecommended", analysis.isCleanupRecommended());
+            request.setAttribute("redundancyPercent", Math.round(analysis.getRedundancyRatio() * 100));
+            request.setAttribute("analysisAvailable", true);
+        } catch (Exception e) {
+            Log.error("Unable to analyze redundant pubsub subscription rows.", e);
+            request.setAttribute("analysisAvailable", false);
+            request.setAttribute("analysisError", e.getMessage());
+        }
+
+        // Current run state, so the page can show a progress bar if a cleanup is already running (e.g. after a reload).
+        final PubSubSubscriptionMaintenance.Progress progress = m.getProgress();
+        request.setAttribute("progressPhase", progress.getPhase().name());
+        request.setAttribute("progressPercent", progress.getPercentComplete());
+        request.setAttribute("progressRemoved", progress.getRemoved());
+        request.setAttribute("excludedServiceCount", m.getExcludedServiceIds().size());
+
+        // A just-started flag survives the POST-Redirect-GET via the session; consume it here so the page begins
+        // polling even during the brief window before the background job reports RUNNING.
+        final Object justStarted = request.getSession().getAttribute("justStarted");
+        if (justStarted != null) {
+            request.getSession().removeAttribute("justStarted");
+        }
+        request.setAttribute("justStarted", Boolean.TRUE.equals(justStarted));
+
+        // Clustering status (mirrors the Blowfish servlet's approach).
+        final boolean clusteringAvailable = ClusterManager.isClusteringAvailable();
+        final boolean clusteringEnabled = ClusterManager.isClusteringEnabled();
+        final boolean clusteringStarted = ClusterManager.isClusteringStarted();
+        final int clusterNodeCount = clusteringStarted ? ClusterManager.getNodesInfo().size() : 0;
+        request.setAttribute("clusteringAvailable", clusteringAvailable);
+        request.setAttribute("clusteringEnabled", clusteringEnabled);
+        request.setAttribute("clusteringStarted", clusteringStarted);
+        request.setAttribute("clusterNodeCount", clusterNodeCount);
+
+        // CSRF token.
+        final String csrf = StringUtils.randomString(16);
+        CookieUtils.setCookie(request, response, "csrf", csrf, -1);
+        request.setAttribute("csrf", csrf);
+
+        request.getRequestDispatcher("pubsub-subscription-maintenance-page.jsp")
+                .forward(request, response);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+
+        // Validate CSRF token.
+        final String submittedCsrf = request.getParameter("csrf");
+        final Cookie csrfCookie = CookieUtils.getCookie(request, "csrf");
+        final String cookieCsrf = csrfCookie != null ? csrfCookie.getValue() : null;
+        if (submittedCsrf == null || cookieCsrf == null || !submittedCsrf.equals(cookieCsrf)) {
+            request.getSession().setAttribute("errorMessage", "pubsub.subscription.maintenance.error.csrf");
+            response.sendRedirect("pubsub-subscription-maintenance.jsp");
+            return;
+        }
+
+        if (ACTION_CLEANUP.equals(request.getParameter(PARAM_ACTION))) {
+            // Require explicit backup confirmation, as the cleanup deletes rows irreversibly.
+            final boolean dbBackup = "true".equals(request.getParameter(PARAM_DB_BACKUP));
+            if (!dbBackup) {
+                request.getSession().setAttribute("errorMessage", "pubsub.subscription.maintenance.error.backup-required");
+                response.sendRedirect("pubsub-subscription-maintenance.jsp");
+                return;
+            }
+
+            // Block in unsafe clustering states: a bulk delete racing across nodes risks deleting rows another node is
+            // concurrently relying on or recreating.
+            final boolean clusteringEnabled = ClusterManager.isClusteringEnabled();
+            final boolean clusteringStarted = ClusterManager.isClusteringStarted();
+            final int clusterNodeCount = clusteringStarted ? ClusterManager.getNodesInfo().size() : 0;
+            if (clusteringEnabled && !clusteringStarted) {
+                request.getSession().setAttribute("errorMessage", "pubsub.subscription.maintenance.error.cluster-enabled-not-started");
+                response.sendRedirect("pubsub-subscription-maintenance.jsp");
+                return;
+            }
+            if (clusterNodeCount > 1) {
+                request.getSession().setAttribute("errorMessage", "pubsub.subscription.maintenance.error.multi-node-active");
+                request.getSession().setAttribute("errorParam", String.valueOf(clusterNodeCount));
+                response.sendRedirect("pubsub-subscription-maintenance.jsp");
+                return;
+            }
+
+            // Launch the background cleanup. startCleanup() returns immediately; the page polls for progress.
+            final boolean started = getMaintenance().startCleanup();
+            if (started) {
+                request.getSession().setAttribute("successMessage", "pubsub.subscription.maintenance.started");
+                request.getSession().setAttribute("justStarted", Boolean.TRUE);
+            } else {
+                // A cleanup was already running; not an error, just informational.
+                request.getSession().setAttribute("successMessage", "pubsub.subscription.maintenance.already-running");
+                request.getSession().setAttribute("justStarted", Boolean.TRUE);
+            }
+        }
+
+        response.sendRedirect("pubsub-subscription-maintenance.jsp");
+    }
+
+    /**
+     * Writes the current cleanup progress as a small JSON object for the page's AJAX polling.
+     *
+     * The JSON shape is {@code {"phase":"RUNNING","percent":42,"removed":1234567,"error":null}}. The values come from
+     * the thread-safe {@link PubSubSubscriptionMaintenance.Progress} snapshot, so no locking is needed here.
+     *
+     * @param response the response to write JSON to.
+     * @throws IOException if writing fails.
+     */
+    private void writeProgressJson(HttpServletResponse response) throws IOException {
+        final PubSubSubscriptionMaintenance.Progress progress = getMaintenance().getProgress();
+        response.setContentType("application/json; charset=UTF-8");
+        response.setHeader("Cache-Control", "no-store");
+
+        final String error = progress.getError();
+        final StringBuilder json = new StringBuilder();
+        json.append('{')
+            .append("\"phase\":\"").append(progress.getPhase().name()).append("\",")
+            .append("\"percent\":").append(progress.getPercentComplete()).append(',')
+            .append("\"removed\":").append(progress.getRemoved()).append(',')
+            .append("\"total\":").append(progress.getTotalToRemove()).append(',')
+            .append("\"error\":").append(error == null ? "null" : ('"' + jsonEscape(error) + '"'))
+            .append('}');
+        response.getWriter().write(json.toString());
+    }
+
+    /**
+     * Minimal JSON string escaping for the error message: escapes backslash, double-quote and control characters so the
+     * progress JSON remains well-formed regardless of the message content.
+     *
+     * @param value the raw string.
+     * @return the escaped string (without surrounding quotes).
+     */
+    private static String jsonEscape(String value) {
+        final StringBuilder sb = new StringBuilder(value.length() + 16);
+        for (int i = 0; i < value.length(); i++) {
+            final char c = value.charAt(i);
+            switch (c) {
+                case '"'  -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/PubSubSubscriptionMaintenanceServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/PubSubSubscriptionMaintenanceServlet.java
@@ -22,6 +22,7 @@ import org.jivesoftware.openfire.pubsub.PubSubModule;
 import org.jivesoftware.openfire.pubsub.PubSubSubscriptionMaintenance;
 import org.jivesoftware.util.CookieUtils;
 import org.jivesoftware.util.StringUtils;
+import org.jivesoftware.util.WebManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -325,6 +326,9 @@ public class PubSubSubscriptionMaintenanceServlet extends HttpServlet {
             if (started) {
                 request.getSession().setAttribute("successMessage", "pubsub.subscription.maintenance.started");
                 request.getSession().setAttribute("justStarted", Boolean.TRUE);
+                final WebManager webManager = new WebManager();
+                webManager.init(request, response, request.getSession(), request.getServletContext());
+                webManager.logEvent("Started pub/sub subscription cleanup", null);
             } else {
                 // A cleanup was already running; not an error, just informational.
                 request.getSession().setAttribute("successMessage", "pubsub.subscription.maintenance.already-running");

--- a/xmppserver/src/main/java/org/jivesoftware/admin/servlet/PubSubSubscriptionMaintenanceServlet.java
+++ b/xmppserver/src/main/java/org/jivesoftware/admin/servlet/PubSubSubscriptionMaintenanceServlet.java
@@ -16,9 +16,7 @@
 
 package org.jivesoftware.admin.servlet;
 
-import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.cluster.ClusterManager;
-import org.jivesoftware.openfire.pubsub.PubSubModule;
 import org.jivesoftware.openfire.pubsub.PubSubSubscriptionMaintenance;
 import org.jivesoftware.util.CookieUtils;
 import org.jivesoftware.util.StringUtils;
@@ -34,11 +32,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.Duration;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Servlet for cleaning up redundant rows in the {@code ofPubsubSubscription} table.
@@ -87,139 +80,6 @@ public class PubSubSubscriptionMaintenanceServlet extends HttpServlet {
      */
     private static final String ACTION_PROGRESS = "progress";
 
-    /**
-     * The maintenance instance, held statically so that a running cleanup and its progress survive page reloads for the
-     * lifetime of the JVM. A one-shot maintenance job needs no longer lifetime than this.
-     *
-     * Guarded by {@link #maintenanceLock} for creation; the instance's own progress state is thread-safe.
-     */
-    private static volatile PubSubSubscriptionMaintenance maintenance;
-
-    /**
-     * Lock guarding lazy creation of {@link #maintenance}.
-     */
-    private static final Object maintenanceLock = new Object();
-
-    /**
-     * Cached answer to "is a cleanup worth recommending?", read by the index page. Updated only by a background
-     * refresh (never on the calling thread), so reading it is always O(1) and never touches the database.
-     */
-    private static final AtomicBoolean cleanupAdvisableCache = new AtomicBoolean(false);
-
-    /**
-     * Epoch-millis timestamp of the last completed background refresh of {@link #cleanupAdvisableCache}, or 0 if it has
-     * never run. Used to decide when the cache is stale.
-     */
-    private static final AtomicLong cleanupAdvisableCheckedAt = new AtomicLong(0L);
-
-    /**
-     * Guards against launching more than one background refresh at a time.
-     */
-    private static final AtomicBoolean cleanupAdvisableRefreshing = new AtomicBoolean(false);
-
-    /**
-     * How long a cached advisability result is considered fresh. After this, the next read triggers a background
-     * refresh (but still returns the cached value immediately).
-     */
-    private static final long CLEANUP_ADVISABLE_TTL_MILLIS = Duration.ofHours(1).toMillis();
-
-    /**
-     * Returns whether a cleanup is worth recommending, for display as an advisory on the admin index page.
-     *
-     * This is deliberately non-blocking and never queries the database on the calling thread: it returns the most
-     * recently cached result immediately. If that result is missing or stale, it schedules a one-off background refresh
-     * (a full {@link PubSubSubscriptionMaintenance#analyze()} can take many seconds on a very large table, which must
-     * never delay rendering of the index page). Consequently the first index view after startup returns {@code false}
-     * (no alert) and the alert may only appear on a later view, once the background check has completed - the same
-     * best-effort, page-load-friendly approach the index page uses for its DNS warning.
-     *
-     * @return the cached advisability flag; {@code false} until the first background check has completed.
-     */
-    public static boolean isCleanupAdvisable() {
-        final PubSubSubscriptionMaintenance m = maintenance;
-        // While a cleanup is actively running, the row count is changing under us. Do not analyze (it would compete
-        // with the delete and could report a misleading interim value); just return the current cached value. Once the
-        // run finishes, the cache is marked stale below so the next read re-evaluates promptly.
-        if (m != null && m.getProgress().getPhase() == PubSubSubscriptionMaintenance.Phase.RUNNING) {
-            cleanupAdvisableCheckedAt.set(0L); // ensure a refresh happens right after the run completes
-            return cleanupAdvisableCache.get();
-        }
-
-        final long checkedAt = cleanupAdvisableCheckedAt.get();
-        final boolean stale = checkedAt == 0L || (System.currentTimeMillis() - checkedAt) > CLEANUP_ADVISABLE_TTL_MILLIS;
-        if (stale && cleanupAdvisableRefreshing.compareAndSet(false, true)) {
-            final Thread refresh = new Thread(() -> {
-                try {
-                    final PubSubSubscriptionMaintenance.Analysis analysis = getMaintenance().analyze();
-                    cleanupAdvisableCache.set(analysis.isCleanupRecommended());
-                } catch (Exception e) {
-                    // On failure, leave the previous cached value in place and log; the next read will retry.
-                    Log.debug("Background check for redundant pubsub subscription rows failed; will retry later.", e);
-                } finally {
-                    cleanupAdvisableCheckedAt.set(System.currentTimeMillis());
-                    cleanupAdvisableRefreshing.set(false);
-                }
-            }, "pubsub-subscription-cleanup-advisability-check");
-            refresh.setDaemon(true);
-            refresh.start();
-        }
-        return cleanupAdvisableCache.get();
-    }
-
-    /**
-     * Returns the shared maintenance instance, creating it on first use with the current set of multiple-subscription
-     * services excluded.
-     *
-     * The exclusion set is computed here, in trusted server-side code that can inspect the live services, rather than
-     * in the maintenance class (which only sees the database). See {@link #collectMultipleSubscriptionServiceIds()}.
-     *
-     * @return the shared maintenance instance.
-     */
-    private static PubSubSubscriptionMaintenance getMaintenance() {
-        PubSubSubscriptionMaintenance result = maintenance;
-        if (result == null) {
-            synchronized (maintenanceLock) {
-                result = maintenance;
-                if (result == null) {
-                    result = new PubSubSubscriptionMaintenance(collectMultipleSubscriptionServiceIds());
-                    maintenance = result;
-                }
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Determines the IDs of pubsub services that permit multiple subscriptions for the same subscription JID, and whose
-     * rows must therefore never be treated as redundant by the cleanup.
-     *
-     * Whether multiple subscriptions are permitted is a service-wide setting. PEP services always return false, so they
-     * are never excluded (and are the dominant source of the redundancy this cleanup targets). The main pubsub service
-     * is governed by the {@code xmpp.pubsub.multiple-subscriptions} property; when it permits multiple subscriptions,
-     * its service ID is excluded.
-     *
-     * Note: this intentionally errs toward excluding (protecting) a service when in doubt. If additional pubsub
-     * services that permit multiple subscriptions are introduced, add their IDs here so their data is protected.
-     *
-     * @return the set of service IDs to exclude from cleanup; never null, possibly empty.
-     */
-    private static Set<String> collectMultipleSubscriptionServiceIds() {
-        final Set<String> excluded = new LinkedHashSet<>();
-        try {
-            final PubSubModule pubSubModule = XMPPServer.getInstance().getPubSubModule();
-            if (pubSubModule != null && pubSubModule.isMultipleSubscriptionsEnabled()) {
-                excluded.add(pubSubModule.getServiceID());
-            }
-        } catch (Exception e) {
-            // The main pubsub service is a singleton that is normally available whenever the admin console is running,
-            // so this is not expected. If it cannot be inspected, its ID is not added, which means its rows would be
-            // treated as eligible for cleanup; log loudly so an operator can verify before proceeding.
-            Log.warn("Unable to determine whether the main pubsub service permits multiple subscriptions; its rows " +
-                "will be treated as eligible for cleanup. Verify this is correct for this deployment before proceeding.", e);
-        }
-        return excluded;
-    }
-
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
@@ -230,38 +90,42 @@ public class PubSubSubscriptionMaintenanceServlet extends HttpServlet {
             return;
         }
 
-        final PubSubSubscriptionMaintenance m = getMaintenance();
-
-        // Read-only analysis for the status table. This can take a few seconds on a very large table, but does not
-        // modify data. Failures are surfaced to the page rather than thrown.
-        try {
-            final PubSubSubscriptionMaintenance.Analysis analysis = m.analyze();
-            request.setAttribute("totalRows", analysis.getTotalRows());
-            request.setAttribute("distinctSubscriptions", analysis.getDistinctSubscriptions());
-            request.setAttribute("removableRows", analysis.getRemovableRows());
-            request.setAttribute("cleanupRecommended", analysis.isCleanupRecommended());
-            request.setAttribute("redundancyPercent", Math.round(analysis.getRedundancyRatio() * 100));
-            request.setAttribute("analysisAvailable", true);
-        } catch (Exception e) {
-            Log.error("Unable to analyze redundant pubsub subscription rows.", e);
+        final PubSubSubscriptionMaintenance m = PubSubSubscriptionMaintenance.getInstance();
+        if (m == null) {
             request.setAttribute("analysisAvailable", false);
-            request.setAttribute("analysisError", e.getMessage());
-        }
+            request.setAttribute("analysisError", "The pubsub service is not running.");
+        } else {
+            // Read-only analysis for the status table. This can take a few seconds on a very large table, but does not
+            // modify data. Failures are surfaced to the page rather than thrown.
+            try {
+                final PubSubSubscriptionMaintenance.Analysis analysis = m.analyze();
+                request.setAttribute("totalRows", analysis.getTotalRows());
+                request.setAttribute("distinctSubscriptions", analysis.getDistinctSubscriptions());
+                request.setAttribute("removableRows", analysis.getRemovableRows());
+                request.setAttribute("cleanupRecommended", analysis.isCleanupRecommended());
+                request.setAttribute("redundancyPercent", Math.round(analysis.getRedundancyRatio() * 100));
+                request.setAttribute("analysisAvailable", true);
+            } catch (Exception e) {
+                Log.error("Unable to analyze redundant pubsub subscription rows.", e);
+                request.setAttribute("analysisAvailable", false);
+                request.setAttribute("analysisError", e.getMessage());
+            }
 
-        // Current run state, so the page can show a progress bar if a cleanup is already running (e.g. after a reload).
-        final PubSubSubscriptionMaintenance.Progress progress = m.getProgress();
-        request.setAttribute("progressPhase", progress.getPhase().name());
-        request.setAttribute("progressPercent", progress.getPercentComplete());
-        request.setAttribute("progressRemoved", progress.getRemoved());
-        request.setAttribute("excludedServiceCount", m.getExcludedServiceIds().size());
+            // Current run state, so the page can show a progress bar if a cleanup is already running (e.g. after a reload).
+            final PubSubSubscriptionMaintenance.Progress progress = m.getProgress();
+            request.setAttribute("progressPhase", progress.getPhase().name());
+            request.setAttribute("progressPercent", progress.getPercentComplete());
+            request.setAttribute("progressRemoved", progress.getRemoved());
+            request.setAttribute("excludedServiceCount", m.getExcludedServiceIds().size());
 
-        // A just-started flag survives the POST-Redirect-GET via the session; consume it here so the page begins
-        // polling even during the brief window before the background job reports RUNNING.
-        final Object justStarted = request.getSession().getAttribute("justStarted");
-        if (justStarted != null) {
-            request.getSession().removeAttribute("justStarted");
+            // A just-started flag survives the POST-Redirect-GET via the session; consume it here so the page begins
+            // polling even during the brief window before the background job reports RUNNING.
+            final Object justStarted = request.getSession().getAttribute("justStarted");
+            if (justStarted != null) {
+                request.getSession().removeAttribute("justStarted");
+            }
+            request.setAttribute("justStarted", Boolean.TRUE.equals(justStarted));
         }
-        request.setAttribute("justStarted", Boolean.TRUE.equals(justStarted));
 
         // Clustering status (mirrors the Blowfish servlet's approach).
         final boolean clusteringAvailable = ClusterManager.isClusteringAvailable();
@@ -323,17 +187,23 @@ public class PubSubSubscriptionMaintenanceServlet extends HttpServlet {
             }
 
             // Launch the background cleanup. startCleanup() returns immediately; the page polls for progress.
-            final boolean started = getMaintenance().startCleanup();
-            if (started) {
-                request.getSession().setAttribute("successMessage", "pubsub.subscription.maintenance.started");
-                request.getSession().setAttribute("justStarted", Boolean.TRUE);
-                final WebManager webManager = new WebManager();
-                webManager.init(request, response, request.getSession(), request.getServletContext());
-                webManager.logEvent("Started pub/sub subscription cleanup", null);
+            final PubSubSubscriptionMaintenance m = PubSubSubscriptionMaintenance.getInstance();
+            if (m == null) {
+                request.setAttribute("analysisAvailable", false);
+                request.setAttribute("analysisError", "The pubsub service is not running.");
             } else {
-                // A cleanup was already running; not an error, just informational.
-                request.getSession().setAttribute("successMessage", "pubsub.subscription.maintenance.already-running");
-                request.getSession().setAttribute("justStarted", Boolean.TRUE);
+                final boolean started = m.startCleanup();
+                if (started) {
+                    request.getSession().setAttribute("successMessage", "pubsub.subscription.maintenance.started");
+                    request.getSession().setAttribute("justStarted", Boolean.TRUE);
+                    final WebManager webManager = new WebManager();
+                    webManager.init(request, response, request.getSession(), request.getServletContext());
+                    webManager.logEvent("Started pub/sub subscription cleanup", null);
+                } else {
+                    // A cleanup was already running; not an error, just informational.
+                    request.getSession().setAttribute("successMessage", "pubsub.subscription.maintenance.already-running");
+                    request.getSession().setAttribute("justStarted", Boolean.TRUE);
+                }
             }
         }
 
@@ -350,16 +220,22 @@ public class PubSubSubscriptionMaintenanceServlet extends HttpServlet {
      * @throws IOException if writing fails.
      */
     private void writeProgressJson(HttpServletResponse response) throws IOException {
-        final PubSubSubscriptionMaintenance.Progress progress = getMaintenance().getProgress();
         response.setContentType("application/json; charset=UTF-8");
         response.setHeader("Cache-Control", "no-store");
-
         final JSONObject json = new JSONObject();
-        json.put("phase", progress.getPhase().name());
-        json.put("percent", progress.getPercentComplete());
-        json.put("removed", progress.getRemoved());
-        json.put("total", progress.getTotalToRemove());
-        json.put("error", progress.getError());
+
+        final PubSubSubscriptionMaintenance m = PubSubSubscriptionMaintenance.getInstance();
+        if (m == null) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            json.put("error", "The pubsub service is not running.");
+        } else {
+            final PubSubSubscriptionMaintenance.Progress progress = m.getProgress();
+            json.put("phase", progress.getPhase().name());
+            json.put("percent", progress.getPercentComplete());
+            json.put("removed", progress.getRemoved());
+            json.put("total", progress.getTotalToRemove());
+            json.put("error", progress.getError());
+        }
 
         response.getWriter().write(json.toString());
     }

--- a/xmppserver/src/main/java/org/jivesoftware/database/DbConnectionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/DbConnectionManager.java
@@ -206,8 +206,11 @@ public class DbConnectionManager {
     }
 
     /**
-     * Returns a Connection from the currently active connection provider that
-     * is ready to participate in transactions (auto commit is set to false).
+     * Returns a Connection from the currently active connection provider that is ready to participate in transactions
+     * (auto commit is set to false).
+     *
+     * Use this when you need setFetchSize to actually stream large result sets (auto-commit connections silently buffer
+     * on PostgreSQL/MySQL)
      *
      * @return a connection with transactions enabled.
      * @throws SQLException if a SQL exception occurs.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/IQPEPHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -585,10 +585,9 @@ public class IQPEPHandler extends IQHandler implements ServerIdentitiesProvider,
 
         // Cancel unsubscriberJID's subscription to recipientJID's PEP service, if it exists.
         CollectionNode rootNode = pepService.getRootCollectionNode();
-        NodeSubscription nodeSubscription = rootNode.getSubscription(unsubscriber);
-        if (nodeSubscription != null) {
-            rootNode.cancelSubscription(nodeSubscription);
-        }
+        rootNode.getSubscriptionsByJID(unsubscriber).forEach(
+            rootNode::cancelSubscription
+        );
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pep/PEPService.java
@@ -510,11 +510,11 @@ public class PEPService implements PubSubService, Cacheable {
     public void sendLastPublishedItems(JID recipientJID, Set<String> nodeIdFilter) {
         // Ensure the recipient has a subscription to this service's root collection node, or is its owner.
         final boolean isOwner = recipientJID.asBareJID().equals(this.serviceOwner);
-        NodeSubscription subscription = rootCollectionNode.getSubscription(recipientJID);
-        if (subscription == null) {
-            subscription = rootCollectionNode.getSubscription(new JID(recipientJID.toBareJID()));
+        Collection<NodeSubscription> subscriptions = rootCollectionNode.getSubscriptionsByJID(recipientJID);
+        if (subscriptions.isEmpty()) {
+            subscriptions = rootCollectionNode.getSubscriptionsByJID(new JID(recipientJID.toBareJID()));
         }
-        if (subscription == null && !isOwner) {
+        if (subscriptions.isEmpty() && !isOwner) {
             return;
         }
 
@@ -530,8 +530,8 @@ public class PEPService implements PubSubService, Cacheable {
             }
 
             // Check if the published item can be sent to the subscriber
-            if (subscription != null && !subscription.canSendPublicationEvent(leafLastPublishedItem.getNode(), leafLastPublishedItem)) {
-                return;
+            if (!subscriptions.isEmpty() && subscriptions.stream().noneMatch(subscription -> subscription.canSendPublicationEvent(leafLastPublishedItem.getNode(), leafLastPublishedItem))) {
+                continue;
             }
 
             // Send event notification to the subscriber
@@ -547,13 +547,24 @@ public class PEPService implements PubSubService, Cacheable {
                 item.add(leafLastPublishedItem.getPayload().createCopy());
             }
             // Add a message body (if required)
-            if (subscription != null && subscription.isIncludingBody()) {
+            if (!subscriptions.isEmpty() && subscriptions.stream().anyMatch(subscription -> subscription.isIncludingBody())) {
                 notification.setBody(LocaleUtils.getLocalizedString("pubsub.notification.message.body"));
             }
             // Include date when published item was created
             notification.getElement().addElement("delay", "urn:xmpp:delay").addAttribute("stamp", XMPPDateTimeFormat.format(leafLastPublishedItem.getCreationDate()));
-            // Send the event notification to the subscriber
-            this.sendNotification(subscription != null ? subscription.getNode() : leafNode, notification, subscription != null ? subscription.getJID() : recipientJID);
+            if (subscriptions.isEmpty()) {
+                // Because of the 'subscriptions is empty' check above, recipient _must_ be an owner.
+                this.sendNotification(leafNode, notification, recipientJID);
+            } else {
+                // Send the event notification to the subscriber
+                final HashSet<JID> notifiedJids = new HashSet<>(); // XEP-0060 section 6.1.6: When the pubsub service generates event notifications, it SHOULD send only one event notification to an entity that has multiple subscriptions.
+                for (final NodeSubscription subscription : subscriptions) {
+                    final JID notifiedJid = subscription.getJID();
+                    if (notifiedJids.add(notifiedJid)) {
+                        this.sendNotification(subscription.getNode(), notification, notifiedJid);
+                    }
+                }
+            }
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultPubSubPersistenceProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/DefaultPubSubPersistenceProvider.java
@@ -983,7 +983,7 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
                 return;
             }
             NodeSubscription.State state = NodeSubscription.State.valueOf(rs.getString(5));
-			NodeSubscription subscription = new NodeSubscription(node, owner, subscriber, state, subID);
+            NodeSubscription subscription = new NodeSubscription(node, owner, subscriber, state, subID);
             subscription.setShouldDeliverNotifications(rs.getInt(6) == 1);
             subscription.setUsingDigest(rs.getInt(7) == 1);
             subscription.setDigestFrequency(rs.getInt(8));
@@ -995,6 +995,38 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
             subscription.setType(NodeSubscription.Type.valueOf(rs.getString(12)));
             subscription.setDepth(rs.getInt(13));
             subscription.setKeyword(rs.getString(14));
+
+            // OF-3306: Skip subscription rows that are redundant under the node's own uniqueness rule.
+            //
+            // On a node that does not allow multiple subscriptions for the same subscription JID (XEP-0060 §6.1.6), at
+            // most one subscription can exist per (subscription JID, subscription type). PEP services (XEP-0163) are
+            // such nodes: a contact's subscription is created automatically from their presence subscription (the
+            // "auto-subscribe" feature), and the service sends at most one notification per subscriber - there is no
+            // PEP semantics under which a single contact holds many subscriptions to one node. A defect that caused the
+            // auto-subscribe path to run repeatedly can therefore leave large numbers of rows that are identical except
+            // for their generated subscription ID. Loading every copy wastes heap (in extreme cases exhausting it) with
+            // no functional value, so only the first equivalent subscription is materialized here. The redundant rows
+            // are left untouched in the database; this only avoids holding duplicate copies in memory.
+            //
+            // Nodes that DO allow multiple subscriptions are unaffected: their same-JID rows are legitimate,
+            // differentiated by subscription ID, and all are loaded. The type comparison preserves the XEP-0248 §6.1.
+            // 3 case where one "nodes" and one "items" subscription may coexist for the same JID on a collection node
+            // (such as the PEP root collection).
+            if (!node.isMultipleSubscriptionsEnabled()) {
+                boolean duplicate = false;
+                for (final NodeSubscription existing : node.getSubscriptionsByJID(subscriber)) {
+                    if (existing.getType() == subscription.getType()) {
+                        duplicate = true;
+                        break;
+                    }
+                }
+                if (duplicate) {
+                    log.trace("Skipping redundant subscription (node: {}, jid: {}, owner: {}, type: {}, id: {}) during load; an equivalent subscription was already loaded.",
+                        node.getUniqueIdentifier(), subscriber, owner, subscription.getType(), subID);
+                    return;
+                }
+            }
+
             // Indicate the subscription that is has already been saved to the database
             subscription.setSavedToDB(true);
             node.addSubscription(subscription);
@@ -1003,7 +1035,6 @@ public class DefaultPubSubPersistenceProvider implements PubSubPersistenceProvid
             log.error("An exception occurred while loading a subscriptions for nodes of a service from the database.", sqle);
         }
     }
-
     @Override
     public void createAffiliation(Node node, NodeAffiliate affiliate)
     {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,22 +169,24 @@ public abstract class Node implements Cacheable, Externalizable {
      * whitelist then this collection acts as the white list (unless user is an outcast)
      */
     protected Collection<NodeAffiliate> affiliates = new CopyOnWriteArrayList<>();
+
     /**
-     * Map that contains the current subscriptions to the node. A user may have more than one
-     * subscription. Each subscription is uniquely identified by its ID.
+     * Map that contains the current subscriptions to the node. Each subscription is uniquely
+     * identified by its ID.
+     *
      * Key: Subscription ID, Value: the subscription.
      */
-    protected Map<String, NodeSubscription> subscriptionsByID =
-            new ConcurrentHashMap<>();
+    protected Map<String, NodeSubscription> subscriptionsByID = new ConcurrentHashMap<>();
+
     /**
-     * Map that contains the current subscriptions to the node. This map should be used only
-     * when node is not configured to allow multiple subscriptions. When multiple subscriptions
-     * is not allowed the subscriptions can be searched by the subscriber JID. Otherwise searches
-     * should be done using the subscription ID.
-     * Key: Subscriber full JID, Value: the subscription.
+     * Map that contains the current subscriptions to the node by exact subscription JID. This
+     * map can resolve at most one subscription per literal JID value. As a result, callers must
+     * use the subscription ID when {@link #isMultipleSubscriptionsEnabled()} is true, as that
+     * allows multiple subscriptions for the same literal JID value.
+     *
+     * Key: Subscription JID, Value: the subscription.
      */
-    protected Map<String, NodeSubscription> subscriptionsByJID =
-            new ConcurrentHashMap<>();
+    protected Map<String, NodeSubscription> subscriptionsByJID = new ConcurrentHashMap<>();
 
     /**
      * A transient reference to the service that this node belongs to. Note that this value is lazily initialized in
@@ -407,12 +409,11 @@ public abstract class Node implements Cacheable, Externalizable {
     }
 
     /**
-     * Returns the list of subscriptions owned by the specified user. The subscription owner
-     * may have more than one subscription based on {@link #isMultipleSubscriptionsEnabled()}.
-     * Each subscription may have a different subscription JID if the owner wants to receive
-     * notifications in different resources (or even JIDs).
+     * Returns the list of subscriptions owned by the specified user. The returned subscriptions
+     * can target different subscription JID values. When multiple subscriptions are enabled,
+     * more than one subscription can additionally exist for the same literal subscription JID.
      *
-     * @param owner the owner of the subscriptions.
+     * @param owner the owner of the subscriptions. This is typically a bare JID.
      * @return the list of subscriptions owned by the specified user.
      */
     public Collection<NodeSubscription> getSubscriptions(JID owner) {
@@ -1170,12 +1171,12 @@ public abstract class Node implements Cacheable, Externalizable {
     }
 
     /**
-     * Returns true if a user may have more than one subscription with the node. When
-     * multiple subscriptions is enabled each subscription request, event notification and
-     * unsubscription request should include a {@code subid} attribute. By default multiple
+     * Returns true if a literal subscription JID value may have more than one subscription with
+     * the node. When multiple subscriptions is enabled each subscription request, event notification
+     * and unsubscription request should include a {@code subid} attribute. By default multiple
      * subscriptions is enabled.
      *
-     * @return true if a user may have more than one subscription with the node.
+     * @return true if a literal subscription JID value may have more than one subscription with the node.
      */
     public boolean isMultipleSubscriptionsEnabled() {
         return getService().isMultipleSubscriptionsEnabled();
@@ -1884,25 +1885,46 @@ public abstract class Node implements Cacheable, Externalizable {
     }
 
     /**
-     * Returns the subscription whose subscription JID matches the specified JID or {@code null}
-     * if none was found. Accessing subscriptions by subscription JID and not by subscription ID
-     * is only possible when the node does not allow multiple subscriptions from the same entity.
-     * If the node allows multiple subscriptions and this message is sent then an
-     * IllegalStateException exception is going to be thrown.
+     * Returns all subscriptions whose subscription JID exactly matches the specified JID.
+     *
+     * @param subscriberJID the exact subscription JID.
+     * @return the subscriptions whose subscription JID exactly matches the specified JID.
+     */
+    public Collection<NodeSubscription> getSubscriptionsByJID(JID subscriberJID)
+    {
+        final Collection<NodeSubscription> subscriptions = new ArrayList<>();
+        for (final NodeSubscription subscription : subscriptionsByID.values()) {
+            if (subscriberJID.equals(subscription.getJID())) {
+                subscriptions.add(subscription);
+            }
+        }
+        getLogger().trace("Got {} subscription(s) for subscription JID '{}'", subscriptions.size(), subscriberJID);
+        return subscriptions;
+    }
+
+    /**
+     * Returns the subscription whose subscription JID exactly matches the specified JID or
+     * {@code null} if none was found.
+     *
+     * Accessing subscriptions by subscription JID and not by subscription ID is only possible when the node does not
+     * allow multiple subscriptions for the same literal subscription JID value. If the node allows multiple
+     * subscriptions and more than one subscription exists for the specified subscription JID, then an
+     * IllegalStateException exception is thrown.
      *
      * @param subscriberJID the JID of the entity that receives event notifications.
      * @return the subscription whose subscription JID matches the specified JID or {@code null}
      *         if none was found.
-     * @throws IllegalStateException If this message was used when the node supports multiple
-     *         subscriptions.
+     * @throws IllegalStateException If this method was used when more than one subscription exists
+     *         for the specified subscription JID.
      */
     public NodeSubscription getSubscription(JID subscriberJID) {
-        // Check that node does not support multiple subscriptions
-        if (isMultipleSubscriptionsEnabled() && (getSubscriptions(subscriberJID).size() > 1)) {
+        // Check that the subscription JID does not have multiple subscriptions.
+        final Collection<NodeSubscription> matchingSubscriptions = getSubscriptionsByJID(subscriberJID);
+        if (isMultipleSubscriptionsEnabled() && matchingSubscriptions.size() > 1) {
             throw new IllegalStateException("Multiple subscriptions is enabled so subscriptions " +
-                    "should be retrieved using subID.");
+                "should be retrieved using subID.");
         }
-        final NodeSubscription nodeSubscription = subscriptionsByJID.get(subscriberJID.toString());
+        final NodeSubscription nodeSubscription = matchingSubscriptions.stream().findFirst().orElse(null);
         getLogger().trace("Got subscription by JID '{}': {}", subscriberJID, nodeSubscription);
         return nodeSubscription;
     }
@@ -1910,9 +1932,9 @@ public abstract class Node implements Cacheable, Externalizable {
     /**
      * Returns the subscription whose subscription ID matches the specified ID or {@code null}
      * if none was found. Accessing subscriptions by subscription ID is always possible no matter
-     * if the node allows one or multiple subscriptions for the same entity. Even when users can
-     * only subscribe once to the node a subscription ID is going to be internally created though
-     * never returned to the user.
+     * if the node allows one or multiple subscriptions for the same literal subscription JID value.
+     * Even when a JID can only subscribe once to the node, a subscription ID is going to be
+     * internally created though never returned to the user.
      *
      * @param subscriptionID the ID of the subscription.
      * @return the subscription whose subscription ID matches the specified ID or {@code null}
@@ -2179,8 +2201,19 @@ public abstract class Node implements Cacheable, Externalizable {
      *        didn't provide a configuration.
      */
     public void createSubscription(IQ originalIQ, JID owner, JID subscriber,
-            boolean authorizationRequired, DataForm options) {
+                                   boolean authorizationRequired, DataForm options) {
         getLogger().trace("Create subscription for '{}' ('{}'). Authorization required: {}", owner, subscriber, authorizationRequired);
+
+        if (!isMultipleSubscriptionsEnabled()) {
+            final NodeSubscription existingSubscription = getSubscription(subscriber);
+            if (existingSubscription != null) {
+                getLogger().trace("Not creating a second subscription for '{}', because multiple subscriptions are disabled. Returning existing state instead.", subscriber);
+                if (originalIQ != null) {
+                    existingSubscription.sendSubscriptionState(originalIQ);
+                }
+                return;
+            }
+        }
 
         // Create a new affiliation if required
         if (getAffiliate(owner) == null) {
@@ -2276,11 +2309,16 @@ public abstract class Node implements Cacheable, Externalizable {
         getLogger().trace("Cancelling subscription for '{}' (state: {}). Send-to-cluster: {}", subscription.getJID(), subscription.getState(), sendToCluster);
         // Remove subscription from memory
         subscriptionsByID.remove(subscription.getID());
-        subscriptionsByJID.remove(subscription.getJID().toString());
+        if (subscriptionsByJID.get(subscription.getJID().toString()) == subscription) {
+            subscriptionsByJID.remove(subscription.getJID().toString());
+            // In multi-subscribe mode, another exact JID may still exist. If it does, keep subscriptionsByJID as useful as possible by repopulating it.
+            getSubscriptionsByJID(subscription.getJID()).stream().findFirst()
+                .ifPresent(remainingSubscription -> subscriptionsByJID.put(remainingSubscription.getJID().toString(), remainingSubscription));
+        }
         // Check if user has affiliation of type "none" and there are no more subscriptions
         NodeAffiliate affiliate = subscription.getAffiliate();
         if (affiliate != null && affiliate.getAffiliation() == NodeAffiliate.Affiliation.none &&
-                getSubscriptions(subscription.getOwner()).isEmpty()) {
+            getSubscriptions(subscription.getOwner()).isEmpty()) {
             // Remove affiliation of type "none"
             removeAffiliation(affiliate);
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -39,7 +39,6 @@ import java.io.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collectors;
 
 import static org.jivesoftware.openfire.muc.spi.IQOwnerHandler.parseFirstValueAsBoolean;
 
@@ -177,16 +176,6 @@ public abstract class Node implements Cacheable, Externalizable {
      * Key: Subscription ID, Value: the subscription.
      */
     protected Map<String, NodeSubscription> subscriptionsByID = new ConcurrentHashMap<>();
-
-    /**
-     * Map that contains the current subscriptions to the node by exact subscription JID. This
-     * map can resolve at most one subscription per literal JID value. As a result, callers must
-     * use the subscription ID when {@link #isMultipleSubscriptionsEnabled()} is true, as that
-     * allows multiple subscriptions for the same literal JID value.
-     *
-     * Key: Subscription JID, Value: the subscription.
-     */
-    protected Map<String, NodeSubscription> subscriptionsByJID = new ConcurrentHashMap<>();
 
     /**
      * A transient reference to the service that this node belongs to. Note that this value is lazily initialized in
@@ -438,20 +427,13 @@ public abstract class Node implements Cacheable, Externalizable {
     }
 
     /**
-     * Returns all subscriptions to the node. If multiple subscriptions are enabled,
-     * this method returns the subscriptions by {@code subId}, otherwise it returns
-     * the subscriptions by {@link JID}.
+     * Returns all subscriptions to the node.
      *
      * @return All subscriptions to the node.
      */
     public Collection<NodeSubscription> getAllSubscriptions() {
-        if (isMultipleSubscriptionsEnabled()) {
-            getLogger().trace("Got {} subscription(s)", subscriptionsByID.size());
-            return subscriptionsByID.values();
-        } else {
-            getLogger().trace("Got {} subscription(s)", subscriptionsByJID.size());
-            return subscriptionsByJID.values();
-        }
+        getLogger().trace("Got {} subscription(s)", subscriptionsByID.size());
+        return subscriptionsByID.values();
     }
 
     /**
@@ -1881,7 +1863,6 @@ public abstract class Node implements Cacheable, Externalizable {
     {
         getLogger().trace("Add subscription for '{}' (state: {}).", subscription.getJID(), subscription.getState());
         subscriptionsByID.put(subscription.getID(), subscription);
-        subscriptionsByJID.put(subscription.getJID().toString(), subscription);
     }
 
     /**
@@ -1893,7 +1874,7 @@ public abstract class Node implements Cacheable, Externalizable {
     public Collection<NodeSubscription> getSubscriptionsByJID(JID subscriberJID)
     {
         final Collection<NodeSubscription> subscriptions = new ArrayList<>();
-        for (final NodeSubscription subscription : subscriptionsByID.values()) {
+        for (final NodeSubscription subscription : subscriptionsByID.values()) { // This is now a linear scan, which is inefficient for large numbers of subscriptions. If this turns out to be a performance issue, consider using a more efficient data structure or a secondary index.
             if (subscriberJID.equals(subscription.getJID())) {
                 subscriptions.add(subscription);
             }
@@ -1907,9 +1888,15 @@ public abstract class Node implements Cacheable, Externalizable {
      * {@code null} if none was found.
      *
      * Accessing subscriptions by subscription JID and not by subscription ID is only possible when the node does not
-     * allow multiple subscriptions for the same literal subscription JID value. If the node allows multiple
-     * subscriptions and more than one subscription exists for the specified subscription JID, then an
-     * IllegalStateException exception is thrown.
+     * allow multiple subscriptions for the same literal subscription JID value. There are two conditions in which
+     * multiple subscriptions for a node can exist:
+     * <ul>
+     * <li>Collection nodes can have a subscription per {@link NodeSubscription.Type}</li>
+     * <li>The service can allow multiple subscriptions through the <tt>multi-subscribe</tt> feature</li>
+     * </ul>
+     *
+     * If the node allows multiple subscriptions and more than one subscription exists for the specified subscription
+     * JID, then an IllegalStateException exception is thrown.
      *
      * @param subscriberJID the JID of the entity that receives event notifications.
      * @return the subscription whose subscription JID matches the specified JID or {@code null}
@@ -1917,12 +1904,12 @@ public abstract class Node implements Cacheable, Externalizable {
      * @throws IllegalStateException If this method was used when more than one subscription exists
      *         for the specified subscription JID.
      */
-    public NodeSubscription getSubscription(JID subscriberJID) {
+    public NodeSubscription getSubscription(JID subscriberJID)
+    {
         // Check that the subscription JID does not have multiple subscriptions.
         final Collection<NodeSubscription> matchingSubscriptions = getSubscriptionsByJID(subscriberJID);
-        if (isMultipleSubscriptionsEnabled() && matchingSubscriptions.size() > 1) {
-            throw new IllegalStateException("Multiple subscriptions is enabled so subscriptions " +
-                "should be retrieved using subID.");
+        if (matchingSubscriptions.size() > 1) {
+            throw new IllegalStateException("Multiple subscriptions detected for subscriber '" + subscriberJID + "' of node '" + getNodeID() + "'. Subscriptions should be retrieved using subID.");
         }
         final NodeSubscription nodeSubscription = matchingSubscriptions.stream().findFirst().orElse(null);
         getLogger().trace("Got subscription by JID '{}': {}", subscriberJID, nodeSubscription);
@@ -1984,7 +1971,6 @@ public abstract class Node implements Cacheable, Externalizable {
         // Clear collections in memory (clear them after broadcast was sent)
         affiliates.clear();
         subscriptionsByID.clear();
-        subscriptionsByJID.clear();
     }
 
     /**
@@ -2105,7 +2091,7 @@ public abstract class Node implements Cacheable, Externalizable {
                 entity.addAttribute("jid", subscription.getJID().toString());
                 //entity.addAttribute("affiliation", affiliate.getAffiliation().name());
                 entity.addAttribute("subscription", subscription.getState().name());
-                if (isMultipleSubscriptionsEnabled()) {
+                if (isMultipleSubscriptionsEnabled() || isCollectionNode()) {
                     entity.addAttribute("subid", subscription.getID());
                 }
             }
@@ -2204,15 +2190,37 @@ public abstract class Node implements Cacheable, Externalizable {
                                    boolean authorizationRequired, DataForm options) {
         getLogger().trace("Create subscription for '{}' ('{}'). Authorization required: {}", owner, subscriber, authorizationRequired);
 
-        if (!isMultipleSubscriptionsEnabled()) {
-            final NodeSubscription existingSubscription = getSubscription(subscriber);
-            if (existingSubscription != null) {
+        final NodeSubscription duplicate = findDuplicate(subscriber, options);
+        if (duplicate != null)
+        {
+            if (!isMultipleSubscriptionsEnabled())
+            {
+                // Multiple subscriptions are not supported: return the current subscription state, as if the
+                // subscription was just approved (XEP-0060 §6.1.6). Note: not an error.
                 getLogger().trace("Not creating a second subscription for '{}', because multiple subscriptions are disabled. Returning existing state instead.", subscriber);
                 if (originalIQ != null) {
-                    existingSubscription.sendSubscriptionState(originalIQ);
+                    duplicate.sendSubscriptionState(originalIQ);
                 }
                 return;
             }
+
+            if (isCollectionNode())
+            {
+                // Even with multi-subscribe, a second same-type subscription to a collection node is redundant (a depth
+                // of "all" subsumes a depth of "1") and SHOULD be rejected with a conflict error (XEP-0248 §6.1.3).
+                getLogger().debug("Not creating a second subscription for '{}', because a second same-type subscription to a collection node is redundant. Returning a conflict error.", subscriber);
+                if (originalIQ != null) {
+                    final IQ response = IQ.createResultIQ(originalIQ);
+                    response.setChildElement(originalIQ.getChildElement().createCopy());
+                    response.setError(PacketError.Condition.conflict);
+                    getService().send(response);
+                }
+                // Silently ignore if this was an internal API call.
+                return;
+            }
+
+            // Leaf node with multi-subscribe enabled: additional subscriptions for the same JID are permitted and
+            // differentiated by SubID (XEP-0060 §6.1.6).
         }
 
         // Create a new affiliation if required
@@ -2239,9 +2247,7 @@ public abstract class Node implements Cacheable, Externalizable {
         }
 
         if ( subscription.isAuthorizationPending() ) {
-            final Set<NodeSubscription> existing = new HashSet<>();
-            existing.add( subscriptionsByJID.get( subscription.getJID().toString() ) ); // potentially null
-            existing.addAll( subscriptionsByID.values().stream().filter( s -> s.getJID().equals( subscription.getJID() ) ).collect( Collectors.toSet()) );
+            final Collection<NodeSubscription> existing = getSubscriptionsByJID(subscription.getJID());
             if (existing.stream().anyMatch( s -> s != null && s.isAuthorizationPending() ) ) {
                 getLogger().debug("This node already has a pending subscription for this JID ('{}'). The XEP forbids this.", subscription.getJID());
 
@@ -2309,12 +2315,7 @@ public abstract class Node implements Cacheable, Externalizable {
         getLogger().trace("Cancelling subscription for '{}' (state: {}). Send-to-cluster: {}", subscription.getJID(), subscription.getState(), sendToCluster);
         // Remove subscription from memory
         subscriptionsByID.remove(subscription.getID());
-        if (subscriptionsByJID.get(subscription.getJID().toString()) == subscription) {
-            subscriptionsByJID.remove(subscription.getJID().toString());
-            // In multi-subscribe mode, another exact JID may still exist. If it does, keep subscriptionsByJID as useful as possible by repopulating it.
-            getSubscriptionsByJID(subscription.getJID()).stream().findFirst()
-                .ifPresent(remainingSubscription -> subscriptionsByJID.put(remainingSubscription.getJID().toString(), remainingSubscription));
-        }
+
         // Check if user has affiliation of type "none" and there are no more subscriptions
         NodeAffiliate affiliate = subscription.getAffiliate();
         if (affiliate != null && affiliate.getAffiliation() == NodeAffiliate.Affiliation.none &&
@@ -2450,6 +2451,62 @@ public abstract class Node implements Cacheable, Externalizable {
             getLogger().debug("Cancel the subscription to the node is it has not been approved: {}", subscription);
             cancelSubscription(subscription);
         }
+    }
+
+    /**
+     * Finds an existing subscription that the provided subscription request duplicates, applying the type exception for
+     * collection nodes (XEP-0248 §6.1.3: one 'nodes' and one 'items' subscription may coexist for the same subscription
+     * JID).
+     *
+     * @param subscriber the JID that will receive the events from a node (distinct from the 'owner' JID of the subscription).
+     * @param optionsForm The form representing the requested subscription.
+     * @return the duplicate subscription, if any.
+     */
+    public NodeSubscription findDuplicate(final JID subscriber, final DataForm optionsForm)
+    {
+        final NodeSubscription.Type requestedType = resolveRequestedType(optionsForm);
+
+        // Detect pre-existing subscriptions for the same subscription JID. This intentionally compares the literal
+        // 'jid' of each subscription (the address that receives event notifications) and not its 'owner': distinct full
+        // JIDs sharing a bare JID may each hold their own subscription, regardless of the multi-subscribe feature
+        // (XEP-0060 §6.1.6).
+        for (final NodeSubscription existing : getSubscriptionsByJID(subscriber))
+        {
+            // On a collection node, one subscription of type "nodes" and one of type "items" may coexist for the same
+            // JID, even without multi-subscribe (XEP-0248 §6.1.3). A subscription of a different type is therefore not
+            // a duplicate.
+            if (isCollectionNode() && existing.getType() != requestedType) {
+                continue;
+            }
+            return existing;
+        }
+        return null;
+    }
+
+    /**
+     * Determine the type of the requested subscription represented by the provided form.
+     *
+     * Subscription types only apply to collection nodes (XEP-0248 §6.1): every subscription to a leaf node concerns
+     * items. For collection nodes the default type is "nodes" (XEP-0248 §6.1).
+     *
+     * @param optionsForm The form representing the requested subscription.
+     * @return The type of the requested subscription.
+     */
+    public NodeSubscription.Type resolveRequestedType(final DataForm optionsForm)
+    {
+        NodeSubscription.Type requestedType = NodeSubscription.Type.items;
+        if (this.isCollectionNode())
+        {
+            requestedType = NodeSubscription.Type.nodes;
+            if (optionsForm != null)
+            {
+                final FormField field = optionsForm.getField("pubsub#subscription_type");
+                if (field != null && !field.getValues().isEmpty() && "items".equals(field.getValues().get(0))) {
+                    requestedType = NodeSubscription.Type.items;
+                }
+            }
+        }
+        return requestedType;
     }
 
     @Override
@@ -2598,7 +2655,6 @@ public abstract class Node implements Cacheable, Externalizable {
         size += CacheSizes.sizeOfBoolean(); // subscriptionConfigurationRequired
         size += CacheSizes.sizeOfBoolean(); // subscriptionEnabled
         size += 350 * subscriptionsByID.size(); // 350 bytes per entry is a guestimate.
-        size += 350 * subscriptionsByJID.size(); // 350 bytes per entry is a guestimate.
         return size;
     }
 
@@ -2652,7 +2708,6 @@ public abstract class Node implements Cacheable, Externalizable {
         util.writeBoolean( out, subscriptionConfigurationRequired );
         util.writeBoolean( out, subscriptionEnabled );
 
-        // write out subscriptions once. When reading, use them to populate both maps.
         final Collection<NodeSubscription> subscriptions = subscriptionsByID.values();
         util.writeInt( out, subscriptions.size() );
         for ( final NodeSubscription subscription : subscriptions )
@@ -2734,7 +2789,6 @@ public abstract class Node implements Cacheable, Externalizable {
             final NodeSubscription subscription = new NodeSubscription( node, owner, jid, state, id );
 
             subscriptionsByID.put( subscription.getID(), subscription );
-            subscriptionsByJID.put( subscription.getJID().toString(), subscription );
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -267,7 +267,7 @@ public class NodeAffiliate implements Cacheable
      *        included in the notification message. The list should not be empty.
      */
     private void sendEventNotification(Message notification, List<NodeSubscription> notifySubscriptions) {
-        if (node.isMultipleSubscriptionsEnabled()) {
+        if (node.isMultipleSubscriptionsEnabled() || node.isCollectionNode()) {
             // Group subscriptions with the same subscriber JID
             Map<JID, Collection<String>> groupedSubs = new HashMap<>();
             for (NodeSubscription subscription : notifySubscriptions) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
@@ -49,12 +49,12 @@ import static org.jivesoftware.openfire.muc.spi.IQOwnerHandler.parseFirstValueAs
  * required. In any case, the subscriber will not get event notifications until the subscription
  * is active.<p>
  *
- * Depending on the node configuration it may be possible for the same subscriber to subscribe
- * multiple times to the node. Each subscription may have a different configuration like for
- * instance different keywords. Keywords can be used as a way to filter the type of
- * {@link PublishedItem} to be notified of. When the same subscriber has subscribed multiple
- * times to the node a single notification is going to be sent to the subscriber instead of
- * sending a notification for each subscription.
+ * Depending on the node configuration it may be possible for the same subscription JID
+ * value to subscribe multiple times to the node. Each subscription may have a different
+ * configuration like for instance different keywords. Keywords can be used as a way to
+ * filter the type of {@link PublishedItem} to be notified of. When the same literal
+ * subscription JID value has subscribed multiple times to the node, a single notification
+ * is going to be sent to that JID instead of sending a notification for each subscription.
  *
  * @author Matt Tucker
  */
@@ -149,13 +149,13 @@ public class NodeSubscription {
     private boolean savedToDB = false;
 
     /**
-     * Creates a new subscription of the specified user with the node.
+     * Creates a new subscription of the specified JID with the node.
      *
      * @param node Node to which this subscription is interested in.
      * @param owner the JID of the entity that owns this subscription.
-     * @param jid the JID of the user that owns the subscription.
+     * @param jid the JID of the entity that will receive event notifications.
      * @param state the state of the subscription with the node.
-     * @param id the id the uniquely identifies this subscription within the node.
+     * @param id the id that uniquely identifies this subscription within the node.
      */
     public NodeSubscription(Node node, JID owner, JID jid, State state, String id)
     {
@@ -204,10 +204,11 @@ public class NodeSubscription {
     /**
      * Returns the JID of the entity that owns this subscription. The owner entity will have
      * a {@link NodeAffiliate} for the owner JID. The owner may have more than one subscription
-     * with the node based on what this message
-     * {@link org.jivesoftware.openfire.pubsub.Node#isMultipleSubscriptionsEnabled()}.
+     * with the node when those subscriptions use different subscription JID values. If
+     * {@link org.jivesoftware.openfire.pubsub.Node#isMultipleSubscriptionsEnabled()} is true,
+     * more than one subscription may additionally exist for the same literal subscription JID value.
      *
-     * @return he JID of the entity that owns this subscription.
+     * @return the JID of the entity that owns this subscription.
      */
     public JID getOwner() {
         return owner;
@@ -298,23 +299,20 @@ public class NodeSubscription {
     }
 
     /**
-     * The presence states for which an entity wants to receive notifications. When the owner
-     * is in any of the returned presence states then he is allowed to receive notifications.
+     * The presence states for which an entity wants to receive notifications. When the subscription JID is in any of
+     * the returned presence states then it is allowed to receive notifications.
      *
-     * @return the presence states for which an entity wants to receive notifications.
-     *         (e.g. available, away, etc.)
+     * @return the presence states for which an entity wants to receive notifications. (e.g. available, away, etc.)
      */
     public Collection<String> getPresenceStates() {
         return presenceStates;
     }
 
     /**
-     * Returns if the owner has subscribed to receive notification of new items only
-     * or of new nodes only. When subscribed to a Leaf Node then only {@code items}
-     * is available.
+     * Returns if the subscription receives notifications of new items only or of new nodes only. When subscribed to a
+     * Leaf Node then only {@code items} is available.
      *
-     * @return whether the owner has subscribed to receive notification of new items only
-     *         or of new nodes only.
+     * @return whether the subscription receives notifications of new items only or of new nodes only.
      */
     public Type getType() {
         return type;
@@ -786,9 +784,9 @@ public class NodeSubscription {
 
     /**
      * Sends the current subscription status to the user that tried to create a subscription to
-     * the node. The subscription status is sent to the subsciber after the subscription was
-     * created or if the subscriber tries to subscribe many times and the node does not support
-     * multpiple subscriptions.
+     * the node. The subscription status is sent to the subscriber after the subscription was
+     * created or if the subscriber tries to subscribe again using the same subscription JID value
+     * and the node does not support multiple subscriptions for that JID.
      *
      * @param originalRequest the IQ packet sent by the subscriber to create the subscription.
      */

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeSubscription.java
@@ -798,7 +798,7 @@ public class NodeSubscription {
             entity.addAttribute("node", node.getUniqueIdentifier().getNodeId());
         }
         entity.addAttribute("jid", getJID().toString());
-        if (node.isMultipleSubscriptionsEnabled()) {
+        if (node.isMultipleSubscriptionsEnabled() || node.isCollectionNode()) {
             entity.addAttribute("subid", getID());
         }
         entity.addAttribute("subscription", getState().name());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -711,13 +711,11 @@ public class PubSubEngine
             }
         }
 
-        // If leaf node does not support multiple subscriptions then check whether subscriber is
-        // creating another subscription or not
+        // If leaf node does not support multiple subscriptions then check whether the same subscription JID is already subscribed.
         if (!node.isCollectionNode() && !node.isMultipleSubscriptionsEnabled()) {
             NodeSubscription existingSubscription = node.getSubscription(subscriberJID);
             if (existingSubscription != null) {
-                // User is trying to create another subscription so
-                // return current subscription state
+                // The same subscription JID is already subscribed, so return current subscription state.
                 existingSubscription.sendSubscriptionState(iq);
                 return;
             }
@@ -735,25 +733,23 @@ public class PubSubEngine
                     }
                 }
             }
-            if (nodeAffiliate != null) {
-                for (NodeSubscription subscription : nodeAffiliate.getSubscriptions()) {
-                    if (isNodeType) {
-                        // User is requesting a subscription of type "nodes"
-                        if (NodeSubscription.Type.nodes == subscription.getType()) {
-                            // Cannot have 2 subscriptions of the same type. Return conflict error
-                            sendErrorPacket(iq, PacketError.Condition.conflict, null);
-                            return;
-                        }
+            for (NodeSubscription subscription : node.getSubscriptionsByJID(subscriberJID)) {
+                if (isNodeType) {
+                    // User is requesting a subscription of type "nodes"
+                    if (NodeSubscription.Type.nodes == subscription.getType()) {
+                        // Cannot have 2 subscriptions of the same type for the same subscription JID. Return conflict error
+                        sendErrorPacket(iq, PacketError.Condition.conflict, null);
+                        return;
                     }
-                    else if (!node.isMultipleSubscriptionsEnabled()) {
-                        // User is requesting a subscription of type "items" and
-                        // multiple subscriptions is not allowed
-                        if (NodeSubscription.Type.items == subscription.getType()) {
-                            // User is trying to create another subscription so
-                            // return current subscription state
-                            subscription.sendSubscriptionState(iq);
-                            return;
-                        }
+                }
+                else if (!node.isMultipleSubscriptionsEnabled()) {
+                    // User is requesting a subscription of type "items" and
+                    // multiple subscriptions for the same subscription JID is not allowed
+                    if (NodeSubscription.Type.items == subscription.getType()) {
+                        // User is trying to create another subscription so
+                        // return current subscription state
+                        subscription.sendSubscriptionState(iq);
+                        return;
                     }
                 }
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -37,6 +37,8 @@ import org.xmpp.forms.DataForm;
 import org.xmpp.forms.FormField;
 import org.xmpp.packet.*;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -711,53 +713,8 @@ public class PubSubEngine
             }
         }
 
-        // If leaf node does not support multiple subscriptions then check whether the same subscription JID is already subscribed.
-        if (!node.isCollectionNode() && !node.isMultipleSubscriptionsEnabled()) {
-            NodeSubscription existingSubscription = node.getSubscription(subscriberJID);
-            if (existingSubscription != null) {
-                // The same subscription JID is already subscribed, so return current subscription state.
-                existingSubscription.sendSubscriptionState(iq);
-                return;
-            }
-        }
-
-        // Check if subscribing twice to a collection node using same subscription type
-        if (node.isCollectionNode()) {
-            // By default assume that new subscription is of type node
-            boolean isNodeType = true;
-            if (optionsForm != null) {
-                FormField field = optionsForm.getField("pubsub#subscription_type");
-                if (field != null) {
-                    if ("items".equals(field.getValues().get(0))) {
-                        isNodeType = false;
-                    }
-                }
-            }
-            for (NodeSubscription subscription : node.getSubscriptionsByJID(subscriberJID)) {
-                if (isNodeType) {
-                    // User is requesting a subscription of type "nodes"
-                    if (NodeSubscription.Type.nodes == subscription.getType()) {
-                        // Cannot have 2 subscriptions of the same type for the same subscription JID. Return conflict error
-                        sendErrorPacket(iq, PacketError.Condition.conflict, null);
-                        return;
-                    }
-                }
-                else if (!node.isMultipleSubscriptionsEnabled()) {
-                    // User is requesting a subscription of type "items" and
-                    // multiple subscriptions for the same subscription JID is not allowed
-                    if (NodeSubscription.Type.items == subscription.getType()) {
-                        // User is trying to create another subscription so
-                        // return current subscription state
-                        subscription.sendSubscriptionState(iq);
-                        return;
-                    }
-                }
-            }
-        }
-
-        // Create a subscription and an affiliation if the subscriber doesn't have one
-        node.createSubscription(iq, owner, subscriberJID, accessModel.isAuthorizationRequired(),
-                optionsForm);
+        // Attempt to create a subscription and an affiliation, assuming none exist or duplicates are permissible.
+        node.createSubscription(iq, owner, subscriberJID, accessModel.isAuthorizationRequired(), optionsForm);
     }
 
     private void unsubscribeNode(PubSubService service, IQ iq, Element unsubscribeElement) {
@@ -797,38 +754,13 @@ public class PubSubEngine
                 return;
             }
         }
-        NodeSubscription subscription;
-        JID owner = new JID(jidAttribute);
-        
-        if (node.isMultipleSubscriptionsEnabled()) {
-            if (subID == null) {
-                // No subid was specified and the node supports multiple subscriptions
-                Element pubsubError = DocumentHelper.createElement(
-                        QName.get("subid-required", "http://jabber.org/protocol/pubsub#errors"));
-                sendErrorPacket(iq, PacketError.Condition.bad_request, pubsubError);
-                return;
-            }
-            else {
-                // Check if the specified subID belongs to an existing node subscription
-                subscription = node.getSubscription(subID);
-                if (subscription == null) {
-                    Element pubsubError = DocumentHelper.createElement(
-                            QName.get("invalid-subid", "http://jabber.org/protocol/pubsub#errors"));
-                    sendErrorPacket(iq, PacketError.Condition.not_acceptable, pubsubError);
-                    return;
-                }
-            }
+
+        final JID subscriberJID = new JID(jidAttribute);
+        final NodeSubscription subscription = resolveSubscriptionOrError(iq, node, subID, subscriberJID);
+        if (subscription == null) {
+            return; // An appropriate error response has already been sent by resolveSubscriptionOrError().
         }
-        else {
-            JID subscriberJID = new JID(jidAttribute);
-            subscription = node.getSubscription(subscriberJID);
-            if (subscription == null) {
-                Element pubsubError = DocumentHelper.createElement(
-                        QName.get("not-subscribed", "http://jabber.org/protocol/pubsub#errors"));
-                sendErrorPacket(iq, PacketError.Condition.unexpected_request, pubsubError);
-                return;
-            }
-        }
+
         JID from = iq.getFrom();
         // Check that unsubscriptions to the node are enabled
         if (!node.isSubscriptionEnabled() && !service.isServiceAdmin(from)) {
@@ -850,10 +782,83 @@ public class PubSubEngine
         router.route(IQ.createResultIQ(iq));
     }
 
+    /**
+     * Resolves a subscription on the specified node for the provided subscriber.
+     *
+     * If a subscription ID is provided, this method verifies that it identifies an existing subscription on the node
+     * and returns that subscription. Otherwise, the subscription is inferred from the subscriber JID:
+     *
+     * <ul>
+     *   <li>If the JID has exactly one subscription on the node, that subscription is returned.</li>
+     *   <li>If the JID has no subscriptions, a {@code not-subscribed} PubSub error is returned.</li>
+     *   <li>If the JID has multiple subscriptions, a {@code subid-required} PubSub error is returned.</li>
+     * </ul>
+     *
+     * When a provided subscription ID does not correspond to an existing subscription, an {@code invalid-subid} PubSub
+     * error is returned.
+     *
+     * @param iq the IQ stanza to which any error response should be sent.
+     * @param node the node on which the subscription is to be resolved.
+     * @param subID the subscription ID to resolve, or {@code null} to resolve the subscription based on the subscriber JID.
+     * @param subscriberJID the JID of the subscriber
+     * @return the resolved subscription, or {@code null} if no unique subscription could be resolved. In that case,
+     *         an appropriate error response has already been sent.
+     */
+    private NodeSubscription resolveSubscriptionOrError(@Nonnull final IQ iq, @Nonnull final Node node, @Nullable final String subID, @Nonnull final JID subscriberJID)
+    {
+        NodeSubscription subscription;
+        if (subID != null)
+        {
+            // Check if the specified subID belongs to an existing node subscription
+            subscription = node.getSubscription(subID);
+            if (subscription == null) {
+                Element pubsubError = DocumentHelper.createElement(QName.get("invalid-subid", "http://jabber.org/protocol/pubsub#errors"));
+                sendErrorPacket(iq, PacketError.Condition.not_acceptable, pubsubError);
+                return null;
+            }
+
+            // XEP-0060 6.2.3.5 SubID does not match JID
+            if (!subscription.getJID().equals(subscriberJID)) {
+                Element pubsubError = DocumentHelper.createElement(QName.get("invalid-subid", "http://jabber.org/protocol/pubsub#errors"));
+                sendErrorPacket(iq, PacketError.Condition.not_acceptable, pubsubError);
+                return null;
+            }
+        }
+        else
+        {
+            final Collection<NodeSubscription> subscriptionsByJID = node.getSubscriptionsByJID(subscriberJID);
+            switch (subscriptionsByJID.size()) {
+                case 0:
+                    sendErrorPacket(iq, PacketError.Condition.unexpected_request, DocumentHelper.createElement(QName.get("not-subscribed", "http://jabber.org/protocol/pubsub#errors")));
+                    return null;
+
+                case 1:
+                    // Only one subscription exists for the specified JID, so use that one.
+                    subscription = subscriptionsByJID.iterator().next();
+                    break;
+
+                default:
+                    // No subid was specified, and the node has multiple subscriptions.
+                    sendErrorPacket(iq, PacketError.Condition.bad_request, DocumentHelper.createElement(QName.get("subid-required", "http://jabber.org/protocol/pubsub#errors")));
+                    return null;
+            }
+        }
+        return subscription;
+    }
+
     private void getSubscriptionConfiguration(PubSubService service, IQ iq,
                                               Element childElement, Element optionsElement) {
         String nodeID = optionsElement.attributeValue("node");
         String subID = optionsElement.attributeValue("subid");
+        String jidAttribute = optionsElement.attributeValue("jid");
+
+        if (jidAttribute == null) {
+            // No JID was specified so return an error indicating that jid is required
+            Element pubsubError = DocumentHelper.createElement(
+                QName.get("jid-required", "http://jabber.org/protocol/pubsub#errors"));
+            sendErrorPacket(iq, PacketError.Condition.bad_request, pubsubError);
+            return;
+        }
         Node node;
         if (nodeID == null) {
             if (service.isCollectionNodesSupported()) {
@@ -877,44 +882,11 @@ public class PubSubEngine
                 return;
             }
         }
-        NodeSubscription subscription;
-        if (node.isMultipleSubscriptionsEnabled()) {
-            if (subID == null) {
-                // No subid was specified and the node supports multiple subscriptions
-                Element pubsubError = DocumentHelper.createElement(
-                        QName.get("subid-required", "http://jabber.org/protocol/pubsub#errors"));
-                sendErrorPacket(iq, PacketError.Condition.bad_request, pubsubError);
-                return;
-            }
-            else {
-                // Check if the specified subID belongs to an existing node subscription
-                subscription = node.getSubscription(subID);
-                if (subscription == null) {
-                    Element pubsubError = DocumentHelper.createElement(
-                            QName.get("invalid-subid", "http://jabber.org/protocol/pubsub#errors"));
-                    sendErrorPacket(iq, PacketError.Condition.not_acceptable, pubsubError);
-                    return;
-                }
-            }
-        }
-        else {
-            // Check if the specified JID has a subscription with the node
-            String jidAttribute = optionsElement.attributeValue("jid");
-            if (jidAttribute == null) {
-                // No JID was specified so return an error indicating that jid is required
-                Element pubsubError = DocumentHelper.createElement(
-                        QName.get("jid-required", "http://jabber.org/protocol/pubsub#errors"));
-                sendErrorPacket(iq, PacketError.Condition.bad_request, pubsubError);
-                return;
-            }
-            JID subscriberJID = new JID(jidAttribute);
-            subscription = node.getSubscription(subscriberJID);
-            if (subscription == null) {
-                Element pubsubError = DocumentHelper.createElement(
-                        QName.get("not-subscribed", "http://jabber.org/protocol/pubsub#errors"));
-                sendErrorPacket(iq, PacketError.Condition.unexpected_request, pubsubError);
-                return;
-            }
+
+        final JID subscriberJID = new JID(jidAttribute);
+        final NodeSubscription subscription = resolveSubscriptionOrError(iq, node, subID, subscriberJID);
+        if (subscription == null) {
+            return; // An appropriate error response has already been sent by resolveSubscriptionOrError().
         }
 
         // A subscription was found so check if the user is allowed to get the subscription options
@@ -936,6 +908,15 @@ public class PubSubEngine
     private void configureSubscription(PubSubService service, IQ iq, Element optionsElement) {
         String nodeID = optionsElement.attributeValue("node");
         String subID = optionsElement.attributeValue("subid");
+        String jidAttribute = optionsElement.attributeValue("jid");
+
+        if (jidAttribute == null) {
+            // No JID was specified so return an error indicating that jid is required
+            Element pubsubError = DocumentHelper.createElement(
+                QName.get("jid-required", "http://jabber.org/protocol/pubsub#errors"));
+            sendErrorPacket(iq, PacketError.Condition.bad_request, pubsubError);
+            return;
+        }
         Node node;
         if (nodeID == null) {
             if (service.isCollectionNodesSupported()) {
@@ -959,44 +940,11 @@ public class PubSubEngine
                 return;
             }
         }
-        NodeSubscription subscription;
-        if (node.isMultipleSubscriptionsEnabled()) {
-            if (subID == null) {
-                // No subid was specified and the node supports multiple subscriptions
-                Element pubsubError = DocumentHelper.createElement(
-                        QName.get("subid-required", "http://jabber.org/protocol/pubsub#errors"));
-                sendErrorPacket(iq, PacketError.Condition.bad_request, pubsubError);
-                return;
-            }
-            else {
-                // Check if the specified subID belongs to an existing node subscription
-                subscription = node.getSubscription(subID);
-                if (subscription == null) {
-                    Element pubsubError = DocumentHelper.createElement(
-                            QName.get("invalid-subid", "http://jabber.org/protocol/pubsub#errors"));
-                    sendErrorPacket(iq, PacketError.Condition.not_acceptable, pubsubError);
-                    return;
-                }
-            }
-        }
-        else {
-            // Check if the specified JID has a subscription with the node
-            String jidAttribute = optionsElement.attributeValue("jid");
-            if (jidAttribute == null) {
-                // No JID was specified so return an error indicating that jid is required
-                Element pubsubError = DocumentHelper.createElement(
-                        QName.get("jid-required", "http://jabber.org/protocol/pubsub#errors"));
-                sendErrorPacket(iq, PacketError.Condition.bad_request, pubsubError);
-                return;
-            }
-            JID subscriberJID = new JID(jidAttribute);
-            subscription = node.getSubscription(subscriberJID);
-            if (subscription == null) {
-                Element pubsubError = DocumentHelper.createElement(
-                        QName.get("not-subscribed", "http://jabber.org/protocol/pubsub#errors"));
-                sendErrorPacket(iq, PacketError.Condition.unexpected_request, pubsubError);
-                return;
-            }
+
+        final JID subscriberJID = new JID(jidAttribute);
+        final NodeSubscription subscription = resolveSubscriptionOrError(iq, node, subID, subscriberJID);
+        if (subscription == null) {
+            return; // An appropriate error response has already been sent by resolveSubscriptionOrError().
         }
 
         // A subscription was found so check if the user is allowed to submits
@@ -1054,7 +1002,7 @@ public class PubSubEngine
             }
             subElement.addAttribute("jid", subscription.getJID().toString());
             subElement.addAttribute("subscription", subscription.getState().name());
-            if (node.isMultipleSubscriptionsEnabled()) {
+            if (node.isMultipleSubscriptionsEnabled() || node.isCollectionNode()) {
                 subElement.addAttribute("subid", subscription.getID());
             }
         }
@@ -1152,8 +1100,7 @@ public class PubSubEngine
         NodeSubscription subscription = null;
         if (node.isMultipleSubscriptionsEnabled() && (node.getSubscriptions(owner).size() > 1)) {
             if (subID == null) {
-                // No subid was specified and the node supports multiple subscriptions and the user
-                // has multiple subscriptions
+                // No subid was specified and the node supports multiple subscriptions and the user has multiple subscriptions
                 Element pubsubError = DocumentHelper.createElement(
                         QName.get("subid-required", "http://jabber.org/protocol/pubsub#errors"));
                 sendErrorPacket(iq, PacketError.Condition.bad_request, pubsubError);
@@ -1645,6 +1592,25 @@ public class PubSubEngine
             sendErrorPacket(iq, PacketError.Condition.forbidden, null);
             return;
         }
+        for (Iterator<Element> it = entitiesElement.elementIterator("subscription"); it.hasNext();) {
+            Element entity = it.next();
+            final String jidAttributeValue = entity.attributeValue("jid");
+            final String subidAttributeValue = entity.attributeValue("subid");
+            if (jidAttributeValue == null) {
+                sendErrorPacket(iq, PacketError.Condition.bad_request, null);
+                return;
+            }
+            if (node.isMultipleSubscriptionsEnabled() && subidAttributeValue == null) {
+                // XEP-0060: "If subscription identifiers are supported by the service, the 'subid' attribute MUST be present as well."
+                sendErrorPacket(iq, PacketError.Condition.bad_request, null);
+                return;
+            }
+            if (subidAttributeValue == null && node.getSubscriptionsByJID(new JID(jidAttributeValue)).size() > 1) {
+                // Unable to differentiate between multiple subscriptions with the same JID.
+                sendErrorPacket(iq, PacketError.Condition.conflict, null);
+                return;
+            }
+        }
 
         IQ reply = IQ.createResultIQ(iq);
 
@@ -1657,16 +1623,16 @@ public class PubSubEngine
             String subStatus = entity.attributeValue("subscription");
             String subID = entity.attributeValue("subid");
             // Process subscriptions changes
+
             // Get current subscription (if any)
-            NodeSubscription subscription = null;
-            if (node.isMultipleSubscriptionsEnabled()) {
-                if (subID != null) {
-                    subscription = node.getSubscription(subID);
-                }
-            }
-            else {
+            NodeSubscription subscription;
+            if (subID != null) {
+                subscription = node.getSubscription(subID);
+            } else {
                 subscription = node.getSubscription(subscriber);
             }
+
+            // Apply changes
             if ("none".equals(subStatus) && subscription != null) {
                 // Owner is cancelling an existing subscription
                 node.cancelSubscription(subscription);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -900,11 +900,17 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
                 .filter( Node::isSendItemSubscribe )
                 .filter( node -> nodeIDs.contains( node.getUniqueIdentifier().getNodeId()) )
                 .forEach( node -> {
-                    final NodeSubscription subscription = node.getSubscription(entity);
-                    if (subscription != null && subscription.isActive()) {
-                        PublishedItem lastItem = node.getLastPublishedItem();
-                        if (lastItem != null) {
-                            subscription.sendLastPublishedItem(lastItem);
+                    final Collection<NodeSubscription> subscriptions = node.getSubscriptionsByJID(entity);
+                    final HashSet<JID> notifiedJids = new HashSet<>();
+                    final PublishedItem lastItem = node.getLastPublishedItem();
+                    if (lastItem == null) {
+                        return;
+                    }
+                    for (final NodeSubscription subscription : subscriptions) {
+                        if (subscription.canSendPublicationEvent(lastItem.getNode(), lastItem)) {
+                            if (notifiedJids.add(subscription.getJID())) { // XEP-0060 section 6.1.6: When the pubsub service generates event notifications, it SHOULD send only one event notification to an entity that has multiple subscriptions
+                                subscription.sendLastPublishedItem(lastItem);
+                            }
                         }
                     }
                 });

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -18,6 +18,7 @@ package org.jivesoftware.openfire.pubsub;
 
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
+import org.jivesoftware.admin.servlet.PubSubSubscriptionMaintenanceServlet;
 import org.jivesoftware.openfire.*;
 import org.jivesoftware.openfire.commands.AdHocCommandManager;
 import org.jivesoftware.openfire.component.InternalComponentManager;
@@ -474,6 +475,10 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
         routingTable.addComponentRoute(getAddress(), this);
         // Start the pubsub engine
         engine.start(this);
+
+        // Schedule a background refresh of the advisability flag, so that there's a chance of it being ready when the index page loads (OF-3306).
+        PubSubSubscriptionMaintenanceServlet.isCleanupAdvisable();
+
         ArrayList<String> params = new ArrayList<>();
         params.add(getServiceDomain());
         Log.info(LocaleUtils.getLocalizedString("startup.starting.pubsub", params));

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -18,7 +18,6 @@ package org.jivesoftware.openfire.pubsub;
 
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
-import org.jivesoftware.admin.servlet.PubSubSubscriptionMaintenanceServlet;
 import org.jivesoftware.openfire.*;
 import org.jivesoftware.openfire.commands.AdHocCommandManager;
 import org.jivesoftware.openfire.component.InternalComponentManager;
@@ -476,8 +475,10 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
         // Start the pubsub engine
         engine.start(this);
 
-        // Schedule a background refresh of the advisability flag, so that there's a chance of it being ready when the index page loads (OF-3306).
-        PubSubSubscriptionMaintenanceServlet.isCleanupAdvisable();
+        // Initialize the maintenance instance with the correct multiple-subscription exclusion set, then warm
+        // the advisability cache so the index-page advisory has a chance to be ready on first view (OF-3306).
+        PubSubSubscriptionMaintenance.initialize(isMultipleSubscriptionsEnabled() ? Set.of(getServiceID()) : Set.of());
+        PubSubSubscriptionMaintenance.isCleanupAdvisable();
 
         ArrayList<String> params = new ArrayList<>();
         params.add(getServiceDomain());

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,11 +108,11 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
      * Manager that keeps the list of ad-hoc commands and processing command requests.
      */
     private final AdHocCommandManager manager;
-    
+
     /**
-     * Flag that indicates if a user may have more than one subscription with the node. When multiple
-     * subscriptions is enabled each subscription request, event notification and unsubscription request
-     * should include a subid attribute.
+     * Flag that indicates if a literal subscription JID value may have more than one subscription
+     * with a node. When multiple subscriptions is enabled each subscription request, event
+     * notification and unsubscription request should include a subid attribute.
      */
     private boolean multipleSubscriptionsEnabled = true;
 
@@ -635,7 +635,7 @@ public class PubSubModule extends BasicModule implements ServerItemsProvider, Di
             // Node owners may manage subscriptions.
             features.add("http://jabber.org/protocol/pubsub#manage-subscriptions");
             if (isMultipleSubscriptionsEnabled()) {
-                // A single entity may subscribe to a node multiple times
+                // A single literal subscription JID value may subscribe to a node multiple times
                 features.add( "http://jabber.org/protocol/pubsub#multi-subscribe" );
             }
             // The outcast affiliation is supported

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubService.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -251,11 +251,11 @@ public interface PubSubService
     void presenceSubscriptionNotRequired(Node node, JID user);
 
     /**
-     * Returns true if a user may have more than one subscription with the node. When
+     * Returns true if a literal subscription JID value may have more than one subscription with a node. When
      * multiple subscriptions is enabled each subscription request, event notification and
      * unsubscription request should include a {@code subid} attribute.
      *
-     * @return true if a user may have more than one subscription with the node.
+     * @return true if a literal subscription JID value may have more than one subscription with a node.
      */
     boolean isMultipleSubscriptionsEnabled();
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubSubscriptionMaintenance.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubSubscriptionMaintenance.java
@@ -16,7 +16,6 @@
 
 package org.jivesoftware.openfire.pubsub;
 
-import org.jivesoftware.admin.servlet.PubSubSubscriptionMaintenanceServlet;
 import org.jivesoftware.database.DbConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +26,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,6 +34,8 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -91,6 +93,84 @@ public class PubSubSubscriptionMaintenance
      * installations with millions of redundant rows.
      */
     private static final int DELETE_BATCH_SIZE = 1000;
+
+    /**
+     * Cached answer to "is a cleanup worth recommending?", read by the admin index page. Updated only by a background
+     * refresh or by the cleanup worker on completion, never on a page-rendering thread, so reading it is O(1) and
+     * never touches the database.
+     *
+     * This lives here, in the pubsub package alongside the maintenance logic, rather than in the admin servlet, so
+     * that the dependency points from the web layer to the core (the servlet calls this class), never the reverse.
+     */
+    private static final AtomicBoolean cleanupAdvisableCache = new AtomicBoolean(false);
+
+    /**
+     * Epoch-millis timestamp of the last completed advisability refresh, or 0 if it has never run. Used to decide when
+     * {@link #cleanupAdvisableCache} is stale.
+     */
+    private static final AtomicLong cleanupAdvisableCheckedAt = new AtomicLong(0L);
+
+    /**
+     * Guards against launching more than one background advisability refresh at a time.
+     */
+    private static final AtomicBoolean cleanupAdvisableRefreshing = new AtomicBoolean(false);
+
+    /**
+     * How long a cached advisability result is considered fresh before a read triggers a background refresh.
+     */
+    private static final long CLEANUP_ADVISABLE_TTL_MILLIS = Duration.ofHours(1).toMillis();
+
+    /**
+     * Returns whether a cleanup is worth recommending, for an advisory on the admin index page.
+     *
+     * Non-blocking: returns the cached value immediately and, if that value is missing or stale (and no run is in
+     * progress), schedules a one-off background refresh. A full {@link #analyze()} can take many seconds on a very
+     * large table, so it must never run on the page-rendering thread; consequently the first index view after startup
+     * returns {@code false} and the advisory may only appear on a later view, once the background check has completed.
+     *
+     * @return the cached advisability flag; {@code false} until the first background check has completed.
+     */
+    public static boolean isCleanupAdvisable()
+    {
+        final PubSubSubscriptionMaintenance m = instance;
+        if (m == null) {
+            return cleanupAdvisableCache.get(); // Not initialized yet; nothing to analyze against.
+        }
+
+        if (m.getProgress().getPhase() == Phase.RUNNING) {
+            return cleanupAdvisableCache.get();
+        }
+
+        final long checkedAt = cleanupAdvisableCheckedAt.get();
+        final boolean stale = checkedAt == 0L || (System.currentTimeMillis() - checkedAt) > CLEANUP_ADVISABLE_TTL_MILLIS;
+        if (stale && cleanupAdvisableRefreshing.compareAndSet(false, true)) {
+            final Thread refresh = new Thread(() -> {
+                try {
+                    cleanupAdvisableCache.set(m.analyze().isCleanupRecommended());
+                } catch (Exception e) {
+                    Log.debug("Background check for redundant pubsub subscription rows failed; will retry later.", e);
+                } finally {
+                    cleanupAdvisableCheckedAt.set(System.currentTimeMillis());
+                    cleanupAdvisableRefreshing.set(false);
+                }
+            }, "pubsub-subscription-cleanup-advisability-check");
+            refresh.setDaemon(true);
+            refresh.start();
+        }
+        return cleanupAdvisableCache.get();
+    }
+
+    /**
+     * Directly sets the cached advisability value and marks it freshly checked. Used by the cleanup worker on
+     * completion, when the outcome is already known, to avoid a redundant re-analysis.
+     *
+     * @param advisable whether a cleanup is now worth recommending.
+     */
+    public static void setCleanupAdvisable(final boolean advisable)
+    {
+        cleanupAdvisableCache.set(advisable);
+        cleanupAdvisableCheckedAt.set(System.currentTimeMillis());
+    }
 
     /**
      * Counts the total rows and the number of distinct logical subscriptions.
@@ -183,6 +263,50 @@ public class PubSubSubscriptionMaintenance
      * Holds the live progress of a cleanup. Replaced atomically so that readers always see a consistent snapshot.
      */
     private final AtomicReference<Progress> progress = new AtomicReference<>(Progress.idle());
+
+    /**
+     * The shared maintenance instance, created once the pubsub service can answer which services permit multiple
+     * subscriptions. Both the admin servlet (for analysis and cleanup) and the background advisability refresh use
+     * this same instance, so progress state and the multiple-subscription exclusion set are consistent everywhere.
+     */
+    private static volatile PubSubSubscriptionMaintenance instance;
+
+    /**
+     * Lock guarding lazy creation of {@link #instance}.
+     */
+    private static final Object instanceLock = new Object();
+
+    /**
+     * Initializes the shared maintenance instance with the set of services that permit multiple subscriptions, if it
+     * has not already been created. Called by the pubsub module at startup, when the live services can be inspected.
+     *
+     * @param multipleSubscriptionServiceIds service IDs to exclude from analysis and cleanup; see the constructor.
+     * @return the shared instance.
+     */
+    public static PubSubSubscriptionMaintenance initialize(@Nonnull final Collection<String> multipleSubscriptionServiceIds)
+    {
+        PubSubSubscriptionMaintenance result = instance;
+        if (result == null) {
+            synchronized (instanceLock) {
+                result = instance;
+                if (result == null) {
+                    result = new PubSubSubscriptionMaintenance(multipleSubscriptionServiceIds);
+                    instance = result;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @return the shared maintenance instance, or null if it has not been initialized yet (the pubsub service has not
+     *         started). Callers that need an instance before startup should treat null as "not yet available".
+     */
+    @Nullable
+    public static PubSubSubscriptionMaintenance getInstance()
+    {
+        return instance;
+    }
 
     /**
      * Creates a maintenance utility that excludes the supplied multiple-subscription services from analysis and
@@ -343,6 +467,7 @@ public class PubSubSubscriptionMaintenance
             if (toRemove == 0) {
                 Log.info("No redundant pubsub subscription rows found; nothing to clean up.");
                 progress.set(Progress.completed(0, 0));
+                setCleanupAdvisable(false);
                 return;
             }
 
@@ -351,15 +476,15 @@ public class PubSubSubscriptionMaintenance
 
             Log.info("Cleanup of redundant pubsub subscription rows finished. Removed {} row(s).", removed);
             progress.set(Progress.completed(toRemove, removed));
+
+            // The cleanup just reduced the table to one row per logical subscription, so no cleanup is advisable now.
+            // Update the cached advisory directly rather than forcing another full re-analysis.
+            setCleanupAdvisable(false);
         }
         catch (Exception e) {
             Log.error("Cleanup of redundant pubsub subscription rows failed.", e);
             final Progress last = progress.get();
             progress.set(Progress.failed(last.totalToRemove, last.removed, e.getMessage()));
-        }
-        finally {
-            // Reset the flag that indicates that a cleanup is advisable. Without this, the warning that cleanup is needed would continue to show.
-            PubSubSubscriptionMaintenanceServlet.isCleanupAdvisable();
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubSubscriptionMaintenance.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubSubscriptionMaintenance.java
@@ -1,0 +1,847 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.pubsub;
+
+import org.jivesoftware.database.DbConnectionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Analyzes and (optionally) cleans up redundant rows in the {@code ofPubsubSubscription} table.
+ *
+ * Some installations have accumulated very large numbers of redundant subscription rows: rows that share the same node,
+ * subscription JID, owner and subscription type, differing only by their generated subscription ID. On a node that does
+ * not allow multiple subscriptions for the same subscription JID (XEP-0060 §6.1.6) - most notably PEP services
+ * (XEP-0163) - at most one such subscription can be meaningful, so the surplus rows carry no functional value. In
+ * extreme cases their sheer number exhausts the Java heap when the data is loaded into memory (OF-3306).
+ *
+ * This utility is intended to be driven from an admin-console page. It offers three operations:
+ * <ul>
+ *     <li>{@link #analyze()} - a read-only assessment of how much redundant data exists (safe to call on page load).</li>
+ *     <li>{@link #startCleanup()} - launches a batched, background deletion of the redundant rows.</li>
+ *     <li>{@link #getProgress()} - a thread-safe snapshot of an in-progress or completed cleanup, for a progress bar.</li>
+ * </ul>
+ *
+ * <h2>What is deleted</h2>
+ * For each group of rows that share {@code (serviceID, nodeID, jid, owner, subscriptionType)}, exactly one row is kept
+ * (the one with the lexicographically greatest {@code id}); all others in the group are removed. Groups with only a
+ * single row are never touched. The deletion is performed in bounded batches, each in its own transaction, so that it
+ * can run against a live server without producing an unmanageably large transaction.
+ *
+ * <h2>Safety with respect to multiple-subscription services</h2>
+ * Same-key rows are only redundant on a service that does <em>not</em> allow multiple subscriptions for the same
+ * subscription JID (XEP-0060 §6.1.6). On a service that <em>does</em> allow them, such rows are legitimate and are
+ * differentiated by their subscription ID; deleting them would destroy live subscriptions. Whether multiple
+ * subscriptions are allowed is a service-wide setting ({@code PubSubService.isMultipleSubscriptionsEnabled()}): PEP
+ * services always return {@code false}, while the main pubsub service is governed by the
+ * {@code xmpp.pubsub.multiple-subscriptions} property.
+ *
+ * Because this deletion runs at the database level, it cannot itself consult that in-memory, per-service setting.
+ * Instead the caller - which runs inside the server and can enumerate the live services - must supply the set of
+ * service IDs that permit multiple subscriptions via the constructor. Those services are excluded from both the
+ * analysis and the deletion, so their rows are never counted as removable and never deleted. Inverting the dependency
+ * this way keeps the authority for the safety decision with the code that can actually answer the question, rather than
+ * having this utility guess.
+ *
+ * This utility performs no deletion until {@link #startCleanup()} is explicitly invoked, and administrators should be
+ * advised to take a database backup first.
+ *
+ * Instances are not designed to run concurrent cleanups; {@link #startCleanup()} guards against launching a second
+ * cleanup while one is already running.
+ */
+public class PubSubSubscriptionMaintenance
+{
+    /**
+     * Logger for this class.
+     */
+    private static final Logger Log = LoggerFactory.getLogger(PubSubSubscriptionMaintenance.class);
+
+    /**
+     * Number of rows deleted per transaction. Kept modest so that no single transaction grows unmanageably large on
+     * installations with millions of redundant rows.
+     */
+    private static final int DELETE_BATCH_SIZE = 1000;
+
+    /**
+     * Counts the total rows and the number of distinct logical subscriptions.
+     *
+     * {@code COUNT(DISTINCT a, b, c)} over multiple columns is not portable across the databases Openfire supports, so
+     * the distinct count is derived from a grouped subquery instead: the inner query produces one row per logical
+     * subscription, and the outer query counts those rows. This is portable to MySQL/MariaDB, PostgreSQL, Oracle,
+     * SQL Server and HSQLDB.
+     *
+     * The service-exclusion predicate (if any) is appended to the inner query's WHERE clause and to a parallel total
+     * count, so excluded services contribute to neither figure.
+     */
+    private static final String COUNT_TOTAL =
+        "SELECT COUNT(*) AS total_rows FROM ofPubsubSubscription";
+
+    /**
+     * Template for counting distinct logical subscriptions: a grouped subquery yields one row per logical
+     * subscription and the outer query counts them. The single {@code %s} carries the optional service-exclusion
+     * predicate. Uses {@code COUNT}/{@code GROUP BY} over a derived table (with a non-{@code AS} table alias for Oracle
+     * compatibility), which is portable across all supported databases.
+     */
+    private static final String COUNT_DISTINCT_TEMPLATE =
+        "SELECT COUNT(*) AS distinct_subs FROM (" +
+            "  SELECT 1 FROM ofPubsubSubscription" +
+            "%s" + // optional WHERE service-exclusion
+            "  GROUP BY serviceID, nodeID, jid, owner, subscriptionType" +
+            ") grouped";
+
+    /**
+     * Selects exactly one surviving subscription id per logical subscription: the greatest id within each
+     * {@code (serviceID, nodeID, jid, owner, subscriptionType)} group. This is a single grouped scan (one survivor per
+     * group), as opposed to a per-row correlated lookup, and uses only {@code MAX}/{@code GROUP BY}, which are portable
+     * across all supported databases.
+     *
+     * The survivors are held in memory; non-survivor rows are then deleted in bounded batches. With at most one
+     * surviving id per logical subscription, the in-memory set is small (on the order of the distinct-subscription
+     * count) even when the table itself is enormous.
+     */
+    private static final String SELECT_SURVIVOR_IDS =
+        "SELECT serviceID, nodeID, MAX(id) AS keep_id " +
+            "FROM ofPubsubSubscription" +
+            "%s" + // optional WHERE service-exclusion (begins with a leading space)
+            " GROUP BY serviceID, nodeID, jid, owner, subscriptionType";
+
+    /**
+     * The columns selected for each page of candidate rows (the primary key).
+     *
+     * Paging works through candidate rows in primary-key order, in bounded chunks, rather than holding one large
+     * result set open. This avoids relying on driver-side streaming (which several supported drivers do not provide for
+     * auto-commit connections), keeping every query bounded and memory use flat regardless of table size.
+     *
+     * The row-limit keyword is dialect-specific ({@code LIMIT} / {@code TOP} / {@code FETCH FIRST}), so the limited
+     * SELECT is assembled at runtime via {@link DbConnectionManager#getResultSetLimitKeyword()}. The key predicate is
+     * written in expanded boolean form rather than as a row-value comparison {@code (a,b,c) > (?,?,?)}, because the
+     * latter is not supported by all databases Openfire targets (for example SQL Server and older Oracle).
+     */
+    private static final String PAGE_COLUMNS = "serviceID, nodeID, id";
+
+    /**
+     * The table that pages are read from.
+     */
+    private static final String PAGE_TABLE = "ofPubsubSubscription";
+
+    /**
+     * The primary-key ordering applied to every page, so that paging by a key cursor is well-defined.
+     */
+    private static final String PAGE_ORDER = " ORDER BY serviceID, nodeID, id";
+
+    /**
+     * Expanded-boolean "primary key strictly greater than (?, ?, ?)" predicate, portable across all supported
+     * databases. Parameters, in order: serviceID, serviceID, nodeID, serviceID, nodeID, id.
+     */
+    private static final String PAGE_KEY_AFTER =
+        "(serviceID > ? OR (serviceID = ? AND nodeID > ?) OR (serviceID = ? AND nodeID = ? AND id > ?))";
+
+    /**
+     * Deletes a single subscription row by its full primary key. Parameters, in order: serviceID, nodeID, id.
+     */
+    private static final String DELETE_ONE =
+        "DELETE FROM ofPubsubSubscription WHERE serviceID = ? AND nodeID = ? AND id = ?";
+
+    /**
+     * Service IDs that permit multiple subscriptions for the same subscription JID, and whose rows must therefore never
+     * be treated as redundant. Immutable after construction.
+     */
+    @Nonnull
+    private final Set<String> excludedServiceIds;
+
+    /**
+     * Holds the live progress of a cleanup. Replaced atomically so that readers always see a consistent snapshot.
+     */
+    private final AtomicReference<Progress> progress = new AtomicReference<>(Progress.idle());
+
+    /**
+     * Creates a maintenance utility that excludes the supplied multiple-subscription services from analysis and
+     * cleanup.
+     *
+     * @param multipleSubscriptionServiceIds the IDs of services for which {@code isMultipleSubscriptionsEnabled()} is
+     *                                       true. Rows belonging to these services are never counted as removable and
+     *                                       never deleted. Must not be null; pass an empty collection only when the
+     *                                       deployment is known to have no service that permits multiple subscriptions.
+     *                                       In practice this set is very small (often just the single main pubsub
+     *                                       service); it is rendered into a SQL {@code IN} list, so it is not intended
+     *                                       to hold thousands of entries.
+     */
+    public PubSubSubscriptionMaintenance(@Nonnull final Collection<String> multipleSubscriptionServiceIds)
+    {
+        this.excludedServiceIds = Collections.unmodifiableSet(new LinkedHashSet<>(multipleSubscriptionServiceIds));
+    }
+
+    /**
+     * @return the service IDs excluded from analysis and cleanup (those permitting multiple subscriptions). Never null.
+     */
+    @Nonnull
+    public Set<String> getExcludedServiceIds()
+    {
+        return excludedServiceIds;
+    }
+
+    /**
+     * Performs a read-only assessment of the redundant-row situation.
+     *
+     * This issues a single aggregate query. On a very large table it can take some seconds (a full scan), but it
+     * neither locks rows for writing nor modifies any data, so it is safe to call when rendering an admin page.
+     *
+     * @return the analysis result, never null.
+     * @throws SQLException if the database could not be queried.
+     */
+    @Nonnull
+    public Analysis analyze() throws SQLException
+    {
+        Connection con = null;
+        try {
+            con = DbConnectionManager.getConnection();
+            final long total = queryLong(con, COUNT_TOTAL + serviceExclusionClause("WHERE", "serviceID"));
+            final String distinctExclusion = serviceExclusionClause("WHERE", "serviceID");
+            final long distinct = queryLong(con, String.format(COUNT_DISTINCT_TEMPLATE, distinctExclusion));
+            return new Analysis(total, distinct);
+        }
+        finally {
+            DbConnectionManager.closeConnection(con);
+        }
+    }
+
+    /**
+     * Executes a single-aggregate query whose only parameters (if any) are the excluded service IDs, and returns the
+     * first column of the single result row as a long.
+     */
+    private long queryLong(@Nonnull final Connection con, @Nonnull final String sql) throws SQLException
+    {
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            pstmt = con.prepareStatement(sql);
+            bindExcludedServiceIds(pstmt, 1);
+            rs = pstmt.executeQuery();
+            return rs.next() ? rs.getLong(1) : 0L;
+        }
+        finally {
+            DbConnectionManager.closeResultSet(rs);
+            DbConnectionManager.closeStatement(pstmt);
+        }
+    }
+
+    /**
+     * Builds a SQL fragment that excludes the configured services, or an empty string when there are none to exclude.
+     *
+     * @param keyword the clause keyword to introduce the predicate with - "WHERE" when the query has no other
+     *                predicate, "AND" when appending to an existing one.
+     * @param column  the (possibly table-qualified) column to test, e.g. "serviceID" or "a.serviceID".
+     * @return a fragment such as " WHERE serviceID NOT IN (?, ?)", or "" when no services are excluded.
+     */
+    @Nonnull
+    private String serviceExclusionClause(@Nonnull final String keyword, @Nonnull final String column)
+    {
+        if (excludedServiceIds.isEmpty()) {
+            return "";
+        }
+        final StringBuilder sb = new StringBuilder(" ").append(keyword).append(' ').append(column).append(" NOT IN (");
+        for (int i = 0; i < excludedServiceIds.size(); i++) {
+            sb.append(i == 0 ? "?" : ",?");
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+    /**
+     * Binds the excluded service IDs as consecutive parameters, starting at the given index.
+     *
+     * @param pstmt      the statement whose parameters are set.
+     * @param startIndex the 1-based index of the first excluded-service parameter.
+     * @return the next free parameter index after the bound values.
+     * @throws SQLException if a parameter could not be set.
+     */
+    private int bindExcludedServiceIds(@Nonnull final PreparedStatement pstmt, final int startIndex) throws SQLException
+    {
+        int index = startIndex;
+        for (final String serviceId : excludedServiceIds) {
+            pstmt.setString(index++, serviceId);
+        }
+        return index;
+    }
+
+    /**
+     * Launches a cleanup on a background thread, unless one is already running.
+     *
+     * The cleanup deletes redundant rows in batches (see {@link #DELETE_BATCH_SIZE}), committing after each batch and
+     * updating {@link #getProgress()} as it goes. Control returns to the caller immediately; the admin page should poll
+     * {@link #getProgress()} to render a progress indicator.
+     *
+     * @return true if a new cleanup was started; false if one was already running.
+     */
+    public boolean startCleanup()
+    {
+        final Progress current = progress.get();
+        if (current.phase == Phase.RUNNING) {
+            return false;
+        }
+        // Reset to a running state before spawning the worker, so a rapid second call is rejected.
+        if (!progress.compareAndSet(current, Progress.starting())) {
+            return false; // Another caller won the race.
+        }
+
+        final Thread worker = new Thread(this::runCleanup, "pubsub-subscription-cleanup");
+        worker.setDaemon(true);
+        worker.start();
+        return true;
+    }
+
+    /**
+     * @return a snapshot of the current (or most recently completed) cleanup progress. Never null.
+     */
+    @Nonnull
+    public Progress getProgress()
+    {
+        return progress.get();
+    }
+
+    /**
+     * The background cleanup routine. Collects the ids to remove, then deletes them in bounded, individually-committed
+     * batches, updating progress throughout.
+     */
+    private void runCleanup()
+    {
+        Log.info("Starting cleanup of redundant pubsub subscription rows.");
+        try {
+            // First, determine the total amount of work, so the progress indicator has a meaningful denominator.
+            final Analysis analysis = analyze();
+            final long toRemove = analysis.getRemovableRows();
+            if (toRemove == 0) {
+                Log.info("No redundant pubsub subscription rows found; nothing to clean up.");
+                progress.set(Progress.completed(0, 0));
+                return;
+            }
+
+            progress.set(Progress.running(toRemove, 0));
+            final long removed = deleteRedundantRows(toRemove);
+
+            Log.info("Cleanup of redundant pubsub subscription rows finished. Removed {} row(s).", removed);
+            progress.set(Progress.completed(toRemove, removed));
+        }
+        catch (Exception e) {
+            Log.error("Cleanup of redundant pubsub subscription rows failed.", e);
+            final Progress last = progress.get();
+            progress.set(Progress.failed(last.totalToRemove, last.removed, e.getMessage()));
+        }
+    }
+
+    /**
+     * Collects the surviving subscription ids into memory, then pages through all candidate rows in primary-key order
+     * and deletes those that are not survivors, in bounded batches.
+     *
+     * The survivor set is computed with a single grouped scan (one row per logical subscription), so it is small even
+     * when the table is enormous. Determining whether a row is a survivor is then an in-memory set lookup, avoiding the
+     * per-row correlated subquery that makes the naive approach quadratic. Candidate rows are read in bounded,
+     * key-ordered pages rather than as one large result set, so memory use stays flat and the work does not depend on
+     * driver-side streaming.
+     *
+     * @param expectedTotal the analysis-derived removable total, used only to keep the progress denominator stable.
+     * @return the number of rows actually removed.
+     * @throws SQLException if the database interaction failed.
+     */
+    private long deleteRedundantRows(final long expectedTotal) throws SQLException
+    {
+        final Set<String> survivors = collectSurvivorKeys();
+        long removed = 0;
+
+        // Batch buffer of (serviceID, nodeID, id) keys for non-survivor rows.
+        final String[][] batch = new String[DELETE_BATCH_SIZE][3];
+        int batchCount = 0;
+
+        // Cursor over the primary key; null until the first page is read.
+        String cursorService = null;
+        String cursorNode = null;
+        String cursorId = null;
+
+        boolean morePages = true;
+        while (morePages) {
+            final Page page = readPage(cursorService, cursorNode, cursorId);
+            morePages = page.full; // A full page implies there may be more rows.
+
+            for (final String[] row : page.rows) {
+                cursorService = row[0];
+                cursorNode = row[1];
+                cursorId = row[2];
+
+                if (survivors.contains(survivorKey(row[0], row[1], row[2]))) {
+                    continue; // Keep exactly one row per logical subscription.
+                }
+
+                batch[batchCount][0] = row[0];
+                batch[batchCount][1] = row[1];
+                batch[batchCount][2] = row[2];
+                batchCount++;
+
+                if (batchCount == DELETE_BATCH_SIZE) {
+                    removed += deleteBatch(batch, batchCount);
+                    batchCount = 0;
+                    progress.set(Progress.running(expectedTotal, removed));
+                }
+            }
+        }
+
+        // Flush any partial final batch.
+        if (batchCount > 0) {
+            removed += deleteBatch(batch, batchCount);
+            progress.set(Progress.running(expectedTotal, removed));
+        }
+
+        return removed;
+    }
+
+    /**
+     * Reads one page of rows, in primary-key order, strictly after the supplied cursor key (or from the start when the
+     * cursor is null). Each page is a bounded query, so no driver-side streaming is required.
+     *
+     * @param afterService the serviceID of the last row read, or null for the first page.
+     * @param afterNode    the nodeID of the last row read, or null for the first page.
+     * @param afterId      the id of the last row read, or null for the first page.
+     * @return the page of rows (never null); {@link Page#full} indicates the page was filled to the page size, so more
+     *         rows may remain.
+     * @throws SQLException if the page could not be read.
+     */
+    @Nonnull
+    private Page readPage(@Nullable final String afterService, @Nullable final String afterNode, @Nullable final String afterId) throws SQLException
+    {
+        final boolean first = afterService == null;
+        final String sql = buildPageSql(first);
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            con = DbConnectionManager.getConnection();
+            pstmt = con.prepareStatement(sql);
+            DbConnectionManager.setFetchSize(pstmt, DELETE_BATCH_SIZE);
+            DbConnectionManager.setMaxRows(pstmt, DELETE_BATCH_SIZE);
+
+            // The row-limit count is rendered as a literal in buildPageSql (portable across dialects), so the only
+            // bind parameters are the excluded service IDs and, for non-first pages, the key-after predicate.
+            int index = bindExcludedServiceIds(pstmt, 1);
+            if (!first) {
+                // Expanded-boolean key predicate parameters: service, service, node, service, node, id.
+                pstmt.setString(index++, afterService);
+                pstmt.setString(index++, afterService);
+                pstmt.setString(index++, afterNode);
+                pstmt.setString(index++, afterService);
+                pstmt.setString(index++, afterNode);
+                pstmt.setString(index, afterId);
+            }
+
+            rs = pstmt.executeQuery();
+            final List<String[]> rows = new ArrayList<>(DELETE_BATCH_SIZE);
+            while (rs.next()) {
+                rows.add(new String[] { rs.getString(1), rs.getString(2), rs.getString(3) });
+            }
+            return new Page(rows, rows.size() == DELETE_BATCH_SIZE);
+        }
+        finally {
+            DbConnectionManager.closeConnection(rs, pstmt, con);
+        }
+    }
+
+    /**
+     * Builds a dialect-correct, row-limited SELECT for one page, applying the service exclusion and (for non-first
+     * pages) the key-after predicate.
+     *
+     * The row-limit keyword position and spelling vary by database, so this uses
+     * {@link DbConnectionManager#getResultSetLimitKeyword()} and {@link DbConnectionManager#isResultSetLimitKeywordPrefix()}.
+     * The limit count is rendered as a literal integer (it is a fixed, trusted constant, never user input), which keeps
+     * the parameter list identical across dialects.
+     *
+     * @param first true for the first page (no key-after predicate), false otherwise.
+     * @return the SQL for one page.
+     */
+    @Nonnull
+    private String buildPageSql(final boolean first)
+    {
+        final StringBuilder where = new StringBuilder();
+        final String exclusion = serviceExclusionClause("WHERE", "serviceID");
+        where.append(exclusion);
+        if (!first) {
+            where.append(exclusion.isEmpty() ? " WHERE " : " AND ").append(PAGE_KEY_AFTER);
+        }
+
+        final DbConnectionManager.ResultSetLimitKeyword limit = DbConnectionManager.getResultSetLimitKeyword();
+        final StringBuilder sql = new StringBuilder();
+        switch (limit) {
+            case TOP -> // e.g. SQL Server: SELECT TOP (n) cols ...
+                sql.append("SELECT TOP (").append(DELETE_BATCH_SIZE).append(") ").append(PAGE_COLUMNS)
+                    .append(" FROM ").append(PAGE_TABLE).append(where).append(PAGE_ORDER);
+            case FETCH_FIRST -> // e.g. Oracle/DB2/Firebird: ... FETCH FIRST n ROWS ONLY
+                sql.append("SELECT ").append(PAGE_COLUMNS).append(" FROM ").append(PAGE_TABLE).append(where)
+                    .append(PAGE_ORDER).append(" FETCH FIRST ").append(DELETE_BATCH_SIZE).append(" ROWS ONLY");
+            default -> // LIMIT style: MySQL/MariaDB/PostgreSQL/HSQLDB/CockroachDB
+                sql.append("SELECT ").append(PAGE_COLUMNS).append(" FROM ").append(PAGE_TABLE).append(where)
+                    .append(PAGE_ORDER).append(" LIMIT ").append(DELETE_BATCH_SIZE);
+        }
+        return sql.toString();
+    }
+
+    /**
+     * One page of read rows.
+     */
+    private static final class Page
+    {
+        /**
+         * The rows in this page, each a {serviceID, nodeID, id} triple, in primary-key order.
+         */
+        @Nonnull private final List<String[]> rows;
+
+        /**
+         * True when the page was filled to the page size, indicating that more rows may follow.
+         */
+        private final boolean full;
+
+        /**
+         * Creates a page.
+         *
+         * @param rows the rows read for this page, in primary-key order.
+         * @param full whether the page was filled to the page size (more rows may remain).
+         */
+        private Page(@Nonnull final List<String[]> rows, final boolean full)
+        {
+            this.rows = rows;
+            this.full = full;
+        }
+    }
+
+    /**
+     * Computes, in memory, the set of surviving subscription ids: one per logical subscription, identified by the
+     * full primary key {@code (serviceID, nodeID, id)}. Built from a single grouped scan.
+     *
+     * The scan runs on a transaction connection (auto-commit disabled) so that the fetch-size hint can engage a
+     * server-side cursor on drivers that ignore it for auto-commit connections. The survivor set is small (one entry
+     * per logical subscription), so this is not a memory concern, but the cursor keeps the driver from buffering the
+     * full grouped result up front on large tables.
+     *
+     * @return a set of survivor keys, in the encoding produced by {@link #survivorKey(String, String, String)}.
+     * @throws SQLException if the survivor query failed.
+     */
+    @Nonnull
+    private Set<String> collectSurvivorKeys() throws SQLException
+    {
+        final String sql = String.format(SELECT_SURVIVOR_IDS, serviceExclusionClause("WHERE", "serviceID"));
+        final Set<String> survivors = new HashSet<>();
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        boolean abortTransaction = false;
+        try {
+            con = DbConnectionManager.getTransactionConnection();
+            pstmt = con.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+            DbConnectionManager.setFetchSize(pstmt, DELETE_BATCH_SIZE);
+            bindExcludedServiceIds(pstmt, 1);
+            rs = pstmt.executeQuery();
+            while (rs.next()) {
+                survivors.add(survivorKey(rs.getString(1), rs.getString(2), rs.getString(3)));
+            }
+        }
+        catch (SQLException e) {
+            abortTransaction = true;
+            throw e;
+        }
+        finally {
+            DbConnectionManager.closeResultSet(rs);
+            DbConnectionManager.closeStatement(pstmt);
+            DbConnectionManager.closeTransactionConnection(con, abortTransaction);
+        }
+        return survivors;
+    }
+
+    /**
+     * Encodes a primary key into the string form used for the in-memory survivor set. The separator is a NUL character,
+     * which cannot occur in a JID, node id or service id, so the encoding is unambiguous.
+     */
+    @Nonnull
+    private static String survivorKey(@Nonnull final String serviceID, @Nonnull final String nodeID, @Nonnull final String id)
+    {
+        return serviceID + '\u0000' + nodeID + '\u0000' + id;
+    }
+
+    /**
+     * Deletes a single batch of subscription rows in its own transaction.
+     *
+     * @param batch a reusable buffer of {serviceID, nodeID, id} triples.
+     * @param count the number of valid entries in the buffer.
+     * @return the number of rows deleted in this batch.
+     * @throws SQLException if the batch could not be committed.
+     */
+    private long deleteBatch(final String[][] batch, final int count) throws SQLException
+    {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        boolean abortTransaction = false;
+        try {
+            con = DbConnectionManager.getTransactionConnection();
+            pstmt = con.prepareStatement(DELETE_ONE);
+            for (int i = 0; i < count; i++) {
+                pstmt.setString(1, batch[i][0]);
+                pstmt.setString(2, batch[i][1]);
+                pstmt.setString(3, batch[i][2]);
+                pstmt.addBatch();
+            }
+            final int[] results = pstmt.executeBatch();
+            long deleted = 0;
+            for (final int r : results) {
+                // Some drivers return SUCCESS_NO_INFO (-2) instead of an exact count; treat that as one deleted row,
+                // since each statement targets a single primary key.
+                deleted += (r >= 0) ? r : 1;
+            }
+            return deleted;
+        }
+        catch (SQLException e) {
+            abortTransaction = true;
+            throw e;
+        }
+        finally {
+            DbConnectionManager.closeStatement(pstmt);
+            DbConnectionManager.closeTransactionConnection(con, abortTransaction);
+        }
+    }
+
+    /**
+     * Read-only assessment of the redundant-row situation. Immutable.
+     */
+    public static final class Analysis
+    {
+        /**
+         * The total number of rows in the table (within the analyzed scope).
+         */
+        private final long totalRows;
+
+        /**
+         * The number of distinct logical subscriptions (the rows that would remain after cleanup).
+         */
+        private final long distinctSubscriptions;
+
+        /**
+         * Creates an analysis result.
+         *
+         * @param totalRows             the total number of rows counted.
+         * @param distinctSubscriptions the number of distinct logical subscriptions counted.
+         */
+        Analysis(final long totalRows, final long distinctSubscriptions)
+        {
+            this.totalRows = totalRows;
+            this.distinctSubscriptions = distinctSubscriptions;
+        }
+
+        /** @return the total number of rows currently in the table. */
+        public long getTotalRows()
+        {
+            return totalRows;
+        }
+
+        /** @return the number of distinct logical subscriptions (rows remaining after cleanup). */
+        public long getDistinctSubscriptions()
+        {
+            return distinctSubscriptions;
+        }
+
+        /** @return the number of rows that cleanup would remove. */
+        public long getRemovableRows()
+        {
+            return totalRows - distinctSubscriptions;
+        }
+
+        /**
+         * @return true if cleanup is worthwhile (there is at least one removable row). An admin page can use this to
+         *         decide whether to show a maintenance alert.
+         */
+        public boolean isCleanupRecommended()
+        {
+            return getRemovableRows() > 0;
+        }
+
+        /**
+         * @return the fraction of the table that is redundant, in the range [0.0, 1.0]; 0.0 when the table is empty.
+         *         Useful for phrasing the alert (e.g. "84% of rows are redundant").
+         */
+        public double getRedundancyRatio()
+        {
+            return totalRows == 0 ? 0.0 : (double) getRemovableRows() / (double) totalRows;
+        }
+    }
+
+    /**
+     * Phase of a cleanup operation.
+     */
+    public enum Phase
+    {
+        /** No cleanup has been started in this server session. */
+        IDLE,
+        /** A cleanup has been requested but has not yet reported progress. */
+        RUNNING,
+        /** A cleanup finished successfully. */
+        COMPLETED,
+        /** A cleanup terminated with an error. */
+        FAILED
+    }
+
+    /**
+     * Immutable snapshot of cleanup progress. New instances are published atomically as the cleanup proceeds.
+     */
+    public static final class Progress
+    {
+        /**
+         * The current phase of the cleanup.
+         */
+        private final Phase phase;
+
+        /**
+         * The number of rows the cleanup set out to remove (the denominator for progress), or 0 until known.
+         */
+        private final long totalToRemove;
+
+        /**
+         * The number of rows removed so far (or in total, once completed).
+         */
+        private final long removed;
+
+        /**
+         * The failure message when the phase is {@link Phase#FAILED}, otherwise null.
+         */
+        @Nullable private final String error;
+
+        /**
+         * Creates a progress snapshot.
+         *
+         * @param phase         the current phase.
+         * @param totalToRemove the number of rows targeted for removal (0 if not yet known).
+         * @param removed       the number of rows removed so far.
+         * @param error         the failure message, or null when not failed.
+         */
+        private Progress(final Phase phase, final long totalToRemove, final long removed, @Nullable final String error)
+        {
+            this.phase = phase;
+            this.totalToRemove = totalToRemove;
+            this.removed = removed;
+            this.error = error;
+        }
+
+        /**
+         * @return a snapshot representing the idle state (no cleanup started).
+         */
+        static Progress idle()
+        {
+            return new Progress(Phase.IDLE, 0, 0, null);
+        }
+
+        /**
+         * @return a snapshot representing a cleanup that has been requested but has not yet reported a total.
+         */
+        static Progress starting()
+        {
+            return new Progress(Phase.RUNNING, 0, 0, null);
+        }
+
+        /**
+         * @param totalToRemove the number of rows targeted for removal.
+         * @param removed       the number of rows removed so far.
+         * @return a snapshot representing a running cleanup.
+         */
+        static Progress running(final long totalToRemove, final long removed)
+        {
+            return new Progress(Phase.RUNNING, totalToRemove, removed, null);
+        }
+
+        /**
+         * @param totalToRemove the number of rows that were targeted for removal.
+         * @param removed       the number of rows removed in total.
+         * @return a snapshot representing a successfully completed cleanup.
+         */
+        static Progress completed(final long totalToRemove, final long removed)
+        {
+            return new Progress(Phase.COMPLETED, totalToRemove, removed, null);
+        }
+
+        /**
+         * @param totalToRemove the number of rows that were targeted for removal.
+         * @param removed       the number of rows removed before the failure.
+         * @param error         the failure message.
+         * @return a snapshot representing a failed cleanup.
+         */
+        static Progress failed(final long totalToRemove, final long removed, @Nullable final String error)
+        {
+            return new Progress(Phase.FAILED, totalToRemove, removed, error);
+        }
+
+        /**
+         * @return the current phase of the cleanup.
+         */
+        public Phase getPhase()
+        {
+            return phase;
+        }
+
+        /** @return the number of rows the cleanup set out to remove (0 until known). */
+        public long getTotalToRemove()
+        {
+            return totalToRemove;
+        }
+
+        /** @return the number of rows removed so far (or in total, when completed). */
+        public long getRemoved()
+        {
+            return removed;
+        }
+
+        /**
+         * @return completion as a percentage in [0, 100]. Returns 100 for a completed cleanup, and 0 when the total is
+         *         not yet known.
+         */
+        public int getPercentComplete()
+        {
+            if (phase == Phase.COMPLETED) {
+                return 100;
+            }
+            if (totalToRemove <= 0) {
+                return 0;
+            }
+            final long pct = (removed * 100) / totalToRemove;
+            return (int) Math.min(100, Math.max(0, pct));
+        }
+
+        /** @return the error message if the cleanup failed, otherwise null. */
+        @Nullable
+        public String getError()
+        {
+            return error;
+        }
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubSubscriptionMaintenance.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubSubscriptionMaintenance.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.pubsub;
 
+import org.jivesoftware.admin.servlet.PubSubSubscriptionMaintenanceServlet;
 import org.jivesoftware.database.DbConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -355,6 +356,10 @@ public class PubSubSubscriptionMaintenance
             Log.error("Cleanup of redundant pubsub subscription rows failed.", e);
             final Progress last = progress.get();
             progress.set(Progress.failed(last.totalToRemove, last.removed, e.getMessage()));
+        }
+        finally {
+            // Reset the flag that indicates that a cleanup is advisable. Without this, the warning that cleanup is needed would continue to show.
+            PubSubSubscriptionMaintenanceServlet.isCleanupAdvisable();
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xmppserver/src/main/webapp/index.jsp
+++ b/xmppserver/src/main/webapp/index.jsp
@@ -39,6 +39,7 @@
 <%@ page import="org.jivesoftware.util.*" %>
 <%@ page import="java.util.concurrent.Future" %>
 <%@ page import="java.util.concurrent.TimeUnit" %>
+<%@ page import="org.jivesoftware.admin.servlet.PubSubSubscriptionMaintenanceServlet" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -123,6 +124,9 @@
 
     // Check if Blowfish migration is needed
     pageContext.setAttribute( "needsBlowfishMigration", JiveGlobals.isBlowfishMigrationNeeded() );
+
+    // Cheap, cached check (never blocks; refreshes in the background) for redundant pubsub subscription rows (OF-3306).
+    pageContext.setAttribute( "pubsubCleanupAdvisable", PubSubSubscriptionMaintenanceServlet.isCleanupAdvisable() );
 %>
 
     <c:if test="${not empty serverUpdate}">
@@ -164,6 +168,15 @@
         <admin:infoBox type="warning">
             <fmt:message key="index.blowfish-migration.warning">
                 <fmt:param value="<a href=\"./security-blowfish-migration.jsp\">" />
+                <fmt:param value="</a>"/>
+            </fmt:message>
+        </admin:infoBox>
+    </c:if>
+
+    <c:if test="${pubsubCleanupAdvisable}">
+        <admin:infoBox type="warning">
+            <fmt:message key="index.pubsub-subscription-maintenance.warning">
+                <fmt:param value="<a href=\"./pubsub-subscription-maintenance.jsp\">" />
                 <fmt:param value="</a>"/>
             </fmt:message>
         </admin:infoBox>

--- a/xmppserver/src/main/webapp/index.jsp
+++ b/xmppserver/src/main/webapp/index.jsp
@@ -39,7 +39,7 @@
 <%@ page import="org.jivesoftware.util.*" %>
 <%@ page import="java.util.concurrent.Future" %>
 <%@ page import="java.util.concurrent.TimeUnit" %>
-<%@ page import="org.jivesoftware.admin.servlet.PubSubSubscriptionMaintenanceServlet" %>
+<%@ page import="org.jivesoftware.openfire.pubsub.PubSubSubscriptionMaintenance" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -126,7 +126,7 @@
     pageContext.setAttribute( "needsBlowfishMigration", JiveGlobals.isBlowfishMigrationNeeded() );
 
     // Cheap, cached check (never blocks; refreshes in the background) for redundant pubsub subscription rows (OF-3306).
-    pageContext.setAttribute( "pubsubCleanupAdvisable", PubSubSubscriptionMaintenanceServlet.isCleanupAdvisable() );
+    pageContext.setAttribute( "pubsubCleanupAdvisable", PubSubSubscriptionMaintenance.isCleanupAdvisable() );
 %>
 
     <c:if test="${not empty serverUpdate}">

--- a/xmppserver/src/main/webapp/pubsub-subscription-maintenance-page.jsp
+++ b/xmppserver/src/main/webapp/pubsub-subscription-maintenance-page.jsp
@@ -13,7 +13,26 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   --%>
-
+<%--@elvariable id="totalRows" type="java.lang.Long"--%>
+<%--@elvariable id="distinctSubscriptions" type="java.lang.Long"--%>
+<%--@elvariable id="removableRows" type="java.lang.Long"--%>
+<%--@elvariable id="cleanupRecommended" type="java.lang.Boolean"--%>
+<%--@elvariable id="redundancyPercent" type="java.lang.Long"--%>
+<%--@elvariable id="analysisAvailable" type="java.lang.Boolean"--%>
+<%--@elvariable id="analysisError" type="java.lang.String"--%>
+<%--@elvariable id="progressPhase" type="java.lang.String"--%>
+<%--@elvariable id="progressPercent" type="java.lang.Integer"--%>
+<%--@elvariable id="progressRemoved" type="java.lang.Long"--%>
+<%--@elvariable id="excludedServiceCount" type="java.lang.Integer"--%>
+<%--@elvariable id="justStarted" type="java.lang.Boolean"--%>
+<%--@elvariable id="clusteringAvailable" type="java.lang.Boolean"--%>
+<%--@elvariable id="clusteringEnabled" type="java.lang.Boolean"--%>
+<%--@elvariable id="clusteringStarted" type="java.lang.Boolean"--%>
+<%--@elvariable id="clusterNodeCount" type="java.lang.Integer"--%>
+<%--@elvariable id="csrf" type="java.lang.String"--%>
+<%--@elvariable id="errorMessage" type="java.lang.String"--%>
+<%--@elvariable id="errorParam" type="java.lang.String"--%>
+<%--@elvariable id="successMessage" type="java.lang.String"--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ page errorPage="error.jsp" %>
 <%@ taglib uri="admin" prefix="admin" %>
@@ -131,7 +150,7 @@
 <div id="completedSection" style="display: ${progressPhase == 'COMPLETED' ? 'block' : 'none'};">
     <admin:infobox type="success">
         <fmt:message key="pubsub.subscription.maintenance.progress.completed">
-            <fmt:param value="${progressRemoved}"/>
+            <fmt:param><fmt:formatNumber value="${progressRemoved}"/></fmt:param>
         </fmt:message>
     </admin:infobox>
 </div>
@@ -164,22 +183,22 @@
             <tbody>
             <tr>
                 <td class="c1"><fmt:message key="pubsub.subscription.maintenance.status.total-rows"/></td>
-                <td class="c2"><strong><c:out value="${totalRows}"/></strong></td>
+                <td class="c2"><strong><fmt:formatNumber value="${totalRows}"/></strong></td>
             </tr>
             <tr>
                 <td class="c1"><fmt:message key="pubsub.subscription.maintenance.status.distinct"/></td>
-                <td class="c2"><strong><c:out value="${distinctSubscriptions}"/></strong></td>
+                <td class="c2"><strong><fmt:formatNumber value="${distinctSubscriptions}"/></strong></td>
             </tr>
             <tr>
                 <td class="c1"><fmt:message key="pubsub.subscription.maintenance.status.removable"/></td>
                 <td class="c2">
-                    <strong><c:out value="${removableRows}"/></strong>
-                    (<c:out value="${redundancyPercent}"/>%)
+                    <strong><fmt:formatNumber value="${removableRows}"/></strong>
+                    (<fmt:formatNumber value="${redundancyPercent}"/>%)
                 </td>
             </tr>
             <tr>
                 <td class="c1"><fmt:message key="pubsub.subscription.maintenance.status.protected-services"/></td>
-                <td class="c2"><strong><c:out value="${excludedServiceCount}"/></strong></td>
+                <td class="c2"><strong><fmt:formatNumber value="${excludedServiceCount}"/></strong></td>
             </tr>
             </tbody>
         </table>
@@ -190,7 +209,7 @@
         <h3><fmt:message key="pubsub.subscription.maintenance.progress.title"/></h3>
         <div class="progress-outer">
             <div id="progressBar" class="progress-inner" style="width: ${progressPercent}%;">
-                <c:out value="${progressPercent}"/>%
+                <fmt:formatNumber value="${progressPercent}"/>%
             </div>
         </div>
         <p id="progressDetail"></p>
@@ -207,7 +226,7 @@
             <c:when test="${clusterNodeCount > 1}">
                 <admin:infobox type="error">
                     <fmt:message key="pubsub.subscription.maintenance.error.multi-node-active">
-                        <fmt:param value="${clusterNodeCount}"/>
+                        <fmt:param><fmt:formatNumber value="${clusterNodeCount}"/></fmt:param>
                     </fmt:message>
                 </admin:infobox>
             </c:when>
@@ -227,7 +246,7 @@
 
                     <form id="cleanupForm" action="pubsub-subscription-maintenance.jsp" method="post"
                           onsubmit="return confirm('<fmt:message key="pubsub.subscription.maintenance.confirm"/>');">
-                        <input type="hidden" name="csrf" value="${csrf}">
+                        <input type="hidden" name="csrf" value="${admin:escapeHTMLTags(csrf)}">
                         <input type="hidden" name="action" value="cleanup">
 
                         <div class="maintenance-checklist">
@@ -252,7 +271,7 @@
         // Localized labels passed from the page so the script needs no hardcoded strings.
         var LBL_DETAIL = "<fmt:message key="pubsub.subscription.maintenance.progress.detail"/>";
 
-        var phase = "${progressPhase}";
+        var phase = "${admin:escapeHTMLTags(progressPhase)}";
 
         function show(id, visible) {
             var el = document.getElementById(id);

--- a/xmppserver/src/main/webapp/pubsub-subscription-maintenance-page.jsp
+++ b/xmppserver/src/main/webapp/pubsub-subscription-maintenance-page.jsp
@@ -1,0 +1,321 @@
+<%--
+  ~ Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ page errorPage="error.jsp" %>
+<%@ taglib uri="admin" prefix="admin" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
+<jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager" />
+<%  webManager.init(request, response, session, application, out ); %>
+
+<%
+    // Retrieve messages from session (set by the POST handler), then clear them (POST-Redirect-GET).
+    String errorMessage = (String) session.getAttribute("errorMessage");
+    String errorParam = (String) session.getAttribute("errorParam");
+    String successMessage = (String) session.getAttribute("successMessage");
+
+    if (errorMessage != null) {
+        session.removeAttribute("errorMessage");
+        session.removeAttribute("errorParam");
+        request.setAttribute("errorMessage", errorMessage);
+        if (errorParam != null) {
+            request.setAttribute("errorParam", errorParam);
+        }
+    }
+    if (successMessage != null) {
+        session.removeAttribute("successMessage");
+        request.setAttribute("successMessage", successMessage);
+    }
+%>
+
+<html>
+<head>
+    <title><fmt:message key="pubsub.subscription.maintenance.title"/></title>
+    <meta name="pageID" content="server-settings"/>
+    <style>
+        .warning-box {
+            background-color: #fff3cd;
+            border: 1px solid #ffc107;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .warning-box h3 {
+            margin-top: 0;
+            color: #856404;
+        }
+        .maintenance-checklist {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .maintenance-checklist input[type="checkbox"] {
+            margin-right: 8px;
+            vertical-align: middle;
+        }
+        .maintenance-checklist label {
+            display: block;
+            margin: 10px 0;
+            font-weight: bold;
+        }
+        .progress-outer {
+            background-color: #e9ecef;
+            border-radius: 4px;
+            height: 22px;
+            width: 100%;
+            margin: 10px 0;
+            overflow: hidden;
+        }
+        .progress-inner {
+            background-color: #28a745;
+            height: 100%;
+            width: 0;
+            text-align: center;
+            color: #fff;
+            font-size: 12px;
+            line-height: 22px;
+            transition: width 0.4s ease;
+        }
+    </style>
+</head>
+<body>
+
+<%-- Page-level status messages, shown first for consistency with other admin pages. --%>
+<c:if test="${not empty errorMessage}">
+    <admin:infobox type="error">
+        <c:choose>
+            <c:when test="${not empty errorParam}">
+                <fmt:message key="${errorMessage}">
+                    <fmt:param value="${errorParam}"/>
+                </fmt:message>
+            </c:when>
+            <c:otherwise>
+                <fmt:message key="${errorMessage}"/>
+            </c:otherwise>
+        </c:choose>
+    </admin:infobox>
+</c:if>
+
+<c:if test="${not empty successMessage}">
+    <admin:infobox type="success">
+        <fmt:message key="${successMessage}"/>
+    </admin:infobox>
+</c:if>
+
+<c:if test="${not analysisAvailable}">
+    <admin:infobox type="error">
+        <fmt:message key="pubsub.subscription.maintenance.analysis-failed">
+            <fmt:param value="${analysisError}"/>
+        </fmt:message>
+    </admin:infobox>
+</c:if>
+
+<%-- Completed/failed banners, toggled by the progress poller (kept here so all status sits at the top). --%>
+<div id="completedSection" style="display: ${progressPhase == 'COMPLETED' ? 'block' : 'none'};">
+    <admin:infobox type="success">
+        <fmt:message key="pubsub.subscription.maintenance.progress.completed">
+            <fmt:param value="${progressRemoved}"/>
+        </fmt:message>
+    </admin:infobox>
+</div>
+<div id="failedSection" style="display: ${progressPhase == 'FAILED' ? 'block' : 'none'};">
+    <admin:infobox type="error">
+        <fmt:message key="pubsub.subscription.maintenance.progress.failed"/>
+    </admin:infobox>
+</div>
+
+<c:if test="${analysisAvailable and not cleanupRecommended and progressPhase != 'RUNNING'}">
+    <admin:infobox type="success">
+        <fmt:message key="pubsub.subscription.maintenance.nothing-to-do"/>
+    </admin:infobox>
+</c:if>
+
+<p>
+    <fmt:message key="pubsub.subscription.maintenance.info"/>
+</p>
+
+<c:if test="${analysisAvailable}">
+
+    <%-- Status table: the effect of a cleanup, in row counts. --%>
+    <div class="jive-table">
+        <table cellpadding="0" cellspacing="0" border="0" width="100%">
+            <thead>
+            <tr>
+                <th colspan="2"><fmt:message key="pubsub.subscription.maintenance.status.title"/></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td class="c1"><fmt:message key="pubsub.subscription.maintenance.status.total-rows"/></td>
+                <td class="c2"><strong><c:out value="${totalRows}"/></strong></td>
+            </tr>
+            <tr>
+                <td class="c1"><fmt:message key="pubsub.subscription.maintenance.status.distinct"/></td>
+                <td class="c2"><strong><c:out value="${distinctSubscriptions}"/></strong></td>
+            </tr>
+            <tr>
+                <td class="c1"><fmt:message key="pubsub.subscription.maintenance.status.removable"/></td>
+                <td class="c2">
+                    <strong><c:out value="${removableRows}"/></strong>
+                    (<c:out value="${redundancyPercent}"/>%)
+                </td>
+            </tr>
+            <tr>
+                <td class="c1"><fmt:message key="pubsub.subscription.maintenance.status.protected-services"/></td>
+                <td class="c2"><strong><c:out value="${excludedServiceCount}"/></strong></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <%-- Progress bar: shown while a cleanup runs (initially visible if a run is already in progress on page load). --%>
+    <div id="progressSection" style="display: ${progressPhase == 'RUNNING' ? 'block' : 'none'};">
+        <h3><fmt:message key="pubsub.subscription.maintenance.progress.title"/></h3>
+        <div class="progress-outer">
+            <div id="progressBar" class="progress-inner" style="width: ${progressPercent}%;">
+                <c:out value="${progressPercent}"/>%
+            </div>
+        </div>
+        <p id="progressDetail"></p>
+    </div>
+
+    <%-- Cleanup form: shown only when there is something to remove and no run is in progress. --%>
+    <c:if test="${cleanupRecommended}">
+        <c:choose>
+            <c:when test="${clusteringEnabled and not clusteringStarted}">
+                <admin:infobox type="error">
+                    <fmt:message key="pubsub.subscription.maintenance.error.cluster-enabled-not-started"/>
+                </admin:infobox>
+            </c:when>
+            <c:when test="${clusterNodeCount > 1}">
+                <admin:infobox type="error">
+                    <fmt:message key="pubsub.subscription.maintenance.error.multi-node-active">
+                        <fmt:param value="${clusterNodeCount}"/>
+                    </fmt:message>
+                </admin:infobox>
+            </c:when>
+            <c:otherwise>
+                <div id="formSection" style="display: ${progressPhase == 'RUNNING' ? 'none' : 'block'};">
+                    <div class="warning-box">
+                        <h3><fmt:message key="pubsub.subscription.maintenance.warning.title"/></h3>
+                        <p><fmt:message key="pubsub.subscription.maintenance.warning.irreversible"/></p>
+                        <ul>
+                            <li><fmt:message key="pubsub.subscription.maintenance.warning.backup"/></li>
+                            <li><fmt:message key="pubsub.subscription.maintenance.warning.quiescent"/></li>
+                            <c:if test="${clusteringEnabled}">
+                                <li><fmt:message key="pubsub.subscription.maintenance.warning.cluster"/></li>
+                            </c:if>
+                        </ul>
+                    </div>
+
+                    <form id="cleanupForm" action="pubsub-subscription-maintenance.jsp" method="post"
+                          onsubmit="return confirm('<fmt:message key="pubsub.subscription.maintenance.confirm"/>');">
+                        <input type="hidden" name="csrf" value="${csrf}">
+                        <input type="hidden" name="action" value="cleanup">
+
+                        <div class="maintenance-checklist">
+                            <h3><fmt:message key="pubsub.subscription.maintenance.checklist.title"/></h3>
+                            <label>
+                                <input type="checkbox" name="dbBackup" value="true" required>
+                                <fmt:message key="pubsub.subscription.maintenance.checklist.db-backup"/>
+                            </label>
+                        </div>
+
+                        <input type="submit" value="<fmt:message key="pubsub.subscription.maintenance.button.cleanup"/>">
+                    </form>
+                </div>
+            </c:otherwise>
+        </c:choose>
+    </c:if>
+
+</c:if>
+
+<script>
+    (function () {
+        // Localized labels passed from the page so the script needs no hardcoded strings.
+        var LBL_DETAIL = "<fmt:message key="pubsub.subscription.maintenance.progress.detail"/>";
+
+        var phase = "${progressPhase}";
+
+        function show(id, visible) {
+            var el = document.getElementById(id);
+            if (el) { el.style.display = visible ? "block" : "none"; }
+        }
+
+        function render(data) {
+            var bar = document.getElementById("progressBar");
+            if (bar) {
+                bar.style.width = data.percent + "%";
+                bar.textContent = data.percent + "%";
+            }
+            var detail = document.getElementById("progressDetail");
+            if (detail) {
+                // LBL_DETAIL is expected to contain two {0}/{1} placeholders (removed / total).
+                detail.textContent = LBL_DETAIL
+                    .replace("{0}", data.removed)
+                    .replace("{1}", data.total);
+            }
+        }
+
+        function poll() {
+            var xhr = new XMLHttpRequest();
+            xhr.open("GET", "pubsub-subscription-maintenance.jsp?action=progress", true);
+            xhr.onreadystatechange = function () {
+                if (xhr.readyState !== 4) { return; }
+                if (xhr.status !== 200) {
+                    // On a transient error, keep polling; the next tick may succeed.
+                    setTimeout(poll, 2000);
+                    return;
+                }
+                var data;
+                try { data = JSON.parse(xhr.responseText); } catch (e) { setTimeout(poll, 2000); return; }
+
+                if (data.phase === "RUNNING") {
+                    show("progressSection", true);
+                    show("formSection", false);
+                    render(data);
+                    setTimeout(poll, 1500);
+                } else if (data.phase === "COMPLETED") {
+                    render({ percent: 100, removed: data.removed, total: data.total });
+                    show("progressSection", false);
+                    show("completedSection", true);
+                    // Reload so the status table reflects the now-reduced row counts.
+                    setTimeout(function () { window.location.href = "pubsub-subscription-maintenance.jsp"; }, 1500);
+                } else if (data.phase === "FAILED") {
+                    show("progressSection", false);
+                    show("failedSection", true);
+                }
+            };
+            xhr.send();
+        }
+
+        // Begin polling if a run is already in progress, or was just started (the background job may still be in its
+        // brief pre-RUNNING analysis phase, so do not rely on the phase alone immediately after starting).
+        var justStarted = ${justStarted ? 'true' : 'false'};
+        if (phase === "RUNNING" || justStarted) {
+            show("progressSection", true);
+            show("formSection", false);
+            poll();
+        }
+    })();
+</script>
+
+</body>
+</html>

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/pubsub/NodeSingleSubscriptionPolicyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/pubsub/NodeSingleSubscriptionPolicyTest.java
@@ -18,6 +18,8 @@ package org.jivesoftware.openfire.pubsub;
 
 import org.jivesoftware.openfire.commands.AdHocCommandManager;
 import org.junit.jupiter.api.Test;
+import org.xmpp.forms.DataForm;
+import org.xmpp.forms.FormField;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.Message;
@@ -30,6 +32,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -39,6 +42,10 @@ import static org.junit.jupiter.api.Assertions.*;
  * XEP-0060 §6.1.6 defines multi-subscribe as allowing more than one subscription for the same literal subscription JID
  * value. This means that, even when multi-subscribe is disabled, a single owner can still have separate subscriptions
  * for distinct bare/full subscription JIDs.
+ *
+ * In addition, XEP-0248 §6.1.3 allows a collection node to hold one subscription of type "nodes" and one of type
+ * "items" for the same subscription JID, even when multi-subscribe is disabled. The dual-type tests below verify that
+ * this capability survives subscription creation, cancellation and exact-JID lookup.
  */
 public class NodeSingleSubscriptionPolicyTest
 {
@@ -47,6 +54,25 @@ public class NodeSingleSubscriptionPolicyTest
     private static final JID OWNER = new JID("user@example.org");
     private static final JID DESKTOP = new JID("user@example.org/desktop");
     private static final JID MOBILE = new JID("user@example.org/mobile");
+
+    /**
+     * Builds a subscription options form that requests a collection-node subscription of type "items"
+     * (the non-default type, per XEP-0248 §6.1).
+     */
+    private static DataForm itemsForm()
+    {
+        final DataForm form = new DataForm(DataForm.Type.submit);
+        FormField formField = form.addField();
+        formField.setVariable("FORM_TYPE");
+        formField.setType(FormField.Type.hidden);
+        formField.addValue("http://jabber.org/protocol/pubsub#subscribe_options");
+
+        formField = form.addField();
+        formField.setVariable("pubsub#subscription_type");
+        formField.setType(FormField.Type.list_single);
+        formField.addValue("items");
+        return form;
+    }
 
     /**
      * Verifies that, when multi-subscribe is disabled, one owner can still have separate subscriptions
@@ -105,9 +131,15 @@ public class NodeSingleSubscriptionPolicyTest
         assertEquals(1, node.getSubscriptions(OWNER).size(), "A duplicate identical JID must not create a second subscription.");
         assertSame(originalSubscription, node.getSubscription(DESKTOP), "The original subscription must remain the current subscription.");
 
-        assertEquals(1, service.sentPackets.size(), "The duplicate request should receive the current subscription state.");
-        assertInstanceOf(IQ.class, service.sentPackets.get(0));
-        final IQ response = (IQ) service.sentPackets.get(0);
+        // Assert on the subscription-state response specifically, rather than the total packet count, so that the test
+        // does not silently depend on the leaf node's send-item-on-subscribe configuration default.
+        final List<IQ> stateResponses = service.sentPackets.stream()
+            .filter(IQ.class::isInstance).map(IQ.class::cast)
+            .filter(packet -> packet.getChildElement() != null && packet.getChildElement().element("subscription") != null)
+            .collect(Collectors.toList());
+        assertEquals(1, stateResponses.size(), "The duplicate request should receive exactly one current-state response.");
+
+        final IQ response = stateResponses.get(0);
         assertEquals(IQ.Type.result, response.getType());
         assertEquals("duplicate-subscribe", response.getID());
         assertEquals(DESKTOP.toString(), response.getChildElement().element("subscription").attributeValue("jid"));
@@ -186,52 +218,141 @@ public class NodeSingleSubscriptionPolicyTest
         assertNotSame(node.getSubscription(DESKTOP), node.getSubscription(MOBILE));
     }
 
-//    /**
-//     * Verifies that looking up subscriptions by JID uses the subscription JID, not the owner JID.
-//     */
-//    @Test
-//    public void testSubscriptionsByJidUsesExactSubscriptionJidNotOwner()
-//    {
-//        // Setup test fixture.
-//        final RecordingPubSubService service = new RecordingPubSubService(false);
-//        final TestLeafNode node = new TestLeafNode(service, "test-node");
-//
-//        node.createSubscription(null, OWNER, DESKTOP, false, null);
-//        node.createSubscription(null, OWNER, MOBILE, false, null);
-//
-//        // Execute system under test and verify results.
-//        assertEquals(1, node.getSubscriptionsByJID(DESKTOP).size());
-//        assertEquals(1, node.getSubscriptionsByJID(MOBILE).size());
-//        assertEquals(0, node.getSubscriptionsByJID(OWNER).size(), "Owner JID must not be used as the subscription-JID lookup key.");
-//    }
+    /**
+     * Verifies that looking up subscriptions by JID uses the subscription JID, not the owner JID.
+     */
+    @Test
+    public void testSubscriptionsByJidUsesExactSubscriptionJidNotOwner()
+    {
+        // Setup test fixture.
+        final RecordingPubSubService service = new RecordingPubSubService(false);
+        final TestLeafNode node = new TestLeafNode(service, "test-node");
 
-//    /**
-//     * Verifies that exact-JID lookup remains usable after cancelling one of multiple same-JID
-//     * subscriptions in multi-subscribe mode.
-//     */
-//    @Test
-//    public void testExactJidLookupAfterCancellingOneOfMultipleSameJidSubscriptions()
-//    {
-//        // Setup test fixture.
-//        final RecordingPubSubService service = new RecordingPubSubService(true);
-//        final TestLeafNode node = new TestLeafNode(service, "test-node");
-//
-//        node.createSubscription(null, OWNER, DESKTOP, false, null);
-//        node.createSubscription(null, OWNER, DESKTOP, false, null);
-//
-//        final List<NodeSubscription> sameJidSubscriptions = new ArrayList<>(node.getSubscriptionsByJID(DESKTOP));
-//        assertEquals(2, sameJidSubscriptions.size(), "Test fixture should have two subscriptions for the same literal subscription JID.");
-//        assertThrows(IllegalStateException.class, () -> node.getSubscription(DESKTOP),
-//            "Exact-JID lookup should be ambiguous before one same-JID subscription is cancelled.");
-//
-//        // Execute system under test.
-//        node.cancelSubscription(sameJidSubscriptions.get(0), false);
-//
-//        // Verify results.
-//        assertEquals(1, node.getSubscriptionsByJID(DESKTOP).size());
-//        assertNotNull(node.getSubscription(DESKTOP), "Exact-JID lookup should return the remaining subscription.");
-//        assertSame(sameJidSubscriptions.get(1), node.getSubscription(DESKTOP));
-//    }
+        node.createSubscription(null, OWNER, DESKTOP, false, null);
+        node.createSubscription(null, OWNER, MOBILE, false, null);
+
+        // Execute system under test and verify results.
+        assertEquals(1, node.getSubscriptionsByJID(DESKTOP).size());
+        assertEquals(1, node.getSubscriptionsByJID(MOBILE).size());
+        assertEquals(0, node.getSubscriptionsByJID(OWNER).size(), "Owner JID must not be used as the subscription-JID lookup key.");
+    }
+
+    /**
+     * Verifies that exact-JID lookup remains usable after cancelling one of multiple same-JID
+     * subscriptions in multi-subscribe mode.
+     */
+    @Test
+    public void testExactJidLookupAfterCancellingOneOfMultipleSameJidSubscriptions()
+    {
+        // Setup test fixture.
+        final RecordingPubSubService service = new RecordingPubSubService(true);
+        final TestLeafNode node = new TestLeafNode(service, "test-node");
+
+        node.createSubscription(null, OWNER, DESKTOP, false, null);
+        node.createSubscription(null, OWNER, DESKTOP, false, null);
+
+        final List<NodeSubscription> sameJidSubscriptions = new ArrayList<>(node.getSubscriptionsByJID(DESKTOP));
+        assertEquals(2, sameJidSubscriptions.size(), "Test fixture should have two subscriptions for the same literal subscription JID.");
+        assertThrows(IllegalStateException.class, () -> node.getSubscription(DESKTOP),
+            "Exact-JID lookup should be ambiguous before one same-JID subscription is cancelled.");
+
+        // Execute system under test.
+        node.cancelSubscription(sameJidSubscriptions.get(0), false);
+
+        // Verify results.
+        assertEquals(1, node.getSubscriptionsByJID(DESKTOP).size());
+        assertNotNull(node.getSubscription(DESKTOP), "Exact-JID lookup should return the remaining subscription.");
+        assertSame(sameJidSubscriptions.get(1), node.getSubscription(DESKTOP));
+    }
+
+    /**
+     * Verifies that a collection node permits one subscription of type "nodes" and one of type "items" for the same
+     * subscription JID, even when multi-subscribe is disabled (XEP-0248 §6.1.3).
+     */
+    @Test
+    public void testCollectionNodeAllowsOneNodesAndOneItemsSubscriptionForSameJid()
+    {
+        // Setup test fixture.
+        final RecordingPubSubService service = new RecordingPubSubService(false);
+        final TestCollectionNode node = new TestCollectionNode(service, "test-collection-node");
+
+        // Execute system under test.
+        node.createSubscription(null, OWNER, DESKTOP, false, null); // defaults to type "nodes"
+        node.createSubscription(null, OWNER, DESKTOP, false, itemsForm()); // type "items"
+
+        // Verify results.
+        final Collection<NodeSubscription> subscriptions = node.getSubscriptionsByJID(DESKTOP);
+        assertEquals(2, subscriptions.size(), "A collection node permits one 'nodes' and one 'items' subscription for the same JID.");
+        assertTrue(subscriptions.stream().anyMatch(subscription -> subscription.getType() == NodeSubscription.Type.nodes));
+        assertTrue(subscriptions.stream().anyMatch(subscription -> subscription.getType() == NodeSubscription.Type.items));
+    }
+
+    /**
+     * Verifies that a second same-type subscription request for the same JID does not create a second subscription on a
+     * collection node when multi-subscribe is disabled. The second request returns current state instead (XEP-0060
+     * §6.1.6).
+     */
+    @Test
+    public void testCollectionNodeRejectsSecondSameTypeSubscriptionForSameJidWhenMultiSubscribeDisabled()
+    {
+        // Setup test fixture.
+        final RecordingPubSubService service = new RecordingPubSubService(false);
+        final TestCollectionNode node = new TestCollectionNode(service, "test-collection-node");
+
+        // Execute system under test.
+        node.createSubscription(null, OWNER, DESKTOP, false, null);
+        node.createSubscription(null, OWNER, DESKTOP, false, null);
+
+        // Verify results.
+        assertEquals(1, node.getSubscriptionsByJID(DESKTOP).size(),"A second same-type subscription must not be created when multi-subscribe is disabled.");
+    }
+
+    /**
+     * Verifies that cancelling one type of a dual-type pair preserves the other type, and that exact-JID lookup becomes
+     * unambiguous again once a single subscription remains for the JID.
+     */
+    @Test
+    public void testCancellingOneTypePreservesOtherTypeForSameJidOnCollectionNode()
+    {
+        // Setup test fixture.
+        final RecordingPubSubService service = new RecordingPubSubService(false);
+        final TestCollectionNode node = new TestCollectionNode(service, "test-collection-node");
+
+        node.createSubscription(null, OWNER, DESKTOP, false, null); // type "nodes"
+        node.createSubscription(null, OWNER, DESKTOP, false, itemsForm()); // type "items"
+
+        final NodeSubscription nodesSubscription = node.getSubscriptionsByJID(DESKTOP).stream()
+            .filter(subscription -> subscription.getType() == NodeSubscription.Type.nodes)
+            .findFirst().orElseThrow(() -> new AssertionError("Test fixture should contain a 'nodes' subscription."));
+
+        // Execute system under test.
+        node.cancelSubscription(nodesSubscription, false);
+
+        // Verify results.
+        final Collection<NodeSubscription> remaining = node.getSubscriptionsByJID(DESKTOP);
+        assertEquals(1, remaining.size(), "Cancelling one type must leave the other type intact.");
+        assertEquals(NodeSubscription.Type.items, remaining.iterator().next().getType());
+        assertNotNull(node.getSubscription(DESKTOP),"After dropping to one subscription, exact-JID lookup must be unambiguous again.");
+    }
+
+    /**
+     * Verifies that exact-JID lookup throws for a same-JID multiplicity regardless of the multi-subscribe feature. A
+     * collection node holding a dual-type pair (XEP-0248 §6.1.3) is ambiguous even when multi-subscribe is disabled.
+     */
+    @Test
+    public void testGetSubscriptionByJidThrowsForDualTypePairEvenWhenMultiSubscribeDisabled()
+    {
+        // Setup test fixture.
+        final RecordingPubSubService service = new RecordingPubSubService(false);
+        final TestCollectionNode node = new TestCollectionNode(service, "test-collection-node");
+
+        node.createSubscription(null, OWNER, DESKTOP, false, null); // type "nodes"
+        node.createSubscription(null, OWNER, DESKTOP, false, itemsForm()); // type "items"
+
+        // Execute system under test and verify results.
+        assertEquals(2, node.getSubscriptionsByJID(DESKTOP).size(), "Test fixture should contain a dual-type pair.");
+        assertThrows(IllegalStateException.class, () -> node.getSubscription(DESKTOP), "Exact-JID lookup must throw on any same-JID multiplicity, not only under multi-subscribe.");
+    }
 
     private static final class TestLeafNode extends LeafNode
     {
@@ -288,6 +409,7 @@ public class NodeSingleSubscriptionPolicyTest
     {
         private final boolean multipleSubscriptionsEnabled;
         private final JID address = new JID("pubsub.example.org");
+        // Note: a List (not a Set) on purpose, so that fan-out tests can detect duplicate delivery to the same JID (XEP-0060 §6.1.6: only one notification per entity). Do not change this to a Set.
         private final List<Packet> sentPackets = new ArrayList<>();
         private final List<JID> broadcastRecipients = new ArrayList<>();
         private final Map<JID, Map<JID, String>> subscriberPresences = new LinkedHashMap<>();

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/pubsub/NodeSingleSubscriptionPolicyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/pubsub/NodeSingleSubscriptionPolicyTest.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.openfire.pubsub;
+
+import org.jivesoftware.openfire.commands.AdHocCommandManager;
+import org.junit.jupiter.api.Test;
+import org.xmpp.packet.IQ;
+import org.xmpp.packet.JID;
+import org.xmpp.packet.Message;
+import org.xmpp.packet.Packet;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies subscription uniqueness rules when multi-subscribe is disabled.
+ *
+ * XEP-0060 §6.1.6 defines multi-subscribe as allowing more than one subscription for the same literal subscription JID
+ * value. This means that, even when multi-subscribe is disabled, a single owner can still have separate subscriptions
+ * for distinct bare/full subscription JIDs.
+ */
+public class NodeSingleSubscriptionPolicyTest
+{
+    private static final PubSubService.UniqueIdentifier SERVICE_ID = new PubSubService.UniqueIdentifier("test-service");
+    private static final JID CREATOR = new JID("creator@example.org");
+    private static final JID OWNER = new JID("user@example.org");
+    private static final JID DESKTOP = new JID("user@example.org/desktop");
+    private static final JID MOBILE = new JID("user@example.org/mobile");
+
+    /**
+     * Verifies that, when multi-subscribe is disabled, one owner can still have separate subscriptions
+     * for different subscription JID values.
+     */
+    @Test
+    public void testSameOwnerCanHaveSubscriptionsForDistinctFullJidsWhenMultiSubscribeDisabled()
+    {
+        // Setup test fixture.
+        final RecordingPubSubService service = new RecordingPubSubService(false);
+        final TestLeafNode node = new TestLeafNode(service, "test-node");
+
+        // Execute system under test.
+        node.createSubscription(null, OWNER, DESKTOP, false, null);
+        node.createSubscription(null, OWNER, MOBILE, false, null);
+
+        // Verify results.
+        final Collection<NodeSubscription> ownerSubscriptions = node.getSubscriptions(OWNER);
+        assertEquals(2, ownerSubscriptions.size(), "The owner should have one subscription for each distinct subscription JID.");
+
+        assertNotNull(node.getSubscription(DESKTOP));
+        assertNotNull(node.getSubscription(MOBILE));
+        assertNotSame(node.getSubscription(DESKTOP), node.getSubscription(MOBILE));
+
+        assertEquals(DESKTOP, node.getSubscription(DESKTOP).getJID());
+        assertEquals(MOBILE, node.getSubscription(MOBILE).getJID());
+    }
+
+    /**
+     * Verifies that a repeated subscribe for an identical subscription JID does not create a second subscription when
+     * multi-subscribe is disabled.
+     */
+    @Test
+    public void testDuplicateSubscribeForIdenticalJidDoesNotCreateSecondSubscriptionWhenMultiSubscribeDisabled()
+    {
+        // Setup test fixture.
+        final RecordingPubSubService service = new RecordingPubSubService(false);
+        final TestLeafNode node = new TestLeafNode(service, "test-node");
+
+        // Execute system under test.
+        node.createSubscription(null, OWNER, DESKTOP, false, null);
+        final NodeSubscription originalSubscription = node.getSubscription(DESKTOP);
+
+        final IQ duplicateRequest = new IQ(IQ.Type.set);
+        duplicateRequest.setFrom(DESKTOP);
+        duplicateRequest.setTo(service.getAddress());
+        duplicateRequest.setID("duplicate-subscribe");
+        duplicateRequest.setChildElement("pubsub", "http://jabber.org/protocol/pubsub")
+            .addElement("subscribe")
+            .addAttribute("node", node.getUniqueIdentifier().getNodeId())
+            .addAttribute("jid", DESKTOP.toString());
+
+        node.createSubscription(duplicateRequest, OWNER, DESKTOP, false, null);
+
+        // Verify results.
+        assertEquals(1, node.getSubscriptions(OWNER).size(), "A duplicate identical JID must not create a second subscription.");
+        assertSame(originalSubscription, node.getSubscription(DESKTOP), "The original subscription must remain the current subscription.");
+
+        assertEquals(1, service.sentPackets.size(), "The duplicate request should receive the current subscription state.");
+        assertInstanceOf(IQ.class, service.sentPackets.get(0));
+        final IQ response = (IQ) service.sentPackets.get(0);
+        assertEquals(IQ.Type.result, response.getType());
+        assertEquals("duplicate-subscribe", response.getID());
+        assertEquals(DESKTOP.toString(), response.getChildElement().element("subscription").attributeValue("jid"));
+        assertEquals(originalSubscription.getState().name(), response.getChildElement().element("subscription").attributeValue("subscription"));
+    }
+
+    /**
+     * Verifies that owner-scoped retrieval returns all of an owner's subscriptions, including those that target
+     * different full JIDs.
+     */
+    @Test
+    public void testOwnerScopedSubscriptionRetrievalReturnsAllSubscriptionJidsForOwner()
+    {
+        // Setup test fixture.
+        final RecordingPubSubService service = new RecordingPubSubService(false);
+        final TestLeafNode node = new TestLeafNode(service, "test-node");
+
+        node.createSubscription(null, OWNER, DESKTOP, false, null);
+        node.createSubscription(null, OWNER, MOBILE, false, null);
+
+        // Execute system under test.
+        final Collection<NodeSubscription> subscriptions = node.getSubscriptions(OWNER);
+
+        // Verify results.
+        assertEquals(2, subscriptions.size());
+        assertTrue(subscriptions.stream().anyMatch(subscription -> DESKTOP.equals(subscription.getJID())));
+        assertTrue(subscriptions.stream().anyMatch(subscription -> MOBILE.equals(subscription.getJID())));
+    }
+
+    /**
+     * Verifies that notification fan-out treats distinct subscription JIDs under the same owner as distinct recipients.
+     */
+    @Test
+    public void testNodeEventNotificationFanOutAddressesEachDistinctSubscriptionJid()
+    {
+        // Setup test fixture.
+        final RecordingPubSubService service = new RecordingPubSubService(false);
+        final TestLeafNode node = new TestLeafNode(service, "test-node");
+
+        node.createSubscription(null, OWNER, DESKTOP, false, null);
+        node.createSubscription(null, OWNER, MOBILE, false, null);
+
+        final Message notification = new Message();
+        notification.addChildElement("event", "http://jabber.org/protocol/pubsub#event")
+            .addElement("items")
+            .addAttribute("node", node.getUniqueIdentifier().getNodeId());
+
+        // Execute system under test.
+        node.broadcastNodeEventForTest(notification);
+
+        // Verify results.
+        assertEquals(2, service.broadcastRecipients.size(), "Each distinct subscription JID should receive a notification.");
+        assertTrue(service.broadcastRecipients.contains(DESKTOP));
+        assertTrue(service.broadcastRecipients.contains(MOBILE));
+    }
+
+    /**
+     * Verifies that collection nodes also allow separate subscriptions for distinct subscription JIDs under the same
+     * owner when multi-subscribe is disabled.
+     */
+    @Test
+    public void testCollectionNodeAllowsDistinctFullJidsForSameOwnerWhenMultiSubscribeDisabled()
+    {
+        // Setup test fixture.
+        final RecordingPubSubService service = new RecordingPubSubService(false);
+        final TestCollectionNode node = new TestCollectionNode(service, "test-collection-node");
+
+        // Execute system under test.
+        node.createSubscription(null, OWNER, DESKTOP, false, null);
+        node.createSubscription(null, OWNER, MOBILE, false, null);
+
+        // Verify results.
+        assertEquals(2, node.getSubscriptions(OWNER).size());
+        assertNotNull(node.getSubscription(DESKTOP));
+        assertNotNull(node.getSubscription(MOBILE));
+        assertNotSame(node.getSubscription(DESKTOP), node.getSubscription(MOBILE));
+    }
+
+//    /**
+//     * Verifies that looking up subscriptions by JID uses the subscription JID, not the owner JID.
+//     */
+//    @Test
+//    public void testSubscriptionsByJidUsesExactSubscriptionJidNotOwner()
+//    {
+//        // Setup test fixture.
+//        final RecordingPubSubService service = new RecordingPubSubService(false);
+//        final TestLeafNode node = new TestLeafNode(service, "test-node");
+//
+//        node.createSubscription(null, OWNER, DESKTOP, false, null);
+//        node.createSubscription(null, OWNER, MOBILE, false, null);
+//
+//        // Execute system under test and verify results.
+//        assertEquals(1, node.getSubscriptionsByJID(DESKTOP).size());
+//        assertEquals(1, node.getSubscriptionsByJID(MOBILE).size());
+//        assertEquals(0, node.getSubscriptionsByJID(OWNER).size(), "Owner JID must not be used as the subscription-JID lookup key.");
+//    }
+
+//    /**
+//     * Verifies that exact-JID lookup remains usable after cancelling one of multiple same-JID
+//     * subscriptions in multi-subscribe mode.
+//     */
+//    @Test
+//    public void testExactJidLookupAfterCancellingOneOfMultipleSameJidSubscriptions()
+//    {
+//        // Setup test fixture.
+//        final RecordingPubSubService service = new RecordingPubSubService(true);
+//        final TestLeafNode node = new TestLeafNode(service, "test-node");
+//
+//        node.createSubscription(null, OWNER, DESKTOP, false, null);
+//        node.createSubscription(null, OWNER, DESKTOP, false, null);
+//
+//        final List<NodeSubscription> sameJidSubscriptions = new ArrayList<>(node.getSubscriptionsByJID(DESKTOP));
+//        assertEquals(2, sameJidSubscriptions.size(), "Test fixture should have two subscriptions for the same literal subscription JID.");
+//        assertThrows(IllegalStateException.class, () -> node.getSubscription(DESKTOP),
+//            "Exact-JID lookup should be ambiguous before one same-JID subscription is cancelled.");
+//
+//        // Execute system under test.
+//        node.cancelSubscription(sameJidSubscriptions.get(0), false);
+//
+//        // Verify results.
+//        assertEquals(1, node.getSubscriptionsByJID(DESKTOP).size());
+//        assertNotNull(node.getSubscription(DESKTOP), "Exact-JID lookup should return the remaining subscription.");
+//        assertSame(sameJidSubscriptions.get(1), node.getSubscription(DESKTOP));
+//    }
+
+    private static final class TestLeafNode extends LeafNode
+    {
+        private final RecordingPubSubService service;
+
+        private TestLeafNode(final RecordingPubSubService service, final String nodeID)
+        {
+            super(SERVICE_ID, null, nodeID, CREATOR, new DefaultNodeConfiguration(true));
+            this.service = service;
+        }
+
+        @Override
+        public PubSubService getService()
+        {
+            return service;
+        }
+
+        @Override
+        public boolean isMultipleSubscriptionsEnabled()
+        {
+            return service.isMultipleSubscriptionsEnabled();
+        }
+
+        private void broadcastNodeEventForTest(final Message message)
+        {
+            broadcastNodeEvent(message, false);
+        }
+    }
+
+    private static final class TestCollectionNode extends CollectionNode
+    {
+        private final RecordingPubSubService service;
+
+        private TestCollectionNode(final RecordingPubSubService service, final String nodeID)
+        {
+            super(SERVICE_ID, null, nodeID, CREATOR, new DefaultNodeConfiguration(false));
+            this.service = service;
+        }
+
+        @Override
+        public PubSubService getService()
+        {
+            return service;
+        }
+
+        @Override
+        public boolean isMultipleSubscriptionsEnabled()
+        {
+            return service.isMultipleSubscriptionsEnabled();
+        }
+    }
+
+    private static final class RecordingPubSubService implements PubSubService
+    {
+        private final boolean multipleSubscriptionsEnabled;
+        private final JID address = new JID("pubsub.example.org");
+        private final List<Packet> sentPackets = new ArrayList<>();
+        private final List<JID> broadcastRecipients = new ArrayList<>();
+        private final Map<JID, Map<JID, String>> subscriberPresences = new LinkedHashMap<>();
+
+        private RecordingPubSubService(final boolean multipleSubscriptionsEnabled)
+        {
+            this.multipleSubscriptionsEnabled = multipleSubscriptionsEnabled;
+        }
+
+        @Override
+        public JID getAddress()
+        {
+            return address;
+        }
+
+        @Override
+        public String getServiceID()
+        {
+            return SERVICE_ID.getServiceId();
+        }
+
+        @Override
+        public Map<JID, Map<JID, String>> getSubscriberPresences()
+        {
+            return subscriberPresences;
+        }
+
+        @Override
+        public boolean canCreateNode(final JID creator)
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isServiceAdmin(final JID user)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isInstantNodeSupported()
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isCollectionNodesSupported()
+        {
+            return true;
+        }
+
+        @Override
+        public CollectionNode getRootCollectionNode()
+        {
+            return null;
+        }
+
+        @Override
+        public Node getNode(final Node.UniqueIdentifier nodeID)
+        {
+            return null;
+        }
+
+        @Override
+        public Collection<Node> getNodes()
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void addNode(final Node node)
+        {
+        }
+
+        @Override
+        public void removeNode(final Node.UniqueIdentifier nodeID)
+        {
+        }
+
+        @Override
+        public void broadcast(final Node node, final Message message, final Collection<JID> jids)
+        {
+            broadcastRecipients.addAll(jids);
+        }
+
+        @Override
+        public void send(final Packet packet)
+        {
+            sentPackets.add(packet);
+        }
+
+        @Override
+        public void sendNotification(final Node node, final Message message, final JID jid)
+        {
+            broadcastRecipients.add(jid);
+        }
+
+        @Override
+        public DefaultNodeConfiguration getDefaultNodeConfiguration(final boolean leafType)
+        {
+            return new DefaultNodeConfiguration(leafType);
+        }
+
+        @Override
+        public Collection<String> getShowPresences(final JID subscriber)
+        {
+            return Collections.singleton("online");
+        }
+
+        @Override
+        public void presenceSubscriptionRequired(final Node node, final JID user)
+        {
+        }
+
+        @Override
+        public void presenceSubscriptionNotRequired(final Node node, final JID user)
+        {
+        }
+
+        @Override
+        public boolean isMultipleSubscriptionsEnabled()
+        {
+            return multipleSubscriptionsEnabled;
+        }
+
+        @Override
+        public AdHocCommandManager getManager()
+        {
+            return new AdHocCommandManager();
+        }
+
+        @Override
+        @Nonnull
+        public UniqueIdentifier getUniqueIdentifier()
+        {
+            return SERVICE_ID;
+        }
+    }
+}


### PR DESCRIPTION
PubSub subscriptions distinguish between the owner of a subscription and the JID that receives notifications.

XEP-0060 defines subscription uniqueness in terms of the node plus the literal subscription JID, while the optional multi-subscribe feature only permits multiple subscriptions for that same node+JID combination.

Update subscription handling to avoid treating an owner as the uniqueness key. This allows one owner to hold separate subscriptions for distinct bare/full subscription JIDs on the same node, even when multi-subscribe is disabled. A duplicate subscribe request for the same literal subscription JID continues to return the current subscription state when multi-subscribe is disabled.

Also ensure exact-JID subscription lookup remains consistent when multi-subscribe is enabled and one of multiple same-JID subscriptions is cancelled.

Clarify related Javadocs and comments to describe owner and subscription JID semantics accurately.