### PR TITLE
ci: Disable ansi in Maestro tests

### DIFF
--- a/.github/actions/conversationstest-action/run-tests.sh
+++ b/.github/actions/conversationstest-action/run-tests.sh
@@ -35,5 +35,5 @@ trap '"$SCRIPT_DIR/stop-sidecar-api.sh"' EXIT
 "$SCRIPT_DIR/start-sidecar-api.sh"
 
 echo "Running Maestro tests (tags: $INCLUDE_TAGS)..."
-maestro test --include-tags "$INCLUDE_TAGS" "$REPO_ROOT/build/ci/conversations/flows/" \
+maestro test --no-ansi --include-tags "$INCLUDE_TAGS" "$REPO_ROOT/build/ci/conversations/flows/" \
   || { RC=$?; adb logcat -d conversations:V '*:S' > adb_logcat.log 2>&1 || true; exit $RC; }


### PR DESCRIPTION
Maestro runs against Conversations were producing output like:

```
Waiting for flows to complete...
ERROR        | Failed to find ColorBuffer: 107
ERROR        | Failed to find ColorBuffer: 135
[Passed] cb (50s)
ERROR        | Failed to find ColorBuffer: 176
ERROR        | Failed to find ColorBuffer: 236
ERROR        | Failed to find ColorBuffer: 248
ERROR        | Failed to find ColorBuffer: 257
ERROR        | Failed to find ColorBuffer: 305
ERROR        | Failed to find ColorBuffer: 326
[Passed] simple (59s)
```

This change attempts to disable ANSI in hopes it cleans the logging a little.