### PR TITLE
OF-3327: Parameterize existing SCRAM implementation

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -348,9 +348,9 @@ public class DefaultAuthProvider implements AuthProvider {
             final byte[] testStoredKey;
             try {
                 final byte[] saltShaker = DatatypeConverter.parseBase64Binary(credential.salt);
-                final byte[] saltedPassword = ScramUtils.createSaltedPassword(saltShaker, testPassword, credential.iterations);
-                final byte[] clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
-                testStoredKey = MessageDigest.getInstance("SHA-1").digest(clientKey);
+                final byte[] saltedPassword = ScramUtils.createSaltedPassword(saltShaker, testPassword, credential.iterations, ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
+                final byte[] clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key", ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
+                testStoredKey = MessageDigest.getInstance(ScramSha1SaslServer.DIGEST_ALGORITHM_NAME).digest(clientKey);
             } catch(SaslException | NoSuchAlgorithmException | IllegalArgumentException e) {
                 Log.warn("Unable to check SCRAM values for PLAIN authentication for user '{}'", username, e);
                 return false;
@@ -391,10 +391,10 @@ public class DefaultAuthProvider implements AuthProvider {
         final int iterations = ScramSha1SaslServer.ITERATION_COUNT.getValue();
         byte[] saltedPassword = null, clientKey = null, storedKey = null, serverKey = null;
         try {
-            saltedPassword = ScramUtils.createSaltedPassword(saltShaker, password, iterations);
-            clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
-            storedKey = MessageDigest.getInstance("SHA-1").digest(clientKey);
-            serverKey = ScramUtils.computeHmac(saltedPassword, "Server Key");
+            saltedPassword = ScramUtils.createSaltedPassword(saltShaker, password, iterations, ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
+            clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key", ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
+            storedKey = MessageDigest.getInstance(ScramSha1SaslServer.DIGEST_ALGORITHM_NAME).digest(clientKey);
+            serverKey = ScramUtils.computeHmac(saltedPassword, "Server Key", ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
         } catch (SaslException | NoSuchAlgorithmException e) {
             Log.warn("Unable to persist values for SCRAM authentication.");
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -405,13 +405,19 @@ public class DefaultAuthProvider implements AuthProvider {
                 plaintextToStore = null;
             }
             catch (UnsupportedOperationException uoe) {
-                // Encryption may fail. In that case, ignore the error and
-                // the plain password will be stored.
+                Log.warn("Unable to encrypt password for user '{}' while updating password. Plain-text authentication will remain available.", username, uoe);
             }
         }
         if (scramOnly) {
             encryptedPassword = null;
             plaintextToStore = null;
+        }
+
+        if (scramOnly && keys == null) {
+            // In scramOnly mode SCRAM is the only stored credential. If none could be derived, committing would
+            // leave the user with no usable credential of any kind (locked out), so refuse rather than persist that.
+            Log.error("Unable to derive any SCRAM credential for user '{}' while user.scramHashedPasswordOnly is set; refusing to store a credential-less password.", username);
+            throw new UserNotFoundException("No SCRAM credentials could be derived (while configured in SCRAM-only mode) for user " + username);
         }
 
         // Persist the ofUser password row and the ofUserScram credential row atomically: because these now live in

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -16,7 +16,6 @@
 
 package org.jivesoftware.openfire.auth;
 
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.sql.Connection;
@@ -345,17 +344,16 @@ public class DefaultAuthProvider implements AuthProvider {
                 Log.debug("No available SCRAM-SHA-1 credentials for checkPassword for user {}", username);
                 return false;
             }
-            final byte[] testStoredKey;
             try {
                 final byte[] saltShaker = DatatypeConverter.parseBase64Binary(credential.salt);
-                final byte[] saltedPassword = ScramUtils.createSaltedPassword(saltShaker, testPassword, credential.iterations, ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
-                final byte[] clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key", ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
-                testStoredKey = MessageDigest.getInstance(ScramSha1SaslServer.DIGEST_ALGORITHM_NAME).digest(clientKey);
+                final ScramUtils.ScramKeys keys = ScramUtils.deriveScramKeys(
+                    saltShaker, testPassword, credential.iterations,
+                    ScramSha1SaslServer.HMAC_ALGORITHM_NAME, ScramSha1SaslServer.DIGEST_ALGORITHM_NAME);
+                return DatatypeConverter.printBase64Binary(keys.storedKey).equals(credential.storedKey);
             } catch(SaslException | NoSuchAlgorithmException | IllegalArgumentException e) {
                 Log.warn("Unable to check SCRAM values for PLAIN authentication for user '{}'", username, e);
                 return false;
             }
-            return DatatypeConverter.printBase64Binary(testStoredKey).equals(credential.storedKey);
         }
         catch (SQLException sqle) {
             Log.warn("A database error occurred while authenticating user {}:", username, sqle);
@@ -388,15 +386,15 @@ public class DefaultAuthProvider implements AuthProvider {
         byte[] saltShaker = new byte[SALT_LENGTH];
         random.nextBytes(saltShaker);
         final String salt = DatatypeConverter.printBase64Binary(saltShaker);
+        ScramUtils.ScramKeys keys = null;
         final int iterations = ScramSha1SaslServer.ITERATION_COUNT.getValue();
-        byte[] saltedPassword = null, clientKey = null, storedKey = null, serverKey = null;
         try {
-            saltedPassword = ScramUtils.createSaltedPassword(saltShaker, password, iterations, ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
-            clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key", ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
-            storedKey = MessageDigest.getInstance(ScramSha1SaslServer.DIGEST_ALGORITHM_NAME).digest(clientKey);
-            serverKey = ScramUtils.computeHmac(saltedPassword, "Server Key", ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
+            keys = ScramUtils.deriveScramKeys(
+                saltShaker, password, iterations,
+                ScramSha1SaslServer.HMAC_ALGORITHM_NAME,
+                ScramSha1SaslServer.DIGEST_ALGORITHM_NAME);
         } catch (SaslException | NoSuchAlgorithmException e) {
-            Log.warn("Unable to persist values for SCRAM authentication.");
+            Log.warn("Unable to derive SCRAM credential while trying to persist values for SCRAM authentication", e);
         }
 
         String plaintextToStore = password;
@@ -453,8 +451,8 @@ public class DefaultAuthProvider implements AuthProvider {
                     ScramSha1SaslServer.MECHANISM_NAME,
                     salt,
                     iterations,
-                    storedKey == null ? null : DatatypeConverter.printBase64Binary(storedKey),
-                    serverKey == null ? null : DatatypeConverter.printBase64Binary(serverKey)
+                    keys == null ? null : DatatypeConverter.printBase64Binary(keys.storedKey),
+                    keys == null ? null : DatatypeConverter.printBase64Binary(keys.serverKey)
                 )
             );
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/DefaultAuthProvider.java
@@ -24,12 +24,16 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.IntSupplier;
 
 import javax.security.sasl.SaslException;
 import javax.xml.bind.DatatypeConverter;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
@@ -48,6 +52,18 @@ import org.slf4j.LoggerFactory;
  * @author Matt Tucker
  */
 public class DefaultAuthProvider implements AuthProvider {
+
+    /**
+     * Describes a SCRAM mechanism for credential derivation: its storage name, JCA algorithm names, and iteration-count source.
+     */
+    private record ScramMechanism(String mechanismName, String hmacAlgorithm, String digestAlgorithm, IntSupplier iterationCount) {}
+
+    /**
+     * Mechanisms supported by this AuthProvider implementation (not necessarily supported at runtime, or by other parts of Openfire).
+     */
+    private static final List<ScramMechanism> SCRAM_MECHANISMS = List.of(
+        new ScramMechanism(ScramSha1SaslServer.MECHANISM_NAME,   ScramSha1SaslServer.HMAC_ALGORITHM_NAME,   ScramSha1SaslServer.DIGEST_ALGORITHM_NAME,   ScramSha1SaslServer.ITERATION_COUNT::getValue)
+    );
 
     /**
      * The length of the salt used to generate salted passwords.
@@ -118,8 +134,13 @@ public class DefaultAuthProvider implements AuthProvider {
             }
             if (!recurse) {
                 if (userInfo.plainText != null) {
+                    // Regenerate SCRAM credentials from the plaintext when a supported mechanism's row is missing
+                    // (e.g. a legacy user predating SCRAM-SHA-256). Note (OF-3322): setPassword() skips any mechanism
+                    // whose derivation fails, so a mechanism that can never be derived here would trigger this on every
+                    // login. Bounded by 'recurse' (no infinite loop); accepted as a per-login cost since derivation
+                    // failure for a JVM-standard mechanism isn't expected.
                     boolean scramOnly = JiveGlobals.getBooleanProperty("user.scramHashedPasswordOnly");
-                    if (scramOnly || !hasScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME)) {
+                    if (scramOnly || hasIncompleteSetOfScramCredentials(username)) {
                         // If we have a password here, but we're meant to be scramOnly, we should reset it.
                         setPassword(username, userInfo.plainText);
                         // RECURSE
@@ -137,6 +158,25 @@ public class DefaultAuthProvider implements AuthProvider {
         finally {
             DbConnectionManager.closeConnection(rs, pstmt, con);
         }
+    }
+
+    /**
+     * Determines whether this user is missing a credential for any SCRAM mechanism supported by this implementation.
+     *
+     * @param username the user identifier
+     * @return true if at least one supported mechanism has no stored credential for this user; false if all are present
+     */
+    @VisibleForTesting
+    boolean hasIncompleteSetOfScramCredentials(String username)
+    {
+        return SCRAM_MECHANISMS.stream().anyMatch(m -> {
+            try {
+                return !hasScramCredential(username, m.mechanismName());
+            } catch (SQLException e) {
+                Log.warn("Unable to determine if credentials for SCRAM mechanism '{}' are available for user '{}' due to a database error.", m.mechanismName(), username, e);
+                return false; // treat as "not known to be missing" so a DB hiccup doesn't force a regeneration storm
+            }
+        });
     }
 
     @Override
@@ -166,14 +206,14 @@ public class DefaultAuthProvider implements AuthProvider {
     /**
      * Returns SCRAM credentials for a user and mechanism.
      *
-     * Only {@code SCRAM-SHA-1} is supported. When SHA-1 credentials are missing but a plaintext (or decryptable)
-     * password is available, the credentials are regenerated (preserving the historical behavior of this provider).
+     * When SCRAM credentials are missing but a plaintext (or decryptable) password is available, the credentials are
+     * regenerated (preserving the historical behavior of this provider).
      */
     @Override
     public ScramCredentialData getScramCredential(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
     {
         final String normalizedMechanism = ScramCredentialData.normalizeMechanismName(mechanism);
-        if (!ScramSha1SaslServer.MECHANISM_NAME.equals(normalizedMechanism)) {
+        if (SCRAM_MECHANISMS.stream().noneMatch(m -> m.mechanismName().equals(normalizedMechanism))) {
             throw new UnsupportedOperationException("SCRAM mechanism is not supported: " + mechanism);
         }
 
@@ -338,22 +378,30 @@ public class DefaultAuthProvider implements AuthProvider {
                 credentialsByMechanismName.put(scram.mechanism, scram);
             } while (rs.next());
 
-            // TODO: When supporting more than just SCRAM-SHA-1, drop this. This got introduced in a commit that refactored the existing storage solution, prior to implementing support for additional mechanisms (OF-3322).
-            final ScramCredentialData credential = credentialsByMechanismName.get(ScramSha1SaslServer.MECHANISM_NAME);
-            if (credential == null) {
-                Log.debug("No available SCRAM-SHA-1 credentials for checkPassword for user {}", username);
-                return false;
+
+            // We don't know what algorithm was used for the provided credentials. We'll have to try all supported ones.
+            for (final ScramCredentialData credential : credentialsByMechanismName.values())
+            {
+                final ScramMechanism mech = SCRAM_MECHANISMS.stream()
+                    .filter(m -> m.mechanismName().equals(credential.mechanism))
+                    .findFirst().orElse(null);
+                if (mech == null) {
+                    Log.debug("Skipping unsupported SCRAM mechanism '{}' for user {}", credential.mechanism, username); continue;
+                }
+                try {
+                    final byte[] saltShaker = DatatypeConverter.parseBase64Binary(credential.salt);
+                    final ScramUtils.ScramKeys keys = ScramUtils.deriveScramKeys(
+                        saltShaker, testPassword, credential.iterations,
+                        mech.hmacAlgorithm(), mech.digestAlgorithm());
+                    if (DatatypeConverter.printBase64Binary(keys.storedKey).equals(credential.storedKey)) {
+                        return true;
+                    }
+                } catch (SaslException | NoSuchAlgorithmException | IllegalArgumentException e) {
+                    Log.warn("Unable to check SCRAM values for PLAIN authentication for user '{}'", username, e);
+                }
             }
-            try {
-                final byte[] saltShaker = DatatypeConverter.parseBase64Binary(credential.salt);
-                final ScramUtils.ScramKeys keys = ScramUtils.deriveScramKeys(
-                    saltShaker, testPassword, credential.iterations,
-                    ScramSha1SaslServer.HMAC_ALGORITHM_NAME, ScramSha1SaslServer.DIGEST_ALGORITHM_NAME);
-                return DatatypeConverter.printBase64Binary(keys.storedKey).equals(credential.storedKey);
-            } catch(SaslException | NoSuchAlgorithmException | IllegalArgumentException e) {
-                Log.warn("Unable to check SCRAM values for PLAIN authentication for user '{}'", username, e);
-                return false;
-            }
+            Log.debug("No usable SCRAM credential found for user {}", username);
+            return false;
         }
         catch (SQLException sqle) {
             Log.warn("A database error occurred while authenticating user {}:", username, sqle);
@@ -382,19 +430,24 @@ public class DefaultAuthProvider implements AuthProvider {
             }
         }
 
-        // Compute the SCRAM (SHA-1) credential from the plaintext password *before* the plaintext is nulled out below.
-        byte[] saltShaker = new byte[SALT_LENGTH];
-        random.nextBytes(saltShaker);
-        final String salt = DatatypeConverter.printBase64Binary(saltShaker);
-        ScramUtils.ScramKeys keys = null;
-        final int iterations = ScramSha1SaslServer.ITERATION_COUNT.getValue();
-        try {
-            keys = ScramUtils.deriveScramKeys(
-                saltShaker, password, iterations,
-                ScramSha1SaslServer.HMAC_ALGORITHM_NAME,
-                ScramSha1SaslServer.DIGEST_ALGORITHM_NAME);
-        } catch (SaslException | NoSuchAlgorithmException e) {
-            Log.warn("Unable to derive SCRAM credential while trying to persist values for SCRAM authentication", e);
+        // Derive SCRAM credentials from the plaintext *before* it's nulled out below.
+        final List<ScramCredentialData> scramCredentials = new ArrayList<>();
+        for (final ScramMechanism mech : SCRAM_MECHANISMS) {
+            final byte[] saltShaker = new byte[SALT_LENGTH];
+            random.nextBytes(saltShaker);
+            final int iterations = mech.iterationCount().getAsInt();
+            try {
+                final ScramUtils.ScramKeys keys = ScramUtils.deriveScramKeys(
+                    saltShaker, password, iterations, mech.hmacAlgorithm(), mech.digestAlgorithm());
+                scramCredentials.add(new ScramCredentialData(
+                    mech.mechanismName(),
+                    DatatypeConverter.printBase64Binary(saltShaker),
+                    iterations,
+                    DatatypeConverter.printBase64Binary(keys.storedKey),
+                    DatatypeConverter.printBase64Binary(keys.serverKey)));
+            } catch (SaslException | NoSuchAlgorithmException e) {
+                Log.warn("Unable to derive SCRAM credential for {} while persisting password for user '{}'", mech.mechanismName(), username, e);
+            }
         }
 
         String plaintextToStore = password;
@@ -413,7 +466,7 @@ public class DefaultAuthProvider implements AuthProvider {
             plaintextToStore = null;
         }
 
-        if (scramOnly && keys == null) {
+        if (scramOnly && scramCredentials.isEmpty()) {
             // In scramOnly mode SCRAM is the only stored credential. If none could be derived, committing would
             // leave the user with no usable credential of any kind (locked out), so refuse rather than persist that.
             Log.error("Unable to derive any SCRAM credential for user '{}' while user.scramHashedPasswordOnly is set; refusing to store a credential-less password.", username);
@@ -450,17 +503,9 @@ public class DefaultAuthProvider implements AuthProvider {
             DbConnectionManager.fastcloseStmt(pstmt);
             pstmt = null;
 
-            upsertScramCredential(
-                con,
-                username,
-                new ScramCredentialData(
-                    ScramSha1SaslServer.MECHANISM_NAME,
-                    salt,
-                    iterations,
-                    keys == null ? null : DatatypeConverter.printBase64Binary(keys.storedKey),
-                    keys == null ? null : DatatypeConverter.printBase64Binary(keys.serverKey)
-                )
-            );
+            for (final ScramCredentialData credential : scramCredentials) {
+                upsertScramCredential(con, username, credential);
+            }
         }
         catch (SQLException sqle) {
             abortTransaction = true;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/HybridAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2008 Jive Software, 2016-2024 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2005-2008 Jive Software, 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.jivesoftware.openfire.auth;
 
 import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.SystemProperty;
 import org.slf4j.Logger;
@@ -290,91 +291,38 @@ public class HybridAuthProvider extends AuthMultiProvider {
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getSalt(String username) throws UnsupportedOperationException, UserNotFoundException
     {
-        if (!isScramSupported()) {
-            throw new UnsupportedOperationException();
-        }
-
-        // Check overrides first.
-        try {
-            return super.getSalt(username);
-        } catch (UserNotFoundException e) {
-            if (hasOverride(username)) {
-                // An override was used. Must not try other providers.
-                throw e;
-            }
-        }
-
-        // When there's no override, try all providers in order.
-        for (final AuthProvider provider: getAuthProviders()) {
-            try {
-                provider.getSalt(username);
-            } catch (UserNotFoundException | UnsupportedOperationException e) {
-                Log.trace("Could get salt for user {} with auth provider {}. Will try remaining providers (if any)", username, provider.getClass().getName(), e);
-            }
-        }
-        throw new UserNotFoundException();
+        return getScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME).salt;
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public int getIterations(String username) throws UnsupportedOperationException, UserNotFoundException
     {
-        if (!isScramSupported()) {
-            throw new UnsupportedOperationException();
-        }
-
-        // Check overrides first.
-        try {
-            return super.getIterations(username);
-        } catch (UserNotFoundException e) {
-            if (hasOverride(username)) {
-                // An override was used. Must not try other providers.
-                throw e;
-            }
-        }
-
-        // When there's no override, try all providers in order.
-        for (final AuthProvider provider: getAuthProviders()) {
-            try {
-                provider.getIterations(username);
-            } catch (UserNotFoundException | UnsupportedOperationException e) {
-                Log.trace("Could get iterations for user {} with auth provider {}. Will try remaining providers (if any)", username, provider.getClass().getName(), e);
-            }
-        }
-        throw new UserNotFoundException();
+        return getScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME).iterations;
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getServerKey(String username) throws UnsupportedOperationException, UserNotFoundException
     {
-        if (!isScramSupported()) {
-            throw new UnsupportedOperationException();
-        }
-
-        // Check overrides first.
-        try {
-            return super.getServerKey(username);
-        } catch (UserNotFoundException e) {
-            if (hasOverride(username)) {
-                // An override was used. Must not try other providers.
-                throw e;
-            }
-        }
-
-        // When there's no override, try all providers in order.
-        for (final AuthProvider provider: getAuthProviders()) {
-            try {
-                provider.getServerKey(username);
-            } catch (UserNotFoundException | UnsupportedOperationException e) {
-                Log.trace("Could get serverkey for user {} with auth provider {}. Will try remaining providers (if any)", username, provider.getClass().getName(), e);
-            }
-        }
-        throw new UserNotFoundException();
+        return getScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME).serverKey;
     }
 
     @Override
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     public String getStoredKey(String username) throws UnsupportedOperationException, UserNotFoundException
+    {
+        return getScramCredential(username, ScramSha1SaslServer.MECHANISM_NAME).storedKey;
+    }
+
+    /**
+     * Returns SCRAM credentials for a user and mechanism.
+     */
+    @Override
+    public ScramCredentialData getScramCredential(final String username, final String mechanism) throws UnsupportedOperationException, UserNotFoundException
     {
         if (!isScramSupported()) {
             throw new UnsupportedOperationException();
@@ -382,7 +330,7 @@ public class HybridAuthProvider extends AuthMultiProvider {
 
         // Check overrides first.
         try {
-            return super.getStoredKey(username);
+            return super.getScramCredential(username, mechanism);
         } catch (UserNotFoundException e) {
             if (hasOverride(username)) {
                 // An override was used. Must not try other providers.
@@ -393,9 +341,9 @@ public class HybridAuthProvider extends AuthMultiProvider {
         // When there's no override, try all providers in order.
         for (final AuthProvider provider: getAuthProviders()) {
             try {
-                provider.getStoredKey(username);
+                return provider.getScramCredential(username, mechanism);
             } catch (UserNotFoundException | UnsupportedOperationException e) {
-                Log.trace("Could get storedkey for user {} with auth provider {}. Will try remaining providers (if any)", username, provider.getClass().getName(), e);
+                Log.trace("Could get SCRAM credential for user {} with auth provider {} and mechanism {}. Will try remaining providers (if any)", username, provider.getClass().getName(), mechanism, e);
             }
         }
         throw new UserNotFoundException();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ScramUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ScramUtils.java
@@ -20,6 +20,7 @@ import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
 
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 import javax.crypto.Mac;
@@ -40,6 +41,32 @@ public class ScramUtils {
     public static final int DEFAULT_ITERATION_COUNT = 4096;
 
     private ScramUtils() {}
+
+    /**
+     * Derives the stored key and server key for a SCRAM credential.
+     *
+     * The keys are derived from the supplied password using the specified salt, iteration count, HMAC algorithm and
+     * digest algorithm, as defined by the SCRAM specification.
+     *
+     * @param salt the salt.
+     * @param password the plaintext password.
+     * @param iterations the SCRAM iteration count.
+     * @param hmacAlgorithm the HMAC algorithm (for example {@code HmacSHA1} or {@code HmacSHA256}).
+     * @param digestAlgorithm the digest algorithm corresponding to the HMAC algorithm (for example {@code SHA-1} or {@code SHA-256}).
+     * @return the derived stored key and server key.
+     * @throws SaslException if the salted password or HMAC values cannot be derived.
+     * @throws NoSuchAlgorithmException if the requested digest algorithm is unavailable.
+     */
+    public static ScramKeys deriveScramKeys(final byte[] salt, final String password, final int iterations, final String hmacAlgorithm, final String digestAlgorithm) throws SaslException, NoSuchAlgorithmException
+    {
+        final byte[] saltedPassword = createSaltedPassword(salt, password, iterations, hmacAlgorithm);
+        final byte[] clientKey = computeHmac(saltedPassword, "Client Key", hmacAlgorithm);
+        final byte[] storedKey = MessageDigest.getInstance(digestAlgorithm).digest(clientKey);
+
+        final byte[] serverKey = computeHmac(saltedPassword, "Server Key", hmacAlgorithm);
+
+        return new ScramKeys(storedKey, serverKey);
+    }
 
     /**
      * Computes a salted password ({@code Hi(password, salt, iterations)} as defined in RFC 5802), using the provided
@@ -150,5 +177,24 @@ public class ScramUtils {
     public static Mac createSha1Hmac(final byte[] keyBytes) throws SaslException
     {
         return createHmac(keyBytes, ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
+    }
+
+    /**
+     * The derived SCRAM keys for a password.
+     *
+     * These keys are derived from a password, salt and iteration count as defined by the SCRAM specification. The
+     * stored key is persisted and used to verify client authentication, while the server key is used by the server when
+     * constructing SCRAM protocol messages.
+     */
+    public static final class ScramKeys
+    {
+        public final byte[] storedKey;
+        public final byte[] serverKey;
+
+        private ScramKeys(byte[] storedKey, byte[] serverKey)
+        {
+            this.storedKey = storedKey;
+            this.serverKey = serverKey;
+        }
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ScramUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ScramUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Surevine Ltd, 2016-2018 Ignite Realtime Foundation. All rights reserved
+ * Copyright (C) 2015 Surevine Ltd, 2016-2026 Ignite Realtime Foundation. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.jivesoftware.openfire.auth;
 
+import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
+
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -25,19 +27,34 @@ import javax.crypto.spec.SecretKeySpec;
 import javax.security.sasl.SaslException;
 
 /**
- * A utility class that provides methods that are useful for dealing with
- * Salted Challenge Response Authentication Mechanism (SCRAM).
- * 
+ * A utility class that provides methods that are useful for dealing with Salted Challenge Response Authentication
+ * Mechanism (SCRAM).
+ *
+ * The HMAC algorithm to be used is provided as an argument (in the form of a JCA standard name, such as
+ * {@code HmacSHA1} or {@code HmacSHA256}), allowing these utilities to serve any SCRAM mechanism.
+ *
  * @author Richard Midwinter
  */
 public class ScramUtils {
-    
+
     public static final int DEFAULT_ITERATION_COUNT = 4096;
 
     private ScramUtils() {}
 
-    public static byte[] createSaltedPassword(byte[] salt, String password, int iters) throws SaslException {
-        Mac mac = createSha1Hmac(password.getBytes(StandardCharsets.UTF_8));
+    /**
+     * Computes a salted password ({@code Hi(password, salt, iterations)} as defined in RFC 5802), using the provided
+     * HMAC algorithm.
+     *
+     * @param salt the salt.
+     * @param password the password.
+     * @param iters the iteration count.
+     * @param hmacAlgorithm the JCA name of the HMAC algorithm to use (for example: {@code HmacSHA1}).
+     * @return the salted password.
+     * @throws SaslException if the HMAC could not be initialized.
+     */
+    public static byte[] createSaltedPassword(byte[] salt, String password, int iters, String hmacAlgorithm) throws SaslException
+    {
+        final Mac mac = createHmac(password.getBytes(StandardCharsets.UTF_8), hmacAlgorithm);
         mac.update(salt);
         mac.update(new byte[]{0, 0, 0, 1});
         byte[] result = mac.doFinal();
@@ -53,23 +70,85 @@ public class ScramUtils {
 
         return result;
     }
-    
-    public static byte[] computeHmac(final byte[] key, final String string)
-            throws SaslException {
-        Mac mac = createSha1Hmac(key);
+
+    /**
+     * Computes an HMAC over the UTF-8 bytes of the provided string, using the provided HMAC algorithm.
+     *
+     * @param key the key.
+     * @param string the value to compute the HMAC over.
+     * @param hmacAlgorithm the JCA name of the HMAC algorithm to use (for example: {@code HmacSHA1}).
+     * @return the computed HMAC.
+     * @throws SaslException if the HMAC could not be initialized.
+     */
+    public static byte[] computeHmac(final byte[] key, final String string, final String hmacAlgorithm) throws SaslException
+    {
+        final Mac mac = createHmac(key, hmacAlgorithm);
         mac.update(string.getBytes(StandardCharsets.UTF_8));
         return mac.doFinal();
     }
 
-    public static Mac createSha1Hmac(final byte[] keyBytes)
-            throws SaslException {
+    /**
+     * Creates an initialized {@link Mac} instance for the provided HMAC algorithm.
+     *
+     * @param keyBytes the key.
+     * @param hmacAlgorithm the JCA name of the HMAC algorithm to use (for example: {@code HmacSHA1}).
+     * @return an initialized Mac.
+     * @throws SaslException if the HMAC could not be initialized.
+     */
+    public static Mac createHmac(final byte[] keyBytes, final String hmacAlgorithm) throws SaslException
+    {
         try {
-            SecretKeySpec key = new SecretKeySpec(keyBytes, "HmacSHA1");
-            Mac mac = Mac.getInstance("HmacSHA1");
+            final SecretKeySpec key = new SecretKeySpec(keyBytes, hmacAlgorithm);
+            final Mac mac = Mac.getInstance(hmacAlgorithm);
             mac.init(key);
             return mac;
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
-            throw new SaslException(e.getMessage(), e);
+            throw new SaslException("Unable to create an initialized Mac instance for algorithm '" + hmacAlgorithm + "'.", e);
         }
+    }
+
+    /**
+     * Computes a SHA-1 salted password ({@code Hi(password, salt, iterations)} as defined in RFC 5802).
+     *
+     * @param salt the salt.
+     * @param password the password.
+     * @param iters the iteration count.
+     * @return the salted password.
+     * @throws SaslException if the HMAC could not be initialized.
+     * @deprecated Use {@link #createSaltedPassword(byte[], String, int, String)}, providing an explicit HMAC algorithm.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
+    public static byte[] createSaltedPassword(byte[] salt, String password, int iters) throws SaslException
+    {
+        return createSaltedPassword(salt, password, iters, ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
+    }
+
+    /**
+     * Computes an HMAC-SHA-1 over the UTF-8 bytes of the provided string.
+     *
+     * @param key the key.
+     * @param string the value to compute the HMAC over.
+     * @return the computed HMAC.
+     * @throws SaslException if the HMAC could not be initialized.
+     * @deprecated Use {@link #computeHmac(byte[], String, String)}, providing an explicit HMAC algorithm.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
+    public static byte[] computeHmac(final byte[] key, final String string) throws SaslException
+    {
+        return computeHmac(key, string, ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
+    }
+
+    /**
+     * Creates an initialized {@link Mac} instance for HMAC-SHA-1.
+     *
+     * @param keyBytes the key.
+     * @return an initialized Mac.
+     * @throws SaslException if the HMAC could not be initialized.
+     * @deprecated Use {@link #createHmac(byte[], String)}, providing an explicit HMAC algorithm.
+     */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
+    public static Mac createSha1Hmac(final byte[] keyBytes) throws SaslException
+    {
+        return createHmac(keyBytes, ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ScramUtils.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/auth/ScramUtils.java
@@ -81,6 +81,9 @@ public class ScramUtils {
      */
     public static byte[] createSaltedPassword(byte[] salt, String password, int iters, String hmacAlgorithm) throws SaslException
     {
+        if (iters < 1) {
+            throw new SaslException("SCRAM iteration count must be positive.");
+        }
         final Mac mac = createHmac(password.getBytes(StandardCharsets.UTF_8), hmacAlgorithm);
         mac.update(salt);
         mac.update(new byte[]{0, 0, 0, 1});

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/ldap/LdapUserProvider.java
@@ -20,6 +20,7 @@ import org.jivesoftware.admin.LdapUserTester;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.group.Group;
 import org.jivesoftware.openfire.group.GroupManager;
+import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
 import org.jivesoftware.openfire.user.*;
 import org.jivesoftware.util.JiveGlobals;
 import org.slf4j.Logger;
@@ -155,7 +156,7 @@ public class LdapUserProvider implements UserProvider {
                     String scheme = parts[0].trim();
     
                     // We only support SCRAM-SHA-1 at the moment.
-                    if ("SCRAM-SHA-1".equals(scheme)) {
+                    if (ScramSha1SaslServer.MECHANISM_NAME.equals(scheme)) {
                         int iterations = Integer.parseInt(authInfo[0].trim());
                         String salt = authInfo[1].trim();
                         String storedKey = authValue[0].trim();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoom.java
@@ -29,6 +29,7 @@ import org.jivesoftware.openfire.event.GroupEventListener;
 import org.jivesoftware.openfire.event.UserEventListener;
 import org.jivesoftware.openfire.group.*;
 import org.jivesoftware.openfire.muc.spi.*;
+import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
 import org.jivesoftware.openfire.user.User;
 import org.jivesoftware.openfire.user.UserAlreadyExistsException;
 import org.jivesoftware.openfire.user.UserNotFoundException;
@@ -4203,9 +4204,9 @@ public class MUCRoom implements GroupEventListener, UserEventListener, Externali
 
         try {
             // Keep the room's identifier with they key, rather than with the data, which should have slightly improved security properties.
-            final byte[] roomKey = ScramUtils.computeHmac(siteKey.getBytes(StandardCharsets.UTF_8), this.getJID().toBareJID());
+            final byte[] roomKey = ScramUtils.computeHmac(siteKey.getBytes(StandardCharsets.UTF_8), this.getJID().toBareJID(), "HmacSHA1");
 
-            return StringUtils.encodeHex(ScramUtils.computeHmac(roomKey, userJid.toBareJID()));
+            return StringUtils.encodeHex(ScramUtils.computeHmac(roomKey, userJid.toBareJID(), "HmacSHA1"));
         } catch (SaslException e) {
             throw new RuntimeException("Unable to compute HMAC for user '" + userJid + "' in room '" + this.getJID() + "' while generating an Occupant ID.");
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -33,6 +33,7 @@ import org.jivesoftware.openfire.sasl.AnonymousSaslServer;
 import org.jivesoftware.openfire.sasl.Failure;
 import org.jivesoftware.openfire.sasl.JiveSharedSecretSaslServer;
 import org.jivesoftware.openfire.sasl.SaslFailureException;
+import org.jivesoftware.openfire.sasl.ScramSaslServer;
 import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
 import org.jivesoftware.openfire.session.*;
 import org.jivesoftware.openfire.spi.ConnectionType;
@@ -611,7 +612,7 @@ public class SASLAuthentication {
                     session.removeSessionData( SASL_LAST_RESPONSE_WAS_PROVIDED_BUT_EMPTY );
                     session.setSessionData("SaslMechanism", saslServer.getMechanismName());
                     if (requiresChannelBinding(saslServer.getMechanismName())) {
-                        session.setSessionData("ChannelBindingType", saslServer.getNegotiatedProperty(ScramSha1SaslServer.PROPNAME_CHANNELBINDINGTYPE));
+                        session.setSessionData("ChannelBindingType", saslServer.getNegotiatedProperty(ScramSaslServer.PROPNAME_CHANNELBINDINGTYPE));
                     }
                     return Status.authenticated;
 
@@ -895,8 +896,8 @@ public class SASLAuthentication {
                     }
                     break;
 
-                case "SCRAM-SHA-1": // intended fall-through
-                case "SCRAM-SHA-1-PLUS":
+                case ScramSha1SaslServer.MECHANISM_NAME: // intended fall-through
+                case ScramSha1SaslServer.MECHANISM_NAME+"-PLUS":
                     if ( !AuthFactory.supportsScram() )
                     {
                         Log.trace( "Cannot support '{}' as the AuthProvider that's in use does not support SCRAM.", mechanism );
@@ -996,7 +997,7 @@ public class SASLAuthentication {
      */
     public static List<String> getEnabledMechanisms()
     {
-        return JiveGlobals.getListProperty("sasl.mechs", Arrays.asList( "ANONYMOUS","PLAIN","DIGEST-MD5","CRAM-MD5","SCRAM-SHA-1","SCRAM-SHA-1-PLUS","JIVE-SHAREDSECRET","GSSAPI","EXTERNAL" ) );
+        return JiveGlobals.getListProperty("sasl.mechs", Arrays.asList( "ANONYMOUS","PLAIN","DIGEST-MD5","CRAM-MD5",ScramSha1SaslServer.MECHANISM_NAME,ScramSha1SaslServer.MECHANISM_NAME+"-PLUS","JIVE-SHAREDSECRET","GSSAPI","EXTERNAL" ) );
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/SaslServerFactoryImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/SaslServerFactoryImpl.java
@@ -53,8 +53,8 @@ public class SaslServerFactoryImpl implements SaslServerFactory
         allMechanisms = new HashSet<>();
         allMechanisms.add( new Mechanism( "ANONYMOUS", true, true ) );
         allMechanisms.add( new Mechanism( "PLAIN", false, true ) );
-        allMechanisms.add( new Mechanism( "SCRAM-SHA-1", false, false ) );
-        allMechanisms.add( new Mechanism( "SCRAM-SHA-1-PLUS", false, false ) );
+        allMechanisms.add( new Mechanism( ScramSha1SaslServer.MECHANISM_NAME, false, false ) );
+        allMechanisms.add( new Mechanism( ScramSha1SaslServer.MECHANISM_NAME + "-PLUS", false, false ) );
         allMechanisms.add( new Mechanism( "JIVE-SHAREDSECRET", true, false ) );
         allMechanisms.add( new Mechanism( "EXTERNAL", false, false ) );
     }
@@ -78,10 +78,10 @@ public class SaslServerFactoryImpl implements SaslServerFactory
                 }
                 return new SaslServerPlainImpl( protocol, serverName, props, cbh );
 
-            case "SCRAM-SHA-1":
+            case ScramSha1SaslServer.MECHANISM_NAME:
                 return new ScramSha1SaslServer(false, props);
 
-            case "SCRAM-SHA-1-PLUS":
+            case ScramSha1SaslServer.MECHANISM_NAME + "-PLUS":
                 return new ScramSha1SaslServer(true, props);
 
             case "ANONYMOUS":

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSaslServer.java
@@ -15,31 +15,451 @@
  */
 package org.jivesoftware.openfire.sasl;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+import javax.crypto.Mac;
+import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
-import java.util.Arrays;
+import javax.xml.bind.DatatypeConverter;
 
+import org.jivesoftware.openfire.auth.AuthFactory;
+import org.jivesoftware.openfire.auth.ConnectionException;
+import org.jivesoftware.openfire.auth.DefaultAuthProvider;
+import org.jivesoftware.openfire.auth.InternalUnauthenticatedException;
+import org.jivesoftware.openfire.auth.ScramUtils;
+import org.jivesoftware.openfire.session.LocalSession;
+import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.jivesoftware.util.channelbinding.ChannelBindingProviderManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implements the server side of the SCRAM SASL exchange as defined in RFC 5802, including the channel binding (-PLUS)
+ * variants defined there and profiled for other hash functions in RFC 7677.
+ *
+ * The exchange logic in this class is hash-function agnostic. Concrete subclasses bind a specific hash function by
+ * implementing the small set of abstract methods: the base mechanism name (which doubles as the credential storage
+ * key), the HMAC and message digest algorithm names, the default iteration count, and the server-side secret used to
+ * derive indistinguishable fake credentials for non-existent users.
+ *
+ * @author Richard Midwinter, Guus der Kinderen
+ */
 public abstract class ScramSaslServer implements SaslServer
 {
-    /**
-     * Retrieve the server key from the database for a given username, but returns a fake key if none is found.
-     *
-     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
-     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
-     *
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
-     */
-    abstract byte[] getOrFakeServerKey(String username);
+    private static final Logger Log = LoggerFactory.getLogger(ScramSaslServer.class);
 
     /**
-     * Retrieve the stored key from the database for a given username, but returns a fake key if none is found.
-     *
-     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
-     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
-     *
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
+     * The name of the negotiated property through which the channel binding type that was used during authentication
+     * is exposed.
      */
-    abstract byte[] getOrFakeStoredKey(final String username);
+    public static final String PROPNAME_CHANNELBINDINGTYPE = "channelbindingtype";
+
+    private static final Pattern
+        CLIENT_FIRST_MESSAGE = Pattern.compile("^(([pny])=?([^,]*),([^,]*),)(m?=?[^,]*,?n=([^,]*),r=([^,]*),?.*)$"),
+        CLIENT_FINAL_MESSAGE = Pattern.compile("(c=([^,]*),r=([^,]*)),p=(.*)$");
+
+    private final ChannelBindingProviderManager channelBindingProviderManager;
+    private final Set<String> serverSupportedSaslMechanismNames;
+
+    private final boolean isPlusMechanism;
+    private final Map<String, ?> props;
+    private String username;
+    private State state = State.INITIAL;
+    private String nonce;
+    private String serverFirstMessage;
+    private String clientFirstMessageBare;
+    private final SecureRandom random = new SecureRandom();
+    private byte[] expectedChannelBindingPayloadInFinalClientMessage;
+    private String gs2CbindName;
+
+    private enum State {
+        INITIAL,
+        IN_PROGRESS,
+        COMPLETE;
+    }
+
+    protected ScramSaslServer(final boolean isPlusMechanism, final Map<String, ?> props, final ChannelBindingProviderManager channelBindingProviderManager, final Set<String> serverSupportedSaslMechanismNames)
+    {
+        this.isPlusMechanism = isPlusMechanism;
+        this.props = props;
+        this.channelBindingProviderManager = channelBindingProviderManager;
+        this.serverSupportedSaslMechanismNames = serverSupportedSaslMechanismNames;
+    }
+
+    /**
+     * The IANA-registered name of the base (non-PLUS) mechanism implemented by this server, for example
+     * {@code SCRAM-SHA-1}. This value is also the key under which SCRAM credentials for this mechanism are stored:
+     * the -PLUS variant shares the credential of the base mechanism.
+     *
+     * @return A non-null string representing the IANA-registered (base) mechanism name.
+     */
+    protected abstract String getMechanismBaseName();
+
+    /**
+     * The JCA name of the HMAC algorithm that corresponds to this mechanism's hash function, for example
+     * {@code HmacSHA1}.
+     *
+     * @return the HMAC algorithm name.
+     */
+    protected abstract String getHmacAlgorithmName();
+
+    /**
+     * The JCA name of the message digest that corresponds to this mechanism's hash function, for example
+     * {@code SHA-1}. Used to compute {@code H(ClientKey)} when verifying the client proof.
+     *
+     * @return the message digest algorithm name.
+     */
+    protected abstract String getDigestAlgorithmName();
+
+    /**
+     * The iteration count to advertise when no per-user value is available.
+     *
+     * @return the default iteration count for this mechanism.
+     */
+    protected abstract int getDefaultIterationCount();
+
+    /**
+     * A server-side secret from which deterministic fake credentials are derived for non-existent users, so that
+     * authentication processing for non-existing users is indistinguishable from that of existing users.
+     *
+     * @return the server secret for this mechanism.
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3258">OF-3258: Guard against user enumeration in ScramSha1SaslServer</a>
+     */
+    protected abstract String getNonExistentUserSecret();
+
+    /**
+     * Returns the IANA-registered mechanism name of this SASL server, which is the base mechanism name with a
+     * {@code -PLUS} suffix for the channel binding variant.
+     *
+     * @return A non-null string representing the IANA-registered mechanism name.
+     */
+    @Override
+    public String getMechanismName() {
+        return isPlusMechanism ? getMechanismBaseName() + "-PLUS" : getMechanismBaseName();
+    }
+
+    /**
+     * Evaluates the response data and generates a challenge.
+     *
+     * If a response is received from the client during the authentication
+     * process, this method is called to prepare an appropriate next
+     * challenge to submit to the client. The challenge is null if the
+     * authentication has succeeded and no more challenge data is to be sent
+     * to the client. It is non-null if the authentication must be continued
+     * by sending a challenge to the client, or if the authentication has
+     * succeeded but challenge data needs to be processed by the client.
+     * {@code isComplete()} should be called
+     * after each call to {@code evaluateResponse()},to determine if any further
+     * response is needed from the client.
+     *
+     * @param response The non-null (but possibly empty) response sent
+     * by the client.
+     *
+     * @return The possibly null challenge to send to the client.
+     * It is null if the authentication has succeeded and there is
+     * no more challenge data to be sent to the client.
+     * @exception SaslException If an error occurred while processing
+     * the response or generating a challenge.
+     */
+    @Override
+    public byte[] evaluateResponse(final byte[] response) throws SaslException {
+        try {
+            byte[] challenge;
+            switch (state)
+            {
+                case INITIAL:
+                    challenge = generateServerFirstMessage(response);
+                    state = State.IN_PROGRESS;
+                    break;
+                case IN_PROGRESS:
+                    challenge = generateServerFinalMessage(response);
+                    state = State.COMPLETE;
+                    break;
+                case COMPLETE:
+                    if (response == null || response.length == 0)
+                    {
+                        challenge = new byte[0];
+                        break;
+                    }
+                    throw new SaslException("Unexpected response after authentication completed");
+                default:
+                    throw new SaslException("No response expected in state " + state);
+
+            }
+            return challenge;
+        } catch (RuntimeException ex) {
+            throw new SaslException("Unexpected exception while evaluating SASL response.", ex);
+        }
+    }
+
+    /**
+     * First response returns:
+     *   - the nonce (client nonce appended with our own random UUID)
+     *   - the salt
+     *   - the number of iterations
+     */
+    private byte[] generateServerFirstMessage(final byte[] response) throws SaslException {
+        String clientFirstMessage = new String(response, StandardCharsets.UTF_8);
+        Matcher m = CLIENT_FIRST_MESSAGE.matcher(clientFirstMessage);
+        if (!m.matches()) {
+            throw new SaslException("Invalid first client message");
+        }
+        final byte[] gs2_header = extractRawGS2Header(response); // Using raw header to prevent any normalization issues that might pop up when using something like: gs2Header.getBytes(StandardCharsets.UTF_8);
+//        String gs2Header = m.group(1);
+        String gs2CbindFlag = m.group(2);
+        gs2CbindName = m.group(3);
+//        String authzId = m.group(4);
+        clientFirstMessageBare = m.group(5);
+        username = m.group(6);
+        String clientNonce = m.group(7);
+
+        if (username == null || username.isEmpty()) {
+            throw new SaslException("Invalid first client message: Username cannot be empty");
+        }
+        if (clientNonce == null || clientNonce.isEmpty()) {
+            throw new SaslException("Invalid first client message: Client nonce cannot be empty");
+        }
+
+        // https://www.rfc-editor.org/rfc/rfc5802.html#section-6: If the flag is set to "y" and the server supports
+        // channel binding, the server MUST fail authentication. This is because if the client sets the channel binding
+        // flag to "y", then the client must have believed that the server did not support channel binding -- if the
+        // server did in fact support channel binding, then this is an indication that there has been a downgrade attack
+        // (e.g., an attacker changed the server's mechanism list to exclude the -PLUS suffixed SCRAM mechanism name(s)).
+        final boolean clientSupportsChannelBindingButThinksServerDoesNot = "y".equals(gs2CbindFlag);
+        final boolean serverSupportsChannelBinding = serverSupportedSaslMechanismNames.stream().anyMatch(mechanism -> mechanism.endsWith("-PLUS"));
+        if (clientSupportsChannelBindingButThinksServerDoesNot && serverSupportsChannelBinding) {
+            throw new SaslException("Client supports channel binding, but thinks the server does not (while it does). Rejecting authentication to prevent downgrade attack.");
+        }
+
+        final boolean clientRequiresChannelBinding = "p".equals(gs2CbindFlag);
+        if (clientRequiresChannelBinding && !isPlusMechanism) {
+            throw new SaslException("Client requires channel binding, but is not using a -PLUS mechanism. Rejecting authentication.");
+        }
+
+        if (isPlusMechanism)
+        {
+            if (!clientRequiresChannelBinding) {
+                throw new SaslException("Channel binding required for -PLUS. Rejecting authentication.");
+            }
+
+            if (!serverSupportsChannelBinding) {
+                throw new SaslException("Client requires channel binding, but server does not support channel binding. Rejecting authentication.");
+            }
+
+            // https://www.rfc-editor.org/rfc/rfc5802.html#section-6: If the channel binding flag was "p" and the server
+            // does not support the indicated channel binding type, then the server MUST fail authentication.
+            if (gs2CbindName == null || gs2CbindName.isEmpty() || !channelBindingProviderManager.supportsChannelBinding(gs2CbindName)) {
+                throw new SaslException("Client requires channel binding, but server does not support the indicated channel binding type '" + gs2CbindName + "'. Rejecting authentication.");
+            }
+
+            // Prepare channel binding data.
+            final LocalSession session = (LocalSession) props.get(LocalSession.class.getCanonicalName());
+            if (session == null || session.getConnection() == null) {
+                throw new SaslException("Local session not found in properties. Rejecting authentication.");
+            }
+            final Optional<byte[]> channelBindingData = session.getConnection().getChannelBindingData(gs2CbindName);
+            if (channelBindingData.isEmpty()) {
+                Log.debug("Unable to retrieve channel binding data for '{}'. Rejecting authentication.", gs2CbindName);
+                throw new SaslException("Unable to retrieve channel binding data for '" + gs2CbindName + "'. Rejecting authentication.");
+            }
+
+            // In the final client message, we expect to find a combination of the gs2 header and channel binding data.
+            final byte[] cb_data = channelBindingData.get();
+            expectedChannelBindingPayloadInFinalClientMessage = new byte[gs2_header.length + cb_data.length];
+            System.arraycopy(gs2_header, 0, expectedChannelBindingPayloadInFinalClientMessage, 0        , gs2_header.length);
+            System.arraycopy(cb_data,    0, expectedChannelBindingPayloadInFinalClientMessage, gs2_header.length, cb_data.length);
+        } else {
+            // If this is _not_ a -PLUS mechanism, we still need to verify the channel binding payload in the final client message.
+            // In that case, it should not have trailing channel binding data.
+            expectedChannelBindingPayloadInFinalClientMessage = gs2_header;
+        }
+
+        nonce = clientNonce + UUID.randomUUID().toString();
+
+        serverFirstMessage = String.format("r=%s,s=%s,i=%d", nonce, DatatypeConverter.printBase64Binary(getOrCreateSalt(username)), getIterations(username));
+        return serverFirstMessage.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Final response returns the server signature.
+     */
+    private byte[] generateServerFinalMessage(final byte[] response) throws SaslException {
+        String clientFinalMessage = new String(response, StandardCharsets.UTF_8);
+        Matcher m = CLIENT_FINAL_MESSAGE.matcher(clientFinalMessage);
+        if (!m.matches()) {
+            throw new SaslException("Invalid client final message");
+        }
+
+        // client-final-message regex: (c=([^,]*),r=([^,]*)),p=(.*)$")
+        final String clientFinalMessageWithoutProof = m.group(1); // (c=([^,]*),r=([^,]*))
+        final String channelBinding = m.group(2);                 // c=([^,]*)
+        final String clientNonce = m.group(3);                    // r=([^,]*)
+        final String proof = m.group(4);                          // p=(.*)
+
+        if (proof == null || proof.isEmpty()) {
+            throw new SaslException("Invalid client final message: missing proof attribute");
+        }
+
+        if (channelBinding == null || channelBinding.isEmpty()) {
+            throw new SaslException("Invalid client final message: missing channel binding attribute");
+        }
+
+        if (clientNonce == null || clientNonce.isEmpty()) {
+            throw new SaslException("Invalid client final message: missing nonce attribute");
+        }
+
+        // Verify nonce: RFC 5802 §5: must equal client_nonce (from initial client response) + server_nonce (from initial server response)
+        if (!nonce.equals(clientNonce)) { // Constant-time operation is important for keys, not for public protocol values like nonces.
+            // Possible replay or tampering
+            throw new SaslException("Invalid client final message: incorrect nonce attribute value");
+        }
+
+        // Verify channel binding payload.
+        final byte[] decodedChannelBinding = DatatypeConverter.parseBase64Binary(channelBinding);
+        if (!Arrays.equals(expectedChannelBindingPayloadInFinalClientMessage, decodedChannelBinding)) {
+            throw new SaslException("Invalid client final message: channel binding payload does not match expected payload");
+        }
+
+        try {
+            String authMessage = clientFirstMessageBare + "," + serverFirstMessage + "," + clientFinalMessageWithoutProof;
+            byte[] storedKey = getOrFakeStoredKey(username);
+            byte[] serverKey = getOrFakeServerKey(username);
+
+            byte[] clientSignature = ScramUtils.computeHmac(storedKey, authMessage, getHmacAlgorithmName());
+            byte[] serverSignature = ScramUtils.computeHmac(serverKey, authMessage, getHmacAlgorithmName());
+
+            byte[] clientKey = clientSignature.clone();
+            byte[] decodedProof = DatatypeConverter.parseBase64Binary(proof);
+            if (decodedProof.length != clientKey.length) {
+                throw new SaslException("Invalid proof length: expected " + clientKey.length + " bytes, got " + decodedProof.length);
+            }
+            for (int i = 0; i < clientKey.length; i++) {
+                clientKey[i] ^= decodedProof[i];
+            }
+
+            if (!MessageDigest.isEqual(storedKey, MessageDigest.getInstance(getDigestAlgorithmName()).digest(clientKey))) {
+                throw new SaslException("Authentication failed for: '"+username+"'");
+            }
+            return ("v=" + DatatypeConverter.printBase64Binary(serverSignature))
+                .getBytes(StandardCharsets.UTF_8);
+        } catch (NoSuchAlgorithmException e) {
+            throw new SaslException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Determines whether the authentication exchange has completed.
+     * This method is typically called after each invocation of
+     * {@code evaluateResponse()} to determine whether the
+     * authentication has completed successfully or should be continued.
+     * @return true if the authentication exchange has completed; false otherwise.
+     */
+    @Override
+    public boolean isComplete() {
+        return state == State.COMPLETE;
+    }
+
+    /**
+     * Reports the authorization ID in effect for the client of this
+     * session.
+     * This method can only be called if isComplete() returns true.
+     * @return The authorization ID of the client.
+     * @exception IllegalStateException if this authentication session has not completed
+     */
+    @Override
+    public String getAuthorizationID() {
+        if (isComplete()) {
+            return username;
+        } else {
+            throw new IllegalStateException(getMechanismName() + " authentication not completed");
+        }
+    }
+
+    /**
+     * Unwraps a byte array received from the client. SCRAM supports no security layer.
+     *
+     * @throws SaslException if attempted to use this method.
+     */
+    @Override
+    public byte[] unwrap(byte[] incoming, int offset, int len)
+        throws SaslException {
+        if (isComplete()) {
+            throw new IllegalStateException(getMechanismName() + " does not support integrity or privacy");
+        } else {
+            throw new IllegalStateException(getMechanismName() + " authentication not completed");
+        }
+    }
+
+    /**
+     * Wraps a byte array to be sent to the client. SCRAM supports no security layer.
+     *
+     * @throws SaslException if attempted to use this method.
+     */
+    @Override
+    public byte[] wrap(byte[] outgoing, int offset, int len)
+        throws SaslException {
+        if (isComplete()) {
+            throw new IllegalStateException(getMechanismName() + " does not support integrity or privacy");
+        } else {
+            throw new IllegalStateException(getMechanismName() + " authentication not completed");
+        }
+    }
+
+    /**
+     * Retrieves the negotiated property.
+     * This method can be called only after the authentication exchange has
+     * completed (i.e., when {@code isComplete()} returns true); otherwise, an
+     * {@code IllegalStateException} is thrown.
+     *
+     * @param propName the property
+     * @return The value of the negotiated property. If null, the property was
+     * not negotiated or is not applicable to this mechanism.
+     * @exception IllegalStateException if this authentication exchange has not completed
+     */
+    @Override
+    public Object getNegotiatedProperty(String propName) {
+        if (isComplete()) {
+            if (propName.equals(Sasl.QOP)) {
+                return "auth";
+            } else if (isPlusMechanism && propName.equals(PROPNAME_CHANNELBINDINGTYPE)) {
+                return gs2CbindName;
+            } else {
+                return null;
+            }
+        } else {
+            throw new IllegalStateException(getMechanismName() + " authentication not completed");
+        }
+    }
+
+    /**
+     * Disposes of any system resources or security-sensitive information
+     * the SaslServer might be using. Invoking this method invalidates
+     * the SaslServer instance. This method is idempotent.
+     * @throws SaslException If a problem was encountered while disposing
+     * the resources.
+     */
+    @Override
+    public void dispose() throws SaslException {
+        username = null;
+        nonce = null;
+        serverFirstMessage = null;
+        clientFirstMessageBare = null;
+        expectedChannelBindingPayloadInFinalClientMessage = null;
+        gs2CbindName = null;
+        state = State.INITIAL;
+    }
 
     /**
      * Retrieve the salt for a given username.
@@ -52,7 +472,219 @@ public abstract class ScramSaslServer implements SaslServer
      *
      * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3258">OF-3258: Guard against user enumeration in ScramSha1SaslServer</a>
      */
-    abstract byte[] getOrCreateSalt(final String username);
+    protected byte[] getOrCreateSalt(final String username)
+    {
+        try
+        {
+            final String saltBase64 = AuthFactory.getSalt(username, getMechanismBaseName());
+            if (saltBase64 == null) {
+                return handleMissingSalt(username);
+            }
+
+            return decodeSalt(saltBase64);
+        }
+        catch (UserNotFoundException e)
+        {
+            Log.debug("User '{}' not found. Returning fake salt.", username, e);
+            return generateFakeSalt(username);
+        }
+        catch (UnsupportedOperationException | ConnectionException | InternalUnauthenticatedException e) {
+            Log.warn("Exception in SCRAM.getSalt() for user '{}'", username, e);
+            return generateFakeSalt(username);
+        }
+    }
+
+    /**
+     * When no salt is found for the user, but a (plain-text) password is available, we can generate a salt by updating
+     * the password to the same value (this should trigger a re-hashing of the password).
+     *
+     * @param username The user for whom to generate a salt
+     * @return A salt
+     * @throws UserNotFoundException when the password could not be loaded for this user.
+     * @throws InternalUnauthenticatedException when there's an authentication issue with connecting to the user-provider
+     * @throws ConnectionException when there's an issue with connecting to the user-provider
+     * @throws UnsupportedOperationException when a plain-text password cannot be retrieved for this user.
+     */
+    private byte[] handleMissingSalt(String username) throws UserNotFoundException, InternalUnauthenticatedException, ConnectionException, UnsupportedOperationException
+    {
+        Log.debug("No salt found for '{}', regenerating.", username);
+
+        final String password = AuthFactory.getPassword(username);
+        if (password == null) {
+            // No password available. This is likely an issue with the provider, which should have thrown a
+            // UserNotFoundException or UnsupportedOperationException. Both of those will cause the same fallback
+            // handling, so this code can generate either to cause that same fallback behavior.
+            throw new UserNotFoundException("No password available for user '" + username + "'");
+        }
+        AuthFactory.setPassword(username, password);
+
+        final String newSalt = AuthFactory.getSalt(username, getMechanismBaseName());
+        if (newSalt == null) {
+            Log.debug("Salt regeneration failed for '{}'", username);
+            return generateFakeSalt(username);
+        }
+        return decodeSalt(newSalt);
+    }
+
+    /**
+     * Decode a base64-encoded salt.
+     *
+     * @param base64Salt The base64-encoded salt to decode
+     * @return The decoded salt as a byte array
+     */
+    private byte[] decodeSalt(@Nonnull final String base64Salt)
+    {
+        return DatatypeConverter.parseBase64Binary(base64Salt);
+    }
+
+    /**
+     * Generate a fake salt to guard against user enumeration attacks (see OF-3258).
+     *
+     * The returned salt is a deterministic but cryptographically unpredictable value derived from the username and a
+     * server-side secret. The returned value is always exactly {@link DefaultAuthProvider#SALT_LENGTH} bytes long.
+     *
+     * @param username The username for which to generate a fake salt
+     * @return a fake salt of length {@link DefaultAuthProvider#SALT_LENGTH}.
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3258">OF-3258: Guard against user enumeration in ScramSha1SaslServer</a>
+     */
+    private byte[] generateFakeSalt(String username)
+    {
+        final int length = DefaultAuthProvider.SALT_LENGTH;
+
+        try
+        {
+            final byte[] key = getNonExistentUserSecret().getBytes(StandardCharsets.UTF_8);
+            final byte[] result = new byte[length];
+
+            int offset = 0;
+            int counter = 0;
+
+            while (offset < length)
+            {
+                // Domain separation + counter to expand output deterministically
+                final byte[] block = ScramUtils.computeHmac(key, "fake-salt-for-" + username + ":" + counter, getHmacAlgorithmName());
+                final int toCopy = Math.min(block.length, length - offset);
+                System.arraycopy(block, 0, result, offset, toCopy);
+
+                offset += toCopy;
+                counter++;
+            }
+
+            return result;
+        }
+        catch (SaslException e)
+        {
+            // Give up trying to be deterministic. Return a random salt.
+            final byte[] salt = new byte[length];
+            random.nextBytes(salt);
+            return salt;
+        }
+    }
+
+    /**
+     * Retrieve the iteration count from the database for a given username.
+     */
+    private int getIterations(final String username) {
+        try {
+            return AuthFactory.getIterations(username, getMechanismBaseName());
+        } catch (UserNotFoundException e) {
+            return getDefaultIterationCount();
+        }
+    }
+
+    /**
+     * Retrieve the server key from the database for a given username, but returns a fake key if none is found.
+     *
+     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
+     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
+     */
+    protected byte[] getOrFakeServerKey(String username) {
+        try {
+            byte[] key = getServerKey(username);
+            if (key != null) {
+                return key;
+            }
+        } catch (UserNotFoundException ignored) {
+            // fall through
+        }
+        return generateFakeKey("server-key-" + username);
+    }
+
+    /**
+     * Retrieve the server key from the database for a given username.
+     */
+    private byte[] getServerKey(final String username) throws UserNotFoundException {
+        final String serverKey = AuthFactory.getServerKey(username, getMechanismBaseName());
+        if (serverKey == null) {
+            return null;
+        } else {
+            return DatatypeConverter.parseBase64Binary( serverKey );
+        }
+    }
+
+    /**
+     * Retrieve the stored key from the database for a given username, but returns a fake key if none is found.
+     *
+     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
+     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
+     */
+    protected byte[] getOrFakeStoredKey(final String username) {
+        try {
+            byte[] key = getStoredKey(username);
+            if (key != null) {
+                return key;
+            }
+        } catch (UserNotFoundException ignored) {
+            // fall through
+        }
+        return generateFakeKey("stored-key-" + username);
+    }
+
+    /**
+     * Retrieve the stored key from the database for a given username.
+     */
+    private byte[] getStoredKey(final String username) throws UserNotFoundException {
+        final String storedKey = AuthFactory.getStoredKey(username, getMechanismBaseName());
+        if (storedKey == null) {
+            return null;
+        } else {
+            return DatatypeConverter.parseBase64Binary( storedKey );
+        }
+    }
+
+    /**
+     * Generate a fake key to guard against timing attacks (see OF-3257).
+     *
+     * The fake key is derived using this mechanism's HMAC algorithm, so that its length matches the length of a real
+     * key for this mechanism.
+     *
+     * @param input a string input for which to generate a fake key
+     * @return a fake key
+     */
+    private byte[] generateFakeKey(String input)
+    {
+        try {
+            return ScramUtils.computeHmac(
+                getNonExistentUserSecret().getBytes(StandardCharsets.UTF_8),
+                input,
+                getHmacAlgorithmName()
+            );
+        } catch (SaslException e) {
+            int fallbackLength;
+            try {
+                fallbackLength = Mac.getInstance(getHmacAlgorithmName()).getMacLength();
+            } catch (NoSuchAlgorithmException ignored) {
+                fallbackLength = 24;
+            }
+            final byte[] fallback = new byte[fallbackLength];
+            random.nextBytes(fallback);
+            return fallback;
+        }
+    }
 
     /**
      * Extracts the raw GS2 header from a SCRAM client-first-message byte array.
@@ -67,7 +699,8 @@ public abstract class ScramSaslServer implements SaslServer
      * {@code 0} up to and including the second comma (i.e., the full GS2 header including its trailing comma).
      *
      * No character decoding or normalization is performed. This ensures that the returned GS2 header is byte-for-
-     * byte identical to the original input, which is required for correct SCRAM-SHA-1-PLUS channel binding validation.
+     * byte identical to the original input, which is required for correct -PLUS channel binding validation in SCRAM
+     * mechanisms.
      *
      * @param data the raw SCRAM client-first-message bytes
      * @return a byte array containing the complete GS2 header including the trailing comma

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -16,52 +16,45 @@
 
 package org.jivesoftware.openfire.sasl;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.annotation.Nonnull;
-import javax.security.sasl.Sasl;
-import javax.security.sasl.SaslException;
-import javax.security.sasl.SaslServer;
-import javax.xml.bind.DatatypeConverter;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.jivesoftware.openfire.auth.AuthFactory;
-import org.jivesoftware.openfire.auth.ConnectionException;
-import org.jivesoftware.openfire.auth.DefaultAuthProvider;
-import org.jivesoftware.openfire.auth.InternalUnauthenticatedException;
 import org.jivesoftware.openfire.auth.ScramUtils;
 import org.jivesoftware.openfire.net.SASLAuthentication;
-import org.jivesoftware.openfire.session.LocalSession;
-import org.jivesoftware.openfire.user.UserNotFoundException;
 import org.jivesoftware.util.StringUtils;
 import org.jivesoftware.util.SystemProperty;
 import org.jivesoftware.util.channelbinding.ChannelBindingProviderManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implements the SCRAM-SHA-1 (and its channel binding -PLUS variant) server-side mechanism.
+ *
+ * The SCRAM exchange itself is implemented by the hash-agnostic {@link ScramSaslServer} superclass. This class binds
+ * that exchange to the SHA-1 hash function.
  *
  * @author Richard Midwinter, Guus der Kinderen
  */
 public class ScramSha1SaslServer extends ScramSaslServer {
 
+    /**
+     * The IANA-registered name of the base (non-PLUS) mechanism implemented by this server.
+     */
     public static final String MECHANISM_NAME = "SCRAM-SHA-1";
+
+    /**
+     * The JCA name of the HMAC algorithm that corresponds to this mechanism's hash function
+     */
+    public static final String HMAC_ALGORITHM_NAME = "HmacSHA1";
+
+    /**
+     * The JCA name of the message digest that corresponds to this mechanism's hash function.
+     */
+    public static final String DIGEST_ALGORITHM_NAME = "SHA-1";
 
     /**
      * Stores a server-side secret used when handling authentication attempts for non-existing users in SCRAM-SHA-1 (-PLUS).
      *
-     * Prefer to use #getInitializedServerSecretForNonExistentUsers() instead of accessing this property directly, as
+     * Prefer to use #getServerSecretForNonExistentUsers() instead of accessing this property directly, as
      * the method will make sure that the one-time initialization that's required for usage will occur.
      *
      * @see #getServerSecretForNonExistentUsers()
@@ -102,44 +95,15 @@ public class ScramSha1SaslServer extends ScramSaslServer {
         return SERVER_SECRET_NONEXISTENT_USERS.getValue();
     }
 
-    public static final String PROPNAME_CHANNELBINDINGTYPE = "channelbindingtype";
-
     public static final SystemProperty<Integer> ITERATION_COUNT = SystemProperty.Builder.ofType(Integer.class)
         .setKey("sasl.scram-sha-1.iteration-count")
         .setDefaultValue(ScramUtils.DEFAULT_ITERATION_COUNT)
         .setDynamic(Boolean.TRUE)
         .build();
-    private static final Logger Log = LoggerFactory.getLogger(ScramSha1SaslServer.class);
-    private static final Pattern
-            CLIENT_FIRST_MESSAGE = Pattern.compile("^(([pny])=?([^,]*),([^,]*),)(m?=?[^,]*,?n=([^,]*),r=([^,]*),?.*)$"),
-            CLIENT_FINAL_MESSAGE = Pattern.compile("(c=([^,]*),r=([^,]*)),p=(.*)$");
-
-    private final ChannelBindingProviderManager channelBindingProviderManager;
-    private final Set<String> serverSupportedSaslMechanismNames;
-
-    private final boolean isPlusMechanism;
-    private final Map<String, ?> props;
-    private String username;
-    private State state = State.INITIAL;
-    private String nonce;
-    private String serverFirstMessage;
-    private String clientFirstMessageBare;
-    private final SecureRandom random = new SecureRandom();
-    private byte[] expectedChannelBindingPayloadInFinalClientMessage;
-    private String gs2CbindName;
-
-    private enum State {
-        INITIAL,
-        IN_PROGRESS,
-        COMPLETE;
-    }
 
     public ScramSha1SaslServer(final boolean isPlusMechanism, final Map<String, ?> props)
     {
-        this.isPlusMechanism = isPlusMechanism;
-        this.props = props;
-        this.channelBindingProviderManager = ChannelBindingProviderManager.getInstance();
-        this.serverSupportedSaslMechanismNames = SASLAuthentication.getSupportedMechanisms();
+        super(isPlusMechanism, props, ChannelBindingProviderManager.getInstance(), SASLAuthentication.getSupportedMechanisms());
     }
 
     /**
@@ -148,549 +112,31 @@ public class ScramSha1SaslServer extends ScramSaslServer {
     @VisibleForTesting
     ScramSha1SaslServer(final boolean isPlusMechanism, final Map<String, ?> props, final ChannelBindingProviderManager channelBindingProviderManager, final Set<String> serverSupportedSaslMechanismNames)
     {
-        this.isPlusMechanism = isPlusMechanism;
-        this.props = props;
-        this.channelBindingProviderManager = channelBindingProviderManager;
-        this.serverSupportedSaslMechanismNames = serverSupportedSaslMechanismNames;
+        super(isPlusMechanism, props, channelBindingProviderManager, serverSupportedSaslMechanismNames);
     }
 
-    /**
-     * Returns the IANA-registered mechanism name of this SASL server.
-     * ("SCRAM-SHA-1").
-     * @return A non-null string representing the IANA-registered mechanism name.
-     */
     @Override
-    public String getMechanismName() {
-        return isPlusMechanism ? "SCRAM-SHA-1-PLUS" : "SCRAM-SHA-1";
+    protected String getMechanismBaseName() {
+        return MECHANISM_NAME;
     }
 
-    /**
-     * Evaluates the response data and generates a challenge.
-     *
-     * If a response is received from the client during the authentication
-     * process, this method is called to prepare an appropriate next
-     * challenge to submit to the client. The challenge is null if the
-     * authentication has succeeded and no more challenge data is to be sent
-     * to the client. It is non-null if the authentication must be continued
-     * by sending a challenge to the client, or if the authentication has
-     * succeeded but challenge data needs to be processed by the client.
-     * {@code isComplete()} should be called
-     * after each call to {@code evaluateResponse()},to determine if any further
-     * response is needed from the client.
-     *
-     * @param response The non-null (but possibly empty) response sent
-     * by the client.
-     *
-     * @return The possibly null challenge to send to the client.
-     * It is null if the authentication has succeeded and there is
-     * no more challenge data to be sent to the client.
-     * @exception SaslException If an error occurred while processing
-     * the response or generating a challenge.
-     */
     @Override
-    public byte[] evaluateResponse(final byte[] response) throws SaslException {
-        try {
-            byte[] challenge;
-            switch (state)
-            {
-                case INITIAL:
-                    challenge = generateServerFirstMessage(response);
-                    state = State.IN_PROGRESS;
-                    break;
-                case IN_PROGRESS:
-                    challenge = generateServerFinalMessage(response);
-                    state = State.COMPLETE;
-                    break;
-                case COMPLETE:
-                    if (response == null || response.length == 0)
-                    {
-                        challenge = new byte[0];
-                        break;
-                    }
-                    throw new SaslException("Unexpected response after authentication completed");
-                default:
-                    throw new SaslException("No response expected in state " + state);
-
-            }
-            return challenge;
-        } catch (RuntimeException ex) {
-           throw new SaslException("Unexpected exception while evaluating SASL response.", ex);
-        }
+    protected String getHmacAlgorithmName() {
+        return HMAC_ALGORITHM_NAME;
     }
 
-    /**
-     * First response returns:
-     *   - the nonce (client nonce appended with our own random UUID)
-     *   - the salt
-     *   - the number of iterations
-     */
-    private byte[] generateServerFirstMessage(final byte[] response) throws SaslException {
-        String clientFirstMessage = new String(response, StandardCharsets.UTF_8);
-        Matcher m = CLIENT_FIRST_MESSAGE.matcher(clientFirstMessage);
-        if (!m.matches()) {
-            throw new SaslException("Invalid first client message");
-        }
-        final byte[] gs2_header = extractRawGS2Header(response); // Using raw header to prevent any normalization issues that might pop up when using something like: gs2Header.getBytes(StandardCharsets.UTF_8);
-//        String gs2Header = m.group(1);
-        String gs2CbindFlag = m.group(2);
-        gs2CbindName = m.group(3);
-//        String authzId = m.group(4);
-        clientFirstMessageBare = m.group(5);
-        username = m.group(6);
-        String clientNonce = m.group(7);
-
-        if (username == null || username.isEmpty()) {
-            throw new SaslException("Invalid first client message: Username cannot be empty");
-        }
-        if (clientNonce == null || clientNonce.isEmpty()) {
-            throw new SaslException("Invalid first client message: Client nonce cannot be empty");
-        }
-
-        // https://www.rfc-editor.org/rfc/rfc5802.html#section-6: If the flag is set to "y" and the server supports
-        // channel binding, the server MUST fail authentication. This is because if the client sets the channel binding
-        // flag to "y", then the client must have believed that the server did not support channel binding -- if the
-        // server did in fact support channel binding, then this is an indication that there has been a downgrade attack
-        // (e.g., an attacker changed the server's mechanism list to exclude the -PLUS suffixed SCRAM mechanism name(s)).
-        final boolean clientSupportsChannelBindingButThinksServerDoesNot = "y".equals(gs2CbindFlag);
-        final boolean serverSupportsChannelBinding = serverSupportedSaslMechanismNames.stream().anyMatch(mechanism -> mechanism.endsWith("-PLUS"));
-        if (clientSupportsChannelBindingButThinksServerDoesNot && serverSupportsChannelBinding) {
-            throw new SaslException("Client supports channel binding, but thinks the server does not (while it does). Rejecting authentication to prevent downgrade attack.");
-        }
-
-        final boolean clientRequiresChannelBinding = "p".equals(gs2CbindFlag);
-        if (clientRequiresChannelBinding && !isPlusMechanism) {
-            throw new SaslException("Client requires channel binding, but is not using a -PLUS mechanism. Rejecting authentication.");
-        }
-
-        if (isPlusMechanism)
-        {
-            if (!clientRequiresChannelBinding) {
-                throw new SaslException("Channel binding required for -PLUS. Rejecting authentication.");
-            }
-
-            if (!serverSupportsChannelBinding) {
-                throw new SaslException("Client requires channel binding, but server does not support channel binding. Rejecting authentication.");
-            }
-
-            // https://www.rfc-editor.org/rfc/rfc5802.html#section-6: If the channel binding flag was "p" and the server
-            // does not support the indicated channel binding type, then the server MUST fail authentication.
-            if (gs2CbindName == null || gs2CbindName.isEmpty() || !channelBindingProviderManager.supportsChannelBinding(gs2CbindName)) {
-                throw new SaslException("Client requires channel binding, but server does not support the indicated channel binding type '" + gs2CbindName + "'. Rejecting authentication.");
-            }
-
-            // Prepare channel binding data.
-            final LocalSession session = (LocalSession) props.get(LocalSession.class.getCanonicalName());
-            if (session == null || session.getConnection() == null) {
-                throw new SaslException("Local session not found in properties. Rejecting authentication.");
-            }
-            final Optional<byte[]> channelBindingData = session.getConnection().getChannelBindingData(gs2CbindName);
-            if (channelBindingData.isEmpty()) {
-                Log.debug("Unable to retrieve channel binding data for '{}'. Rejecting authentication.", gs2CbindName);
-                throw new SaslException("Unable to retrieve channel binding data for '" + gs2CbindName + "'. Rejecting authentication.");
-            }
-
-            // In the final client message, we expect to find a combination of the gs2 header and channel binding data.
-            final byte[] cb_data = channelBindingData.get();
-            expectedChannelBindingPayloadInFinalClientMessage = new byte[gs2_header.length + cb_data.length];
-            System.arraycopy(gs2_header, 0, expectedChannelBindingPayloadInFinalClientMessage, 0        , gs2_header.length);
-            System.arraycopy(cb_data,    0, expectedChannelBindingPayloadInFinalClientMessage, gs2_header.length, cb_data.length);
-        } else {
-            // If this is _not_ a -PLUS mechanism, we still need to verify the channel binding payload in the final client message.
-            // In that case, it should not have trailing channel binding data.
-            expectedChannelBindingPayloadInFinalClientMessage = gs2_header;
-        }
-
-        nonce = clientNonce + UUID.randomUUID().toString();
-
-        serverFirstMessage = String.format("r=%s,s=%s,i=%d", nonce, DatatypeConverter.printBase64Binary(getOrCreateSalt(username)),
-                getIterations(username));
-        return serverFirstMessage.getBytes(StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Final response returns the server signature.
-     */
-    private byte[] generateServerFinalMessage(final byte[] response) throws SaslException {
-        String clientFinalMessage = new String(response, StandardCharsets.UTF_8);
-        Matcher m = CLIENT_FINAL_MESSAGE.matcher(clientFinalMessage);
-        if (!m.matches()) {
-            throw new SaslException("Invalid client final message");
-        }
-
-        // client-final-message regex: (c=([^,]*),r=([^,]*)),p=(.*)$")
-        final String clientFinalMessageWithoutProof = m.group(1); // (c=([^,]*),r=([^,]*))
-        final String channelBinding = m.group(2);                 // c=([^,]*)
-        final String clientNonce = m.group(3);                    // r=([^,]*)
-        final String proof = m.group(4);                          // p=(.*)
-
-        if (proof == null || proof.isEmpty()) {
-            throw new SaslException("Invalid client final message: missing proof attribute");
-        }
-
-        if (channelBinding == null || channelBinding.isEmpty()) {
-            throw new SaslException("Invalid client final message: missing channel binding attribute");
-        }
-
-        if (clientNonce == null || clientNonce.isEmpty()) {
-            throw new SaslException("Invalid client final message: missing nonce attribute");
-        }
-
-        // Verify nonce: RFC 5802 §5: must equal client_nonce (from initial client response) + server_nonce (from initial server response)
-        if (!nonce.equals(clientNonce)) { // Constant-time operation is important for keys, not for public protocol values like nonces.
-            // Possible replay or tampering
-            throw new SaslException("Invalid client final message: incorrect nonce attribute value");
-        }
-
-        // Verify channel binding payload.
-        final byte[] decodedChannelBinding = DatatypeConverter.parseBase64Binary(channelBinding);
-        if (!Arrays.equals(expectedChannelBindingPayloadInFinalClientMessage, decodedChannelBinding)) {
-            throw new SaslException("Invalid client final message: channel binding payload does not match expected payload");
-        }
-
-        try {
-            String authMessage = clientFirstMessageBare + "," + serverFirstMessage + "," + clientFinalMessageWithoutProof;
-            byte[] storedKey = getOrFakeStoredKey(username);
-            byte[] serverKey = getOrFakeServerKey(username);
-
-            byte[] clientSignature = ScramUtils.computeHmac(storedKey, authMessage);
-            byte[] serverSignature = ScramUtils.computeHmac(serverKey, authMessage);
-            
-            byte[] clientKey = clientSignature.clone();
-            byte[] decodedProof = DatatypeConverter.parseBase64Binary(proof);
-            if (decodedProof.length != clientKey.length) {
-                throw new SaslException("Invalid proof length: expected " + clientKey.length + " bytes, got " + decodedProof.length);
-            }
-            for (int i = 0; i < clientKey.length; i++) {
-                clientKey[i] ^= decodedProof[i];
-            }
-
-            if (!MessageDigest.isEqual(storedKey, MessageDigest.getInstance("SHA-1").digest(clientKey))) {
-                throw new SaslException("Authentication failed for: '"+username+"'");
-            }
-            return ("v=" + DatatypeConverter.printBase64Binary(serverSignature))
-                    .getBytes(StandardCharsets.UTF_8);
-        } catch (NoSuchAlgorithmException e) {
-            throw new SaslException(e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Determines whether the authentication exchange has completed.
-     * This method is typically called after each invocation of
-     * {@code evaluateResponse()} to determine whether the
-     * authentication has completed successfully or should be continued.
-     * @return true if the authentication exchange has completed; false otherwise.
-     */
     @Override
-    public boolean isComplete() {
-        return state == State.COMPLETE;
+    protected String getDigestAlgorithmName() {
+        return DIGEST_ALGORITHM_NAME;
     }
 
-    /**
-     * Reports the authorization ID in effect for the client of this
-     * session.
-     * This method can only be called if isComplete() returns true.
-     * @return The authorization ID of the client.
-     * @exception IllegalStateException if this authentication session has not completed
-     */
     @Override
-    public String getAuthorizationID() {
-        if (isComplete()) {
-            return username;
-        } else {
-            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
-        }
+    protected int getDefaultIterationCount() {
+        return ITERATION_COUNT.getValue();
     }
 
-    /**
-     * Unwraps a byte array received from the client. SCRAM-SHA-1 supports no security layer.
-     * 
-     * @throws SaslException if attempted to use this method.
-     */
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len)
-        throws SaslException {
-        if (isComplete()) {
-            throw new IllegalStateException("SCRAM-SHA-1 does not support integrity or privacy");
-        } else {
-            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
-        }
-    }
-
-    /**
-     * Wraps a byte array to be sent to the client. SCRAM-SHA-1 supports no security layer.
-     *
-     * @throws SaslException if attempted to use this method.
-     */
-    @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len)
-        throws SaslException {
-        if (isComplete()) {
-            throw new IllegalStateException("SCRAM-SHA-1 does not support integrity or privacy");
-        } else {
-            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
-        }
-    }
-
-    /**
-     * Retrieves the negotiated property.
-     * This method can be called only after the authentication exchange has
-     * completed (i.e., when {@code isComplete()} returns true); otherwise, an
-     * {@code IllegalStateException} is thrown.
-     *
-     * @param propName the property
-     * @return The value of the negotiated property. If null, the property was
-     * not negotiated or is not applicable to this mechanism.
-     * @exception IllegalStateException if this authentication exchange has not completed
-     */
-    @Override
-    public Object getNegotiatedProperty(String propName) {
-        if (isComplete()) {
-            if (propName.equals(Sasl.QOP)) {
-                return "auth";
-            } else if (isPlusMechanism && propName.equals(PROPNAME_CHANNELBINDINGTYPE)) {
-                return gs2CbindName;
-            } else {
-                return null;
-            }
-        } else {
-            throw new IllegalStateException("SCRAM-SHA-1 authentication not completed");
-        }
-    }
-
-     /**
-      * Disposes of any system resources or security-sensitive information
-      * the SaslServer might be using. Invoking this method invalidates
-      * the SaslServer instance. This method is idempotent.
-      * @throws SaslException If a problem was encountered while disposing
-      * the resources.
-      */
-    @Override
-    public void dispose() throws SaslException {
-        username = null;
-        nonce = null;
-        serverFirstMessage = null;
-        clientFirstMessageBare = null;
-        expectedChannelBindingPayloadInFinalClientMessage = null;
-        gs2CbindName = null;
-        state = State.INITIAL;
-    }
-
-    /**
-     * Retrieve the salt for a given username.
-     *
-     * When a salt does not currently exist for an existing user, but a password is set, that value is used to create
-     * and persist a new salt for that user.
-     *
-     * Returns a username-specific salt if the user doesn't exist to mimic an invalid password. This also guards against
-     * user enumeration attacks.
-     *
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3258">OF-3258: Guard against user enumeration in ScramSha1SaslServer</a>
-     */
-    @Override
-    protected byte[] getOrCreateSalt(final String username)
-    {
-        try
-        {
-            final String saltBase64 = AuthFactory.getSalt(username, MECHANISM_NAME);
-            if (saltBase64 == null) {
-                return handleMissingSalt(username);
-            }
-
-            return decodeSalt(saltBase64);
-        }
-        catch (UserNotFoundException e)
-        {
-            Log.debug("User '{}' not found. Returning fake salt.", username, e);
-            return generateFakeSalt(username);
-        }
-        catch (UnsupportedOperationException | ConnectionException | InternalUnauthenticatedException e) {
-            Log.warn("Exception in SCRAM.getSalt() for user '{}'", username, e);
-            return generateFakeSalt(username);
-        }
-    }
-
-    /**
-     * When no salt is found for the user, but a (plain-text) password is available, we can generate a salt by updating
-     * the password to the same value (this should trigger a re-hashing of the password).
-     *
-     * @param username The user for whom to generate a salt
-     * @return A salt
-     * @throws UserNotFoundException when the password could not be loaded for this user.
-     * @throws InternalUnauthenticatedException when there's an authentication issue with connecting to the user-provider
-     * @throws ConnectionException when there's an issue with connecting to the user-provider
-     * @throws UnsupportedOperationException when a plain-text password cannot be retrieved for this user.
-     */
-    private byte[] handleMissingSalt(String username) throws UserNotFoundException, InternalUnauthenticatedException, ConnectionException, UnsupportedOperationException
-    {
-        Log.debug("No salt found for '{}', regenerating.", username);
-
-        final String password = AuthFactory.getPassword(username);
-        if (password == null) {
-            // No password available. This is likely an issue with the provider, which should have thrown a
-            // UserNotFoundException or UnsupportedOperationException. Both of those will cause the same fallback
-            // handling, so this code can generate either to cause that same fallback behavior.
-            throw new UserNotFoundException("No password available for user '" + username + "'");
-        }
-        AuthFactory.setPassword(username, password);
-
-        final String newSalt = AuthFactory.getSalt(username, MECHANISM_NAME);
-        if (newSalt == null) {
-            Log.debug("Salt regeneration failed for '{}'", username);
-            return generateFakeSalt(username);
-        }
-        return decodeSalt(newSalt);
-    }
-
-    /**
-     * Decode a base64-encoded salt.
-     *
-     * @param base64Salt The base64-encoded salt to decode
-     * @return The decoded salt as a byte array
-     */
-    private byte[] decodeSalt(@Nonnull final String base64Salt)
-    {
-        return DatatypeConverter.parseBase64Binary(base64Salt);
-    }
-
-    /**
-     * Generate a fake salt to guard against user enumeration attacks (see OF-3258).
-     *
-     * The returned salt is a deterministic but cryptographically unpredictable value derived from the username and a
-     * server-side secret. The returned value is always exactly {@link DefaultAuthProvider#SALT_LENGTH} bytes long.
-     *
-     * @param username The username for which to generate a fake salt
-     * @return a fake salt of length {@link DefaultAuthProvider#SALT_LENGTH}.
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3258">OF-3258: Guard against user enumeration in ScramSha1SaslServer</a>
-     */
-    private byte[] generateFakeSalt(String username)
-    {
-        final int length = DefaultAuthProvider.SALT_LENGTH;
-
-        try
-        {
-            final byte[] key = getServerSecretForNonExistentUsers().getBytes(StandardCharsets.UTF_8);
-            final byte[] result = new byte[length];
-
-            int offset = 0;
-            int counter = 0;
-
-            while (offset < length)
-            {
-                // Domain separation + counter to expand output deterministically
-                final byte[] block = ScramUtils.computeHmac(key, "fake-salt-for-" + username + ":" + counter);
-                final int toCopy = Math.min(block.length, length - offset);
-                System.arraycopy(block, 0, result, offset, toCopy);
-
-                offset += toCopy;
-                counter++;
-            }
-
-            return result;
-        }
-        catch (SaslException e)
-        {
-            // Give up trying to be deterministic. Return a random salt.
-            final byte[] salt = new byte[length];
-            random.nextBytes(salt);
-            return salt;
-        }
-    }
-    
-    /**
-     * Retrieve the iteration count from the database for a given username.
-     */
-    private int getIterations(final String username) {
-        try {
-            return AuthFactory.getIterations(username, MECHANISM_NAME);
-        } catch (UserNotFoundException e) {
-            return ITERATION_COUNT.getValue();
-        }
-    }
-
-    /**
-     * Retrieve the server key from the database for a given username, but returns a fake key if none is found.
-     *
-     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
-     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
-     *
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
-     */
-    @Override
-    protected byte[] getOrFakeServerKey(String username) {
-        try {
-            byte[] key = getServerKey(username);
-            if (key != null) {
-                return key;
-            }
-        } catch (UserNotFoundException ignored) {
-            // fall through
-        }
-        return generateFakeKey("server-key-" + username);
-    }
-
-    /**
-     * Retrieve the server key from the database for a given username.
-     */
-    private byte[] getServerKey(final String username) throws UserNotFoundException {
-        final String serverKey = AuthFactory.getServerKey(username, MECHANISM_NAME);
-        if (serverKey == null) {
-            return null;
-        } else {
-            return DatatypeConverter.parseBase64Binary( serverKey );
-        }
-    }
-
-    /**
-     * Retrieve the stored key from the database for a given username, but returns a fake key if none is found.
-     *
-     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
-     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
-     *
-     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
-     */
-    @Override
-    protected byte[] getOrFakeStoredKey(final String username) {
-        try {
-            byte[] key = getStoredKey(username);
-            if (key != null) {
-                return key;
-            }
-        } catch (UserNotFoundException ignored) {
-            // fall through
-        }
-        return generateFakeKey("stored-key-" + username);
-    }
-
-    /**
-     * Retrieve the stored key from the database for a given username.
-     */
-    private byte[] getStoredKey(final String username) throws UserNotFoundException {
-        final String storedKey = AuthFactory.getStoredKey(username, MECHANISM_NAME);
-        if (storedKey == null) {
-            return null;
-        } else {
-            return DatatypeConverter.parseBase64Binary( storedKey );
-        }
-    }
-
-    /**
-     * Generate a fake key to guard against timing attacks (see OF-3257).
-     *
-     * @param input a string input for which to generate a fake key
-     * @return a fake key
-     */
-    private byte[] generateFakeKey(String input)
-    {
-        try {
-            return ScramUtils.computeHmac(
-                getServerSecretForNonExistentUsers().getBytes(StandardCharsets.UTF_8),
-                input
-            );
-        } catch (SaslException e) {
-            byte[] fallback = new byte[24];
-            random.nextBytes(fallback);
-            return fallback;
-        }
+    protected String getNonExistentUserSecret() {
+        return getServerSecretForNonExistentUsers();
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
@@ -18,11 +18,15 @@ package org.jivesoftware.openfire.auth;
 import org.jivesoftware.Fixtures;
 import org.jivesoftware.database.DbConnectionManager;
 import org.jivesoftware.openfire.sasl.ScramSha1SaslServer;
+import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.jivesoftware.util.JiveGlobals;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import javax.security.sasl.SaslException;
 import javax.xml.bind.DatatypeConverter;
 import java.security.MessageDigest;
 import java.sql.Connection;
@@ -30,9 +34,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.Locale;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 /**
@@ -62,6 +67,11 @@ public class DefaultAuthProviderScramStorageTest
     {
         Fixtures.reconfigureOpenfireHome();
         Fixtures.disableDatabasePersistence();
+    }
+
+    @AfterEach
+    void clearProperties() {
+        Fixtures.clearExistingProperties();
     }
 
     /**
@@ -366,5 +376,38 @@ public class DefaultAuthProviderScramStorageTest
 
         // Verify result.
         assertFalse(result, "An empty password should not verify against a non-empty SCRAM credential.");
+    }
+
+    /**
+     * When {@code user.scramHashedPasswordOnly} is set and *no* SCRAM mechanism can derive a credential, setPassword
+     * must refuse rather than persist a user with no plaintext, no encrypted password, and no SCRAM rows, a state that
+     * would silently lock the user out of every authentication path.
+     *
+     * The guard must fire <em>before</em> the database transaction is opened: this test asserts both that
+     * {@link UserNotFoundException} is thrown and that {@link DbConnectionManager#getTransactionConnection()} is never
+     * called, so a broken guard that threw only after committing would fail here.
+     */
+    @Test
+    void setPassword_scramOnly_refusesWhenNoScramCredentialCanBeDerived()
+    {
+        // Setup test fixture: SCRAM-only mode, and force every mechanism's key derivation to fail.
+        JiveGlobals.setProperty("user.scramHashedPasswordOnly", "true");
+
+        try (final MockedStatic<ScramUtils> scramUtils = Mockito.mockStatic(ScramUtils.class);
+             final MockedStatic<DbConnectionManager> db = Mockito.mockStatic(DbConnectionManager.class))
+        {
+            scramUtils.when(() -> ScramUtils.deriveScramKeys(
+                    Mockito.any(byte[].class), Mockito.anyString(), Mockito.anyInt(),
+                    Mockito.anyString(), Mockito.anyString()))
+                .thenThrow(new SaslException("forced derivation failure for test"));
+
+            // Execute system under test & verify result: setPassword must refuse.
+            assertThrows(UserNotFoundException.class,
+                () -> new DefaultAuthProvider().setPassword("user", "pencil"),
+                "In scramOnly mode with no derivable SCRAM credential, setPassword must throw rather than persist a credential-less user.");
+
+            // Verify the refusal happened before any transaction was opened (nothing was written).
+            db.verify(DbConnectionManager::getTransactionConnection, never());
+        }
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
@@ -33,6 +33,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.Locale;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -177,6 +178,61 @@ public class DefaultAuthProviderScramStorageTest
     private static boolean runCheckPassword(final String username, final String testPassword, final ResultSet storedCredentials) throws Exception
     {
         return runCheckPassword(username, testPassword, storedCredentials, false);
+    }
+
+    /**
+     * Runs {@link DefaultAuthProvider#hasIncompleteSetOfScramCredentials(String)} against a mocked database.
+     *
+     * Each supported mechanism is probed independently via {@code LOAD_SCRAM_CREDENTIAL} (keyed on username + mechanism),
+     * so the fixture is expressed as "which mechanisms have a stored row." A mechanism whose name is in
+     * {@code presentMechanisms} yields a one-row ResultSet (credential exists); any other yields an empty ResultSet.
+     *
+     * @param username           the user identifier
+     * @param presentMechanisms  the mechanism names for which a credential row exists
+     * @return the result of {@code hasIncompleteSetOfScramCredentials}
+     */
+    @SuppressWarnings("SqlSourceToSinkFlow")
+    private static boolean runHasIncompleteSet(final String username, final Set<String> presentMechanisms) throws Exception
+    {
+        final PreparedStatement scramStmt = Mockito.mock(PreparedStatement.class);
+
+        // Capture the mechanism bound as parameter 2, then answer executeQuery() based on it.
+        final String[] boundMechanism = new String[1];
+        Mockito
+            .doAnswer(inv -> { boundMechanism[0] = inv.getArgument(1); return null; })
+            .when(scramStmt)
+            .setString(Mockito.eq(2), Mockito.anyString());
+
+        when(
+            scramStmt.executeQuery()
+        ).thenAnswer(inv -> {
+            final ResultSet rs = Mockito.mock(ResultSet.class);
+            final boolean present = presentMechanisms.contains(boundMechanism[0]);
+
+            when(
+                rs.next()
+            ).thenReturn(present, false);
+
+            if (present) {
+                when(rs.getInt(1)).thenReturn(ITERATIONS);
+                when(rs.getString(2)).thenReturn(SALT_BASE64);
+                when(rs.getString(3)).thenReturn("stored");
+                when(rs.getString(4)).thenReturn("server");
+            }
+            return rs;
+        });
+
+        final Connection connection = Mockito.mock(Connection.class);
+        when(
+            connection.prepareStatement(
+                argThat(sql -> sql.toLowerCase(Locale.ROOT).contains("from ofuserscram") && !sql.toLowerCase(Locale.ROOT).contains("left join"))
+            )
+        ).thenReturn(scramStmt);
+
+        try (final MockedStatic<DbConnectionManager> db = Mockito.mockStatic(DbConnectionManager.class)) {
+            db.when(DbConnectionManager::getConnection).thenReturn(connection);
+            return new DefaultAuthProvider().hasIncompleteSetOfScramCredentials(username);
+        }
     }
 
     /**
@@ -376,6 +432,22 @@ public class DefaultAuthProviderScramStorageTest
 
         // Verify result.
         assertFalse(result, "An empty password should not verify against a non-empty SCRAM credential.");
+    }
+
+    /**
+     * No SCRAM credentials at all → incomplete → returns true.
+     */
+    @Test
+    void hasIncompleteSet_returnsTrue_whenNoMechanismsPresent() throws Exception
+    {
+        // Setup test fixture.
+        final Set<String> presentMechanisms = Set.of();
+
+        // Execute system under test.
+        final boolean result = runHasIncompleteSet("user", presentMechanisms);
+
+        // Verify result.
+        assertTrue(result, "A user with no SCRAM credentials has an incomplete set.");
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/auth/DefaultAuthProviderScramStorageTest.java
@@ -71,9 +71,9 @@ public class DefaultAuthProviderScramStorageTest
     private static String storedKeyFor(final String password) throws Exception
     {
         final byte[] salt = DatatypeConverter.parseBase64Binary(SALT_BASE64);
-        final byte[] saltedPassword = ScramUtils.createSaltedPassword(salt, password, ITERATIONS);
-        final byte[] clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key");
-        return DatatypeConverter.printBase64Binary(MessageDigest.getInstance("SHA-1").digest(clientKey));
+        final byte[] saltedPassword = ScramUtils.createSaltedPassword(salt, password, ITERATIONS, ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
+        final byte[] clientKey = ScramUtils.computeHmac(saltedPassword, "Client Key", ScramSha1SaslServer.HMAC_ALGORITHM_NAME);
+        return DatatypeConverter.printBase64Binary(MessageDigest.getInstance(ScramSha1SaslServer.DIGEST_ALGORITHM_NAME).digest(clientKey));
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/auth/ScramUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/auth/ScramUtilsTest.java
@@ -32,7 +32,9 @@ public class ScramUtilsTest
      * that are provided by the XSF.
      *
      * @see <a href="https://wiki.xmpp.org/web/SASL_Authentication_and_SCRAM">XSF SCRAM test vectors.</a>
+     * @deprecated This tests an implementation that shall be removed. When it is, this test can be deleted.
      */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     @Test
     public void testCreateSaltedPassword() throws Exception
     {
@@ -55,7 +57,9 @@ public class ScramUtilsTest
      * This test uses the test vectors identified as the 'client key'.
      *
      * @see <a href="https://wiki.xmpp.org/web/SASL_Authentication_and_SCRAM">XSF SCRAM test vectors.</a>
+     * @deprecated This tests an implementation that shall be removed. When it is, this test can be deleted.
      */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     @Test
     public void testComputeHmac() throws Exception
     {
@@ -77,7 +81,9 @@ public class ScramUtilsTest
      * This test uses the test vectors identified as the 'server key'.
      *
      * @see <a href="https://wiki.xmpp.org/web/SASL_Authentication_and_SCRAM">XSF SCRAM test vectors.</a>
+     * @deprecated This tests an implementation that shall be removed. When it is, this test can be deleted.
      */
+    @Deprecated(forRemoval = true) // Remove in or after Openfire 5.3.0
     @Test
     public void testComputeHmac2() throws Exception
     {
@@ -87,6 +93,74 @@ public class ScramUtilsTest
 
         // Execute system under test.
         final byte[] result = ScramUtils.computeHmac(key, value);
+
+        // Verify results.
+        assertArrayEquals(StringUtils.decodeHex("0fe09258b3ac852ba502cc62ba903eaacdbf7d31"), result); // test against 'server key' from the test vectors.
+    }
+
+    /**
+     * Verifies the implementation of {@link ScramUtils#createSaltedPassword(byte[], String, int, String)} by using
+     * SCRAM-SHA-1(-PLUS) test vectors that are provided by the XSF.
+     *
+     * @see <a href="https://wiki.xmpp.org/web/SASL_Authentication_and_SCRAM">XSF SCRAM test vectors.</a>
+     */
+    @Test
+    public void testScramSha1CreateSaltedPassword() throws Exception
+    {
+        // Setup test fixture.
+        final byte[] salt = StringUtils.decodeHex("4125c247e43ab1e93c6dff76");
+        final String password = "pencil";
+        final int iterations = 4096;
+        final String hmacAlgorithm = "HmacSHA1";
+
+        // Execute system under test.
+        final byte[] result = ScramUtils.createSaltedPassword(salt, password, iterations, hmacAlgorithm);
+
+        // Verify results.
+        assertArrayEquals(StringUtils.decodeHex("1d96ee3a529b5a5f9e47c01f229a2cb8a6e15f7d"), result);
+    }
+
+    /**
+     * Verifies the implementation of {@link ScramUtils#computeHmac(byte[], String, String)} by using SCRAM-SHA-1(-PLUS)
+     * test vectors that are provided by the XSF.
+     *
+     * This test uses the test vectors identified as the 'client key'.
+     *
+     * @see <a href="https://wiki.xmpp.org/web/SASL_Authentication_and_SCRAM">XSF SCRAM test vectors.</a>
+     */
+    @Test
+    public void testScramSha1ComputeHmac() throws Exception
+    {
+        // Setup test fixture.
+        final byte[] key = StringUtils.decodeHex("1d96ee3a529b5a5f9e47c01f229a2cb8a6e15f7d"); // 'salted password' from the test vectors.
+        final String value = "Client Key";
+        final String hmacAlgorithm = "HmacSHA1";
+
+        // Execute system under test.
+        final byte[] result = ScramUtils.computeHmac(key, value, hmacAlgorithm);
+
+        // Verify results.
+        assertArrayEquals(StringUtils.decodeHex("e234c47bf6c36696dd6d852b99aaa2ba26555728"), result); // test against 'client key' from the test vectors.
+    }
+
+    /**
+     * Verifies the implementation of {@link ScramUtils#computeHmac(byte[], String, String)} by using
+     * SCRAM-SHA-1(-PLUS) test vectors that are provided by the XSF.
+     *
+     * This test uses the test vectors identified as the 'server key'.
+     *
+     * @see <a href="https://wiki.xmpp.org/web/SASL_Authentication_and_SCRAM">XSF SCRAM test vectors.</a>
+     */
+    @Test
+    public void testScramSha1ComputeHmac2() throws Exception
+    {
+        // Setup test fixture.
+        final byte[] key = StringUtils.decodeHex("1d96ee3a529b5a5f9e47c01f229a2cb8a6e15f7d"); // 'salted password' from the test vectors.
+        final String value = "Server Key";
+        final String hmacAlgorithm = "HmacSHA1";
+
+        // Execute system under test.
+        final byte[] result = ScramUtils.computeHmac(key, value, hmacAlgorithm);
 
         // Verify results.
         assertArrayEquals(StringUtils.decodeHex("0fe09258b3ac852ba502cc62ba903eaacdbf7d31"), result); // test against 'server key' from the test vectors.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/auth/ScramUtilsTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/auth/ScramUtilsTest.java
@@ -165,4 +165,28 @@ public class ScramUtilsTest
         // Verify results.
         assertArrayEquals(StringUtils.decodeHex("0fe09258b3ac852ba502cc62ba903eaacdbf7d31"), result); // test against 'server key' from the test vectors.
     }
+
+    /**
+     * Verifies the implementation of {@link ScramUtils#deriveScramKeys(byte[], String, int, String, String)}
+     * by using SCRAM-SHA-1(-PLUS) test vectors that are provided by the XSF.
+     *
+     * @see <a href="https://wiki.xmpp.org/web/SASL_Authentication_and_SCRAM">XSF SCRAM test vectors.</a>
+     */
+    @Test
+    public void testScramSha1DeriveScramKeys() throws Exception
+    {
+        // Setup test fixture.
+        final byte[] salt = StringUtils.decodeHex("4125c247e43ab1e93c6dff76");
+        final String password = "pencil";
+        final int iterations = 4096;
+        final String hmacAlgorithm = "HmacSHA1";
+        final String digestAlgorithm = "SHA-1";
+
+        // Execute system under test.
+        final ScramUtils.ScramKeys result = ScramUtils.deriveScramKeys(salt, password, iterations, hmacAlgorithm, digestAlgorithm);
+
+        // Verify results.
+        assertArrayEquals(StringUtils.decodeHex("e9d94660c39d65c38fbad91c358f14da0eef2bd6"), result.storedKey);
+        assertArrayEquals(StringUtils.decodeHex("0fe09258b3ac852ba502cc62ba903eaacdbf7d31"), result.serverKey);
+    }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
@@ -105,7 +105,7 @@ public class ScramSha1SaslServerTest extends AbstractScramSaslServerTest
     protected String createValidProof(final byte[] initialMessage, final String firstServerResponse, final FirstExchangeResult firstExchangeResult) throws Exception
     {
         final SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
-        final KeySpec spec = new PBEKeySpec(ScramSha1TestFixtures.PASSWORD.toCharArray(), firstExchangeResult.salt, firstExchangeResult.iterations, 160);
+        final KeySpec spec = new PBEKeySpec(ScramSha1TestFixtures.PASSWORD.toCharArray(), firstExchangeResult.salt, firstExchangeResult.iterations, expectedProofLengthBytes()*8); // SCRAM derives the salted password at the hash's native output length, which equals the proof length
         final byte[] saltedPassword = factory.generateSecret(spec).getEncoded();
 
         final byte[] clientKey       = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, saltedPassword).hmac(ScramSha1TestFixtures.CLIENT_KEY);
@@ -196,7 +196,7 @@ public class ScramSha1SaslServerTest extends AbstractScramSaslServerTest
         // Setup test fixture: prepare second client message.
         final String clientFinalMessageBare = "c=biws,r=" + firstExchangeResult.serverNonce;
 
-        final KeySpec saltedPasswordSpec = new PBEKeySpec(ScramSha1TestFixtures.PASSWORD.toCharArray(), firstExchangeResult.salt, firstExchangeResult.iterations, 20*8);
+        final KeySpec saltedPasswordSpec = new PBEKeySpec(ScramSha1TestFixtures.PASSWORD.toCharArray(), firstExchangeResult.salt, firstExchangeResult.iterations, expectedProofLengthBytes()*8); // SCRAM derives the salted password at the hash's native output length, which equals the proof length
         final byte[] saltedPassword = pbkdf2Factory.generateSecret(saltedPasswordSpec).getEncoded();
 
         final byte[] clientKey = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, saltedPassword).hmac(ScramSha1TestFixtures.CLIENT_KEY);
@@ -273,7 +273,7 @@ public class ScramSha1SaslServerTest extends AbstractScramSaslServerTest
         System.arraycopy(channelBindingData, 0, cbindInput, gs2HeaderBytes.length, channelBindingData.length);
         final String clientFinalMessageBare = "c=" + Base64.getEncoder().encodeToString(cbindInput) + ",r=" + firstExchangeResult.serverNonce;
 
-        final KeySpec saltedPasswordSpec = new PBEKeySpec(ScramSha1TestFixtures.PASSWORD.toCharArray(), firstExchangeResult.salt, firstExchangeResult.iterations, 20*8);
+        final KeySpec saltedPasswordSpec = new PBEKeySpec(ScramSha1TestFixtures.PASSWORD.toCharArray(), firstExchangeResult.salt, firstExchangeResult.iterations, expectedProofLengthBytes()*8); // SCRAM derives the salted password at the hash's native output length, which equals the proof length
         final byte[] saltedPassword = pbkdf2Factory.generateSecret(saltedPasswordSpec).getEncoded();
 
         final byte[] clientKey = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, saltedPassword).hmac(ScramSha1TestFixtures.CLIENT_KEY);

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerTest.java
@@ -85,11 +85,11 @@ public class ScramSha1SaslServerTest extends AbstractScramSaslServerTest
     @Override
     protected void setupCanonicalAuthData()
     {
-        authFactory.when(() -> AuthFactory.getSalt(anyString(), eq(ScramSha1TestFixtures.MECHANISM))).thenReturn(ScramSha1TestFixtures.SALT);
-        authFactory.when(() -> AuthFactory.getIterations(anyString(), eq(ScramSha1TestFixtures.MECHANISM))).thenReturn(ScramSha1TestFixtures.ITERATIONS);
+        authFactory.when(() -> AuthFactory.getSalt(anyString(), eq(ScramSha1SaslServer.MECHANISM_NAME))).thenReturn(ScramSha1TestFixtures.SALT);
+        authFactory.when(() -> AuthFactory.getIterations(anyString(), eq(ScramSha1SaslServer.MECHANISM_NAME))).thenReturn(ScramSha1TestFixtures.ITERATIONS);
         authFactory.when(() -> AuthFactory.getPassword(any())).thenReturn(ScramSha1TestFixtures.PASSWORD);
-        authFactory.when(() -> AuthFactory.getStoredKey(anyString(), eq(ScramSha1TestFixtures.MECHANISM))).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.STORED_KEY_HEX)));
-        authFactory.when(() -> AuthFactory.getServerKey(anyString(), eq(ScramSha1TestFixtures.MECHANISM))).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.SERVER_KEY_HEX)));
+        authFactory.when(() -> AuthFactory.getStoredKey(anyString(), eq(ScramSha1SaslServer.MECHANISM_NAME))).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.STORED_KEY_HEX)));
+        authFactory.when(() -> AuthFactory.getServerKey(anyString(), eq(ScramSha1SaslServer.MECHANISM_NAME))).thenReturn(DatatypeConverter.printBase64Binary(StringUtils.decodeHex(ScramSha1TestFixtures.SERVER_KEY_HEX)));
     }
 
     /**
@@ -109,7 +109,7 @@ public class ScramSha1SaslServerTest extends AbstractScramSaslServerTest
         final byte[] saltedPassword = factory.generateSecret(spec).getEncoded();
 
         final byte[] clientKey       = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, saltedPassword).hmac(ScramSha1TestFixtures.CLIENT_KEY);
-        final byte[] storedKey       = StringUtils.decodeHex(StringUtils.hash(clientKey, "SHA-1"));
+        final byte[] storedKey       = StringUtils.decodeHex(StringUtils.hash(clientKey, ScramSha1SaslServer.DIGEST_ALGORITHM_NAME));
         final String clientFinalBare = "c=biws,r=" + firstExchangeResult.serverNonce;
         final String authMessage     = "n=" + ScramSha1TestFixtures.USER + ",r=" + ScramSha1TestFixtures.CLIENT_NONCE + "," + firstServerResponse + "," + clientFinalBare;
         final byte[] clientSignature = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, storedKey).hmac(authMessage);
@@ -200,7 +200,7 @@ public class ScramSha1SaslServerTest extends AbstractScramSaslServerTest
         final byte[] saltedPassword = pbkdf2Factory.generateSecret(saltedPasswordSpec).getEncoded();
 
         final byte[] clientKey = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, saltedPassword).hmac(ScramSha1TestFixtures.CLIENT_KEY);
-        final byte[] storedKey = StringUtils.decodeHex(StringUtils.hash(clientKey, "SHA-1"));
+        final byte[] storedKey = StringUtils.decodeHex(StringUtils.hash(clientKey, ScramSha1SaslServer.DIGEST_ALGORITHM_NAME));
         final String authMessage = new String(initialMessage, StandardCharsets.UTF_8).substring(gs2Header.length()) + "," + firstServerResponse + "," + clientFinalMessageBare;
 
         final byte[] clientSignature = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, storedKey).hmac(authMessage);
@@ -277,7 +277,7 @@ public class ScramSha1SaslServerTest extends AbstractScramSaslServerTest
         final byte[] saltedPassword = pbkdf2Factory.generateSecret(saltedPasswordSpec).getEncoded();
 
         final byte[] clientKey = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, saltedPassword).hmac(ScramSha1TestFixtures.CLIENT_KEY);
-        final byte[] storedKey = StringUtils.decodeHex(StringUtils.hash(clientKey, "SHA-1"));
+        final byte[] storedKey = StringUtils.decodeHex(StringUtils.hash(clientKey, ScramSha1SaslServer.DIGEST_ALGORITHM_NAME));
         final String authMessage = new String(initialMessage, StandardCharsets.UTF_8).substring(gs2Header.length()) + "," + firstServerResponse + "," + clientFinalMessageBare;
 
         final byte[] clientSignature = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, storedKey).hmac(authMessage);
@@ -314,7 +314,7 @@ public class ScramSha1SaslServerTest extends AbstractScramSaslServerTest
         final String mechanismName = server.getMechanismName();
 
         // Verify result
-        assertEquals(ScramSha1TestFixtures.MECHANISM, mechanismName, "Non-PLUS mechanism should return 'SCRAM-SHA-1' as its name");
+        assertEquals(ScramSha1SaslServer.MECHANISM_NAME, mechanismName, "Non-PLUS mechanism should return 'SCRAM-SHA-1' as its name");
     }
 
     /**
@@ -330,6 +330,6 @@ public class ScramSha1SaslServerTest extends AbstractScramSaslServerTest
         final String mechanismName = server.getMechanismName();
 
         // Verify result
-        assertEquals(ScramSha1TestFixtures.PLUS_MECHANISM, mechanismName, "PLUS mechanism should return 'SCRAM-SHA-1-PLUS' as its name");
+        assertEquals(ScramSha1SaslServer.MECHANISM_NAME+"-PLUS", mechanismName, "PLUS mechanism should return 'SCRAM-SHA-1-PLUS' as its name");
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1TestFixtures.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1TestFixtures.java
@@ -40,9 +40,7 @@ public final class ScramSha1TestFixtures
     public static final String CLIENT_NONCE = "fyko+d2lbbFgONRv9qkxdawL";
     public static final String STORED_KEY_HEX = "e9d94660c39d65c38fbad91c358f14da0eef2bd6";
     public static final String SERVER_KEY_HEX = "0fe09258b3ac852ba502cc62ba903eaacdbf7d31";
-    public static final String MECHANISM = "SCRAM-SHA-1";
-    public static final String PLUS_MECHANISM = "SCRAM-SHA-1-PLUS";
-    public static final Set<String> SUPPORTED_MECHANISMS = Set.of(MECHANISM, PLUS_MECHANISM);
+    public static final Set<String> SUPPORTED_MECHANISMS = Set.of(ScramSha1SaslServer.MECHANISM_NAME, ScramSha1SaslServer.MECHANISM_NAME+"-PLUS");
 
     private ScramSha1TestFixtures() {}
 }


### PR DESCRIPTION
This prepares the codebase to have additional SCRAM-based mechanisms (such as `SCRAM-SHA-256`). It does so by moving generic bits of the implementation that is currently specific to the implementation of `SCRAM-SHA-` into a base class that was introduced earlier for this purpose.

The implementation in `ScramUtils` now no longer is specific the `SCRAM-SHA-1`: overloaded methods (that take an algorithm reference) have been introduced, the old methods that are implicitly specific to `SCRAM-SHA-1` have been deprecated.

This all allows the `ScramSha1SaslServer` implementation to shrink significantly, to only this `SHA-1` bindings. Future implementations of algorithms like `SHA-256` should follow suit and be equally small/short.