### PR TITLE
OF-3337, OF-3338: Detect SQL row-value comparison support and use it to work around an HSQLDB cleanup failure

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/database/DbConnectionManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/database/DbConnectionManager.java
@@ -74,6 +74,8 @@ public class DbConnectionManager {
     private static boolean pstmt_fetchSizeSupported = true;
     /** The char used to quote identifiers */
     private static String identifierQuoteString;
+    /** True if the database supports SQL row-value (tuple) comparison, e.g. {@code (a, b, c) > (?, ?, ?)}, in a WHERE clause. */
+    private static boolean rowValueComparisonSupported;
 
     private static final String SETTING_DATABASE_MAX_RETRIES = "database.maxRetries";
     private static final String SETTING_DATABASE_RETRY_DELAY = "database.retryDelay";
@@ -865,6 +867,7 @@ public class DbConnectionManager {
         streamTextRequired = false;
         maxRowsSupported   = true;
         fetchSizeSupported = true;
+        rowValueComparisonSupported = false; // this cannot be dynamically detected. Opt-in per-database below for those known to support it.
 
         String dbName      = metaData.getDatabaseProductName().toLowerCase(Locale.ROOT);
         String dbVersion   = metaData.getDatabaseProductVersion().toLowerCase(Locale.ROOT);
@@ -903,11 +906,13 @@ public class DbConnectionManager {
             databaseType = DatabaseType.cockroachdb;
             scrollResultsSupported = false;
             fetchSizeSupported = false;
+            rowValueComparisonSupported = true;
         }
 
         // Postgres properties
         else if (dbName.contains("postgres")) {
             databaseType = DatabaseType.postgresql;
+            rowValueComparisonSupported = true;
 
             // PostgreSQL JDBC 42.x reports TYPE_SCROLL_INSENSITIVE as supported, which is accurate - but server-side
             // cursors (required for scrolling) only work when auto-commit is off. Since many connections in this
@@ -939,16 +944,19 @@ public class DbConnectionManager {
         // MariaDB properties (must be checked before MySQL, as MariaDB reports its product name as "MariaDB")
         else if (dbName.contains("maria")) {
             databaseType = DatabaseType.mariadb;
+            rowValueComparisonSupported = true;
         }
 
         // MySQLproperties
         else if (dbName.contains("mysql")) {
             databaseType = DatabaseType.mysql;
+            rowValueComparisonSupported = true;
         }
 
         // HSQLDB
         else if (dbName.contains("hsql")) {
             databaseType = DatabaseType.hsqldb;
+            rowValueComparisonSupported = true;
         }
 
         // DB2
@@ -961,8 +969,8 @@ public class DbConnectionManager {
             databaseType = DatabaseType.firebird;
         }
 
-        Log.debug("Database capabilities: transactions={}, scrollResults={}, batchUpdates={}, subqueries={}, streamText={}, maxRows={}, fetchSize={}, identifierQuoteString={}",
-            transactionsSupported, scrollResultsSupported, batchUpdatesSupported, subqueriesSupported, streamTextRequired, maxRowsSupported, fetchSizeSupported, identifierQuoteString);
+        Log.debug("Database capabilities: transactions={}, scrollResults={}, batchUpdates={}, subqueries={}, streamText={}, maxRows={}, fetchSize={}, rowValueComparison={}, identifierQuoteString={}",
+            transactionsSupported, scrollResultsSupported, batchUpdatesSupported, subqueriesSupported, streamTextRequired, maxRowsSupported, fetchSizeSupported, rowValueComparisonSupported, identifierQuoteString);
     }
 
     /**
@@ -1221,6 +1229,10 @@ public class DbConnectionManager {
     public static boolean isResultSetLimitKeywordPrefix()
     {
         return databaseType.isResultSetLimitKeywordPrefix();
+    }
+
+    public static boolean isRowValueComparisonSupported() {
+        return rowValueComparisonSupported;
     }
 
     public static String getTestSQL(String driver) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubSubscriptionMaintenance.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubSubscriptionMaintenance.java
@@ -223,9 +223,7 @@ public class PubSubSubscriptionMaintenance
      * auto-commit connections), keeping every query bounded and memory use flat regardless of table size.
      *
      * The row-limit keyword is dialect-specific ({@code LIMIT} / {@code TOP} / {@code FETCH FIRST}), so the limited
-     * SELECT is assembled at runtime via {@link DbConnectionManager#getResultSetLimitKeyword()}. The key predicate is
-     * written in expanded boolean form rather than as a row-value comparison {@code (a,b,c) > (?,?,?)}, because the
-     * latter is not supported by all databases Openfire targets (for example SQL Server and older Oracle).
+     * SELECT is assembled at runtime via {@link DbConnectionManager#getResultSetLimitKeyword()}.
      */
     private static final String PAGE_COLUMNS = "serviceID, nodeID, id";
 
@@ -240,8 +238,27 @@ public class PubSubSubscriptionMaintenance
     private static final String PAGE_ORDER = " ORDER BY serviceID, nodeID, id";
 
     /**
+     * Row-value "primary key strictly greater than (?, ?, ?)" predicate, semantically equivalent to the
+     * expanded-boolean {@link #PAGE_KEY_AFTER} form.
+     *
+     * The two forms are equivalent only when all three columns are non-null (as is the case for these
+     * primary-key columns); row-value and expanded-boolean comparison diverge in their treatment of NULL.
+     *
+     * This relies on SQL row-value (tuple) comparison, which compares the columns lexicographically in the given order.
+     * It is more concise and generally optimizes better, but is NOT supported on every database Openfire targets.
+     * Parameters, in order: serviceID, nodeID, id.
+     */
+    private static final String PAGE_KEY_AFTER_ROWVALUE =
+        "((serviceID, nodeID, id) > (?, ?, ?))";
+
+    /**
      * Expanded-boolean "primary key strictly greater than (?, ?, ?)" predicate, portable across all supported
-     * databases. Parameters, in order: serviceID, serviceID, nodeID, serviceID, nodeID, id.
+     * databases. Semantically equivalent to the row-value {@link #PAGE_KEY_AFTER_ROWVALUE} form.
+     *
+     * The two forms are equivalent only when all three columns are non-null (as is the case for these
+     * primary-key columns); row-value and expanded-boolean comparison diverge in their treatment of NULL.
+     *
+     * Parameters, in order: serviceID, serviceID, nodeID, serviceID, nodeID, id.
      */
     private static final String PAGE_KEY_AFTER =
         "(serviceID > ? OR (serviceID = ? AND nodeID > ?) OR (serviceID = ? AND nodeID = ? AND id > ?))";
@@ -566,8 +583,11 @@ public class PubSubSubscriptionMaintenance
     @Nonnull
     private Page readPage(@Nullable final String afterService, @Nullable final String afterNode, @Nullable final String afterId) throws SQLException
     {
+        // OF-3338: HSQLDB 2.7.4 seems to suffer from an optimizer/index traversal bug that is circumvented by using tuple-comparison.
+        final boolean useRowValue = DbConnectionManager.isRowValueComparisonSupported();
+
         final boolean first = afterService == null;
-        final String sql = buildPageSql(first);
+        final String sql = buildPageSql(first, useRowValue);
 
         Connection con = null;
         PreparedStatement pstmt = null;
@@ -582,13 +602,20 @@ public class PubSubSubscriptionMaintenance
             // bind parameters are the excluded service IDs and, for non-first pages, the key-after predicate.
             int index = bindExcludedServiceIds(pstmt, 1);
             if (!first) {
-                // Expanded-boolean key predicate parameters: service, service, node, service, node, id.
-                pstmt.setString(index++, afterService);
-                pstmt.setString(index++, afterService);
-                pstmt.setString(index++, afterNode);
-                pstmt.setString(index++, afterService);
-                pstmt.setString(index++, afterNode);
-                pstmt.setString(index, afterId);
+                if (useRowValue) {
+                    // row-value parameters: serviceID, nodeID, id.
+                    pstmt.setString(index++, afterService);
+                    pstmt.setString(index++, afterNode);
+                    pstmt.setString(index, afterId);
+                } else {
+                    // Expanded-boolean key predicate parameters: service, service, node, service, node, id.
+                    pstmt.setString(index++, afterService);
+                    pstmt.setString(index++, afterService);
+                    pstmt.setString(index++, afterNode);
+                    pstmt.setString(index++, afterService);
+                    pstmt.setString(index++, afterNode);
+                    pstmt.setString(index, afterId);
+                }
             }
 
             rs = pstmt.executeQuery();
@@ -608,21 +635,23 @@ public class PubSubSubscriptionMaintenance
      * pages) the key-after predicate.
      *
      * The row-limit keyword position and spelling vary by database, so this uses
-     * {@link DbConnectionManager#getResultSetLimitKeyword()} and {@link DbConnectionManager#isResultSetLimitKeywordPrefix()}.
+     * {@link DbConnectionManager#getResultSetLimitKeyword()}.
      * The limit count is rendered as a literal integer (it is a fixed, trusted constant, never user input), which keeps
      * the parameter list identical across dialects.
      *
      * @param first true for the first page (no key-after predicate), false otherwise.
+     * @param useRowValue true when the database supports tuple comparison, false otherwise.
      * @return the SQL for one page.
      */
     @Nonnull
-    private String buildPageSql(final boolean first)
+    private String buildPageSql(final boolean first, final boolean useRowValue)
     {
         final StringBuilder where = new StringBuilder();
         final String exclusion = serviceExclusionClause("WHERE", "serviceID");
         where.append(exclusion);
         if (!first) {
-            where.append(exclusion.isEmpty() ? " WHERE " : " AND ").append(PAGE_KEY_AFTER);
+            where.append(exclusion.isEmpty() ? " WHERE " : " AND ")
+                .append(useRowValue ? PAGE_KEY_AFTER_ROWVALUE : PAGE_KEY_AFTER);
         }
 
         final DbConnectionManager.ResultSetLimitKeyword limit = DbConnectionManager.getResultSetLimitKeyword();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubSubscriptionMaintenance.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubSubscriptionMaintenance.java
@@ -583,17 +583,18 @@ public class PubSubSubscriptionMaintenance
     @Nonnull
     private Page readPage(@Nullable final String afterService, @Nullable final String afterNode, @Nullable final String afterId) throws SQLException
     {
-        // OF-3338: HSQLDB 2.7.4 seems to suffer from an optimizer/index traversal bug that is circumvented by using tuple-comparison.
-        final boolean useRowValue = DbConnectionManager.isRowValueComparisonSupported();
-
         final boolean first = afterService == null;
-        final String sql = buildPageSql(first, useRowValue);
 
         Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
         try {
             con = DbConnectionManager.getConnection();
+
+            // OF-3338: HSQLDB 2.7.4 seems to suffer from an optimizer/index traversal bug that is circumvented by using tuple-comparison.
+            final boolean useRowValue = DbConnectionManager.isRowValueComparisonSupported();
+            final String sql = buildPageSql(first, useRowValue);
+
             pstmt = con.prepareStatement(sql);
             DbConnectionManager.setFetchSize(pstmt, DELETE_BATCH_SIZE);
             DbConnectionManager.setMaxRows(pstmt, DELETE_BATCH_SIZE);


### PR DESCRIPTION
This PR adds detection of SQL row-value (tuple) comparison support and uses it to fix a pubsub subscription cleanup failure on HSQLDB. It is split into two commits; see each commit message for full detail.