### PR TITLE
OF-3311: Fix nodeMeetsPreconditions() ignoring extra precondition values for single-valued config

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.pubsub;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import org.dom4j.DocumentHelper;
@@ -492,16 +493,32 @@ public class PubSubEngine
     }
 
     /**
-     * Checks of the configuration of the node meets the preconditions, as supplied in the dataform.
+     * Checks whether the configuration of a node satisfies the supplied preconditions.
      *
-     * This method returns true only if the configuration of the node at least contains each of the fields
-     * defined in the preconditions (with matching values).
+     * This method is used to evaluate the "publish-options as preconditions" flow of XEP-0060 (§7.1.5):
+     * a publisher supplies a data form naming the configuration fields it requires the (existing) node to
+     * have, and publishing is only allowed if the node already meets them.
      *
-     * @param node The node (cannot be null)
-     * @param preconditions The preconditions (can be null, in which case 'true' is returned).
-     * @return True if all preconditions are met, otherwise false.
+     * For the preconditions to be met, the node's configuration must, for every precondition field, contain
+     * a field with the same variable name whose value(s) include all of the value(s) required by the
+     * precondition. The node may have additional values beyond those required; only the absence of a
+     * required value causes rejection. Value comparison is order-independent: a field's values are treated
+     * as a set rather than an ordered list.
+     *
+     * Comparison follows the boolean equivalences defined by XEP-0004: the values {@code "true"} and
+     * {@code "1"} are considered equal, as are {@code "false"} and {@code "0"}.
+     *
+     * A precondition is not satisfied if the node configuration is missing the named field entirely, or if
+     * any value required by the precondition is absent from the node's value set (after boolean
+     * normalization). The {@code FORM_TYPE} field is ignored and never compared.
+     *
+     * @param node The node whose configuration is checked (cannot be null).
+     * @param preconditions The preconditions to check against. May be null, in which case {@code true} is
+     *                      returned (no preconditions to satisfy).
+     * @return {@code true} if every precondition is met, otherwise {@code false}.
      */
-    private boolean nodeMeetsPreconditions( Node node, DataForm preconditions )
+    @VisibleForTesting
+    static boolean nodeMeetsPreconditions(final Node node, final DataForm preconditions)
     {
         if ( preconditions == null )
         {
@@ -509,9 +526,15 @@ public class PubSubEngine
         }
 
         final DataForm conditions = node.getConfigurationForm(null);
+        if ( conditions == null )
+        {
+            // No configuration to match against; any non-FORM_TYPE precondition cannot be met.
+            return preconditions.getFields().stream().allMatch( f -> "FORM_TYPE".equals( f.getVariable() ) );
+        }
+
         for ( final FormField precondition : preconditions.getFields() )
         {
-            if ( precondition.getVariable().equals( "FORM_TYPE" ) )
+            if ( "FORM_TYPE".equals( precondition.getVariable() ) )
             {
                 continue;
             }
@@ -519,30 +542,43 @@ public class PubSubEngine
             final FormField condition = conditions.getField( precondition.getVariable() );
             if ( condition == null )
             {
-                // Unknown condition. Reject.
+                // Node config does not define this field. Reject.
                 return false;
             }
 
-            if ( condition.getValues().size() > 1 )
+            final Set<String> nodeValues = normalizeValues( condition );
+            final Set<String> requiredValues = normalizeValues( precondition );
+
+            if ( !nodeValues.containsAll( requiredValues ) )
             {
-                if ( !condition.getValues().containsAll( precondition.getValues() ) || !precondition.getValues().containsAll( condition.getValues() ) )
-                {
-                    // The condition value list does contain different values than the precondtion value list.
-                    return false;
-                }
-            }
-            else
-            {
-                final String a = condition.getFirstValue();
-                final String b = precondition.getFirstValue();
-                if ( !a.equals( b ) && !(a.equals( "true" ) && b.equals( "1" )) && !(a.equals( "1" ) && b.equals( "true" ))
-                                    && !(a.equals( "false" ) && b.equals( "0" )) && !(a.equals( "0" ) && b.equals( "false" )) )
-                {
-                    return false;
-                }
+                return false;
             }
         }
+
         return true;
+    }
+
+    private static Set<String> normalizeValues(final FormField field)
+    {
+        final Set<String> normalized = new HashSet<>();
+        if ( field == null )
+        {
+            return normalized;
+        }
+        for ( final String value : field.getValues() )
+        {
+            if ( value == null )
+            {
+                continue;
+            }
+            switch ( value )
+            {
+                case "true":  normalized.add( "1" ); break;
+                case "false": normalized.add( "0" ); break;
+                default:      normalized.add( value );
+            }
+        }
+        return normalized;
     }
 
     private void deleteItems(PubSubService service, IQ iq, Element retractElement) {

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/pubsub/PubSubEngineTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/pubsub/PubSubEngineTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.xmpp.forms.DataForm;
+import org.xmpp.forms.FormField;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.JID;
 import org.xmpp.packet.PacketError;
@@ -127,5 +129,221 @@ public class PubSubEngineTest
         final Element pubsubError = response.getError().getElement()
                 .element("payload-too-big");
         assertNotNull(pubsubError, "Expected a 'payload-too-big' pubsub error element");
+    }
+
+    /**
+     * Tests that a node meets preconditions when the preconditions have more than the one value that matches the node configuration.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3311">OF-3311: nodeMeetsPreconditions() ignores extra precondition values when the node configuration has only one value</a>
+     */
+    @Test
+    public void testNodeMeetsPreconditionsFailsWhenPreconditionHasAdditionalValues()
+    {
+        // Setup node configuration.
+        final Node node = Mockito.mock(Node.class);
+
+        final DataForm configuration = new DataForm(DataForm.Type.form);
+        final FormField configField = configuration.addField();
+        configField.setVariable("pubsub#access_model");
+        configField.addValue("open");
+
+        Mockito.when(node.getConfigurationForm(null)).thenReturn(configuration);
+
+        // Setup preconditions with TWO values.
+        final DataForm preconditions = new DataForm(DataForm.Type.submit);
+        final FormField preconditionField = preconditions.addField();
+        preconditionField.setVariable("pubsub#access_model");
+        preconditionField.addValue("open");
+        preconditionField.addValue("presence");
+
+        // Execute system under test.
+        final boolean result = PubSubEngine.nodeMeetsPreconditions(node, preconditions);
+
+        // Verify result.
+        assertFalse(result);
+    }
+
+    /**
+     * Order-independent equal sets match. (Note: this does not exercise the subset behavior, see
+     * {@link #testNodeMeetsPreconditionsSucceedsWhenConfigHasExtraValues} for that.)
+     */
+    @Test
+    public void testNodeMeetsPreconditionsSucceedsWhenMultiValueFieldsMatchRegardlessOfOrder()
+    {
+        // Setup test fixture.
+        final Node node = Mockito.mock(Node.class);
+        final DataForm configuration = new DataForm(DataForm.Type.form);
+        final FormField configField = configuration.addField();
+        configField.setVariable("pubsub#roster_groups_allowed");
+        configField.addValue("admins");
+        configField.addValue("moderators");
+        Mockito.when(node.getConfigurationForm(null)).thenReturn(configuration);
+
+        final DataForm preconditions = new DataForm(DataForm.Type.submit);
+        final FormField preconditionField = preconditions.addField();
+        preconditionField.setVariable("pubsub#roster_groups_allowed");
+        preconditionField.addValue("moderators");
+        preconditionField.addValue("admins");
+
+        // Execute system under test.
+        final boolean result = PubSubEngine.nodeMeetsPreconditions(node, preconditions);
+
+        // Verify result.
+        assertTrue(result);
+    }
+
+    /**
+     * The node configuration may contain more values than the precondition requires; the precondition is met as long as
+     * all required values are present. This pins the subset (containsAll) semantics, distinguishing them from exact set
+     * equality.
+     */
+    @Test
+    public void testNodeMeetsPreconditionsSucceedsWhenConfigHasExtraValues()
+    {
+        // Setup test fixture.
+        final Node node = Mockito.mock(Node.class);
+        final DataForm configuration = new DataForm(DataForm.Type.form);
+        final FormField configField = configuration.addField();
+        configField.setVariable("pubsub#roster_groups_allowed");
+        configField.addValue("admins");
+        configField.addValue("moderators");
+        configField.addValue("guests");
+        Mockito.when(node.getConfigurationForm(null)).thenReturn(configuration);
+
+        final DataForm preconditions = new DataForm(DataForm.Type.submit);
+        final FormField preconditionField = preconditions.addField();
+        preconditionField.setVariable("pubsub#roster_groups_allowed");
+        preconditionField.addValue("admins");
+        preconditionField.addValue("moderators");
+
+        // Execute system under test.
+        final boolean result = PubSubEngine.nodeMeetsPreconditions(node, preconditions);
+
+        // Verify result.
+        assertTrue(result);
+    }
+
+    /**
+     * XEP-0004 boolean equivalence: "true"/"1" and "false"/"0" are treated as equal.
+     */
+    @Test
+    public void testNodeMeetsPreconditionsTreatsBooleanValuesAsEquivalent()
+    {
+        // Setup test fixture.
+        final Node node = Mockito.mock(Node.class);
+        final DataForm configuration = new DataForm(DataForm.Type.form);
+        final FormField configField = configuration.addField();
+        configField.setVariable("pubsub#persist_items");
+        configField.addValue("true");
+        Mockito.when(node.getConfigurationForm(null)).thenReturn(configuration);
+
+        final DataForm preconditions = new DataForm(DataForm.Type.submit);
+        final FormField preconditionField = preconditions.addField();
+        preconditionField.setVariable("pubsub#persist_items");
+        preconditionField.addValue("1");
+
+        // Execute system under test.
+        final boolean result = PubSubEngine.nodeMeetsPreconditions(node, preconditions);
+
+        // Verify result.
+        assertTrue(result);
+    }
+
+    /**
+     * "true" and "false" (i.e. "0") are not equivalent.
+     */
+    @Test
+    public void testNodeMeetsPreconditionsRejectsMismatchedBooleanValues()
+    {
+        // Setup test fixture.
+        final Node node = Mockito.mock(Node.class);
+        final DataForm configuration = new DataForm(DataForm.Type.form);
+        final FormField configField = configuration.addField();
+        configField.setVariable("pubsub#persist_items");
+        configField.addValue("true");
+        Mockito.when(node.getConfigurationForm(null)).thenReturn(configuration);
+
+        final DataForm preconditions = new DataForm(DataForm.Type.submit);
+        final FormField preconditionField = preconditions.addField();
+        preconditionField.setVariable("pubsub#persist_items");
+        preconditionField.addValue("0");
+
+        // Execute system under test.
+        final boolean result = PubSubEngine.nodeMeetsPreconditions(node, preconditions);
+
+        // Verify result.
+        assertFalse(result);
+    }
+
+    /**
+     * Null preconditions are trivially satisfied.
+     */
+    @Test
+    public void testNodeMeetsPreconditionsReturnsTrueForNullPreconditions()
+    {
+        // Setup test fixture.
+        final Node node = Mockito.mock(Node.class);
+
+        // Execute system under test.
+        final boolean result = PubSubEngine.nodeMeetsPreconditions(node, null);
+
+        // Verify result.
+        assertTrue(result);
+        Mockito.verify(node, Mockito.never()).getConfigurationForm(Mockito.any());
+    }
+
+    /**
+     * A precondition naming a field absent from the node configuration is not met.
+     */
+    @Test
+    public void testNodeMeetsPreconditionsRejectsUnknownField()
+    {
+        // Setup test fixture.
+        final Node node = Mockito.mock(Node.class);
+        final DataForm configuration = new DataForm(DataForm.Type.form);
+        final FormField configField = configuration.addField();
+        configField.setVariable("pubsub#access_model");
+        configField.addValue("open");
+        Mockito.when(node.getConfigurationForm(null)).thenReturn(configuration);
+
+        final DataForm preconditions = new DataForm(DataForm.Type.submit);
+        final FormField preconditionField = preconditions.addField();
+        preconditionField.setVariable("pubsub#persist_items");
+        preconditionField.addValue("1");
+
+        // Execute system under test.
+        final boolean result = PubSubEngine.nodeMeetsPreconditions(node, preconditions);
+
+        // Verify result.
+        assertFalse(result);
+    }
+
+    /**
+     * The FORM_TYPE field is ignored and never compared, even if the node config omits it.
+     */
+    @Test
+    public void testNodeMeetsPreconditionsIgnoresFormType()
+    {
+        // Setup test fixture.
+        final Node node = Mockito.mock(Node.class);
+        final DataForm configuration = new DataForm(DataForm.Type.form);
+        final FormField configField = configuration.addField();
+        configField.setVariable("pubsub#access_model");
+        configField.addValue("open");
+        Mockito.when(node.getConfigurationForm(null)).thenReturn(configuration);
+
+        final DataForm preconditions = new DataForm(DataForm.Type.submit);
+        final FormField formType = preconditions.addField();
+        formType.setVariable("FORM_TYPE");
+        formType.addValue("http://jabber.org/protocol/pubsub#publish-options");
+        final FormField preconditionField = preconditions.addField();
+        preconditionField.setVariable("pubsub#access_model");
+        preconditionField.addValue("open");
+
+        // Execute system under test.
+        final boolean result = PubSubEngine.nodeMeetsPreconditions(node, preconditions);
+
+        // Verify result.
+        assertTrue(result);
     }
 }


### PR DESCRIPTION
The comparison strategy was chosen from condition.getValues().size() alone, so a single-valued config field compared only first values and discarded any extra precondition values. For example, condition ["friends"] against precondition ["friends", "family"] wrongly returned true.

Always compare normalized value sets instead: a field is satisfied only if the node's values contain all those the precondition requires.

Booleans are treated per XEP-0004 ("true"/"1", "false"/"0").

Also removes a latent NPE from the old getFirstValue().equals(...) path and updates the javadoc to match.