### PR TITLE
OF-3336: Bind JDWP debugger to localhost

### DIFF
--- a/distribution/src/bin/openfire.sh
+++ b/distribution/src/bin/openfire.sh
@@ -126,7 +126,7 @@ do
   case $arguments in
     -debug)
       echo "Starting debug mode"
-      JAVACMD="$JAVACMD -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+      JAVACMD="$JAVACMD -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=localhost:5005"
       ;;
     -remotedebug)
       echo "Starting remote debug mode"


### PR DESCRIPTION
Configure the JDWP agent to listen on `localhost:5005` instead of using a bare port number.

While JDWP cannot bind to all loopback interfaces without also accepting remote connections, using `localhost` makes the intent to bind locally explicit and is likely to provide more consistent behavior than relying on the JVM's default address selection (which for me, picked the IPv6 loopback while my IDE tried the IPv4 one, leading to confusion).