### PR TITLE
ci: fix Docker layer cache never being read back

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -98,7 +98,7 @@ jobs:
           load: true
           tags: ${{ env.IMAGE_NAME }}:ci-${{ github.sha }}
           cache-from: type=gha,scope=openfire-${{ steps.cache-hash.outputs.hash }}
-          cache-to: type=gha,mode=max,scope=openfire-${{ steps.cache-hash.outputs.hash }}-${{ github.sha }}
+          cache-to: type=gha,mode=max,scope=openfire-${{ steps.cache-hash.outputs.hash }}
 
       - name: Save Docker image to tar archive
         run: docker save ${{ env.IMAGE_NAME }}:ci-${{ github.sha }} | gzip > openfire-docker-image.tar.gz


### PR DESCRIPTION
The Docker build's cache-to scope appended `${{ github.sha }}` while cache-from did not, so every run wrote its layer cache to a unique per-commit scope that no later run ever read from.

The GHA cache was effectively write-only, and even trivially reusable layers (base images, the poms stage) rebuilt from scratch on every run. The build logs show zero CACHED steps.

Drop the `-${{ github.sha }}` suffix so cache-to and cache-from target the same scope. GHA cache is already isolated per-branch by Actions' own scoping, and mode=max handles overwrites, so the per-SHA suffix served no purpose beyond defeating the cache.