### PR TITLE
OF-3335: Add dependency-check suppressions

### DIFF
--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -100,4 +100,18 @@
         <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
         <cve>CVE-2023-41080</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        False positive: this CVE is against org.apache.httpcomponents.core5:httpcore5 (HttpCore 5.x), which was a ground-up rewrite. The CPE range is "up to 5.4.2", and so dependency-check matches. CVE-2026-54428 is in the HTTP/2 HPACK decoder, which does not exist in HttpCore 4.x at all.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@4\..*$</packageUrl>
+        <cve>CVE-2026-54399</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        False positive: HTTP/2 HPACK decoder CVE for org.apache.httpcomponents.core5:httpcore5 (5.x). HttpCore 4.x has no HTTP/2 support, so the vulnerable code does not exist in httpcore 4.4.x. See the CVE-2026-54399 suppression above.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@4\..*$</packageUrl>
+        <cve>CVE-2026-54428</cve>
+    </suppress>
 </suppressions>

--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -114,4 +114,32 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@4\..*$</packageUrl>
         <cve>CVE-2026-54428</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppress eclipse:jetty issues for apache-jsp - this is Apache Tomcat's Jasper JSP engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <cpe>cpe:/a:eclipse:jetty</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppress jetty:jetty issues for apache-jsp - this is Apache Tomcat's Jasper JSP engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <cpe>cpe:/a:jetty:jetty</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppress mortbay:jetty issues for apache-jsp - this is Apache Tomcat's Jasper JSP engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <cpe>cpe:/a:mortbay:jetty</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppress mortbay_jetty:jetty issues for apache-jsp - this is Apache Tomcat's Jasper JSP engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <cpe>cpe:/a:mortbay_jetty:jetty</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Add suppressions for two dependencies

- Suppress 2 dependencies for httpcore4. They are HTTP/2 related, and only affect httpcore5, which was a complete rewrite - httpcore4 doesn't even have any HTTP/2 capabilities.
- Suppress all jetty related matches for Mortbay Jasper JSP engine, which isn't Jetty. We do have Jetty, but this confuses the numbers. Mortbay Jasper is v9 but brings in Jetty v9 issues. Openfire has Jetty v12. This breaks the relationship between the two.

This has a nice side effect of leaving the report completely clean :)