### PR TITLE
OF-3325: Publish container images on tags

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1247,7 +1247,7 @@ jobs:
     name: Publish to GitHub's Docker registry
     runs-on: ubuntu-latest
     needs: [build-docker, aioxmpp, connectivity, integration, xitf, check_branch, hsqldb-install, hsqldb-upgrade, sqlserver-install, sqlserver-upgrade, postgres-install, postgres-upgrade, cockroachdb-install, cockroachdb-upgrade, firebird-install, firebird-upgrade, mysql-install, mysql-upgrade, mariadb-install, mariadb-upgrade, oracle-install, oracle-upgrade]
-    if: ${{ github.event_name == 'push' && needs.check_branch.outputs.is_publishable_branch == 'true' }}
+    if: ${{ github.repository == 'igniterealtime/Openfire' && github.event_name == 'push' && needs.check_branch.outputs.is_publishable_branch == 'true' }}
 
     permissions:
       contents: read

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -250,7 +250,7 @@ jobs:
       is_publishable_branch: ${{ steps.check-branch.outputs.is_publishable_branch }}
       branch_tag: ${{ steps.check-branch.outputs.branch_tag }}
     steps:
-      - name: check branch ${{ github.ref }} is either main or a version number
+      - name: check if ${{ github.ref }} is main, a version branch, or a version tag
         id: check-branch
         run: |
           if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -256,11 +256,11 @@ jobs:
           if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
             echo "is_publishable_branch=true" >> "${GITHUB_OUTPUT}"
             echo "branch_tag=development" >> "${GITHUB_OUTPUT}"
-          elif [[ ${{ github.ref }} =~ refs\/heads\/[0-9]+\.[0-9]+ ]]; then
+          elif [[ ${{ github.ref }} =~ ^refs\/heads\/[0-9]+\.[0-9]+$ ]]; then
             echo "is_publishable_branch=true" >> "${GITHUB_OUTPUT}"
             echo -n "branch_tag=" >> "${GITHUB_OUTPUT}"
             echo "${{ github.ref }}" | sed -e 's!refs/heads/!!' >> "${GITHUB_OUTPUT}"
-          elif [[ ${{ github.ref }} =~ refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          elif [[ ${{ github.ref }} =~ ^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "is_publishable_branch=true" >> "${GITHUB_OUTPUT}"
             echo -n "branch_tag=" >> "${GITHUB_OUTPUT}"
             echo "${{ github.ref }}" | sed -e 's!refs/tags/!!' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -260,6 +260,10 @@ jobs:
             echo "is_publishable_branch=true" >> "${GITHUB_OUTPUT}"
             echo -n "branch_tag=" >> "${GITHUB_OUTPUT}"
             echo "${{ github.ref }}" | sed -e 's!refs/heads/!!' >> "${GITHUB_OUTPUT}"
+          elif [[ ${{ github.ref }} =~ refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_publishable_branch=true" >> "${GITHUB_OUTPUT}"
+            echo -n "branch_tag=" >> "${GITHUB_OUTPUT}"
+            echo "${{ github.ref }}" | sed -e 's!refs/tags/!!' >> "${GITHUB_OUTPUT}"
           else
             echo "is_publishable_branch=false" >> "${GITHUB_OUTPUT}"
             echo "branch_tag=rando" >> "${GITHUB_OUTPUT}"
@@ -1243,9 +1247,7 @@ jobs:
     name: Publish to GitHub's Docker registry
     runs-on: ubuntu-latest
     needs: [build-docker, aioxmpp, connectivity, integration, xitf, check_branch, hsqldb-install, hsqldb-upgrade, sqlserver-install, sqlserver-upgrade, postgres-install, postgres-upgrade, cockroachdb-install, cockroachdb-upgrade, firebird-install, firebird-upgrade, mysql-install, mysql-upgrade, mariadb-install, mariadb-upgrade, oracle-install, oracle-upgrade]
-    if: |
-      github.event_name == 'push' && 
-      (contains(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')
+    if: ${{ github.event_name == 'push' && needs.check_branch.outputs.is_publishable_branch == 'true' }}
 
     permissions:
       contents: read


### PR DESCRIPTION
This GitHub actions change will enable tag pushes to publish images. Previously, a gate existed to do it on the publish_docker job, but the job was gated on other jobs that wouldn't be run for a tag.

It'll still run on main, but also every tag and every commit to a version number branch. This change alters what a publishable branch is, so will also affect publish-maven in the same way.