### PR TITLE
OF-3321: Fix ConcurrentModificationException in createSocketToXmppDomain

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketUtil.java
@@ -120,7 +120,7 @@ public class SocketUtil
         Log.debug( "Creating a socket connection to XMPP domain '{}' ...", xmppDomain );
 
         final Instant deadline = Instant.now().plus(RESOLUTION_TIMEOUT.getValue());
-        final List<Future<Map.Entry<SocketChannel, Boolean>>> futures = new ArrayList<>();
+        final List<Future<Map.Entry<SocketChannel, Boolean>>> futures = new CopyOnWriteArrayList<>();
         final BlockingQueue<Future<Map.Entry<SocketChannel, Boolean>>> resolvedHostsQueue = new LinkedBlockingQueue<>();
         final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(MAX_CONNECTION_CONCURRENCY.getValue());
         executor.setRemoveOnCancelPolicy(true);


### PR DESCRIPTION
The 'futures' list is populated by the resolver thread while the calling thread iterates it via futures.forEach(...) in the finally block, causing a ConcurrentModificationException. Replace ArrayList with CopyOnWriteArrayList so concurrent reads and writes are safe.