### PR TITLE
OF-3322: Move SCRAM credential storage into a dedicated ofUserScram table

### DIFF
--- a/distribution/src/database/openfire_cockroachdb.sql
+++ b/distribution/src/database/openfire_cockroachdb.sql
@@ -3,10 +3,6 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR(64)     NOT NULL,
-  storedKey             VARCHAR(32),
-  serverKey             VARCHAR(32),
-  salt                  VARCHAR(32),
-  iterations            INTEGER,
   plainPassword         VARCHAR(32),
   encryptedPassword     VARCHAR(255),
   name                  VARCHAR(100),
@@ -17,6 +13,15 @@ CREATE TABLE ofUser (
 );
 CREATE INDEX ofUser_cDate_idx ON ofUser (creationDate);
 
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
 
 CREATE TABLE ofUserProp (
   username              VARCHAR(64)     NOT NULL,
@@ -397,5 +402,4 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
 -- Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 38);
-
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 40);

--- a/distribution/src/database/openfire_db2.sql
+++ b/distribution/src/database/openfire_db2.sql
@@ -1,10 +1,6 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR(64)     NOT NULL,
-  storedKey             VARCHAR(32),
-  serverKey             VARCHAR(32),
-  salt                  VARCHAR(32),
-  iterations            INTEGER,
   plainPassword         VARCHAR(32),
   encryptedPassword     VARCHAR(255),
   name                  VARCHAR(100),
@@ -15,6 +11,15 @@ CREATE TABLE ofUser (
 );
 CREATE INDEX ofUser_cDate_idx ON ofUser (creationDate ASC);
 
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
 
 CREATE TABLE ofUserProp (
   username              VARCHAR(64)     NOT NULL,
@@ -403,4 +408,4 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
 -- Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 38);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 40);

--- a/distribution/src/database/openfire_firebird.sql
+++ b/distribution/src/database/openfire_firebird.sql
@@ -3,10 +3,6 @@
 CREATE TABLE ofUser
 (
     username          VARCHAR(64) NOT NULL,
-    storedKey         VARCHAR(32),
-    serverKey         VARCHAR(32),
-    salt              VARCHAR(32),
-    iterations        INTEGER,
     plainPassword     VARCHAR(32),
     encryptedPassword VARCHAR(255),
     name              VARCHAR(100),
@@ -17,6 +13,16 @@ CREATE TABLE ofUser
 );
 CREATE INDEX ofUser_cDate_idx ON ofUser (creationDate);
 
+CREATE TABLE ofUserScram
+(
+    username          VARCHAR(64)  NOT NULL,
+    mechanism         VARCHAR(32)  NOT NULL,
+    storedKey         VARCHAR(255),
+    serverKey         VARCHAR(255),
+    salt              VARCHAR(255),
+    iterations        INTEGER      NOT NULL,
+    CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
 
 CREATE TABLE ofUserProp
 (
@@ -437,5 +443,4 @@ VALUES (1, 'conference', 0);
 
 -- Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
 INSERT INTO ofVersion (name, version)
-VALUES ('openfire', 38);
-
+VALUES ('openfire', 40);

--- a/distribution/src/database/openfire_hsqldb.sql
+++ b/distribution/src/database/openfire_hsqldb.sql
@@ -1,10 +1,6 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR(64)     NOT NULL,
-  storedKey             VARCHAR(32),
-  serverKey             VARCHAR(32),
-  salt                  VARCHAR(32),
-  iterations            INTEGER,
   plainPassword         VARCHAR(32),
   encryptedPassword     VARCHAR(255),
   name                  VARCHAR(100),
@@ -15,6 +11,15 @@ CREATE TABLE ofUser (
 );
 CREATE INDEX ofUser_cDate_idx ON ofUser (creationDate);
 
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
 
 CREATE TABLE ofUserProp (
   username              VARCHAR(64)     NOT NULL,
@@ -391,7 +396,7 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
 // Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 38);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 40);
 
 // The value is the size in megabytes that the .log file can reach before an automatic
 // checkpoint occurs. A checkpoint rewrites the .script file and clears the .log file

--- a/distribution/src/database/openfire_mariadb.sql
+++ b/distribution/src/database/openfire_mariadb.sql
@@ -1,10 +1,6 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR(64)     NOT NULL,
-  storedKey             VARCHAR(32),
-  serverKey             VARCHAR(32),
-  salt                  VARCHAR(32),
-  iterations            INTEGER,
   plainPassword         VARCHAR(32),
   encryptedPassword     VARCHAR(255),
   name                  VARCHAR(100),
@@ -13,6 +9,16 @@ CREATE TABLE ofUser (
   modificationDate      CHAR(15)        NOT NULL,
   PRIMARY KEY (username),
   INDEX ofUser_cDate_idx (creationDate)
+);
+
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  PRIMARY KEY (username, mechanism)
 );
 
 CREATE TABLE ofUserProp (
@@ -381,4 +387,4 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
 # Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 38);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 40);

--- a/distribution/src/database/openfire_mysql.sql
+++ b/distribution/src/database/openfire_mysql.sql
@@ -1,10 +1,6 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR(64)     NOT NULL,
-  storedKey             VARCHAR(32),
-  serverKey             VARCHAR(32),
-  salt                  VARCHAR(32),
-  iterations            INTEGER,
   plainPassword         VARCHAR(32),
   encryptedPassword     VARCHAR(255),
   name                  VARCHAR(100),
@@ -13,6 +9,16 @@ CREATE TABLE ofUser (
   modificationDate      CHAR(15)        NOT NULL,
   PRIMARY KEY (username),
   INDEX ofUser_cDate_idx (creationDate)
+);
+
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  PRIMARY KEY (username, mechanism)
 );
 
 CREATE TABLE ofUserProp (
@@ -381,4 +387,4 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
 # Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 38);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 40);

--- a/distribution/src/database/openfire_oracle.sql
+++ b/distribution/src/database/openfire_oracle.sql
@@ -1,10 +1,6 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR2(64)     NOT NULL,
-  storedKey             VARCHAR(32),
-  serverKey             VARCHAR(32),
-  salt                  VARCHAR(32),
-  iterations            INTEGER,
   plainPassword         VARCHAR2(32),
   encryptedPassword     VARCHAR2(255),
   name                  VARCHAR2(100),
@@ -15,6 +11,15 @@ CREATE TABLE ofUser (
 );
 CREATE INDEX ofUser_cDate_idx ON ofUser (creationDate ASC);
 
+CREATE TABLE ofUserScram (
+  username              VARCHAR2(64)    NOT NULL,
+  mechanism             VARCHAR2(32)    NOT NULL,
+  storedKey             VARCHAR2(255),
+  serverKey             VARCHAR2(255),
+  salt                  VARCHAR2(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
 
 CREATE TABLE ofUserProp (
   username              VARCHAR2(64)    NOT NULL,
@@ -389,6 +394,6 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
 -- Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 38);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 40);
 
 commit;

--- a/distribution/src/database/openfire_postgresql.sql
+++ b/distribution/src/database/openfire_postgresql.sql
@@ -3,10 +3,6 @@
 
 CREATE TABLE ofUser (
   username              VARCHAR(64)     NOT NULL,
-  storedKey             VARCHAR(32),
-  serverKey             VARCHAR(32),
-  salt                  VARCHAR(32),
-  iterations            INTEGER,
   plainPassword         VARCHAR(32),
   encryptedPassword     VARCHAR(255),
   name                  VARCHAR(100),
@@ -17,6 +13,15 @@ CREATE TABLE ofUser (
 );
 CREATE INDEX ofUser_cDate_idx ON ofUser (creationDate);
 
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
 
 CREATE TABLE ofUserProp (
   username              VARCHAR(64)     NOT NULL,
@@ -397,4 +402,4 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
 -- Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully.
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 38);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 40);

--- a/distribution/src/database/openfire_sqlserver.sql
+++ b/distribution/src/database/openfire_sqlserver.sql
@@ -1,10 +1,6 @@
 
 CREATE TABLE ofUser (
   username              NVARCHAR(64)    NOT NULL,
-  storedKey             VARCHAR(32),
-  serverKey             VARCHAR(32),
-  salt                  VARCHAR(32),
-  iterations            INTEGER,
   plainPassword         NVARCHAR(32),
   encryptedPassword     NVARCHAR(255),
   name                  NVARCHAR(100),
@@ -15,6 +11,15 @@ CREATE TABLE ofUser (
 );
 CREATE INDEX ofUser_cDate_idx ON ofUser (creationDate ASC);
 
+CREATE TABLE ofUserScram (
+  username              NVARCHAR(64)    NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
 
 CREATE TABLE ofUserProp (
   username              NVARCHAR(64)    NOT NULL,
@@ -394,4 +399,4 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0);
 
 /* Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully. */
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 38);
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 40);

--- a/distribution/src/database/openfire_sybase.sql
+++ b/distribution/src/database/openfire_sybase.sql
@@ -1,9 +1,5 @@
 CREATE TABLE ofUser (
   username              NVARCHAR(64)    NOT NULL,
-  storedKey             VARCHAR(32)     NULL,
-  serverKey             VARCHAR(32)     NULL,
-  salt                  VARCHAR(32)     NULL,
-  iterations            INTEGER         NULL,
   plainPassword         NVARCHAR(32)    NULL,
   encryptedPassword     NVARCHAR(255)   NULL,
   name                  NVARCHAR(100)   NULL,
@@ -14,6 +10,15 @@ CREATE TABLE ofUser (
 )
 CREATE INDEX ofUser_cDate_idx ON ofUser (creationDate ASC)
 
+CREATE TABLE ofUserScram (
+  username              NVARCHAR(64)    NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+)
 
 CREATE TABLE ofUserProp (
   username              NVARCHAR(64)    NOT NULL,
@@ -394,4 +399,4 @@ INSERT INTO ofUser (username, plainPassword, name, email, creationDate, modifica
 INSERT INTO ofMucService (serviceID, subdomain, isHidden) VALUES (1, 'conference', 0)
 
 /* Do this last, as it is used by a continuous integration check to verify that the entire script was executed successfully. */
-INSERT INTO ofVersion (name, version) VALUES ('openfire', 38)
+INSERT INTO ofVersion (name, version) VALUES ('openfire', 40)

--- a/distribution/src/database/upgrade/39/openfire_cockroachdb.sql
+++ b/distribution/src/database/upgrade/39/openfire_cockroachdb.sql
@@ -19,6 +19,7 @@ SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
   FROM ofUser
  WHERE storedKey IS NOT NULL
    AND serverKey IS NOT NULL
-   AND salt IS NOT NULL;
+   AND salt IS NOT NULL
+   AND iterations IS NOT NULL;
 
 UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_cockroachdb.sql
+++ b/distribution/src/database/upgrade/39/openfire_cockroachdb.sql
@@ -1,0 +1,24 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This first step (schema version 39) creates the new table and copies existing SHA-1 credentials into it.
+-- The old columns on ofUser are left in place for now, and are dropped in the next step (version 40). Splitting
+-- create-and-copy (39) from drop (40) means that a half-applied upgrade never loses credential data.
+
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
+
+INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey)
+SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
+  FROM ofUser
+ WHERE storedKey IS NOT NULL
+   AND serverKey IS NOT NULL
+   AND salt IS NOT NULL;
+
+UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_db2.sql
+++ b/distribution/src/database/upgrade/39/openfire_db2.sql
@@ -19,6 +19,7 @@ SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
   FROM ofUser
  WHERE storedKey IS NOT NULL
    AND serverKey IS NOT NULL
-   AND salt IS NOT NULL;
+   AND salt IS NOT NULL
+   AND iterations IS NOT NULL;
 
 UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_db2.sql
+++ b/distribution/src/database/upgrade/39/openfire_db2.sql
@@ -1,0 +1,24 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This first step (schema version 39) creates the new table and copies existing SHA-1 credentials into it.
+-- The old columns on ofUser are left in place for now, and are dropped in the next step (version 40). Splitting
+-- create-and-copy (39) from drop (40) means that a half-applied upgrade never loses credential data.
+
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
+
+INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey)
+SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
+  FROM ofUser
+ WHERE storedKey IS NOT NULL
+   AND serverKey IS NOT NULL
+   AND salt IS NOT NULL;
+
+UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_firebird.sql
+++ b/distribution/src/database/upgrade/39/openfire_firebird.sql
@@ -20,6 +20,7 @@ SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
 FROM ofUser
 WHERE storedKey IS NOT NULL
   AND serverKey IS NOT NULL
-  AND salt IS NOT NULL;
+  AND salt IS NOT NULL
+  AND iterations IS NOT NULL;
 
 UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_firebird.sql
+++ b/distribution/src/database/upgrade/39/openfire_firebird.sql
@@ -1,0 +1,25 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This first step (schema version 39) creates the new table and copies existing SHA-1 credentials into it.
+-- The old columns on ofUser are left in place for now, and are dropped in the next step (version 40). Splitting
+-- create-and-copy (39) from drop (40) means that a half-applied upgrade never loses credential data.
+
+CREATE TABLE ofUserScram
+(
+    username          VARCHAR(64)  NOT NULL,
+    mechanism         VARCHAR(32)  NOT NULL,
+    storedKey         VARCHAR(255),
+    serverKey         VARCHAR(255),
+    salt              VARCHAR(255),
+    iterations        INTEGER      NOT NULL,
+    CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
+
+INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey)
+SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
+FROM ofUser
+WHERE storedKey IS NOT NULL
+  AND serverKey IS NOT NULL
+  AND salt IS NOT NULL;
+
+UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/39/openfire_hsqldb.sql
@@ -19,6 +19,7 @@ SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
   FROM ofUser
  WHERE storedKey IS NOT NULL
    AND serverKey IS NOT NULL
-   AND salt IS NOT NULL;
+   AND salt IS NOT NULL
+   AND iterations IS NOT NULL;
 
 UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/39/openfire_hsqldb.sql
@@ -1,0 +1,24 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This first step (schema version 39) creates the new table and copies existing SHA-1 credentials into it.
+-- The old columns on ofUser are left in place for now, and are dropped in the next step (version 40). Splitting
+-- create-and-copy (39) from drop (40) means that a half-applied upgrade never loses credential data.
+
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
+
+INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey)
+SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
+  FROM ofUser
+ WHERE storedKey IS NOT NULL
+   AND serverKey IS NOT NULL
+   AND salt IS NOT NULL;
+
+UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/39/openfire_mariadb.sql
@@ -19,6 +19,7 @@ SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
   FROM ofUser
  WHERE storedKey IS NOT NULL
    AND serverKey IS NOT NULL
-   AND salt IS NOT NULL;
+   AND salt IS NOT NULL
+   AND iterations IS NOT NULL;
 
 UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/39/openfire_mariadb.sql
@@ -1,0 +1,24 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This first step (schema version 39) creates the new table and copies existing SHA-1 credentials into it.
+-- The old columns on ofUser are left in place for now, and are dropped in the next step (version 40). Splitting
+-- create-and-copy (39) from drop (40) means that a half-applied upgrade never loses credential data.
+
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  PRIMARY KEY (username, mechanism)
+);
+
+INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey)
+SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
+  FROM ofUser
+ WHERE storedKey IS NOT NULL
+   AND serverKey IS NOT NULL
+   AND salt IS NOT NULL;
+
+UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/39/openfire_mysql.sql
@@ -19,6 +19,7 @@ SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
   FROM ofUser
  WHERE storedKey IS NOT NULL
    AND serverKey IS NOT NULL
-   AND salt IS NOT NULL;
+   AND salt IS NOT NULL
+   AND iterations IS NOT NULL;
 
 UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/39/openfire_mysql.sql
@@ -1,0 +1,24 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This first step (schema version 39) creates the new table and copies existing SHA-1 credentials into it.
+-- The old columns on ofUser are left in place for now, and are dropped in the next step (version 40). Splitting
+-- create-and-copy (39) from drop (40) means that a half-applied upgrade never loses credential data.
+
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  PRIMARY KEY (username, mechanism)
+);
+
+INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey)
+SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
+  FROM ofUser
+ WHERE storedKey IS NOT NULL
+   AND serverKey IS NOT NULL
+   AND salt IS NOT NULL;
+
+UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/39/openfire_oracle.sql
@@ -19,6 +19,7 @@ SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
   FROM ofUser
  WHERE storedKey IS NOT NULL
    AND serverKey IS NOT NULL
-   AND salt IS NOT NULL;
+   AND salt IS NOT NULL
+   AND iterations IS NOT NULL;
 
 UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/39/openfire_oracle.sql
@@ -1,0 +1,24 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This first step (schema version 39) creates the new table and copies existing SHA-1 credentials into it.
+-- The old columns on ofUser are left in place for now, and are dropped in the next step (version 40). Splitting
+-- create-and-copy (39) from drop (40) means that a half-applied upgrade never loses credential data.
+
+CREATE TABLE ofUserScram (
+  username              VARCHAR2(64)    NOT NULL,
+  mechanism             VARCHAR2(32)    NOT NULL,
+  storedKey             VARCHAR2(255),
+  serverKey             VARCHAR2(255),
+  salt                  VARCHAR2(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
+
+INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey)
+SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
+  FROM ofUser
+ WHERE storedKey IS NOT NULL
+   AND serverKey IS NOT NULL
+   AND salt IS NOT NULL;
+
+UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/39/openfire_postgresql.sql
@@ -19,6 +19,7 @@ SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
   FROM ofUser
  WHERE storedKey IS NOT NULL
    AND serverKey IS NOT NULL
-   AND salt IS NOT NULL;
+   AND salt IS NOT NULL
+   AND iterations IS NOT NULL;
 
 UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/39/openfire_postgresql.sql
@@ -1,0 +1,24 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This first step (schema version 39) creates the new table and copies existing SHA-1 credentials into it.
+-- The old columns on ofUser are left in place for now, and are dropped in the next step (version 40). Splitting
+-- create-and-copy (39) from drop (40) means that a half-applied upgrade never loses credential data.
+
+CREATE TABLE ofUserScram (
+  username              VARCHAR(64)     NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
+
+INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey)
+SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
+  FROM ofUser
+ WHERE storedKey IS NOT NULL
+   AND serverKey IS NOT NULL
+   AND salt IS NOT NULL;
+
+UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/39/openfire_sqlserver.sql
@@ -19,6 +19,7 @@ SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
   FROM ofUser
  WHERE storedKey IS NOT NULL
    AND serverKey IS NOT NULL
-   AND salt IS NOT NULL;
+   AND salt IS NOT NULL
+   AND iterations IS NOT NULL;
 
 UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/39/openfire_sqlserver.sql
@@ -1,0 +1,24 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This first step (schema version 39) creates the new table and copies existing SHA-1 credentials into it.
+-- The old columns on ofUser are left in place for now, and are dropped in the next step (version 40). Splitting
+-- create-and-copy (39) from drop (40) means that a half-applied upgrade never loses credential data.
+
+CREATE TABLE ofUserScram (
+  username              NVARCHAR(64)    NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
+
+INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey)
+SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
+  FROM ofUser
+ WHERE storedKey IS NOT NULL
+   AND serverKey IS NOT NULL
+   AND salt IS NOT NULL;
+
+UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/39/openfire_sybase.sql
@@ -13,7 +13,6 @@ CREATE TABLE ofUserScram (
   iterations            INTEGER         NOT NULL,
   CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
 );
-go
 
 INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey)
 SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
@@ -22,5 +21,5 @@ SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
    AND serverKey IS NOT NULL
    AND salt IS NOT NULL
    AND iterations IS NOT NULL;
-go
+
 UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/39/openfire_sybase.sql
@@ -20,6 +20,7 @@ SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
   FROM ofUser
  WHERE storedKey IS NOT NULL
    AND serverKey IS NOT NULL
-   AND salt IS NOT NULL;
+   AND salt IS NOT NULL
+   AND iterations IS NOT NULL;
 go
 UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/39/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/39/openfire_sybase.sql
@@ -1,0 +1,25 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This first step (schema version 39) creates the new table and copies existing SHA-1 credentials into it.
+-- The old columns on ofUser are left in place for now, and are dropped in the next step (version 40). Splitting
+-- create-and-copy (39) from drop (40) means that a half-applied upgrade never loses credential data.
+
+CREATE TABLE ofUserScram (
+  username              NVARCHAR(64)    NOT NULL,
+  mechanism             VARCHAR(32)     NOT NULL,
+  storedKey             VARCHAR(255),
+  serverKey             VARCHAR(255),
+  salt                  VARCHAR(255),
+  iterations            INTEGER         NOT NULL,
+  CONSTRAINT ofUserScram_pk PRIMARY KEY (username, mechanism)
+);
+go
+
+INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey)
+SELECT username, 'SCRAM-SHA-1', iterations, salt, storedKey, serverKey
+  FROM ofUser
+ WHERE storedKey IS NOT NULL
+   AND serverKey IS NOT NULL
+   AND salt IS NOT NULL;
+go
+UPDATE ofVersion SET version = 39 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/40/openfire_cockroachdb.sql
+++ b/distribution/src/database/upgrade/40/openfire_cockroachdb.sql
@@ -1,0 +1,11 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This second step (schema version 40) drops the old SCRAM columns from ofUser, now that version 39 has
+-- created ofUserScram and copied the data across.
+
+ALTER TABLE ofUser DROP COLUMN storedKey;
+ALTER TABLE ofUser DROP COLUMN serverKey;
+ALTER TABLE ofUser DROP COLUMN salt;
+ALTER TABLE ofUser DROP COLUMN iterations;
+
+UPDATE ofVersion SET version = 40 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/40/openfire_db2.sql
+++ b/distribution/src/database/upgrade/40/openfire_db2.sql
@@ -1,0 +1,11 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This second step (schema version 40) drops the old SCRAM columns from ofUser, now that version 39 has
+-- created ofUserScram and copied the data across.
+
+ALTER TABLE ofUser DROP COLUMN storedKey;
+ALTER TABLE ofUser DROP COLUMN serverKey;
+ALTER TABLE ofUser DROP COLUMN salt;
+ALTER TABLE ofUser DROP COLUMN iterations;
+
+UPDATE ofVersion SET version = 40 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/40/openfire_firebird.sql
+++ b/distribution/src/database/upgrade/40/openfire_firebird.sql
@@ -1,0 +1,11 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This second step (schema version 40) drops the old SCRAM columns from ofUser, now that version 39 has
+-- created ofUserScram and copied the data across.
+
+ALTER TABLE ofUser DROP storedKey;
+ALTER TABLE ofUser DROP serverKey;
+ALTER TABLE ofUser DROP salt;
+ALTER TABLE ofUser DROP iterations;
+
+UPDATE ofVersion SET version = 40 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/40/openfire_hsqldb.sql
+++ b/distribution/src/database/upgrade/40/openfire_hsqldb.sql
@@ -1,0 +1,11 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This second step (schema version 40) drops the old SCRAM columns from ofUser, now that version 39 has
+-- created ofUserScram and copied the data across.
+
+ALTER TABLE ofUser DROP COLUMN storedKey;
+ALTER TABLE ofUser DROP COLUMN serverKey;
+ALTER TABLE ofUser DROP COLUMN salt;
+ALTER TABLE ofUser DROP COLUMN iterations;
+
+UPDATE ofVersion SET version = 40 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/40/openfire_mariadb.sql
+++ b/distribution/src/database/upgrade/40/openfire_mariadb.sql
@@ -1,0 +1,11 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This second step (schema version 40) drops the old SCRAM columns from ofUser, now that version 39 has
+-- created ofUserScram and copied the data across.
+
+ALTER TABLE ofUser DROP COLUMN storedKey;
+ALTER TABLE ofUser DROP COLUMN serverKey;
+ALTER TABLE ofUser DROP COLUMN salt;
+ALTER TABLE ofUser DROP COLUMN iterations;
+
+UPDATE ofVersion SET version = 40 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/40/openfire_mysql.sql
+++ b/distribution/src/database/upgrade/40/openfire_mysql.sql
@@ -1,0 +1,11 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This second step (schema version 40) drops the old SCRAM columns from ofUser, now that version 39 has
+-- created ofUserScram and copied the data across.
+
+ALTER TABLE ofUser DROP COLUMN storedKey;
+ALTER TABLE ofUser DROP COLUMN serverKey;
+ALTER TABLE ofUser DROP COLUMN salt;
+ALTER TABLE ofUser DROP COLUMN iterations;
+
+UPDATE ofVersion SET version = 40 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/40/openfire_oracle.sql
+++ b/distribution/src/database/upgrade/40/openfire_oracle.sql
@@ -1,0 +1,11 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This second step (schema version 40) drops the old SCRAM columns from ofUser, now that version 39 has
+-- created ofUserScram and copied the data across.
+
+ALTER TABLE ofUser DROP COLUMN storedKey;
+ALTER TABLE ofUser DROP COLUMN serverKey;
+ALTER TABLE ofUser DROP COLUMN salt;
+ALTER TABLE ofUser DROP COLUMN iterations;
+
+UPDATE ofVersion SET version = 40 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/40/openfire_postgresql.sql
+++ b/distribution/src/database/upgrade/40/openfire_postgresql.sql
@@ -1,0 +1,11 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This second step (schema version 40) drops the old SCRAM columns from ofUser, now that version 39 has
+-- created ofUserScram and copied the data across.
+
+ALTER TABLE ofUser DROP COLUMN storedKey;
+ALTER TABLE ofUser DROP COLUMN serverKey;
+ALTER TABLE ofUser DROP COLUMN salt;
+ALTER TABLE ofUser DROP COLUMN iterations;
+
+UPDATE ofVersion SET version = 40 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/40/openfire_sqlserver.sql
+++ b/distribution/src/database/upgrade/40/openfire_sqlserver.sql
@@ -1,0 +1,11 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This second step (schema version 40) drops the old SCRAM columns from ofUser, now that version 39 has
+-- created ofUserScram and copied the data across.
+
+ALTER TABLE ofUser DROP COLUMN storedKey;
+ALTER TABLE ofUser DROP COLUMN serverKey;
+ALTER TABLE ofUser DROP COLUMN salt;
+ALTER TABLE ofUser DROP COLUMN iterations;
+
+UPDATE ofVersion SET version = 40 WHERE name = 'openfire';

--- a/distribution/src/database/upgrade/40/openfire_sybase.sql
+++ b/distribution/src/database/upgrade/40/openfire_sybase.sql
@@ -1,0 +1,11 @@
+-- Move SCRAM credentials from ofUser columns into a dedicated, mechanism-keyed table.
+--
+-- This second step (schema version 40) drops the old SCRAM columns from ofUser, now that version 39 has
+-- created ofUserScram and copied the data across.
+
+ALTER TABLE ofUser DROP COLUMN storedKey;
+ALTER TABLE ofUser DROP COLUMN serverKey;
+ALTER TABLE ofUser DROP COLUMN salt;
+ALTER TABLE ofUser DROP COLUMN iterations;
+
+UPDATE ofVersion SET version = 40 WHERE name = 'openfire';

--- a/documentation/database-guide.html
+++ b/documentation/database-guide.html
@@ -73,6 +73,7 @@
                 <li><a href="#ofPresence">ofPresence</a></li>
                 <li><a href="#ofPrivate">ofPrivate</a></li>
                 <li><a href="#ofUser">ofUser</a></li>
+                <li><a href="#ofUserScram">ofUserScram</a></li>
                 <li><a href="#ofUserProp">ofUserProp</a></li>
                 <li><a href="#ofUserFlag">ofUserFlag</a></li>
 
@@ -401,6 +402,57 @@
                 <td>VARCHAR</td>
                 <td>15</td>
                 <td>Last Modified Date</td>
+            </tr>
+            </tbody>
+        </table>
+        &nbsp;<a href="#top" class="top">top of page</a>
+
+        <table id="ofUserScram" class="dbtable">
+            <tbody>
+            <tr>
+                <th colspan="4">ofUserScram (SCRAM authentication credentials, per user and mechanism)</th>
+            </tr>
+            <tr>
+                <th>Column Name</th>
+                <th>Type</th>
+                <th>Length</th>
+                <th>Description</th>
+            </tr>
+            <tr class="primary-key">
+                <td>username</td>
+                <td>VARCHAR</td>
+                <td>64</td>
+                <td>User Name (Primary Key)</td>
+            </tr>
+            <tr class="primary-key">
+                <td>mechanism</td>
+                <td>VARCHAR</td>
+                <td>32</td>
+                <td>SCRAM mechanism name, e.g. SCRAM-SHA-1 (Primary Key)</td>
+            </tr>
+            <tr>
+                <td>storedKey</td>
+                <td>VARCHAR</td>
+                <td>255</td>
+                <td>Base64-encoded StoredKey for this mechanism</td>
+            </tr>
+            <tr>
+                <td>serverKey</td>
+                <td>VARCHAR</td>
+                <td>255</td>
+                <td>Base64-encoded ServerKey for this mechanism</td>
+            </tr>
+            <tr>
+                <td>salt</td>
+                <td>VARCHAR</td>
+                <td>255</td>
+                <td>Base64-encoded salt used to derive the credential</td>
+            </tr>
+            <tr>
+                <td>iterations</td>
+                <td>NUMBER</td>
+                <td>n/a</td>
+                <td>Iteration count used to derive the credential</td>
             </tr>
             </tbody>
         </table>

--- a/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/SchemaManager.java
@@ -68,7 +68,7 @@ public class SchemaManager {
     /**
      * Current Openfire database schema version.
      */
-    private static final int DATABASE_VERSION = 38;
+    private static final int DATABASE_VERSION = 40;
 
     /**
      * Checks the Openfire database schema to ensure that it's installed and up to date.

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthFactory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 import org.jivesoftware.openfire.lockout.LockOutManager;
+import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.util.Blowfish;
 import org.jivesoftware.util.JiveGlobals;
@@ -281,17 +282,79 @@ public class AuthFactory {
         return authProvider.isScramSupported();
     }
 
+    /**
+     * Returns a SCRAM-SHA-1 salt for a user.
+     *
+     * @deprecated Use getSalt(String, String) with the mechanism name.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public static String getSalt(String username) throws UnsupportedOperationException, UserNotFoundException {
-        return authProvider.getSalt(username);
+        return authProvider.getSalt(username, ScramSha1SaslServer.MECHANISM_NAME);
     }
+
+    /**
+     * Returns a SCRAM salt for a user and mechanism.
+     */
+    public static String getSalt(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException {
+        return authProvider.getSalt(username, mechanism);
+    }
+
+    /**
+     * Returns a SCRAM-SHA-1 iteration count for a user.
+     *
+     * @deprecated Use getIterations(String, String) with the mechanism name.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public static int getIterations(String username) throws UnsupportedOperationException, UserNotFoundException {
-        return authProvider.getIterations(username);
+        return authProvider.getIterations(username, ScramSha1SaslServer.MECHANISM_NAME);
     }
+
+    /**
+     * Returns a SCRAM iteration count for a user and mechanism.
+     */
+    public static int getIterations(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException {
+        return authProvider.getIterations(username, mechanism);
+    }
+
+    /**
+     * Returns a SCRAM-SHA-1 server key for a user.
+     *
+     * @deprecated Use getServerKey(String, String) with the mechanism name.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public static String getServerKey(String username) throws UnsupportedOperationException, UserNotFoundException {
-        return authProvider.getServerKey(username);
+        return authProvider.getServerKey(username, ScramSha1SaslServer.MECHANISM_NAME);
     }
+
+    /**
+     * Returns a SCRAM server key for a user and mechanism.
+     */
+    public static String getServerKey(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException {
+        return authProvider.getServerKey(username, mechanism);
+    }
+
+    /**
+     * Returns a SCRAM-SHA-1 stored key for a user.
+     *
+     * @deprecated Use getStoredKey(String, String) with the mechanism name.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public static String getStoredKey(String username) throws UnsupportedOperationException, UserNotFoundException {
-        return authProvider.getStoredKey(username);
+        return authProvider.getStoredKey(username, ScramSha1SaslServer.MECHANISM_NAME);
+    }
+
+    /**
+     * Returns a SCRAM stored key for a user and mechanism.
+     */
+    public static String getStoredKey(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException {
+        return authProvider.getStoredKey(username, mechanism);
+    }
+
+    /**
+     * Returns all SCRAM credentials for a user and mechanism.
+     */
+    public static ScramCredentialData getScramCredential(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException {
+        return authProvider.getScramCredential(username, mechanism);
     }
 
     public static final String ONE_TIME_PROPERTY = "oneTimeAccessToken";

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthMultiProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthMultiProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Ignite Realtime Foundation. All rights reserved
+ * Copyright (C) 2024-2026 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,6 +169,7 @@ public abstract class AuthMultiProvider implements AuthProvider
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getSalt(String username) throws UserNotFoundException
     {
         final AuthProvider provider = getAuthProvider(username);
@@ -180,6 +181,7 @@ public abstract class AuthMultiProvider implements AuthProvider
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public int getIterations(String username) throws UserNotFoundException
     {
         final AuthProvider provider = getAuthProvider(username);
@@ -191,6 +193,7 @@ public abstract class AuthMultiProvider implements AuthProvider
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getServerKey(String username) throws UserNotFoundException
     {
         final AuthProvider provider = getAuthProvider(username);
@@ -201,6 +204,7 @@ public abstract class AuthMultiProvider implements AuthProvider
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getStoredKey(String username) throws UserNotFoundException
     {
         final AuthProvider provider = getAuthProvider(username);
@@ -208,5 +212,54 @@ public abstract class AuthMultiProvider implements AuthProvider
             throw new UserNotFoundException();
         }
         return provider.getStoredKey(username);
+    }
+
+    /**
+     * Returns SCRAM credentials for a user and mechanism from the mapped provider.
+     */
+    @Override
+    public ScramCredentialData getScramCredential(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
+    {
+        final AuthProvider provider = getAuthProvider(username);
+        if (provider == null) {
+            throw new UserNotFoundException();
+        }
+        return provider.getScramCredential(username, mechanism);
+    }
+
+    /**
+     * Returns a SCRAM salt for a user and mechanism.
+     */
+    @Override
+    public String getSalt(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
+    {
+        return getScramCredential(username, mechanism).salt;
+    }
+
+    /**
+     * Returns a SCRAM iteration count for a user and mechanism.
+     */
+    @Override
+    public int getIterations(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
+    {
+        return getScramCredential(username, mechanism).iterations;
+    }
+
+    /**
+     * Returns a SCRAM server key for a user and mechanism.
+     */
+    @Override
+    public String getServerKey(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
+    {
+        return getScramCredential(username, mechanism).serverKey;
+    }
+
+    /**
+     * Returns a SCRAM stored key for a user and mechanism.
+     */
+    @Override
+    public String getStoredKey(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
+    {
+        return getScramCredential(username, mechanism).storedKey;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/AuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2019 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.openfire.auth;
 
+import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
 import org.jivesoftware.openfire.user.UserNotFoundException;
 
 /**
@@ -86,8 +87,97 @@ public interface AuthProvider {
     boolean supportsPasswordRetrieval();
 
     boolean isScramSupported();
+
+    /**
+     * Returns SCRAM credentials for a user and mechanism.
+     *
+     * This default implementation is backed by the deprecated single-argument accessors, which can only supply
+     * {@code SCRAM-SHA-1} material. It therefore supports only the {@code SCRAM-SHA-1} mechanism (with or without the
+     * {@code -PLUS} suffix). Providers that add support for other SCRAM mechanisms must override this method.
+     *
+     * @param username the username of the user.
+     * @param mechanism the SCRAM mechanism name.
+     * @return the SCRAM credentials for the user under the (normalized) mechanism.
+     * @throws UnsupportedOperationException if the mechanism is not {@code SCRAM-SHA-1}.
+     * @throws UserNotFoundException if the user's credentials could not be loaded.
+     */
+    default ScramCredentialData getScramCredential(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
+    {
+        final String normalizedMechanism = ScramCredentialData.normalizeMechanismName(mechanism);
+        if (!ScramSha1SaslServer.MECHANISM_NAME.equals(normalizedMechanism)) {
+            throw new UnsupportedOperationException("SCRAM mechanism is not supported: " + mechanism);
+        }
+
+        return new ScramCredentialData(
+            normalizedMechanism,
+            getSalt(username),
+            getIterations(username),
+            getStoredKey(username),
+            getServerKey(username)
+        );
+    }
+
+    /**
+     * Returns a SCRAM salt for a user and mechanism.
+     */
+    default String getSalt(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
+    {
+        return getScramCredential(username, mechanism).salt;
+    }
+
+    /**
+     * Returns a SCRAM iteration count for a user and mechanism.
+     */
+    default int getIterations(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
+    {
+        return getScramCredential(username, mechanism).iterations;
+    }
+
+    /**
+     * Returns a SCRAM server key for a user and mechanism.
+     */
+    default String getServerKey(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
+    {
+        return getScramCredential(username, mechanism).serverKey;
+    }
+
+    /**
+     * Returns a SCRAM stored key for a user and mechanism.
+     */
+    default String getStoredKey(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
+    {
+        return getScramCredential(username, mechanism).storedKey;
+    }
+
+    /**
+     * Returns a SCRAM-SHA-1 salt for a user.
+     *
+     * @deprecated Use getSalt(String, String) with the mechanism name.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     String getSalt(String username) throws UnsupportedOperationException, UserNotFoundException;
+
+    /**
+     * Returns a SCRAM-SHA-1 iteration count for a user.
+     *
+     * @deprecated Use getIterations(String, String) with the mechanism name.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     int getIterations(String username) throws UnsupportedOperationException, UserNotFoundException;
+
+    /**
+     * Returns a SCRAM-SHA-1 server key for a user.
+     *
+     * @deprecated Use getServerKey(String, String) with the mechanism name.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     String getServerKey(String username) throws UnsupportedOperationException, UserNotFoundException;
+
+    /**
+     * Returns a SCRAM-SHA-1 stored key for a user.
+     *
+     * @deprecated Use getStoredKey(String, String) with the mechanism name.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     String getStoredKey(String username) throws UnsupportedOperationException, UserNotFoundException;
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -54,13 +54,19 @@ public class DefaultAuthProvider implements AuthProvider {
 
     private static final Logger Log = LoggerFactory.getLogger(DefaultAuthProvider.class);
 
-        private static final String LOAD_PASSWORD =
-                "SELECT plainPassword,encryptedPassword FROM ofUser WHERE username=?";
-        private static final String TEST_PASSWORD =
-                "SELECT plainPassword,encryptedPassword,iterations,salt,storedKey,serverKey FROM ofUser WHERE username=?";
+    private static final String LOAD_PASSWORD =
+        "SELECT plainPassword,encryptedPassword FROM ofUser WHERE username=?";
     private static final String UPDATE_PASSWORD =
-            "UPDATE ofUser SET plainPassword=?, encryptedPassword=?, storedKey=?, serverKey=?, salt=?, iterations=? WHERE username=?";
-    
+        "UPDATE ofUser SET plainPassword=?, encryptedPassword=? WHERE username=?";
+    private static final String LOAD_SCRAM_CREDENTIAL =
+        "SELECT iterations,salt,storedKey,serverKey FROM ofUserScram WHERE username=? AND mechanism=?";
+    private static final String UPDATE_SCRAM_CREDENTIAL =
+        "UPDATE ofUserScram SET iterations=?, salt=?, storedKey=?, serverKey=? WHERE username=? AND mechanism=?";
+    private static final String INSERT_SCRAM_CREDENTIAL =
+        "INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey) VALUES (?, ?, ?, ?, ?, ?)";
+    private static final String TEST_SCRAM_CREDENTIAL =
+        "SELECT username FROM ofUserScram WHERE username=? AND mechanism=?";
+
     private static final SecureRandom random = new SecureRandom();
 
     /**
@@ -73,18 +79,15 @@ public class DefaultAuthProvider implements AuthProvider {
     private class UserInfo {
         String plainText;
         String encrypted;
-        int iterations;
-        String salt;
-        String storedKey;
-        String serverKey;
     }
 
     private UserInfo getUserInfo(String username) throws UnsupportedOperationException, UserNotFoundException {
         return getUserInfo(username, false);
     }
+
     private UserInfo getUserInfo(String username, boolean recurse) throws UnsupportedOperationException, UserNotFoundException {
         if (!isScramSupported()) {
-            // Reject the operation since the provider  does not support SCRAM
+            // Reject the operation since the provider does not support SCRAM
             throw new UnsupportedOperationException();
         }
         Connection con = null;
@@ -92,7 +95,7 @@ public class DefaultAuthProvider implements AuthProvider {
         ResultSet rs = null;
         try {
             con = DbConnectionManager.getConnection();
-            pstmt = con.prepareStatement(TEST_PASSWORD);
+            pstmt = con.prepareStatement(LOAD_PASSWORD);
             pstmt.setString(1, username);
             rs = pstmt.executeQuery();
             if (!rs.next()) {
@@ -101,10 +104,6 @@ public class DefaultAuthProvider implements AuthProvider {
             UserInfo userInfo = new UserInfo();
             userInfo.plainText = rs.getString(1);
             userInfo.encrypted = rs.getString(2);
-            userInfo.iterations = rs.getInt(3);
-            userInfo.salt = rs.getString(4);
-            userInfo.storedKey = rs.getString(5);
-            userInfo.serverKey = rs.getString(6);
             if (userInfo.encrypted != null) {
                 try {
                     userInfo.plainText = AuthFactory.decryptPassword(userInfo.encrypted);
@@ -116,7 +115,7 @@ public class DefaultAuthProvider implements AuthProvider {
             if (!recurse) {
                 if (userInfo.plainText != null) {
                     boolean scramOnly = JiveGlobals.getBooleanProperty("user.scramHashedPasswordOnly");
-                    if (scramOnly || userInfo.salt == null) {
+                    if (scramOnly || !hasScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME)) {
                         // If we have a password here, but we're meant to be scramOnly, we should reset it.
                         setPassword(username, userInfo.plainText);
                         // RECURSE
@@ -137,23 +136,56 @@ public class DefaultAuthProvider implements AuthProvider {
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getSalt(String username) throws UserNotFoundException {
-        return getUserInfo(username).salt;
+        return getScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME).salt;
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public int getIterations(String username) throws UserNotFoundException {
-        return getUserInfo(username).iterations;
+        return getScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME).iterations;
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getStoredKey(String username) throws UserNotFoundException {
-        return getUserInfo(username).storedKey;
+        return getScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME).storedKey;
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getServerKey(String username) throws UserNotFoundException {
-        return getUserInfo(username).serverKey;
+        return getScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME).serverKey;
+    }
+
+    /**
+     * Returns SCRAM credentials for a user and mechanism.
+     *
+     * Only {@code SCRAM-SHA-1} is supported. When SHA-1 credentials are missing but a plaintext (or decryptable)
+     * password is available, the credentials are regenerated (preserving the historical behavior of this provider).
+     */
+    @Override
+    public ScramCredentialData getScramCredential(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
+    {
+        final String normalizedMechanism = ScramCredentialData.normalizeMechanismName(mechanism);
+        if (!ScramSha1SaslServer.MECHANISM_NAME.equals(normalizedMechanism)) {
+            throw new UnsupportedOperationException("SCRAM mechanism is not supported: " + mechanism);
+        }
+
+        // Preserve previous behavior: if SHA-1 credentials are missing while plaintext exists, regenerate.
+        getUserInfo(username);
+
+        final ScramCredentialData credential;
+        try {
+            credential = loadScramCredential(username, normalizedMechanism);
+        } catch (SQLException sqle) {
+            throw new UserNotFoundException(sqle);
+        }
+        if (credential == null) {
+            throw new UserNotFoundException(username);
+        }
+        return credential;
     }
 
     @Override
@@ -252,7 +284,7 @@ public class DefaultAuthProvider implements AuthProvider {
         }
         try {
             con = DbConnectionManager.getConnection();
-            pstmt = con.prepareStatement(TEST_PASSWORD);
+            pstmt = con.prepareStatement(LOAD_PASSWORD);
             pstmt.setString(1, username);
             rs = pstmt.executeQuery();
             if (!rs.next()) {
@@ -260,9 +292,6 @@ public class DefaultAuthProvider implements AuthProvider {
             }
             String plainText = rs.getString(1);
             String encrypted = rs.getString(2);
-            int iterations = rs.getInt(3);
-            String salt = rs.getString(4);
-            String storedKey = rs.getString(5);
             if (encrypted != null) {
                 try {
                     plainText = AuthFactory.decryptPassword(encrypted);
@@ -280,21 +309,22 @@ public class DefaultAuthProvider implements AuthProvider {
                 return testPassword.equals(plainText);
             }
             // Don't have either plain or encrypted, so test SCRAM hash.
-            if (salt == null || iterations == 0 || storedKey == null) {
+            final ScramCredentialData credential = getScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME);
+            if (credential.salt == null || credential.iterations == 0 || credential.storedKey == null) {
                 Log.warn("No available credentials for checkPassword.");
                 return false;
             }
-            byte[] saltShaker = DatatypeConverter.parseBase64Binary(salt);
+            byte[] saltShaker = DatatypeConverter.parseBase64Binary(credential.salt);
             byte[] saltedPassword = null, clientKey = null, testStoredKey = null;
             try {
-                   saltedPassword = ScramUtils.createSaltedPassword(saltShaker, testPassword, iterations);
-                   clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
-                   testStoredKey = MessageDigest.getInstance("SHA-1").digest(clientKey);
+                saltedPassword = ScramUtils.createSaltedPassword(saltShaker, testPassword, credential.iterations);
+                clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
+                testStoredKey = MessageDigest.getInstance("SHA-1").digest(clientKey);
             } catch(SaslException | NoSuchAlgorithmException e) {
                 Log.warn("Unable to check SCRAM values for PLAIN authentication.");
                 return false;
             }
-            return DatatypeConverter.printBase64Binary(testStoredKey).equals(storedKey);
+            return DatatypeConverter.printBase64Binary(testStoredKey).equals(credential.storedKey);
         }
         catch (SQLException sqle) {
             Log.error("User SQL failure:", sqle);
@@ -322,29 +352,28 @@ public class DefaultAuthProvider implements AuthProvider {
                 throw new UserNotFoundException();
             }
         }
-        
-        // Store the salt and salted password so SCRAM-SHA-1 SASL auth can be used later.
+
+        // Compute the SCRAM (SHA-1) credential from the plaintext password *before* the plaintext is nulled out below.
         byte[] saltShaker = new byte[SALT_LENGTH];
         random.nextBytes(saltShaker);
-        String salt = DatatypeConverter.printBase64Binary(saltShaker);
-
-        
+        final String salt = DatatypeConverter.printBase64Binary(saltShaker);
         final int iterations = ScramSha1SaslServer.ITERATION_COUNT.getValue();
         byte[] saltedPassword = null, clientKey = null, storedKey = null, serverKey = null;
-    try {
-           saltedPassword = ScramUtils.createSaltedPassword(saltShaker, password, iterations);
-               clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
-               storedKey = MessageDigest.getInstance("SHA-1").digest(clientKey);
-               serverKey = ScramUtils.computeHmac(saltedPassword, "Server Key");
-       } catch (SaslException | NoSuchAlgorithmException e) {
-           Log.warn("Unable to persist values for SCRAM authentication.");
-       }
-   
+        try {
+            saltedPassword = ScramUtils.createSaltedPassword(saltShaker, password, iterations);
+            clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
+            storedKey = MessageDigest.getInstance("SHA-1").digest(clientKey);
+            serverKey = ScramUtils.computeHmac(saltedPassword, "Server Key");
+        } catch (SaslException | NoSuchAlgorithmException e) {
+            Log.warn("Unable to persist values for SCRAM authentication.");
+        }
+
+        String plaintextToStore = password;
         if (!scramOnly && !usePlainPassword) {
             try {
                 encryptedPassword = AuthFactory.encryptPassword(password);
-                // Set password to null so that it's inserted that way.
-                password = null;
+                // Set plaintext to null so that it's inserted that way.
+                plaintextToStore = null;
             }
             catch (UnsupportedOperationException uoe) {
                 // Encryption may fail. In that case, ignore the error and
@@ -353,19 +382,23 @@ public class DefaultAuthProvider implements AuthProvider {
         }
         if (scramOnly) {
             encryptedPassword = null;
-            password = null;
+            plaintextToStore = null;
         }
 
+        // Persist the ofUser password row and the ofUserScram credential row atomically: because these now live in
+        // two tables, a single UPDATE is no longer sufficient to keep them consistent.
         Connection con = null;
         PreparedStatement pstmt = null;
+        boolean abortTransaction = false;
         try {
-            con = DbConnectionManager.getConnection();
+            con = DbConnectionManager.getTransactionConnection();
+
             pstmt = con.prepareStatement(UPDATE_PASSWORD);
-            if (password == null) {
+            if (plaintextToStore == null) {
                 pstmt.setNull(1, Types.VARCHAR);
             }
             else {
-                pstmt.setString(1, password);
+                pstmt.setString(1, plaintextToStore);
             }
             if (encryptedPassword == null) {
                 pstmt.setNull(2, Types.VARCHAR);
@@ -373,28 +406,30 @@ public class DefaultAuthProvider implements AuthProvider {
             else {
                 pstmt.setString(2, encryptedPassword);
             }
-            if (storedKey == null) {
-                pstmt.setNull(3, Types.VARCHAR);
-            }
-            else {
-                pstmt.setString(3, DatatypeConverter.printBase64Binary(storedKey));
-            }
-            if (serverKey == null) {
-                pstmt.setNull(4, Types.VARCHAR);
-            }
-            else {
-                pstmt.setString(4, DatatypeConverter.printBase64Binary(serverKey));
-            }
-            pstmt.setString(5, salt);
-            pstmt.setInt(6, iterations);
-            pstmt.setString(7, username);
+            pstmt.setString(3, username);
             pstmt.executeUpdate();
+            DbConnectionManager.fastcloseStmt(pstmt);
+            pstmt = null;
+
+            upsertScramCredential(
+                con,
+                username,
+                new ScramCredentialData(
+                    ScramSha1SaslServer.MECHANISM_NAME,
+                    salt,
+                    iterations,
+                    storedKey == null ? null : DatatypeConverter.printBase64Binary(storedKey),
+                    serverKey == null ? null : DatatypeConverter.printBase64Binary(serverKey)
+                )
+            );
         }
         catch (SQLException sqle) {
+            abortTransaction = true;
             throw new UserNotFoundException(sqle);
         }
         finally {
-            DbConnectionManager.closeConnection(pstmt, con);
+            DbConnectionManager.closeStatement(pstmt);
+            DbConnectionManager.closeTransactionConnection(con, abortTransaction);
         }
     }
 
@@ -407,5 +442,81 @@ public class DefaultAuthProvider implements AuthProvider {
     @Override
     public boolean isScramSupported() {
         return true;
+    }
+
+    /**
+     * Inserts or updates the SCRAM credential for a user and mechanism, using the provided (transaction) connection.
+     */
+    private void upsertScramCredential(final Connection con, final String username, final ScramCredentialData credential) throws SQLException
+    {
+        PreparedStatement existsStmt = null;
+        ResultSet existsRs = null;
+        PreparedStatement upsertStmt = null;
+
+        try {
+            existsStmt = con.prepareStatement(TEST_SCRAM_CREDENTIAL);
+            existsStmt.setString(1, username);
+            existsStmt.setString(2, credential.mechanism);
+            existsRs = existsStmt.executeQuery();
+
+            if (existsRs.next()) {
+                upsertStmt = con.prepareStatement(UPDATE_SCRAM_CREDENTIAL);
+                upsertStmt.setInt(1, credential.iterations);
+                upsertStmt.setString(2, credential.salt);
+                upsertStmt.setString(3, credential.storedKey);
+                upsertStmt.setString(4, credential.serverKey);
+                upsertStmt.setString(5, username);
+                upsertStmt.setString(6, credential.mechanism);
+            } else {
+                upsertStmt = con.prepareStatement(INSERT_SCRAM_CREDENTIAL);
+                upsertStmt.setString(1, username);
+                upsertStmt.setString(2, credential.mechanism);
+                upsertStmt.setInt(3, credential.iterations);
+                upsertStmt.setString(4, credential.salt);
+                upsertStmt.setString(5, credential.storedKey);
+                upsertStmt.setString(6, credential.serverKey);
+            }
+            upsertStmt.executeUpdate();
+        } finally {
+            DbConnectionManager.closeConnection(existsRs, existsStmt, null);
+            DbConnectionManager.closeStatement(upsertStmt);
+        }
+    }
+
+    /**
+     * Loads the SCRAM credential for a user and mechanism, or {@code null} when none is stored.
+     */
+    private ScramCredentialData loadScramCredential(final String username, final String mechanism) throws SQLException
+    {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            con = DbConnectionManager.getConnection();
+            pstmt = con.prepareStatement(LOAD_SCRAM_CREDENTIAL);
+            pstmt.setString(1, username);
+            pstmt.setString(2, mechanism);
+            rs = pstmt.executeQuery();
+            if (!rs.next()) {
+                return null;
+            }
+            return new ScramCredentialData(
+                mechanism,
+                rs.getString(2),
+                rs.getInt(1),
+                rs.getString(3),
+                rs.getString(4)
+            );
+        } finally {
+            DbConnectionManager.closeConnection(rs, pstmt, con);
+        }
+    }
+
+    /**
+     * Returns {@code true} when a SCRAM credential exists for a user and mechanism.
+     */
+    private boolean hasScramCredential(final String username, final String mechanism) throws SQLException
+    {
+        return loadScramCredential(username, mechanism) != null;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -335,7 +335,8 @@ public class DefaultAuthProvider implements AuthProvider {
                     continue;
                 }
 
-                credentialsByMechanismName.put(mechanism, new ScramCredentialData(mechanism, salt, iterations, storedKey, serverKey));
+                final ScramCredentialData scram = new ScramCredentialData(mechanism, salt, iterations, storedKey, serverKey);
+                credentialsByMechanismName.put(scram.mechanism, scram);
             } while (rs.next());
 
             // TODO: When supporting more than just SCRAM-SHA-1, drop this. This got introduced in a commit that refactored the existing storage solution, prior to implementing support for additional mechanisms (OF-3322).

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -321,11 +321,6 @@ public class DefaultAuthProvider implements AuthProvider {
             final Map<String, ScramCredentialData> credentialsByMechanismName = new HashMap<>();
             do {
                 final String mechanism = rs.getString(3);
-                if (mechanism == null) {
-                    // No SCRAM credentials for this user
-                    Log.debug("No SCRAM credentials available for checkPassword for user {}", username);
-                    return false;
-                }
                 Integer iterations = rs.getInt(4);
                 if (rs.wasNull()) { // correct for 'getInt' returning '0' on null values.
                     iterations = null;
@@ -333,9 +328,11 @@ public class DefaultAuthProvider implements AuthProvider {
                 final String salt = rs.getString(5);
                 final String storedKey = rs.getString(6);
                 final String serverKey = rs.getString(7);
-                if (salt == null || iterations == null || iterations == 0 || storedKey == null || serverKey == null) {
-                    Log.debug("No available SCRAM credentials for checkPassword for user {}", username);
-                    return false;
+                if (mechanism == null || salt == null || iterations == null || iterations == 0 || storedKey == null || serverKey == null) {
+                    // Either the LEFT JOIN produced no ofUserScram row (all columns null), or a stored row is incomplete.
+                    // Skip it rather than failing authentication outright: another row may hold a usable credential.
+                    Log.debug("Skipping unavailable or incomplete SCRAM credential (mechanism '{}') for user {}", mechanism, username);
+                    continue;
                 }
 
                 credentialsByMechanismName.put(mechanism, new ScramCredentialData(mechanism, salt, iterations, storedKey, serverKey));

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -24,6 +24,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.security.sasl.SaslException;
 import javax.xml.bind.DatatypeConverter;
@@ -56,6 +58,10 @@ public class DefaultAuthProvider implements AuthProvider {
 
     private static final String LOAD_PASSWORD =
         "SELECT plainPassword,encryptedPassword FROM ofUser WHERE username=?";
+    private static final String LOAD_PASSWORD_AND_SCRAM =
+        "SELECT u.plainPassword, u.encryptedPassword, s.mechanism, s.iterations, s.salt, s.storedKey, s.serverKey " +
+        "FROM ofUser u LEFT JOIN ofUserScram s ON u.username = s.username " +
+        "WHERE u.username = ?";
     private static final String UPDATE_PASSWORD =
         "UPDATE ofUser SET plainPassword=?, encryptedPassword=? WHERE username=?";
     private static final String LOAD_SCRAM_CREDENTIAL =
@@ -271,6 +277,7 @@ public class DefaultAuthProvider implements AuthProvider {
         Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
+        Log.debug("Checking password for user '{}'", username);
         if (username.contains("@")) {
             // Check that the specified domain matches the server's domain
             int index = username.indexOf("@");
@@ -284,12 +291,13 @@ public class DefaultAuthProvider implements AuthProvider {
         }
         try {
             con = DbConnectionManager.getConnection();
-            pstmt = con.prepareStatement(LOAD_PASSWORD);
+            pstmt = con.prepareStatement(LOAD_PASSWORD_AND_SCRAM);
             pstmt.setString(1, username);
             rs = pstmt.executeQuery();
             if (!rs.next()) {
                 throw new UserNotFoundException(username);
             }
+
             String plainText = rs.getString(1);
             String encrypted = rs.getString(2);
             if (encrypted != null) {
@@ -308,26 +316,52 @@ public class DefaultAuthProvider implements AuthProvider {
                 }
                 return testPassword.equals(plainText);
             }
+
             // Don't have either plain or encrypted, so test SCRAM hash.
-            final ScramCredentialData credential = getScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME);
-            if (credential.salt == null || credential.iterations == 0 || credential.storedKey == null) {
-                Log.warn("No available credentials for checkPassword.");
+            // LEFT JOIN result set may have multiple rows (one per SCRAM mechanism).
+            final Map<String, ScramCredentialData> credentialsByMechanismName = new HashMap<>();
+            do {
+                final String mechanism = rs.getString(3);
+                if (mechanism == null) {
+                    // No SCRAM credentials for this user
+                    Log.debug("No SCRAM credentials available for checkPassword for user {}", username);
+                    return false;
+                }
+                Integer iterations = rs.getInt(4);
+                if (rs.wasNull()) { // correct for 'getInt' returning '0' on null values.
+                    iterations = null;
+                }
+                final String salt = rs.getString(5);
+                final String storedKey = rs.getString(6);
+                final String serverKey = rs.getString(7);
+                if (salt == null || iterations == null || iterations == 0 || storedKey == null || serverKey == null) {
+                    Log.debug("No available SCRAM credentials for checkPassword for user {}", username);
+                    return false;
+                }
+
+                credentialsByMechanismName.put(mechanism, new ScramCredentialData(mechanism, salt, iterations, storedKey, serverKey));
+            } while (rs.next());
+
+            // TODO: When supporting more than just SCRAM-SHA-1, drop this. This got introduced in a commit that refactored the existing storage solution, prior to implementing support for additional mechanisms (OF-3322).
+            final ScramCredentialData credential = credentialsByMechanismName.get(ScramSha1SaslServer.MECHANISM_NAME);
+            if (credential == null) {
+                Log.debug("No available SCRAM-SHA-1 credentials for checkPassword for user {}", username);
                 return false;
             }
-            byte[] saltShaker = DatatypeConverter.parseBase64Binary(credential.salt);
-            byte[] saltedPassword = null, clientKey = null, testStoredKey = null;
+            final byte[] testStoredKey;
             try {
-                saltedPassword = ScramUtils.createSaltedPassword(saltShaker, testPassword, credential.iterations);
-                clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
+                final byte[] saltShaker = DatatypeConverter.parseBase64Binary(credential.salt);
+                final byte[] saltedPassword = ScramUtils.createSaltedPassword(saltShaker, testPassword, credential.iterations);
+                final byte[] clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
                 testStoredKey = MessageDigest.getInstance("SHA-1").digest(clientKey);
-            } catch(SaslException | NoSuchAlgorithmException e) {
-                Log.warn("Unable to check SCRAM values for PLAIN authentication.");
+            } catch(SaslException | NoSuchAlgorithmException | IllegalArgumentException e) {
+                Log.warn("Unable to check SCRAM values for PLAIN authentication for user '{}'", username, e);
                 return false;
             }
             return DatatypeConverter.printBase64Binary(testStoredKey).equals(credential.storedKey);
         }
         catch (SQLException sqle) {
-            Log.error("User SQL failure:", sqle);
+            Log.warn("A database error occurred while authenticating user {}:", username, sqle);
             throw new UserNotFoundException(sqle);
         }
         finally {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -23,6 +23,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
@@ -70,8 +71,6 @@ public class DefaultAuthProvider implements AuthProvider {
         "UPDATE ofUserScram SET iterations=?, salt=?, storedKey=?, serverKey=? WHERE username=? AND mechanism=?";
     private static final String INSERT_SCRAM_CREDENTIAL =
         "INSERT INTO ofUserScram (username, mechanism, iterations, salt, storedKey, serverKey) VALUES (?, ?, ?, ?, ?, ?)";
-    private static final String TEST_SCRAM_CREDENTIAL =
-        "SELECT username FROM ofUserScram WHERE username=? AND mechanism=?";
 
     private static final SecureRandom random = new SecureRandom();
 
@@ -480,41 +479,113 @@ public class DefaultAuthProvider implements AuthProvider {
 
     /**
      * Inserts or updates the SCRAM credential for a user and mechanism, using the provided (transaction) connection.
+     *
+     * @param con        an open (transaction) connection to use
+     * @param username   the user whose credential is being stored
+     * @param credential the SCRAM credential to persist
+     * @throws SQLException if the credential could not be persisted
      */
     private void upsertScramCredential(final Connection con, final String username, final ScramCredentialData credential) throws SQLException
     {
-        PreparedStatement existsStmt = null;
-        ResultSet existsRs = null;
-        PreparedStatement upsertStmt = null;
-
-        try {
-            existsStmt = con.prepareStatement(TEST_SCRAM_CREDENTIAL);
-            existsStmt.setString(1, username);
-            existsStmt.setString(2, credential.mechanism);
-            existsRs = existsStmt.executeQuery();
-
-            if (existsRs.next()) {
-                upsertStmt = con.prepareStatement(UPDATE_SCRAM_CREDENTIAL);
-                upsertStmt.setInt(1, credential.iterations);
-                upsertStmt.setString(2, credential.salt);
-                upsertStmt.setString(3, credential.storedKey);
-                upsertStmt.setString(4, credential.serverKey);
-                upsertStmt.setString(5, username);
-                upsertStmt.setString(6, credential.mechanism);
-            } else {
-                upsertStmt = con.prepareStatement(INSERT_SCRAM_CREDENTIAL);
-                upsertStmt.setString(1, username);
-                upsertStmt.setString(2, credential.mechanism);
-                upsertStmt.setInt(3, credential.iterations);
-                upsertStmt.setString(4, credential.salt);
-                upsertStmt.setString(5, credential.storedKey);
-                upsertStmt.setString(6, credential.serverKey);
-            }
-            upsertStmt.executeUpdate();
-        } finally {
-            DbConnectionManager.closeConnection(existsRs, existsStmt, null);
-            DbConnectionManager.closeStatement(upsertStmt);
+        // UPDATE first: for a password change the row already exists, which is the common case.
+        if (executeScramUpdate(con, username, credential) > 0) {
+            return;
         }
+        // No existing row (e.g. first-time SCRAM generation after migration). Try to INSERT it.
+        try {
+            executeScramInsert(con, username, credential);
+        } catch (final SQLException sqle) {
+            // A concurrent setPassword() may have inserted the row between our UPDATE and INSERT, yielding a
+            // unique/primary-key violation. The row now exists, so a single UPDATE retry resolves it.
+            if (!isIntegrityConstraintViolation(sqle) || executeScramUpdate(con, username, credential) == 0) {
+                throw sqle;
+            }
+        }
+    }
+
+    /**
+     * Updates the stored SCRAM credential for a user and mechanism on the given connection.
+     *
+     * @param con        an open connection to use
+     * @param username   the user whose credential is being updated
+     * @param credential the SCRAM credential to store
+     * @return the number of rows affected: zero when no matching row exists
+     * @throws SQLException if the update failed
+     */
+    private int executeScramUpdate(final Connection con, final String username, final ScramCredentialData credential) throws SQLException
+    {
+        try (final PreparedStatement stmt = con.prepareStatement(UPDATE_SCRAM_CREDENTIAL)){
+            stmt.setInt(1, credential.iterations);
+            stmt.setString(2, credential.salt);
+            stmt.setString(3, credential.storedKey);
+            stmt.setString(4, credential.serverKey);
+            stmt.setString(5, username);
+            stmt.setString(6, credential.mechanism);
+            return stmt.executeUpdate();
+        }
+    }
+
+    /**
+     * Inserts a new SCRAM credential for a user and mechanism on the given connection.
+     *
+     * @param con        an open connection to use
+     * @param username   the user whose credential is being inserted
+     * @param credential the SCRAM credential to store
+     * @throws SQLException if the insert failed, including when a row for this user and mechanism already exists
+     *                      (a unique/primary-key violation)
+     */
+    private void executeScramInsert(final Connection con, final String username, final ScramCredentialData credential) throws SQLException
+    {
+        try (final PreparedStatement stmt = con.prepareStatement(INSERT_SCRAM_CREDENTIAL)){
+            stmt.setString(1, username);
+            stmt.setString(2, credential.mechanism);
+            stmt.setInt(3, credential.iterations);
+            stmt.setString(4, credential.salt);
+            stmt.setString(5, credential.storedKey);
+            stmt.setString(6, credential.serverKey);
+            stmt.executeUpdate();
+        }
+    }
+
+    /**
+     * Determines whether the given exception signals a unique or primary-key constraint violation, in a manner intended
+     * to work across the different databases that Openfire supports.
+     *
+     * @param sqle the exception to inspect
+     * @return {@code true} if the exception represents a unique or primary-key constraint violation
+     */
+    private static boolean isIntegrityConstraintViolation(final SQLException sqle)
+    {
+        // Walk the standard cause chain.
+        for (Throwable t = sqle; t != null; t = t.getCause()) {
+            if (isConstraintViolationNode(t)) {
+                return true;
+            }
+        }
+        // Walk the JDBC-specific chain (independent of getCause()).
+        for (SQLException e = sqle; e != null; e = e.getNextException()) {
+            if (isConstraintViolationNode(e)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Tests a single exception (one node in an exception chain) for an integrity-constraint violation.
+     */
+    private static boolean isConstraintViolationNode(final Throwable t)
+    {
+        // Two signals are combined: the JDBC 4 SQLIntegrityConstraintViolationException subclass (which drivers should throw but not all do)...
+        if (t instanceof SQLIntegrityConstraintViolationException) {
+            return true;
+        }
+        // ... and an SQLState in class 23, which the SQL standard assigns to integrity-constraint violations and into which most databases map PK/unique violations.
+        if (t instanceof SQLException) {
+            final String sqlState = ((SQLException) t).getSQLState();
+            return sqlState != null && sqlState.startsWith("23");
+        }
+        return false;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -438,7 +438,11 @@ public class DefaultAuthProvider implements AuthProvider {
                 pstmt.setString(2, encryptedPassword);
             }
             pstmt.setString(3, username);
-            pstmt.executeUpdate();
+            final int updated = pstmt.executeUpdate();
+            if (updated == 0) {
+                abortTransaction = true;
+                throw new UserNotFoundException(username);
+            }
             DbConnectionManager.fastcloseStmt(pstmt);
             pstmt = null;
 
@@ -459,8 +463,7 @@ public class DefaultAuthProvider implements AuthProvider {
             throw new UserNotFoundException(sqle);
         }
         finally {
-            DbConnectionManager.closeStatement(pstmt);
-            DbConnectionManager.closeTransactionConnection(con, abortTransaction);
+            DbConnectionManager.closeTransactionConnection(pstmt, con, abortTransaction);
         }
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ScramCredentialData.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ScramCredentialData.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.auth;
+
+import java.util.Locale;
+
+/**
+ * SCRAM credentials for a single user and a single mechanism.
+ *
+ * The mechanism is stored in its normalized ('base') form: upper-cased and without the optional
+ * {@code -PLUS} suffix (channel binding does not affect the stored credential material, only the SASL exchange).
+ *
+ * This type exists to give the credential storage a stable, mechanism-keyed shape. In the current release only
+ * {@code SCRAM-SHA-1} is produced and consumed; the type is intentionally kept minimal.
+ */
+public class ScramCredentialData
+{
+    public final String mechanism;
+    public final String salt;
+    public final int iterations;
+    public final String storedKey;
+    public final String serverKey;
+
+    public ScramCredentialData(final String mechanism, final String salt, final int iterations, final String storedKey, final String serverKey)
+    {
+        this.mechanism = normalizeMechanismName(mechanism);
+        this.salt = salt;
+        this.iterations = iterations;
+        this.storedKey = storedKey;
+        this.serverKey = serverKey;
+    }
+
+    /**
+     * Normalizes a SCRAM mechanism name to upper case and strips the optional {@code -PLUS} suffix.
+     *
+     * @param mechanism The mechanism name (for example: {@code SCRAM-SHA-1-PLUS}).
+     * @return The normalized base mechanism name (for example: {@code SCRAM-SHA-1}).
+     * @throws IllegalArgumentException if the value is null, empty, or not a SCRAM mechanism name.
+     */
+    public static String normalizeMechanismName(final String mechanism)
+    {
+        if (mechanism == null || mechanism.trim().isEmpty()) {
+            throw new IllegalArgumentException("SCRAM mechanism cannot be null or empty.");
+        }
+
+        final String normalized = mechanism.trim().toUpperCase(Locale.ROOT);
+        final String baseName = normalized.endsWith("-PLUS")
+            ? normalized.substring(0, normalized.length() - "-PLUS".length())
+            : normalized;
+
+        if (!baseName.startsWith("SCRAM-SHA-")) {
+            throw new IllegalArgumentException("Unsupported SCRAM mechanism name: " + mechanism);
+        }
+
+        return baseName;
+    }
+}

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -56,6 +56,8 @@ import org.slf4j.LoggerFactory;
  */
 public class ScramSha1SaslServer extends ScramSaslServer {
 
+    public static final String MECHANISM_NAME = "SCRAM-SHA-1";
+
     /**
      * Stores a server-side secret used when handling authentication attempts for non-existing users in SCRAM-SHA-1 (-PLUS).
      *

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -492,7 +492,7 @@ public class ScramSha1SaslServer extends ScramSaslServer {
     {
         try
         {
-            final String saltBase64 = AuthFactory.getSalt(username);
+            final String saltBase64 = AuthFactory.getSalt(username, MECHANISM_NAME);
             if (saltBase64 == null) {
                 return handleMissingSalt(username);
             }
@@ -534,7 +534,7 @@ public class ScramSha1SaslServer extends ScramSaslServer {
         }
         AuthFactory.setPassword(username, password);
 
-        final String newSalt = AuthFactory.getSalt(username);
+        final String newSalt = AuthFactory.getSalt(username, MECHANISM_NAME);
         if (newSalt == null) {
             Log.debug("Salt regeneration failed for '{}'", username);
             return generateFakeSalt(username);
@@ -602,7 +602,7 @@ public class ScramSha1SaslServer extends ScramSaslServer {
      */
     private int getIterations(final String username) {
         try {
-            return AuthFactory.getIterations(username);
+            return AuthFactory.getIterations(username, MECHANISM_NAME);
         } catch (UserNotFoundException e) {
             return ITERATION_COUNT.getValue();
         }
@@ -633,7 +633,7 @@ public class ScramSha1SaslServer extends ScramSaslServer {
      * Retrieve the server key from the database for a given username.
      */
     private byte[] getServerKey(final String username) throws UserNotFoundException {
-        final String serverKey = AuthFactory.getServerKey(username);
+        final String serverKey = AuthFactory.getServerKey(username, MECHANISM_NAME);
         if (serverKey == null) {
             return null;
         } else {
@@ -666,7 +666,7 @@ public class ScramSha1SaslServer extends ScramSaslServer {
      * Retrieve the stored key from the database for a given username.
      */
     private byte[] getStoredKey(final String username) throws UserNotFoundException {
-        final String storedKey = AuthFactory.getStoredKey(username);
+        final String storedKey = AuthFactory.getStoredKey(username, MECHANISM_NAME);
         if (storedKey == null) {
             return null;
         } else {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/DefaultUserProvider.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.auth.AuthFactory;
+import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
 import org.jivesoftware.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +57,9 @@ public class DefaultUserProvider implements UserProvider {
     private static final Logger Log = LoggerFactory.getLogger(DefaultUserProvider.class);
 
     private static final String LOAD_USER =
-            "SELECT salt, serverKey, storedKey, iterations, name, email, creationDate, modificationDate FROM ofUser WHERE username=?";
+        "SELECT name, email, creationDate, modificationDate FROM ofUser WHERE username=?";
+    private static final String LOAD_SCRAM_CREDENTIAL =
+        "SELECT salt, serverKey, storedKey, iterations FROM ofUserScram WHERE username=? AND mechanism=?";
     private static final String USER_COUNT =
             "SELECT count(*) FROM ofUser";
     private static final String ALL_USERS =
@@ -81,6 +84,7 @@ public class DefaultUserProvider implements UserProvider {
     private static final boolean IS_READ_ONLY = false;
     
     @Override
+    @SuppressWarnings("removal") // populates User's deprecated (forRemoval) SCRAM-SHA-1 accessors from ofUserScram
     public User loadUser(String username) throws UserNotFoundException {
         if(username.contains("@")) {
             if (!XMPPServer.getInstance().isLocal(new JID(username))) {
@@ -99,20 +103,24 @@ public class DefaultUserProvider implements UserProvider {
             if (!rs.next()) {
                 throw new UserNotFoundException();
             }
-            String salt = rs.getString(1);
-            String serverKey = rs.getString(2);
-            String storedKey = rs.getString(3);
-            int iterations = rs.getInt(4);
-            String name = rs.getString(5);
-            String email = rs.getString(6);
-            Date creationDate = new Date(Long.parseLong(rs.getString(7).trim()));
-            Date modificationDate = new Date(Long.parseLong(rs.getString(8).trim()));
+            String name = rs.getString(1);
+            String email = rs.getString(2);
+            Date creationDate = new Date(Long.parseLong(rs.getString(3).trim()));
+            Date modificationDate = new Date(Long.parseLong(rs.getString(4).trim()));
+            DbConnectionManager.fastcloseStmt(rs, pstmt);
 
             User user = new User(username, name, email, creationDate, modificationDate);
-            user.setSalt(salt);
-            user.setServerKey(serverKey);
-            user.setStoredKey(storedKey);
-            user.setIterations(iterations);
+
+            pstmt = con.prepareStatement(LOAD_SCRAM_CREDENTIAL);
+            pstmt.setString(1, username);
+            pstmt.setString(2, ScramSha1SaslServer.MECHANISM_NAME); // "SCRAM-SHA-1"
+            rs = pstmt.executeQuery();
+            if (rs.next()) {
+                user.setSalt(rs.getString(1));
+                user.setServerKey(rs.getString(2));
+                user.setStoredKey(rs.getString(3));
+                user.setIterations(rs.getInt(4));
+            }
             return user;
         }
         catch (Exception e) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/User.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/User.java
@@ -157,34 +157,99 @@ public class User implements Cacheable, Externalizable, Result {
         }
     }
 
+    /**
+     * Returns the SCRAM-SHA-1 stored key for this user, or {@code null} if the user has no SCRAM-SHA-1 credential.
+     *
+     * @return the SCRAM-SHA-1 stored key, or {@code null}.
+     * @deprecated This accessor exposes only the SCRAM-SHA-1 credential. SCRAM credentials are stored per mechanism
+     *             (see the {@code ofUserScram} table) and should be obtained through the authentication provider rather
+     *             than from the {@link User} object. Retained for backwards compatibility with third-party integrations.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getStoredKey() {
         return storedKey;
     }
 
+    /**
+     * Sets the SCRAM-SHA-1 stored key for this user.
+     *
+     * @param storedKey the SCRAM-SHA-1 stored key.
+     * @deprecated This accessor exposes only the SCRAM-SHA-1 credential. See {@link #getStoredKey()}.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public void setStoredKey(String storedKey) {
         this.storedKey = storedKey;
     }
 
+    /**
+     * Returns the SCRAM-SHA-1 server key for this user, or {@code null} if the user has no SCRAM-SHA-1 credential.
+     *
+     * @return the SCRAM-SHA-1 server key, or {@code null}.
+     * @deprecated This accessor exposes only the SCRAM-SHA-1 credential. SCRAM credentials are stored per mechanism
+     *             (see the {@code ofUserScram} table) and should be obtained through the authentication provider rather
+     *             than from the {@link User} object. Retained for backwards compatibility with third-party integrations.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getServerKey() {
         return serverKey;
     }
 
+    /**
+     * Sets the SCRAM-SHA-1 server key for this user.
+     *
+     * @param serverKey the SCRAM-SHA-1 server key.
+     * @deprecated This accessor exposes only the SCRAM-SHA-1 credential. See {@link #getServerKey()}.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public void setServerKey(String serverKey) {
         this.serverKey = serverKey;
     }
 
+    /**
+     * Returns the SCRAM-SHA-1 salt for this user, or {@code null} if the user has no
+     * SCRAM-SHA-1 credential.
+     *
+     * @return the SCRAM-SHA-1 salt, or {@code null}.
+     * @deprecated This accessor exposes only the SCRAM-SHA-1 credential. SCRAM credentials are stored per mechanism
+     *             (see the {@code ofUserScram} table) and should be obtained through the authentication provider rather
+     *             than from the {@link User} object. Retained for backwards compatibility with third-party integrations.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getSalt() {
         return salt;
     }
 
+    /**
+     * Sets the SCRAM-SHA-1 salt for this user.
+     *
+     * @param salt the SCRAM-SHA-1 salt.
+     * @deprecated This accessor exposes only the SCRAM-SHA-1 credential. See {@link #getSalt()}.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public void setSalt(String salt) {
         this.salt = salt;
     }
 
+    /**
+     * Returns the SCRAM-SHA-1 iteration count for this user, or {@code 0} if the user has no SCRAM-SHA-1 credential.
+     *
+     * @return the SCRAM-SHA-1 iteration count, or {@code 0}.
+     * @deprecated This accessor exposes only the SCRAM-SHA-1 credential. SCRAM credentials are stored per mechanism
+     *             (see the {@code ofUserScram} table) and should be obtained through the authentication provider rather
+     *             than from the {@link User} object. Retained for backwards compatibility with third-party integrations.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public int getIterations() {
         return iterations;
     }
 
+    /**
+     * Sets the SCRAM-SHA-1 iteration count for this user.
+     *
+     * @param iterations the SCRAM-SHA-1 iteration count.
+     * @deprecated This accessor exposes only the SCRAM-SHA-1 credential. See {@link #getIterations()}.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public void setIterations(int iterations) {
         this.iterations = iterations;
     }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
@@ -84,8 +84,8 @@ public class DefaultAuthProviderScramStorageTest
      *   <li>{@code plainPassword} - the {@code ofUser.plainPassword} value, or {@code null} when not stored.</li>
      *   <li>{@code encryptedPassword} - the {@code ofUser.encryptedPassword} value, or {@code null} when not stored.</li>
      *   <li>{@code mechanism} - the {@code ofUserScram.mechanism} value. Pass {@code null} to model a {@code LEFT JOIN}
-     *       with no matching {@code ofUserScram} row (i.e. the user has no SCRAM credentials); in that case the
-     *       remaining SCRAM columns are left unstubbed because production code never reads them.</li>
+     *       with no matching {@code ofUserScram} row (i.e. the user has no SCRAM credentials); in that case the remaining
+     *       SCRAM columns can be left unstubbed (Mockito defaults them to {@code null}/{@code 0}, which production logic skips).</li>
      *   <li>{@code iterations} - the {@code ofUserScram.iterations} value. Only stubbed when {@code mechanism} is
      *       non-null. A {@code null} value models a SQL {@code NULL} (mirrored via {@link ResultSet#wasNull()}).</li>
      *   <li>{@code salt} - the {@code ofUserScram.salt} value. Only stubbed when {@code mechanism} is non-null.</li>

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.auth;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.database.DbConnectionManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import javax.xml.bind.DatatypeConverter;
+import java.security.MessageDigest;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that {@link DefaultAuthProvider} sources SCRAM credentials from the dedicated {@code ofUserScram} table
+ * (rather than from columns on {@code ofUser}, which is where they lived prior to this change).
+ */
+public class DefaultAuthProviderScramStorageTest
+{
+    private static final String PASSWORD = "pencil";
+    private static final String SALT_BASE64 = "QSXCR+Q6sek8bf92";
+    private static final int ITERATIONS = 4096;
+
+    @BeforeAll
+    public static void setupClass() throws Exception
+    {
+        Fixtures.reconfigureOpenfireHome();
+        Fixtures.disableDatabasePersistence();
+    }
+
+    /**
+     * Computes the base64 stored key for a password using the same SCRAM-SHA-1 derivation as production code, so the
+     * test verifies real cryptographic agreement rather than an echoed constant.
+     */
+    private static String storedKeyFor(final String password) throws Exception
+    {
+        final byte[] salt = DatatypeConverter.parseBase64Binary(SALT_BASE64);
+        final byte[] saltedPassword = ScramUtils.createSaltedPassword(salt, password, ITERATIONS);
+        final byte[] clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
+        return DatatypeConverter.printBase64Binary(MessageDigest.getInstance("SHA-1").digest(clientKey));
+    }
+
+    /**
+     * Builds a mock Connection whose prepareStatement() dispatches to a SCRAM statement or a password statement based
+     * on whether the SQL references {@code ofUserScram}.
+     *
+     * The {@code ofUser} password lookup always returns a single row with null plaintext and null encrypted password,
+     * forcing the provider down the SCRAM-verification path. The {@code ofUserScram} lookup returns the supplied
+     * credential row.
+     */
+    private static Connection mockConnection(final PreparedStatement loadPassword, final PreparedStatement loadScram) throws Exception
+    {
+        final Connection connection = Mockito.mock(Connection.class);
+        when(connection.prepareStatement(anyString())).thenAnswer(invocation -> {
+            final String sql = invocation.getArgument(0, String.class).toLowerCase(Locale.ROOT);
+            return sql.contains("ofuserscram") ? loadScram : loadPassword;
+        });
+        return connection;
+    }
+
+    /**
+     * Configures the {@code ofUser} password lookup to return a single row with no plaintext/encrypted password. A
+     * fresh ResultSet is returned on each executeQuery() so that repeated LOAD_PASSWORD calls (checkPassword's own
+     * lookup and the lookup performed while resolving the SCRAM credential) each see a valid, independent cursor.
+     */
+    private static void stubEmptyPasswordRow(final PreparedStatement loadPassword) throws Exception
+    {
+        when(loadPassword.executeQuery()).thenAnswer(invocation -> {
+            final ResultSet rs = Mockito.mock(ResultSet.class);
+            when(rs.next()).thenReturn(true, false);
+            when(rs.getString(1)).thenReturn(null); // plainPassword
+            when(rs.getString(2)).thenReturn(null); // encryptedPassword
+            return rs;
+        });
+    }
+
+    /**
+     * Verifies that a correct password is accepted by verifying against SCRAM material held in {@code ofUserScram},
+     * and that the {@code ofUserScram} table was actually consulted.
+     */
+    @Test
+    void checkPassword_acceptsCorrectPassword_fromOfUserScram() throws Exception
+    {
+        // Setup test fixture.
+        final PreparedStatement loadPassword = Mockito.mock(PreparedStatement.class);
+        final PreparedStatement loadScram = Mockito.mock(PreparedStatement.class);
+        stubEmptyPasswordRow(loadPassword);
+
+        final ResultSet scramRow = Mockito.mock(ResultSet.class);
+        when(loadScram.executeQuery()).thenReturn(scramRow);
+        when(scramRow.next()).thenReturn(true);
+        when(scramRow.getInt(1)).thenReturn(ITERATIONS);
+        when(scramRow.getString(2)).thenReturn(SALT_BASE64);
+        when(scramRow.getString(3)).thenReturn(storedKeyFor(PASSWORD));
+        when(scramRow.getString(4)).thenReturn("server-key-not-used-for-password-check");
+
+        final Connection connection = mockConnection(loadPassword, loadScram);
+
+        try (final MockedStatic<DbConnectionManager> db = Mockito.mockStatic(DbConnectionManager.class)) {
+            db.when(DbConnectionManager::getConnection).thenReturn(connection);
+
+            // Execute system under test.
+            final DefaultAuthProvider provider = new DefaultAuthProvider();
+            final boolean result = provider.checkPassword("user", PASSWORD);
+
+            // Verify result.
+            assertTrue(result, "A correct password should verify against SCRAM material stored in ofUserScram.");
+            verify(connection, atLeastOnce()).prepareStatement(
+                ArgumentMatchers.argThat(sql -> sql != null && sql.toLowerCase(Locale.ROOT).contains("ofuserscram")));
+        }
+    }
+
+    /**
+     * Verifies that an incorrect password is rejected when checked against SCRAM material in {@code ofUserScram}.
+     */
+    @Test
+    void checkPassword_rejectsIncorrectPassword_fromOfUserScram() throws Exception
+    {
+        // Setup test fixture.
+        final PreparedStatement loadPassword = Mockito.mock(PreparedStatement.class);
+        final PreparedStatement loadScram = Mockito.mock(PreparedStatement.class);
+        stubEmptyPasswordRow(loadPassword);
+
+        final ResultSet scramRow = Mockito.mock(ResultSet.class);
+        when(loadScram.executeQuery()).thenReturn(scramRow);
+        when(scramRow.next()).thenReturn(true);
+        when(scramRow.getInt(1)).thenReturn(ITERATIONS);
+        when(scramRow.getString(2)).thenReturn(SALT_BASE64);
+        when(scramRow.getString(3)).thenReturn(storedKeyFor(PASSWORD)); // stored key for the *correct* password
+        when(scramRow.getString(4)).thenReturn("server-key-not-used-for-password-check");
+
+        final Connection connection = mockConnection(loadPassword, loadScram);
+
+        try (final MockedStatic<DbConnectionManager> db = Mockito.mockStatic(DbConnectionManager.class)) {
+            db.when(DbConnectionManager::getConnection).thenReturn(connection);
+
+            // Execute system under test.
+            final DefaultAuthProvider provider = new DefaultAuthProvider();
+            final boolean result = provider.checkPassword("user", "not-the-password");
+
+            // Verify result.
+            assertFalse(result, "An incorrect password must not verify against SCRAM material stored in ofUserScram.");
+        }
+    }
+}

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
@@ -17,9 +17,9 @@ package org.jivesoftware.openfire.auth;
 
 import org.jivesoftware.Fixtures;
 import org.jivesoftware.database.DbConnectionManager;
+import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -32,20 +32,30 @@ import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests that {@link DefaultAuthProvider} sources SCRAM credentials from the dedicated {@code ofUserScram} table
- * (rather than from columns on {@code ofUser}, which is where they lived prior to this change).
+ * Unit tests for {@link DefaultAuthProvider#checkPassword(String, String)}.
+ *
+ * These tests verify authentication behavior for the supported credential types and the precedence rules that apply
+ * when multiple credential types are available.
+ *
+ * <h2>How these tests are wired</h2>
+ * {@link DefaultAuthProvider#checkPassword(String, String)} loads a user's password and SCRAM material with a single
+ * {@code LEFT JOIN} query against {@code ofUser} and {@code ofUserScram}. Every test therefore needs the same fixture:
+ * a mocked {@link ResultSet} describing one user's stored credentials, wrapped in a mocked {@link PreparedStatement}
+ * and {@link Connection}, reached through a statically-mocked {@link DbConnectionManager}. That shared wiring lives in
+ * {@link #runCheckPassword}, so each test only has to describe the stored credentials and assert the outcome.
  */
 public class DefaultAuthProviderScramStorageTest
 {
     private static final String PASSWORD = "pencil";
     private static final String SALT_BASE64 = "QSXCR+Q6sek8bf92";
     private static final int ITERATIONS = 4096;
+
+    /** The encrypted-password sentinel that {@link #runCheckPassword} teaches {@code AuthFactory} to decrypt. */
+    private static final String ENCRYPTED_VALUE = "encrypted-value";
 
     @BeforeAll
     public static void setupClass() throws Exception
@@ -67,105 +77,294 @@ public class DefaultAuthProviderScramStorageTest
     }
 
     /**
-     * Builds a mock Connection whose prepareStatement() dispatches to a SCRAM statement or a password statement based
-     * on whether the SQL references {@code ofUserScram}.
+     * Builds a mock {@link ResultSet} representing the single row that the combined {@code LEFT JOIN} query returns for
+     * one user. The column layout mirrors {@code DefaultAuthProvider.LOAD_PASSWORD_AND_SCRAM}:
      *
-     * The {@code ofUser} password lookup always returns a single row with null plaintext and null encrypted password,
-     * forcing the provider down the SCRAM-verification path. The {@code ofUserScram} lookup returns the supplied
-     * credential row.
+     * <ol>
+     *   <li>{@code plainPassword} - the {@code ofUser.plainPassword} value, or {@code null} when not stored.</li>
+     *   <li>{@code encryptedPassword} - the {@code ofUser.encryptedPassword} value, or {@code null} when not stored.</li>
+     *   <li>{@code mechanism} - the {@code ofUserScram.mechanism} value. Pass {@code null} to model a {@code LEFT JOIN}
+     *       with no matching {@code ofUserScram} row (i.e. the user has no SCRAM credentials); in that case the
+     *       remaining SCRAM columns are left unstubbed because production code never reads them.</li>
+     *   <li>{@code iterations} - the {@code ofUserScram.iterations} value. Only stubbed when {@code mechanism} is
+     *       non-null. A {@code null} value models a SQL {@code NULL} (mirrored via {@link ResultSet#wasNull()}).</li>
+     *   <li>{@code salt} - the {@code ofUserScram.salt} value. Only stubbed when {@code mechanism} is non-null.</li>
+     *   <li>{@code storedKey} - the {@code ofUserScram.storedKey} value. Only stubbed when {@code mechanism} is
+     *       non-null.</li>
+     * </ol>
+     *
+     * The {@code serverKey} column (7) is stubbed with a placeholder whenever SCRAM data is present, because
+     * {@code checkPassword} reads it but does not use it for password verification.
+     *
+     * @param plainPassword     stored plaintext password, or {@code null}
+     * @param encryptedPassword stored encrypted password, or {@code null}
+     * @param mechanism         stored SCRAM mechanism name, or {@code null} for no SCRAM row
+     * @param iterations        stored SCRAM iteration count (ignored when {@code mechanism} is {@code null})
+     * @param salt              stored SCRAM salt (ignored when {@code mechanism} is {@code null})
+     * @param storedKey         stored SCRAM stored-key (ignored when {@code mechanism} is {@code null})
+     * @return a mocked single-row {@link ResultSet}
      */
-    private static Connection mockConnection(final PreparedStatement loadPassword, final PreparedStatement loadScram) throws Exception
+    private static ResultSet storedCredentialsRow(final String plainPassword, final String encryptedPassword, final String mechanism, final Integer iterations, final String salt, final String storedKey) throws Exception
     {
+        final ResultSet rs = Mockito.mock(ResultSet.class);
+        when(rs.next()).thenReturn(true, false); // exactly one row, then exhausted
+        when(rs.getString(1)).thenReturn(plainPassword);
+        when(rs.getString(2)).thenReturn(encryptedPassword);
+        when(rs.getString(3)).thenReturn(mechanism);
+        if (mechanism != null) {
+            when(rs.getInt(4)).thenReturn(iterations == null ? 0 : iterations);
+            when(rs.wasNull()).thenReturn(iterations == null);
+            when(rs.getString(5)).thenReturn(salt);
+            when(rs.getString(6)).thenReturn(storedKey);
+            when(rs.getString(7)).thenReturn("server-key-not-used-for-password-check");
+        }
+        return rs;
+    }
+
+    /**
+     * Runs {@link DefaultAuthProvider#checkPassword(String, String)} against a mocked database whose combined
+     * {@code LEFT JOIN} query returns {@code storedCredentials}. This method owns all the shared fixture wiring:
+     * the {@link PreparedStatement}, the {@link Connection}, and the statically-mocked {@link DbConnectionManager}.
+     *
+     * <p>When {@code withDecrypt} is {@code true}, {@link AuthFactory} is also statically mocked so that
+     * {@link AuthFactory#decryptPassword(String) decryptPassword("encrypted-value")} returns {@link #PASSWORD}. Both
+     * static mocks are opened in try-with-resources and closed before this method returns, so no static mock leaks
+     * outside the call.
+     *
+     * @param username          the username to authenticate
+     * @param testPassword      the password to check
+     * @param storedCredentials the mocked row describing what is stored for the user
+     * @param withDecrypt       whether to also mock {@link AuthFactory} to decrypt {@link #ENCRYPTED_VALUE}
+     * @return the result of {@code checkPassword}
+     */
+    @SuppressWarnings("SqlSourceToSinkFlow")
+    private static boolean runCheckPassword(final String username, final String testPassword, final ResultSet storedCredentials, final boolean withDecrypt) throws Exception
+    {
+        final PreparedStatement combinedStmt = Mockito.mock(PreparedStatement.class);
+        when(combinedStmt.executeQuery()).thenReturn(storedCredentials);
+
         final Connection connection = Mockito.mock(Connection.class);
-        when(connection.prepareStatement(anyString())).thenAnswer(invocation -> {
-            final String sql = invocation.getArgument(0, String.class).toLowerCase(Locale.ROOT);
-            return sql.contains("ofuserscram") ? loadScram : loadPassword;
-        });
-        return connection;
-    }
-
-    /**
-     * Configures the {@code ofUser} password lookup to return a single row with no plaintext/encrypted password. A
-     * fresh ResultSet is returned on each executeQuery() so that repeated LOAD_PASSWORD calls (checkPassword's own
-     * lookup and the lookup performed while resolving the SCRAM credential) each see a valid, independent cursor.
-     */
-    private static void stubEmptyPasswordRow(final PreparedStatement loadPassword) throws Exception
-    {
-        when(loadPassword.executeQuery()).thenAnswer(invocation -> {
-            final ResultSet rs = Mockito.mock(ResultSet.class);
-            when(rs.next()).thenReturn(true, false);
-            when(rs.getString(1)).thenReturn(null); // plainPassword
-            when(rs.getString(2)).thenReturn(null); // encryptedPassword
-            return rs;
-        });
-    }
-
-    /**
-     * Verifies that a correct password is accepted by verifying against SCRAM material held in {@code ofUserScram},
-     * and that the {@code ofUserScram} table was actually consulted.
-     */
-    @Test
-    void checkPassword_acceptsCorrectPassword_fromOfUserScram() throws Exception
-    {
-        // Setup test fixture.
-        final PreparedStatement loadPassword = Mockito.mock(PreparedStatement.class);
-        final PreparedStatement loadScram = Mockito.mock(PreparedStatement.class);
-        stubEmptyPasswordRow(loadPassword);
-
-        final ResultSet scramRow = Mockito.mock(ResultSet.class);
-        when(loadScram.executeQuery()).thenReturn(scramRow);
-        when(scramRow.next()).thenReturn(true);
-        when(scramRow.getInt(1)).thenReturn(ITERATIONS);
-        when(scramRow.getString(2)).thenReturn(SALT_BASE64);
-        when(scramRow.getString(3)).thenReturn(storedKeyFor(PASSWORD));
-        when(scramRow.getString(4)).thenReturn("server-key-not-used-for-password-check");
-
-        final Connection connection = mockConnection(loadPassword, loadScram);
+        when(connection.prepareStatement(argThat(sql -> {
+            final String s = sql.toLowerCase(Locale.ROOT);
+            return s.contains("from ofuser") && s.contains("left join ofuserscram");
+        }))).thenReturn(combinedStmt);
 
         try (final MockedStatic<DbConnectionManager> db = Mockito.mockStatic(DbConnectionManager.class)) {
             db.when(DbConnectionManager::getConnection).thenReturn(connection);
-
-            // Execute system under test.
-            final DefaultAuthProvider provider = new DefaultAuthProvider();
-            final boolean result = provider.checkPassword("user", PASSWORD);
-
-            // Verify result.
-            assertTrue(result, "A correct password should verify against SCRAM material stored in ofUserScram.");
-            verify(connection, atLeastOnce()).prepareStatement(
-                ArgumentMatchers.argThat(sql -> sql != null && sql.toLowerCase(Locale.ROOT).contains("ofuserscram")));
+            if (withDecrypt) {
+                try (final MockedStatic<AuthFactory> authFactory = Mockito.mockStatic(AuthFactory.class)) {
+                    authFactory.when(() -> AuthFactory.decryptPassword(ENCRYPTED_VALUE)).thenReturn(PASSWORD);
+                    return new DefaultAuthProvider().checkPassword(username, testPassword);
+                }
+            }
+            return new DefaultAuthProvider().checkPassword(username, testPassword);
         }
+    }
+
+    /**
+     * Convenience overload for the common case where {@link AuthFactory} does not need to be mocked.
+     */
+    private static boolean runCheckPassword(final String username, final String testPassword, final ResultSet storedCredentials) throws Exception
+    {
+        return runCheckPassword(username, testPassword, storedCredentials, false);
+    }
+
+    /**
+     * Verifies that a correct password is accepted by verifying against SCRAM material held in {@code ofUserScram}.
+     */
+    @Test
+    void checkPassword_acceptsMatchingScramCredential() throws Exception
+    {
+        // Setup test fixture.
+        final String plainPassword = null;
+        final String encryptedPassword = null;
+        final String mechanism = ScramSha1SaslServer.MECHANISM_NAME;
+        final String storedKey = storedKeyFor(PASSWORD);
+        final ResultSet storedCredentials = storedCredentialsRow(plainPassword, encryptedPassword, mechanism, ITERATIONS, SALT_BASE64, storedKey);
+
+        // Execute system under test.
+        final boolean result = runCheckPassword("user", PASSWORD, storedCredentials);
+
+        // Verify result.
+        assertTrue(result, "Correct password should verify against SCRAM-SHA-1.");
     }
 
     /**
      * Verifies that an incorrect password is rejected when checked against SCRAM material in {@code ofUserScram}.
      */
     @Test
-    void checkPassword_rejectsIncorrectPassword_fromOfUserScram() throws Exception
+    void checkPassword_rejectsNonMatchingScramCredential() throws Exception
     {
         // Setup test fixture.
-        final PreparedStatement loadPassword = Mockito.mock(PreparedStatement.class);
-        final PreparedStatement loadScram = Mockito.mock(PreparedStatement.class);
-        stubEmptyPasswordRow(loadPassword);
+        final String plainPassword = null;
+        final String encryptedPassword = null;
+        final String mechanism = ScramSha1SaslServer.MECHANISM_NAME;
+        final String storedKey = storedKeyFor(PASSWORD);
+        final ResultSet storedCredentials = storedCredentialsRow(plainPassword, encryptedPassword, mechanism, ITERATIONS, SALT_BASE64, storedKey);
 
-        final ResultSet scramRow = Mockito.mock(ResultSet.class);
-        when(loadScram.executeQuery()).thenReturn(scramRow);
-        when(scramRow.next()).thenReturn(true);
-        when(scramRow.getInt(1)).thenReturn(ITERATIONS);
-        when(scramRow.getString(2)).thenReturn(SALT_BASE64);
-        when(scramRow.getString(3)).thenReturn(storedKeyFor(PASSWORD)); // stored key for the *correct* password
-        when(scramRow.getString(4)).thenReturn("server-key-not-used-for-password-check");
+        // Execute system under test.
+        final boolean result = runCheckPassword("user", "not-the-password", storedCredentials);
 
-        final Connection connection = mockConnection(loadPassword, loadScram);
+        // Verify result.
+        assertFalse(result, "Incorrect password should be rejected against SCRAM-SHA-1.");
+    }
 
-        try (final MockedStatic<DbConnectionManager> db = Mockito.mockStatic(DbConnectionManager.class)) {
-            db.when(DbConnectionManager::getConnection).thenReturn(connection);
+    /**
+     * Verifies that a correct plaintext password is accepted when ONLY plaintext password exists.
+     */
+    @Test
+    void checkPassword_acceptsMatchingPlaintextPassword() throws Exception
+    {
+        // Setup test fixture.
+        final String plainPassword = PASSWORD;
+        final String encryptedPassword = null;
+        final String mechanism = null; // no SCRAM row
+        final ResultSet storedCredentials = storedCredentialsRow(plainPassword, encryptedPassword, mechanism, null, null, null);
 
-            // Execute system under test.
-            final DefaultAuthProvider provider = new DefaultAuthProvider();
-            final boolean result = provider.checkPassword("user", "not-the-password");
+        // Execute system under test.
+        final boolean result = runCheckPassword("user", PASSWORD, storedCredentials);
 
-            // Verify result.
-            assertFalse(result, "An incorrect password must not verify against SCRAM material stored in ofUserScram.");
-        }
+        // Verify result.
+        assertTrue(result, "Correct plaintext password should be accepted.");
+    }
+
+    /**
+     * Verifies that an incorrect plaintext password is rejected.
+     */
+    @Test
+    void checkPassword_rejectsNonMatchingPlaintextPassword() throws Exception
+    {
+        // Setup test fixture.
+        final String plainPassword = PASSWORD;
+        final String encryptedPassword = null;
+        final String mechanism = null; // no SCRAM row
+        final ResultSet storedCredentials = storedCredentialsRow(plainPassword, encryptedPassword, mechanism, null, null, null);
+
+        // Execute system under test.
+        final boolean result = runCheckPassword("user", "wrong-password", storedCredentials);
+
+        // Verify result.
+        assertFalse(result, "Incorrect plaintext password should be rejected.");
+    }
+
+    /**
+     * Verifies that a correct password is accepted when ONLY encrypted password exists.
+     */
+    @Test
+    void checkPassword_acceptsMatchingEncryptedPassword() throws Exception
+    {
+        // Setup test fixture.
+        final String plainPassword = null;
+        final String encryptedPassword = ENCRYPTED_VALUE;
+        final String mechanism = null; // no SCRAM row
+        final ResultSet storedCredentials = storedCredentialsRow(plainPassword, encryptedPassword, mechanism, null, null, null);
+
+        // Execute system under test.
+        final boolean result = runCheckPassword("user", PASSWORD, storedCredentials, true);
+
+        // Verify result.
+        assertTrue(result, "Correct password decrypted from encrypted value should be accepted.");
+    }
+
+    /**
+     * Verifies that an incorrect password is rejected against encrypted password.
+     */
+    @Test
+    void checkPassword_rejectsNonMatchingEncryptedPassword() throws Exception
+    {
+        // Setup test fixture.
+        final String plainPassword = null;
+        final String encryptedPassword = ENCRYPTED_VALUE;
+        final String mechanism = null; // no SCRAM row
+        final ResultSet storedCredentials = storedCredentialsRow(plainPassword, encryptedPassword, mechanism, null, null, null);
+
+        // Execute system under test.
+        final boolean result = runCheckPassword("user", "wrong-password", storedCredentials, true);
+
+        // Verify result.
+        assertFalse(result, "Incorrect password should be rejected against decrypted password.");
+    }
+
+    /**
+     * Verifies that missing credentials return false (not an exception).
+     */
+    @Test
+    void checkPassword_returnsFalseWhenNoCredentialsExist() throws Exception
+    {
+        // Setup test fixture.
+        final String plainPassword = null;
+        final String encryptedPassword = null;
+        final String mechanism = null; // no SCRAM row
+        final ResultSet storedCredentials = storedCredentialsRow(plainPassword, encryptedPassword, mechanism, null, null, null);
+
+        // Execute system under test.
+        final boolean result = runCheckPassword("user", PASSWORD, storedCredentials);
+
+        // Verify result.
+        assertFalse(result, "Should return false when no credentials exist (not throw exception).");
+    }
+
+    /**
+     * Verifies that a SCRAM row missing a required column (here a null salt) is treated as unusable and rejected,
+     * rather than being used to derive a stored key. Production guards this with an explicit null/zero check.
+     */
+    @Test
+    void checkPassword_rejectsIncompleteScramCredential() throws Exception
+    {
+        // Setup test fixture.
+        final String plainPassword = null;
+        final String encryptedPassword = null;
+        final String mechanism = ScramSha1SaslServer.MECHANISM_NAME;
+        final String salt = null; // corrupt/partial SCRAM row: required column missing
+        final String storedKey = storedKeyFor(PASSWORD);
+        final ResultSet storedCredentials = storedCredentialsRow(plainPassword, encryptedPassword, mechanism, ITERATIONS, salt, storedKey);
+
+        // Execute system under test.
+        final boolean result = runCheckPassword("user", PASSWORD, storedCredentials);
+
+        // Verify result.
+        assertFalse(result, "A SCRAM credential missing a required column should be rejected.");
+    }
+
+    /**
+     * Verifies that a SCRAM row with a zero iteration count is treated as unusable and rejected. Production explicitly
+     * rejects {@code iterations == 0} rather than attempting a (meaningless) zero-iteration derivation.
+     */
+    @Test
+    void checkPassword_rejectsScramCredentialWithZeroIterations() throws Exception
+    {
+        // Setup test fixture.
+        final String plainPassword = null;
+        final String encryptedPassword = null;
+        final String mechanism = ScramSha1SaslServer.MECHANISM_NAME;
+        final int iterations = 0; // unusable iteration count
+        final String storedKey = storedKeyFor(PASSWORD);
+        final ResultSet storedCredentials = storedCredentialsRow(plainPassword, encryptedPassword, mechanism, iterations, SALT_BASE64, storedKey);
+
+        // Execute system under test.
+        final boolean result = runCheckPassword("user", PASSWORD, storedCredentials);
+
+        // Verify result.
+        assertFalse(result, "A SCRAM credential with zero iterations should be rejected.");
+    }
+
+    /**
+     * Verifies that an empty password does not authenticate against a real (non-empty) SCRAM credential.
+     */
+    @Test
+    void checkPassword_rejectsEmptyPasswordAgainstScramCredential() throws Exception
+    {
+        // Setup test fixture.
+        final String plainPassword = null;
+        final String encryptedPassword = null;
+        final String mechanism = ScramSha1SaslServer.MECHANISM_NAME;
+        final String storedKey = storedKeyFor(PASSWORD);
+        final ResultSet storedCredentials = storedCredentialsRow(plainPassword, encryptedPassword, mechanism, ITERATIONS, SALT_BASE64, storedKey);
+
+        // Execute system under test.
+        final boolean result = runCheckPassword("user", "", storedCredentials);
+
+        // Verify result.
+        assertFalse(result, "An empty password should not verify against a non-empty SCRAM credential.");
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/AbstractScramCredentialObfuscationTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/AbstractScramCredentialObfuscationTest.java
@@ -99,8 +99,8 @@ public abstract class AbstractScramCredentialObfuscationTest
     void setUp()
     {
         authFactoryMock = Mockito.mockStatic(AuthFactory.class);
-        authFactoryMock.when(() -> AuthFactory.getSalt(EXISTENT_USER)).thenReturn(configuredUserSalt());
-        authFactoryMock.when(() -> AuthFactory.getSalt(NON_EXISTENT_USER)).thenThrow(new UserNotFoundException(NON_EXISTENT_USER));
+        authFactoryMock.when(() -> AuthFactory.getSalt(EXISTENT_USER, ScramSha1SaslServer.MECHANISM_NAME)).thenReturn(configuredUserSalt());
+        authFactoryMock.when(() -> AuthFactory.getSalt(NON_EXISTENT_USER, ScramSha1SaslServer.MECHANISM_NAME)).thenThrow(new UserNotFoundException(NON_EXISTENT_USER));
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
@@ -46,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -83,11 +84,11 @@ public class ScramSha1SaslServerTest extends AbstractScramSaslServerTest
     @Override
     protected void setupCanonicalAuthData()
     {
-        authFactory.when(() -> AuthFactory.getSalt(any())).thenReturn(ScramSha1TestFixtures.SALT);
-        authFactory.when(() -> AuthFactory.getIterations(any())).thenReturn(ScramSha1TestFixtures.ITERATIONS);
+        authFactory.when(() -> AuthFactory.getSalt(anyString(), anyString())).thenReturn(ScramSha1TestFixtures.SALT);
+        authFactory.when(() -> AuthFactory.getIterations(anyString(), anyString())).thenReturn(ScramSha1TestFixtures.ITERATIONS);
         authFactory.when(() -> AuthFactory.getPassword(any())).thenReturn(ScramSha1TestFixtures.PASSWORD);
-        authFactory.when(() -> AuthFactory.getStoredKey(any())).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.STORED_KEY_HEX)));
-        authFactory.when(() -> AuthFactory.getServerKey(any())).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.SERVER_KEY_HEX)));
+        authFactory.when(() -> AuthFactory.getStoredKey(anyString(), anyString())).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.STORED_KEY_HEX)));
+        authFactory.when(() -> AuthFactory.getServerKey(anyString(), anyString())).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.SERVER_KEY_HEX)));
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
@@ -45,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -84,11 +85,11 @@ public class ScramSha1SaslServerTest extends AbstractScramSaslServerTest
     @Override
     protected void setupCanonicalAuthData()
     {
-        authFactory.when(() -> AuthFactory.getSalt(anyString(), anyString())).thenReturn(ScramSha1TestFixtures.SALT);
-        authFactory.when(() -> AuthFactory.getIterations(anyString(), anyString())).thenReturn(ScramSha1TestFixtures.ITERATIONS);
+        authFactory.when(() -> AuthFactory.getSalt(anyString(), eq(ScramSha1TestFixtures.MECHANISM))).thenReturn(ScramSha1TestFixtures.SALT);
+        authFactory.when(() -> AuthFactory.getIterations(anyString(), eq(ScramSha1TestFixtures.MECHANISM))).thenReturn(ScramSha1TestFixtures.ITERATIONS);
         authFactory.when(() -> AuthFactory.getPassword(any())).thenReturn(ScramSha1TestFixtures.PASSWORD);
-        authFactory.when(() -> AuthFactory.getStoredKey(anyString(), anyString())).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.STORED_KEY_HEX)));
-        authFactory.when(() -> AuthFactory.getServerKey(anyString(), anyString())).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.SERVER_KEY_HEX)));
+        authFactory.when(() -> AuthFactory.getStoredKey(anyString(), eq(ScramSha1TestFixtures.MECHANISM))).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.STORED_KEY_HEX)));
+        authFactory.when(() -> AuthFactory.getServerKey(anyString(), eq(ScramSha1TestFixtures.MECHANISM))).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.SERVER_KEY_HEX)));
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/user/DefaultUserProviderScramStorageTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/user/DefaultUserProviderScramStorageTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.user;
+
+import org.jivesoftware.Fixtures;
+import org.jivesoftware.database.DbConnectionManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that {@link DefaultUserProvider#loadUser(String)} sources a user's descriptive fields from {@code ofUser} and
+ * its SCRAM-SHA-1 credential fields from the dedicated {@code ofUserScram} table.
+ *
+ * Prior to the storage refactor, the SCRAM columns lived on {@code ofUser} and were selected in the same query. They
+ * now live in {@code ofUserScram}, keyed by {@code (username, mechanism)}, and are loaded via a second query. A user
+ * without a SCRAM row (for example, the admin account during initial auto-setup, before any password has been set) must
+ * still load successfully, with the SCRAM fields left unset. That case is the one that regressed during development: the
+ * old query selected columns that no longer existed, causing a hard failure at server startup.
+ */
+@SuppressWarnings("removal") // User's SCRAM accessors are deprecated for removal; this test verifies loadUser still populates them until removed.
+public class DefaultUserProviderScramStorageTest
+{
+    @BeforeAll
+    public static void setupClass() throws Exception
+    {
+        Fixtures.reconfigureOpenfireHome();
+        Fixtures.disableDatabasePersistence();
+    }
+
+    /**
+     * Builds a mock Connection whose prepareStatement() dispatches to the SCRAM-credential statement or the user
+     * statement based on whether the SQL references {@code ofUserScram}.
+     */
+    private static Connection mockConnection(final PreparedStatement loadUser, final PreparedStatement loadScram) throws Exception
+    {
+        final Connection connection = Mockito.mock(Connection.class);
+        when(connection.prepareStatement(anyString())).thenAnswer(invocation -> {
+            final String sql = invocation.getArgument(0, String.class).toLowerCase(Locale.ROOT);
+            return sql.contains("ofuserscram") ? loadScram : loadUser;
+        });
+        return connection;
+    }
+
+    /**
+     * Stubs the {@code ofUser} lookup to return a single row of descriptive fields: name, email, creationDate,
+     * modificationDate. The dates are Openfire's millisecond-string format.
+     */
+    private static void stubUserRow(final PreparedStatement loadUser, final String name, final String email) throws Exception
+    {
+        final ResultSet userRow = Mockito.mock(ResultSet.class);
+        when(loadUser.executeQuery()).thenReturn(userRow);
+        when(userRow.next()).thenReturn(true);
+        when(userRow.getString(1)).thenReturn(name);            // name
+        when(userRow.getString(2)).thenReturn(email);           // email
+        when(userRow.getString(3)).thenReturn("1000");          // creationDate (millis)
+        when(userRow.getString(4)).thenReturn("2000");          // modificationDate (millis)
+    }
+
+    /**
+     * Verifies that when an {@code ofUserScram} row exists, its salt, serverKey, storedKey and iterations are hydrated
+     * onto the returned {@link User}.
+     */
+    @Test
+    void loadUser_populatesScramFieldsFromOfUserScram() throws Exception
+    {
+        // Setup test fixture.
+        final PreparedStatement loadUser = Mockito.mock(PreparedStatement.class);
+        final PreparedStatement loadScram = Mockito.mock(PreparedStatement.class);
+        stubUserRow(loadUser, "Test User", "user@example.org");
+
+        final ResultSet scramRow = Mockito.mock(ResultSet.class);
+        when(loadScram.executeQuery()).thenReturn(scramRow);
+        when(scramRow.next()).thenReturn(true);
+        when(scramRow.getString(1)).thenReturn("salt-value");   // salt
+        when(scramRow.getString(2)).thenReturn("server-key");   // serverKey
+        when(scramRow.getString(3)).thenReturn("stored-key");   // storedKey
+        when(scramRow.getInt(4)).thenReturn(4096);              // iterations
+
+        final Connection connection = mockConnection(loadUser, loadScram);
+
+        try (final MockedStatic<DbConnectionManager> db = Mockito.mockStatic(DbConnectionManager.class)) {
+            db.when(DbConnectionManager::getConnection).thenReturn(connection);
+
+            // Execute system under test.
+            final DefaultUserProvider provider = new DefaultUserProvider();
+            final User user = provider.loadUser("user");
+
+            // Verify result.
+            assertEquals("salt-value", user.getSalt(), "User salt should be sourced from ofUserScram.");
+            assertEquals("server-key", user.getServerKey(), "User server key should be sourced from ofUserScram.");
+            assertEquals("stored-key", user.getStoredKey(), "User stored key should be sourced from ofUserScram.");
+            assertEquals(4096, user.getIterations(), "User iteration count should be sourced from ofUserScram.");
+        }
+    }
+
+    /**
+     * Verifies that a user with no {@code ofUserScram} row loads successfully, with SCRAM fields left unset. This is the
+     * auto-setup / admin case: the account exists in {@code ofUser} but has no SCRAM credential yet, and must not cause
+     * loadUser to fail.
+     */
+    @Test
+    void loadUser_succeedsWithoutScramRow() throws Exception
+    {
+        // Setup test fixture.
+        final PreparedStatement loadUser = Mockito.mock(PreparedStatement.class);
+        final PreparedStatement loadScram = Mockito.mock(PreparedStatement.class);
+        stubUserRow(loadUser, "Admin", "admin@example.org");
+
+        final ResultSet scramRow = Mockito.mock(ResultSet.class);
+        when(loadScram.executeQuery()).thenReturn(scramRow);
+        when(scramRow.next()).thenReturn(false); // no SCRAM credential for this user
+
+        final Connection connection = mockConnection(loadUser, loadScram);
+
+        try (final MockedStatic<DbConnectionManager> db = Mockito.mockStatic(DbConnectionManager.class)) {
+            db.when(DbConnectionManager::getConnection).thenReturn(connection);
+
+            // Execute system under test.
+            final DefaultUserProvider provider = new DefaultUserProvider();
+            final User user = provider.loadUser("admin");
+
+            // Verify result.
+            assertEquals("Admin", user.getName(), "User without a SCRAM row should still load its descriptive fields.");
+            assertNull(user.getSalt(), "Salt should be unset when the user has no ofUserScram row.");
+            assertNull(user.getServerKey(), "Server key should be unset when the user has no ofUserScram row.");
+            assertNull(user.getStoredKey(), "Stored key should be unset when the user has no ofUserScram row.");
+            assertEquals(0, user.getIterations(), "Iteration count should default to 0 when the user has no ofUserScram row.");
+        }
+    }
+}


### PR DESCRIPTION
Openfire stores SCRAM credentials (`storedKey`, `serverKey`, `salt`, `iterations`) as columns on the `ofUser` table. This hard-codes the assumption that a user has exactly one SCRAM credential (which is SCRAM-SHA-1). Supporting additional mechanisms (SCRAM-SHA-256, SCRAM-SHA-512) requires storing more than one credential per user.

This change relocates SCRAM credentials to a new ofUserScram table keyed by (`username`, `mechanism`), without adding any new mechanism. Behavior is intended to be identical to before: SCRAM-SHA-1 remains the only mechanism written or read, and credentials are still regenerated from a stored plaintext/encrypted password when absent. This is a storage refactor only; it is a precursor to a follow-up change that adds the additional SCRAM mechanisms, kept separate so that the schema migration and the new-mechanism logic can be reviewed independently.

This commit introduces a new ofUserScram table added to all base install scripts, and a two-step migration:

1. upgrade script 39 creates `ofUserScram` and copies existing SHA-1 credentials from `ofUser`
2.  upgrade script 40 drops the old columns from ofUser.

`User`'s `getSalt`/`getStoredKey`/`getServerKey`/`getIterations` accessors (and their setters) expose only the single SCRAM-SHA-1 credential and have no role in the per-mechanism model. They are marked `@Deprecated` and retained for backwards compatibility with third-party integrations.

`AuthProvider`, `AuthMultiProvider` and `AuthFactory` gain mechanism-aware SCRAM accessors. the existing single-argument methods are retained and delegate to SCRAM-SHA-1, and marked as `@Deprecated`.