### PR TITLE
OF-3313: Return previous value when setting a property

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/JiveGlobals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2017-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -808,9 +808,10 @@ public class JiveGlobals {
      *
      * @param name the name of the property being set.
      * @param value the value of the property being set.
+     * @return the previous value of the property, or {@code null} if it didn't exist.
      */
-    public static void setProperty(String name, String value) {
-        setProperty(name, value, false);
+    public static String setProperty(String name, String value) {
+        return setProperty(name, value, false);
     }
 
     /**
@@ -820,15 +821,16 @@ public class JiveGlobals {
      * @param name the name of the property being set.
      * @param value the value of the property being set.
      * @param encrypt {@code true} to encrypt the property in the database, other {@code false}
+     * @return the previous value of the property, or {@code null} if it didn't exist.
      */
-    public static void setProperty(String name, String value, boolean encrypt) {
+    public static String setProperty(String name, String value, boolean encrypt) {
         if (properties == null) {
             if (isSetupMode()) {
-                return;
+                return null;
             }
             properties = JiveProperties.getInstance();
         }
-        properties.put(name, value, encrypt);
+        return properties.put(name, value, encrypt);
     }
 
     /**
@@ -850,14 +852,15 @@ public class JiveGlobals {
      *
      * @param name   the name of the property being set.
      * @param values the values of the property.
+     * @return the previous value of the property, or {@code null} if it didn't exist.
      */
-    public static void setProperty( String name, List<String> values )
+    public static List<String> setProperty(String name, List<String> values)
     {
         if ( properties == null )
         {
             if ( isSetupMode() )
             {
-                return;
+                return null;
             }
             properties = JiveProperties.getInstance();
         }
@@ -866,7 +869,7 @@ public class JiveGlobals {
         if ( existing != null && existing.equals( values ) )
         {
             // no change.
-            return;
+            return existing.isEmpty() ? null : existing;
         }
 
         properties.remove( name );
@@ -893,6 +896,7 @@ public class JiveGlobals {
             params.put("value", values);
             PropertyEventDispatcher.dispatchEvent(name, PropertyEventDispatcher.EventType.property_set, params);
         }
+        return existing == null || existing.isEmpty() ? null : existing;
     }
 
     /**
@@ -919,16 +923,18 @@ public class JiveGlobals {
      * does nothing. All children of the property will be deleted as well.
      *
      * @param name the name of the property to delete.
+     * @return the previous value associated with this property, or null if there was no property.
      */
-    public static void deleteProperty(String name) {
+    public static String deleteProperty(String name) {
         if (properties == null) {
             if (isSetupMode()) {
-                return;
+                return null;
             }
             properties = JiveProperties.getInstance();
         }
-        properties.remove(name);
+        final String removed = properties.remove(name);
         clearXMLPropertyEncryptionEntry(name);
+        return removed;
     }
 
     static void clearXMLPropertyEncryptionEntry(String name) {

--- a/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/SystemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -364,12 +364,22 @@ public final class SystemProperty<T> {
 
     /**
      * Sets the value of the SystemProperty. Note that the new value can be outside any minimum/maximum for the property,
-     * and will be saved to the database as such, however subsequent attempts to retrieve it's value will return the default.
+     * and will be saved to the database as such, however subsequent attempts to retrieve its value will return the default.
+     *
+     * This method returns the previous value of the property, or {@code null} if it didn't exist. The returned value
+     * may also be outside any minimum/maximum for the property.
      *
      * @param value the new value for the SystemProperty
+     * @return the previous value of the property, or {@code null} if it didn't exist.
      */
-    public void setValue(final T value) {
-        JiveGlobals.setProperty(key, TO_STRING.get(getConverterClass()).apply(value, this), isEncrypted());
+    public T setValue(final T value)
+    {
+        final String previousValue = JiveGlobals.setProperty(key, TO_STRING.get(getConverterClass()).apply(value, this), isEncrypted());
+        if (previousValue != null) {
+            //noinspection unchecked
+            return (T) FROM_STRING.get(getConverterClass()).apply(previousValue, this);
+        }
+        return null;
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/util/SystemPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -679,5 +679,117 @@ public class SystemPropertyTest {
         assertThat(JiveGlobals.getProperty(key), is("TEST_2"));
     }
 
+    @Test
+    public void setValueReturnsNullWhenNoPreviousValueExists() {
 
+        final SystemProperty<Long> longProperty = SystemProperty.Builder.ofType(Long.class)
+            .setKey("a-test-previous-value-absent")
+            .setDefaultValue(42L)
+            .setDynamic(true)
+            .build();
+
+        // Even though a default is configured, nothing has been persisted, so there is no previous value.
+        assertThat(longProperty.setValue(84L), is(nullValue()));
+    }
+
+    @Test
+    public void setValueReturnsThePreviousValue() {
+
+        final SystemProperty<Long> longProperty = SystemProperty.Builder.ofType(Long.class)
+            .setKey("a-test-previous-value-present")
+            .setDefaultValue(42L)
+            .setDynamic(true)
+            .build();
+
+        assertThat(longProperty.setValue(84L), is(nullValue()));
+        assertThat(longProperty.setValue(168L), is(84L));
+        assertThat(longProperty.getValue(), is(168L));
+    }
+
+    @Test
+    public void setValueReturnsThePreviousValueForAStringProperty() {
+
+        final SystemProperty<String> stringProperty = SystemProperty.Builder.ofType(String.class)
+            .setKey("a-test-previous-string-value")
+            .setDefaultValue("this-is-a-default")
+            .setDynamic(true)
+            .build();
+
+        assertThat(stringProperty.setValue("first"), is(nullValue()));
+        assertThat(stringProperty.setValue("second"), is("first"));
+    }
+
+    @Test
+    public void setValueReturnsThePreviousValueConvertedToType() {
+
+        // Confirms the returned previous value is converted back from its stored String form, not returned raw.
+        final SystemProperty<Duration> durationProperty = SystemProperty.Builder.ofType(Duration.class)
+            .setKey("a-test-previous-duration-value")
+            .setDefaultValue(Duration.ofHours(1))
+            .setChronoUnit(ChronoUnit.MINUTES)
+            .setDynamic(true)
+            .build();
+
+        assertThat(durationProperty.setValue(Duration.ofMinutes(30)), is(nullValue()));
+        final Duration previous = durationProperty.setValue(Duration.ofMinutes(90));
+        assertThat(previous, is(Duration.ofMinutes(30)));
+    }
+
+    @Test
+    public void setValueReturnsThePreviousPlaintextValueForAnEncryptedProperty() {
+
+        // The previous value must be returned as decrypted plaintext, converted back to type - not as ciphertext.
+        final SystemProperty<Long> longProperty = SystemProperty.Builder.ofType(Long.class)
+            .setKey("a-test-encrypted-previous-value")
+            .setDefaultValue(42L)
+            .setDynamic(false)
+            .setEncrypted(true)
+            .build();
+
+        assertThat(longProperty.setValue(84L), is(nullValue()));
+        assertThat(JiveGlobals.isPropertyEncrypted("a-test-encrypted-previous-value"), is(true));
+        assertThat(longProperty.setValue(168L), is(84L));
+    }
+
+    @Test
+    public void jiveGlobalsSetPropertyReturnsNullWhenNoPreviousValueExists() {
+        assertThat(JiveGlobals.setProperty("a-test-jiveglobals-absent", "value"), is(nullValue()));
+    }
+
+    @Test
+    public void jiveGlobalsSetPropertyReturnsThePreviousValue() {
+        final String key = "a-test-jiveglobals-present";
+        assertThat(JiveGlobals.setProperty(key, "first"), is(nullValue()));
+        assertThat(JiveGlobals.setProperty(key, "second"), is("first"));
+    }
+
+    @Test
+    public void jiveGlobalsDeletePropertyReturnsThePreviousValue() {
+        final String key = "a-test-jiveglobals-delete";
+        JiveGlobals.setProperty(key, "value-to-delete");
+        assertThat(JiveGlobals.deleteProperty(key), is("value-to-delete"));
+        assertThat(JiveGlobals.deleteProperty(key), is(nullValue()));
+    }
+
+    @Test
+    public void jiveGlobalsSetListPropertyReturnsNullWhenNoPreviousValueExists() {
+        final String key = "a-test-jiveglobals-list-absent";
+        assertThat(JiveGlobals.setProperty(key, Arrays.asList("a", "b")), is(nullValue()));
+    }
+
+    @Test
+    public void jiveGlobalsSetListPropertyReturnsThePreviousValue() {
+        final String key = "a-test-jiveglobals-list-present";
+        assertThat(JiveGlobals.setProperty(key, Arrays.asList("a", "b")), is(nullValue()));
+        assertThat(JiveGlobals.setProperty(key, Arrays.asList("c", "d")), is(Arrays.asList("a", "b")));
+    }
+
+    @Test
+    public void jiveGlobalsSetListPropertyReturnsThePreviousValueOnUnchangedSet() {
+        // The no-change early-return path: a present, unchanged value should still report the prior list (non-empty),
+        // consistent with the changed path returning null only when the prior value was absent/empty.
+        final String key = "a-test-jiveglobals-list-unchanged";
+        JiveGlobals.setProperty(key, Arrays.asList("a", "b"));
+        assertThat(JiveGlobals.setProperty(key, Arrays.asList("a", "b")), is(Arrays.asList("a", "b")));
+    }
 }


### PR DESCRIPTION
JiveGlobals.setProperty (both String overloads and the List variant) and deleteProperty now return the previous value, mirroring Map semantics.

SystemProperty.setValue returns the prior value converted back to its type, or null if none existed.

Add SystemPropertyTest coverage for the new return values, including the encrypted-property case.