### PR TITLE
OF-3334: Use monotonic timers to avoid system clock dependencies

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -325,6 +325,7 @@ jobs:
       - name: Run XMPP Interop Testing Framework tests against server
         uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.7.2
         with:
+          testId: interop # Used in the naming of the artifacts that this action uploads (eg: "XMPP debug logs (for test ID 'interop')").
           domain: 'example.org'
           adminAccountUsername: 'admin'
           adminAccountPassword: 'admin'
@@ -332,6 +333,12 @@ jobs:
       - name: Stop CI server
         if: ${{ always() && steps.startCIServer.conclusion == 'success' }} # TODO figure out if this is correct. The intent is to have the server stopped if it was successfully started, even if the tests fail. Failing tests should still cause the job to fail.
         uses: ./.github/actions/stopserver-action
+      - name: Expose openfire logs # Pairs with the interop action's "XMPP debug logs (for test ID 'interop')" client-side artifact.
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: XMPP Openfire logs (for test ID 'interop')
+          path: distribution/target/distribution-base/logs/*
 
   conversations:
     name: Execute Conversations e2e tests (${{ matrix.name }})

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/IQRouter.java
@@ -248,7 +248,7 @@ public class IQRouter extends BasicModule {
     public void addIQResultListener(String id, IQResultListener listener, long timeoutmillis) {
         resultListeners.put(id, listener);
         resultPending.put(id, XMPPServer.getInstance().getNodeID());
-        resultTimeout.put(id, System.currentTimeMillis() + timeoutmillis);
+        resultTimeout.put(id, System.nanoTime() + Duration.ofMillis(timeoutmillis).toNanos());
     }
 
     @Override
@@ -551,7 +551,7 @@ public class IQRouter extends BasicModule {
             while (it.hasNext()) {
                 final Map.Entry<String, Long> pointer = it.next();
 
-                if (System.currentTimeMillis() < pointer.getValue()) {
+                if (System.nanoTime() - pointer.getValue() < 0) {
                     // This entry has not expired yet. Ignore it.
                     continue;
                 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SocketConnection.java
@@ -46,8 +46,8 @@ import java.net.UnknownHostException;
 import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
+import java.time.Duration;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -85,7 +85,8 @@ public class SocketConnection extends AbstractConnection {
     private org.jivesoftware.util.XMLWriter xmlSerializer;
     private TLSStreamHandler tlsStreamHandler;
 
-    private long writeStarted = -1;
+    private volatile boolean writeInProgress = false;
+    private volatile long writeStartedNanos;
 
     private boolean usingSelfSignedCertificate;
 
@@ -420,11 +421,12 @@ public class SocketConnection extends AbstractConnection {
     }
 
     void writeStarted() {
-        writeStarted = System.currentTimeMillis();
+        writeStartedNanos = System.nanoTime();
+        writeInProgress = true;
     }
 
     void writeFinished() {
-        writeStarted = -1;
+        writeInProgress = false;
     }
 
     /**
@@ -437,22 +439,22 @@ public class SocketConnection extends AbstractConnection {
      */
     boolean checkHealth() {
         // Check that the sending operation is still active
-        long writeTimestamp = writeStarted;
-        if (writeTimestamp > -1 && System.currentTimeMillis() - writeTimestamp >
-                JiveGlobals.getIntProperty("xmpp.session.sending-limit", 60000)) {
-            // Close the socket
-            if (Log.isDebugEnabled()) {
-                Log.debug("Closing connection: " + this + " that started sending data at: " +
-                        new Date(writeTimestamp));
+        if (writeInProgress) {
+            final Duration sending = Duration.ofNanos(System.nanoTime() - writeStartedNanos);
+            if (sending.toMillis() > JiveGlobals.getIntProperty("xmpp.session.sending-limit", 60000)) {
+                // Close the socket
+                if (Log.isDebugEnabled()) {
+                    Log.debug("Closing connection: " + this + " that has been sending data for: " + sending);
+                }
+                close(new StreamError(StreamError.Condition.connection_timeout, "Unable to validate the connection. Connection has been idle long enough for it to be considered 'unhealthy'."), true);
+                return true;
             }
-            close(new StreamError(StreamError.Condition.connection_timeout, "Unable to validate the connection. Connection has been idle long enough for it to be considered 'unhealthy'."), true);
-            return true;
         }
         return false;
     }
 
     private void release() {
-        writeStarted = -1;
+        writeInProgress = false;
         instances.remove(this);
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultCache.java
+++ b/xmppserver/src/main/java/org/jivesoftware/util/cache/DefaultCache.java
@@ -534,14 +534,14 @@ public class DefaultCache<K extends Serializable, V extends Serializable> implem
             deleteExpiredEntries();
             desiredSize = (long) (maxCacheSize * .90);
             if (cacheSize > desiredSize) {
-                long t = System.currentTimeMillis();
-                cullTimes.add(t);
+                cullTimes.add(System.currentTimeMillis());
+                final long start = System.nanoTime(); // Use monotonic time to avoid any system clock changes
                 do {
                     // Get the key and invoke the remove method on it.
                     remove(lastAccessedList.getLast().object);
                 } while (cacheSize > desiredSize);
-                t = System.currentTimeMillis() - t;
-                Log.warn("Cache " + name + " was full, shrunk to 90% in " + t + "ms.");
+                final long elapsedMillis = Duration.ofNanos(System.nanoTime() - start).toMillis();
+                Log.warn("Cache " + name + " was full, shrunk to 90% in " + elapsedMillis + "ms.");
             }
         }
 


### PR DESCRIPTION
Monotonic timers are immune to changes in the system clock. This PR prevents some areas of the codebase from misbehaving when the system clock changes. 

Each altered area of the code is its own separate commit.