### PR TITLE
OF-3318: Fix SessionManager teardown marking a live session offline

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -270,7 +270,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
      * @param session The (detached) session to be terminated.
      */
     public synchronized void terminateDetached(LocalSession session) {
-        if (!(session instanceof LocalClientSession)) {
+        if (!(session instanceof LocalClientSession clientSession)) {
             Log.trace("Silently ignoring a request to terminate a non LocalClientSession: {}", session);
             return;
         }
@@ -279,13 +279,9 @@ public class SessionManager extends BasicModule implements ClusterEventListener
             Log.info("Unable to terminate detachment of session '{}' ({}), as it was not registered as being a detached.", session.getAddress(), session.getStreamID());
             return;
         }
-        final LocalClientSession clientSession = (LocalClientSession)session;
 
-        // OF-1923: Only close the session if it has not been replaced by another session (if the session
-        // has been replaced, then the condition below will compare to distinct instances). This *should* not
-        // occur (but has been observed, prior to the fix of OF-1923). This check is left in as a safeguard.
-        final ClientSession currentSession = routingTable.getClientRoute(session.getAddress());
-        if (session == currentSession) {
+        // OF-1923 / OF-3318: Only close the session if it has not been replaced by another session for the same full JID.
+        if (isRouteOwner(clientSession)) {
             try {
                 if ((clientSession.getPresence().isAvailable() || !clientSession.wasAvailable()) &&
                     routingTable.hasClientRoute(session.getAddress())) {
@@ -305,7 +301,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
             }
         } else {
             // This could be the start of data state inconsistency. See OF-3044.
-            Log.warn("Not removing detached session '{}' ({}) that appears to have been replaced by another session. New session: {} - original session {}", session.getAddress(), session.getStreamID(), currentSession, session);
+            Log.warn("Not removing detached session '{}' ({}) that appears to have been replaced by another session.", session.getAddress(), session.getStreamID());
         }
     }
 
@@ -1284,6 +1280,26 @@ public class SessionManager extends BasicModule implements ClusterEventListener
     }
 
     /**
+     * Determines whether the supplied session currently owns the client route for its own address.
+     *
+     * @param session the session being evaluated (may be null).
+     * @return true if the session currently owns the route for its own address.
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3318">OF-3318: SessionManager teardown ownership</a>
+     */
+    private boolean isRouteOwner(final ClientSession session)
+    {
+        if (session == null) {
+            return false;
+        }
+        final ClientSession current = routingTable.getClientRoute(session.getAddress());
+
+        // Ownership is verified by comparing StreamID, replacing an earlier implementation that depended on object
+        // identity. Object identity would in fact be correct (as paths that use it are local-first even in a cluster,
+        // so it returns the very same local instance). The StreamID comparison is defensive hardening.
+        return current != null && session.getStreamID().equals(current.getStreamID());
+    }
+
+    /**
      * Removes a session.
      *
      * @param session the session.
@@ -1328,7 +1344,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         // route or mark it offline.
         // Ownership is captured before removal (the route still exists at this point). Bookkeeping (session_destroyed
         // dispatch) is still performed for stale sessions below, so they are not leaked.
-        final boolean ownsRoute = (session == routingTable.getClientRoute(fullJID));
+        final boolean ownsRoute = isRouteOwner(session);
 
         // Remove route to the removed session (anonymous or not), but only when this session owns it.
         boolean removed = ownsRoute && routingTable.removeClientRoute(fullJID);
@@ -1436,15 +1452,17 @@ public class SessionManager extends BasicModule implements ClusterEventListener
             // can briefly exist for the same full JID - for example after a reconnect. Only one owns the route). Verifying
             // ownership (as terminateDetached() does for OF-1923) prevents sending unavailable presence for a live session
             // when a stale session closes.
-            if ((session.getPresence().isAvailable() || !session.wasAvailable()) && session == routingTable.getClientRoute(session.getAddress())) {
-                // Send an unavailable presence to the user's subscribers. This gives us a chance to send an
-                // unavailable presence to the entities that the user sent directed presences
-                final Presence presence = new Presence();
-                presence.setType(Presence.Type.unavailable);
-                presence.setFrom(session.getAddress());
+            result = result.thenRunAsync(() -> {
+                if ((session.getPresence().isAvailable() || !session.wasAvailable()) && isRouteOwner(session)) {
+                    // Send an unavailable presence to the user's subscribers. This gives us a chance to send an
+                    // unavailable presence to the entities that the user sent directed presences
+                    final Presence presence = new Presence();
+                    presence.setType(Presence.Type.unavailable);
+                    presence.setFrom(session.getAddress());
 
-                result = result.thenRunAsync(() -> router.route(presence));
-            }
+                    router.route(presence);
+                }
+            });
 
             // In the completion stage remove the session (which means it'll be removed no matter if the previous stage had exceptions).
             return result.whenComplete((v,t) -> {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -302,6 +302,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         } else {
             // This could be the start of data state inconsistency. See OF-3044.
             Log.warn("Not removing detached session '{}' ({}) that appears to have been replaced by another session.", session.getAddress(), session.getStreamID());
+            // TODO investigate if the session should be removed (see OF-3320).
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -1322,25 +1322,37 @@ public class SessionManager extends BasicModule implements ClusterEventListener
             session = getSession(fullJID);
         }
 
-        // Remove route to the removed session (anonymous or not)
-        boolean removed = routingTable.removeClientRoute(fullJID);
+        // OF-3318: Only the session that currently OWNS the route may remove it, emit the server-side unavailable, or
+        // clear the session-info cache (two LocalClientSession instances can briefly exist for the same full JID - for
+        // example after a reconnect. Only one owns the route). A stale teardown must not tear down the live session's
+        // route or mark it offline.
+        // Ownership is captured before removal (the route still exists at this point). Bookkeeping (session_destroyed
+        // dispatch) is still performed for stale sessions below, so they are not leaked.
+        final boolean ownsRoute = (session == routingTable.getClientRoute(fullJID));
+
+        // Remove route to the removed session (anonymous or not), but only when this session owns it.
+        boolean removed = ownsRoute && routingTable.removeClientRoute(fullJID);
 
         if (removed) {
             // Fire session event.
-            if (anonymous) {
-                SessionEventDispatcher
-                        .dispatchEvent(session, SessionEventDispatcher.EventType.anonymous_session_destroyed);
-            }
-            else {
-                SessionEventDispatcher.dispatchEvent(session, SessionEventDispatcher.EventType.session_destroyed);
-
-            }
+            SessionEventDispatcher.dispatchEvent(session,
+                anonymous ? SessionEventDispatcher.EventType.anonymous_session_destroyed : SessionEventDispatcher.EventType.session_destroyed
+            );
+        } else if (!ownsRoute) {
+            // OF-3318: A stale/replaced session that does not own the route is being torn down. It will not remove a
+            // route, but listeners must still be notified, so the session instance is not leaked. (The route owner,
+            // the live session, will fire its own session_destroyed when it is eventually removed.)
+            SessionEventDispatcher.dispatchEvent(session,
+                anonymous ? SessionEventDispatcher.EventType.anonymous_session_destroyed : SessionEventDispatcher.EventType.session_destroyed
+            );
         }
 
         // Remove the session from the pre-Authenticated sessions list (if present)
         boolean preauth_removed = session instanceof LocalClientSession && localSessionManager.removePreAuthenticatedSession((LocalClientSession) session);
-        // If the user is still available then send an unavailable presence
-        if (forceUnavailable || session.getPresence().isAvailable()) {
+
+        // If the user was still 'available' then send an unavailable presence, however (OF-3318) suppressed this for a
+        // session that does not own the route, as routing it would mark the live session (the route owner) offline.
+        if (forceUnavailable || (ownsRoute && session.getPresence().isAvailable())) {
             Presence offline = new Presence();
             offline.setFrom(fullJID);
             offline.setTo(new JID(null, serverName, null, true));
@@ -1350,7 +1362,9 @@ public class SessionManager extends BasicModule implements ClusterEventListener
 
         // Stop tracking information about the session and share it with other cluster nodes.
         // Note that, unlike other caches, this cache is populated only when clustering is enabled.
-        sessionInfoCache.remove(fullJID.toString());
+        if (ownsRoute) { // OF-3318: only clear when this session owns the route, otherwise the live session's cached info is evicted.
+            sessionInfoCache.remove(fullJID.toString());
+        }
 
         if (removed || preauth_removed) {
             // Decrement the counter of user sessions
@@ -1418,7 +1432,11 @@ public class SessionManager extends BasicModule implements ClusterEventListener
 
             CompletableFuture<Void> result = CompletableFuture.runAsync(() -> Log.debug("Closing client session with address {} and streamID {} that does not have SM resume.", session.getAddress(), session.getStreamID()));
 
-            if ((session.getPresence().isAvailable() || !session.wasAvailable()) && routingTable.hasClientRoute(session.getAddress())) {
+            // OF-3318: Only emit unavailable when this closing session still owns the route (two LocalClientSession instances
+            // can briefly exist for the same full JID - for example after a reconnect. Only one owns the route). Verifying
+            // ownership (as terminateDetached() does for OF-1923) prevents sending unavailable presence for a live session
+            // when a stale session closes.
+            if ((session.getPresence().isAvailable() || !session.wasAvailable()) && session == routingTable.getClientRoute(session.getAddress())) {
                 // Send an unavailable presence to the user's subscribers. This gives us a chance to send an
                 // unavailable presence to the entities that the user sent directed presences
                 final Presence presence = new Presence();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -1297,7 +1297,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         // Ownership is verified by comparing StreamID, replacing an earlier implementation that depended on object
         // identity. Object identity would in fact be correct (as paths that use it are local-first even in a cluster,
         // so it returns the very same local instance). The StreamID comparison is defensive hardening.
-        return current != null && session.getStreamID().equals(current.getStreamID());
+        return current != null && Objects.equals(session.getStreamID(), current.getStreamID());
     }
 
     /**
@@ -1346,7 +1346,7 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         // Ownership is captured before removal (the route still exists at this point). Bookkeeping (session_destroyed
         // dispatch) is still performed for stale sessions below, so they are not leaked.
         final ClientSession current = (session == null) ? null : routingTable.getClientRoute(fullJID);
-        final boolean ownsRoute = current != null && session.getStreamID().equals(current.getStreamID());
+        final boolean ownsRoute = current != null && Objects.equals(session.getStreamID(), current.getStreamID());
         final boolean replacedByOther = current != null && !ownsRoute; // a route exists, owned by a different session
 
         // Remove route to the removed session (anonymous or not), but only when this session owns it.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/SessionManager.java
@@ -1344,7 +1344,9 @@ public class SessionManager extends BasicModule implements ClusterEventListener
         // route or mark it offline.
         // Ownership is captured before removal (the route still exists at this point). Bookkeeping (session_destroyed
         // dispatch) is still performed for stale sessions below, so they are not leaked.
-        final boolean ownsRoute = isRouteOwner(session);
+        final ClientSession current = (session == null) ? null : routingTable.getClientRoute(fullJID);
+        final boolean ownsRoute = current != null && session.getStreamID().equals(current.getStreamID());
+        final boolean replacedByOther = current != null && !ownsRoute; // a route exists, owned by a different session
 
         // Remove route to the removed session (anonymous or not), but only when this session owns it.
         boolean removed = ownsRoute && routingTable.removeClientRoute(fullJID);
@@ -1354,10 +1356,10 @@ public class SessionManager extends BasicModule implements ClusterEventListener
             SessionEventDispatcher.dispatchEvent(session,
                 anonymous ? SessionEventDispatcher.EventType.anonymous_session_destroyed : SessionEventDispatcher.EventType.session_destroyed
             );
-        } else if (!ownsRoute) {
-            // OF-3318: A stale/replaced session that does not own the route is being torn down. It will not remove a
-            // route, but listeners must still be notified, so the session instance is not leaked. (The route owner,
-            // the live session, will fire its own session_destroyed when it is eventually removed.)
+        } else if (replacedByOther) {
+            // OF-3318: a route for this address exists but is owned by a different session (StreamID mismatch):
+            // this instance was replaced. Notify listeners so it is not leaked, without firing for null or
+            // pre-auth sessions (which never had a route / never fired session_created).
             SessionEventDispatcher.dispatchEvent(session,
                 anonymous ? SessionEventDispatcher.EventType.anonymous_session_destroyed : SessionEventDispatcher.EventType.session_destroyed
             );

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/SessionManagerCloseListenerRouteOwnershipTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/SessionManagerCloseListenerRouteOwnershipTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.session.LocalClientSession;
+import org.jivesoftware.openfire.spi.BasicStreamIDFactory;
+import org.jivesoftware.openfire.streammanagement.StreamManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+import org.xmpp.packet.JID;
+import org.xmpp.packet.Presence;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Characterization test for the client {@code ConnectionCloseListener} path in {@link SessionManager}.
+ *
+ * This complements {@code SessionManagerRouteOwnershipTest} (which drives {@code removeSession} directly). The close
+ * listener emits an unavailable presence <em>before</em> {@code removeSession} is reached, gated only on
+ * {@code routingTable.hasClientRoute(...)} (a route-existence check, not an ownership check). When a stale session
+ * closes after a reconnect while a live session owns the route for the same full JID, that emission could incorrectly
+ * mark the live session offline. This test exercises exactly that emission.
+ *
+ * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3318">OF-3318: SessionManager teardown ownership</a>
+ * @see SessionManagerRouteOwnershipTest
+ */
+@ExtendWith(MockitoExtension.class)
+public class SessionManagerCloseListenerRouteOwnershipTest
+{
+    private static final JID FULL_JID = new JID("johndoe", Fixtures.XMPP_DOMAIN, "resourcepart-used-for-testing", true);
+
+    private SessionManager sessionManager;
+    private RoutingTable routingTable;
+    private PacketRouter packetRouter;
+
+    @BeforeAll
+    public static void setUpClass() throws Exception
+    {
+        Fixtures.reconfigureOpenfireHome();
+        Fixtures.disableDatabasePersistence();
+    }
+
+    @BeforeEach
+    public void setUp()
+    {
+        routingTable = mock(RoutingTable.class, withSettings().strictness(Strictness.LENIENT));
+        packetRouter = mock(PacketRouter.class, withSettings().strictness(Strictness.LENIENT));
+
+        final XMPPServer server = Fixtures.mockXMPPServer();
+        doReturn(routingTable).when(server).getRoutingTable();
+        doReturn(packetRouter).when(server).getPacketRouter();
+
+        //noinspection deprecation
+        XMPPServer.setInstance(server);
+
+        sessionManager = new SessionManager();
+        sessionManager.initialize(server);
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        Fixtures.clearExistingProperties();
+    }
+
+    /**
+     * A mock {@link LocalClientSession} configured so that the close-listener reaches the unavailable-presence
+     * emission branch: it is not detached, has no stream-management resume, reports an available presence, and
+     * carries the shared full JID.
+     */
+    private LocalClientSession session(final String streamId)
+    {
+        final LocalClientSession session = mock(LocalClientSession.class, withSettings().strictness(Strictness.LENIENT));
+        doReturn(BasicStreamIDFactory.createStreamID(streamId)).when(session).getStreamID();
+        doReturn(FULL_JID).when(session).getAddress();
+        doReturn(new Presence()).when(session).getPresence(); // default type == available
+        doReturn(false).when(session).isDetached();
+
+        // Stream management must report "no resume" so the listener proceeds to teardown rather than detaching.
+        final StreamManager streamManager = mock(StreamManager.class, withSettings().strictness(Strictness.LENIENT));
+        doReturn(false).when(streamManager).getResume();
+        doReturn(streamManager).when(session).getStreamManager();
+        return session;
+    }
+
+    /**
+     * Reflectively invoke the private client close listener for the given session. Any returned future is joined so that
+     * assertions observe a settled state.
+     */
+    private void fireConnectionClose(final LocalClientSession session) throws Exception
+    {
+        final Field listenerField = SessionManager.class.getDeclaredField("clientSessionListener");
+        listenerField.setAccessible(true);
+        final Object listener = listenerField.get(sessionManager);
+
+        final Method method = listener.getClass().getDeclaredMethod("onConnectionClosing", Object.class);
+        method.setAccessible(true);
+
+        final Object result = method.invoke(listener, session);
+        if (result instanceof CompletableFuture) {
+            ((CompletableFuture<?>) result).join(); // wait for async routing to complete before asserting
+        }
+    }
+
+    /**
+     * The core presence bug. A stale session closes while the live session owns the route for the same full JID. The
+     * close listener must not route an unavailable presence for that full JID (which would mark the live session
+     * offline).
+     */
+    @Test
+    public void staleSessionClose_doesNotRouteUnavailableForLiveSession() throws Exception
+    {
+        // Setup test fixture: a stale session closes; a route exists (owned by the live session).
+        final LocalClientSession stale = session("stalestreamid");
+        final LocalClientSession live = session("livestreamid");
+        when(routingTable.hasClientRoute(FULL_JID)).thenReturn(true);
+        when(routingTable.getClientRoute(FULL_JID)).thenReturn(live);
+
+        // Execute system under test: the stale session's connection closes.
+        fireConnectionClose(stale);
+
+        // Verify result: no unavailable presence whose 'from' is the shared full JID was routed.
+        verify(packetRouter, never()).route((Presence) argThat(p ->
+            p instanceof Presence
+                && Presence.Type.unavailable.equals(((Presence) p).getType())
+                && FULL_JID.equals(((Presence) p).getFrom())));
+    }
+
+    /**
+     * Guard against a no-op regression: when the session that closes is the one that owns the route, the listener
+     * SHOULD route an unavailable presence for the full JID. This passes both before and after the fix; it ensures a
+     * fix does not make the listener stop emitting unavailable presence for genuine closes.
+     */
+    @Test
+    public void owningSessionClose_routesUnavailableForJid() throws Exception
+    {
+        // Setup test fixture: the closing session owns the route.
+        final LocalClientSession owner = session("ownerstreamid");
+        when(routingTable.hasClientRoute(FULL_JID)).thenReturn(true);
+        when(routingTable.getClientRoute(FULL_JID)).thenReturn(owner);
+
+        // Execute system under test.
+        fireConnectionClose(owner);
+
+        // Verify result: at least one unavailable presence whose 'from' is the full JID IS routed.
+        verify(packetRouter, atLeastOnce()).route((Presence) argThat(p ->
+            p instanceof Presence
+                && Presence.Type.unavailable.equals(((Presence) p).getType())
+                && FULL_JID.equals(((Presence) p).getFrom())));
+    }
+}

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/SessionManagerRouteOwnershipTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/SessionManagerRouteOwnershipTest.java
@@ -27,7 +27,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.quality.Strictness;
 import org.xmpp.packet.JID;
-import org.xmpp.packet.Packet;
 import org.xmpp.packet.Presence;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -137,11 +136,10 @@ public class SessionManagerRouteOwnershipTest
         sessionManager.removeSession(stale, FULL_JID, false, false);
 
         // Verify result: no unavailable presence for the shared full JID was routed.
-        final ArgumentCaptor<Packet> routed = ArgumentCaptor.forClass(Packet.class);
+        final ArgumentCaptor<Presence> routed = ArgumentCaptor.forClass(Presence.class);
         verify(packetRouter, atLeast(0)).route(routed.capture());
 
         final boolean routedUnavailableForJid = routed.getAllValues().stream()
-            .filter(p -> p instanceof Presence)
             .map(p -> (Presence) p)
             .anyMatch(p -> Presence.Type.unavailable.equals(p.getType()) && FULL_JID.equals(p.getFrom()));
         assertFalse(routedUnavailableForJid, "Teardown of the stale session must not route an unavailable presence for the live session's full JID.");

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/SessionManagerRouteOwnershipTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/SessionManagerRouteOwnershipTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.openfire.session.ClientSession;
+import org.jivesoftware.openfire.spi.BasicStreamIDFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+import org.xmpp.packet.JID;
+import org.xmpp.packet.Packet;
+import org.xmpp.packet.Presence;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Characterization tests for {@link SessionManager#removeSession(ClientSession, JID, boolean, boolean)} in the presence
+ * of two sessions for the same full JID (as happens after a reconnect, or under a conflict-limit that tolerates
+ * concurrent sessions).
+ *
+ * This complements {@code SessionManagerCloseListenerRouteOwnershipTest} (which covers the close-listener path, which
+ * also drives removeSession, but not in isolation).
+ *
+ * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3318">OF-3318: SessionManager teardown ownership</a>
+ * @see SessionManagerCloseListenerRouteOwnershipTest
+ */
+@ExtendWith(MockitoExtension.class)
+public class SessionManagerRouteOwnershipTest
+{
+    private static final JID FULL_JID = new JID("johndoe", Fixtures.XMPP_DOMAIN, "resourcepart-used-for-testing", true);
+
+    private SessionManager sessionManager;
+    private RoutingTable routingTable;
+    private PacketRouter packetRouter;
+
+    @BeforeAll
+    public static void setUpClass() throws Exception
+    {
+        Fixtures.reconfigureOpenfireHome();
+        Fixtures.disableDatabasePersistence();
+    }
+
+    @BeforeEach
+    public void setUp()
+    {
+        routingTable = mock(RoutingTable.class, withSettings().strictness(Strictness.LENIENT));
+        packetRouter = mock(PacketRouter.class, withSettings().strictness(Strictness.LENIENT));
+
+        // Wire the two collaborators SessionManager.initialize(...) pulls from the server, on top of the standard mock
+        // server provided by the test fixtures.
+        final XMPPServer server = Fixtures.mockXMPPServer();
+        doReturn(routingTable).when(server).getRoutingTable();
+        doReturn(packetRouter).when(server).getPacketRouter();
+
+        //noinspection deprecation
+        XMPPServer.setInstance(server);
+
+        sessionManager = new SessionManager();
+        sessionManager.initialize(server);
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        Fixtures.clearExistingProperties();
+    }
+
+    /**
+     * A lenient mock client session that reports the given stream ID, the shared full JID, and an available presence.
+     * <p>
+     * Note: this is a plain {@link ClientSession} rather than a {@code LocalClientSession}. That is deliberate and
+     * harmless here. {@code removeSession} only dereferences {@code localSessionManager} inside a
+     * {@code session instanceof LocalClientSession} branch, so a plain {@code ClientSession} mock avoids needing to
+     * stub that collaborator while leaving the route- and presence-handling paths under test fully exercised.
+     */
+    private ClientSession session(final String streamId)
+    {
+        final ClientSession session = mock(ClientSession.class, withSettings().strictness(Strictness.LENIENT));
+        when(session.getStreamID()).thenReturn(BasicStreamIDFactory.createStreamID(streamId));
+        when(session.getAddress()).thenReturn(FULL_JID);
+        when(session.getPresence()).thenReturn(new Presence()); // default type == available
+        return session;
+    }
+
+    /**
+     * The core bug. Two sessions exist for the same full JID; the live session owns the route. When the stale session
+     * is torn down, the live session's route must NOT be removed.
+     */
+    @Test
+    public void tearingDownStaleSession_doesNotRemoveLiveRoute()
+    {
+        // Setup test fixture: live session owns the route; a stale session also exists for the same full JID.
+        final ClientSession live = session("livestreamid");
+        final ClientSession stale = session("stalestreamid");
+        when(routingTable.getClientRoute(FULL_JID)).thenReturn(live);
+
+        // Execute system under test: the stale session's connection closes and it is removed.
+        sessionManager.removeSession(stale, FULL_JID, false, false);
+
+        // Verify result: the live session's route must never be removed by the stale teardown.
+        verify(routingTable, never()).removeClientRoute(FULL_JID);
+    }
+
+    /**
+     * Companion assertion on presence: tearing down the stale session must not route an unavailable presence from the
+     * full JID (which would mark the live session offline to its subscribers and server-side).
+     */
+    @Test
+    public void tearingDownStaleSession_doesNotRouteUnavailableForLiveSession()
+    {
+        // Setup test fixture.
+        final ClientSession live = session("livestreamid");
+        final ClientSession stale = session("stalestreamid");
+        when(routingTable.getClientRoute(FULL_JID)).thenReturn(live);
+
+        // Execute system under test.
+        sessionManager.removeSession(stale, FULL_JID, false, false);
+
+        // Verify result: no unavailable presence for the shared full JID was routed.
+        final ArgumentCaptor<Packet> routed = ArgumentCaptor.forClass(Packet.class);
+        verify(packetRouter, atLeast(0)).route(routed.capture());
+
+        final boolean routedUnavailableForJid = routed.getAllValues().stream()
+            .filter(p -> p instanceof Presence)
+            .map(p -> (Presence) p)
+            .anyMatch(p -> Presence.Type.unavailable.equals(p.getType()) && FULL_JID.equals(p.getFrom()));
+        assertFalse(routedUnavailableForJid, "Teardown of the stale session must not route an unavailable presence for the live session's full JID.");
+    }
+
+    /**
+     * Guard against a no-op regression: tearing down the session that ACTUALLY owns the route must still remove that
+     * route.
+     */
+    @Test
+    public void tearingDownOwningSession_stillRemovesRoute()
+    {
+        // Setup test fixture: a single session that owns the route.
+        final ClientSession owner = session("ownerstreamid");
+        when(routingTable.getClientRoute(FULL_JID)).thenReturn(owner);
+        when(routingTable.removeClientRoute(FULL_JID)).thenReturn(true);
+
+        // Execute system under test
+        sessionManager.removeSession(owner, FULL_JID, false, false);
+
+        // Verify result: the owner's own route IS removed.
+        verify(routingTable).removeClientRoute(FULL_JID);
+    }
+
+    /**
+     * Sanity: the two sessions are genuinely distinct instances with distinct stream IDs, so the scenario under test is
+     * the real two-session overlap and not an artefact of mock reuse.
+     */
+    @Test
+    public void preconditions_sessionsAreDistinct()
+    {
+        final ClientSession live = session("livestreamid");
+        final ClientSession stale = session("stalestreamid");
+        assertNotEquals(live, stale, "Sanity check failed: the sessions used for testing are expected to be non-equal instances (but they are equal). This will cause the outcome of other tests in this suite to be unreliable.");
+        assertNotEquals(live.getStreamID(), stale.getStreamID(), "Sanity check failed: the stream IDs of the sessions used for testing are expected to be non-equal instances (but they are equal). This will cause the outcome of other tests in this suite to be unreliable.");
+    }
+}


### PR DESCRIPTION
When two LocalClientSession instances briefly coexist for the same full JID (after a reconnect, or under a conflict-limit that tolerates concurrent sessions), only one owns the route. Teardown of the stale, non-owning session previously keyed off route existence rather than ownership, so it removed the live session's route and routed an unavailable presence on its behalf - marking a connected user offline.

This PR gates the teardown paths on route ownership, so a stale teardown no longer affects the live session; session_destroyed still fires for the stale session so it isn't leaked. 

A follow-up commit routes all three through a single isRouteOwner helper that verifies ownership by StreamID rather than object identity. This is intended as defensive hardening, with no behavioural change for sessions reachable today.

See the individual commit messages for details on each stage. Behaviour is covered by new tests that assert on observable teardown effects (which route is removed, whether an unavailable is routed); Some of these tests failed before the fixes, but pass after.