### PR TITLE
CI: Fix backport workflow failing on actions/checkout@v7

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,8 +10,12 @@ jobs:
     name: Backport pull request
     runs-on: ubuntu-latest
     # Don't run on closed unmerged pull requests
-    if: github.event.pull_request.merged
+    if: >
+      github.event.pull_request.merged &&
+      contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
       - name: Create backport pull requests
         uses: korthout/backport-action@v4


### PR DESCRIPTION
The v7 upgrade of actions/checkout added a guard that refuses to check out fork PR code in a pull_request_target workflow, causing the backport job to fail. Pin the checkout to the base branch ref so it no longer trips the guard, since the backport action only needs a git-initialized repo of the target branch and never the fork's PR head.

Also gate the job on the presence of a "backport " label so it only runs when a backport is actually requested.