### PR TITLE
OF-3340 & OF-3341: Fix error for MUC self-ping

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1156,9 +1156,17 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                         }
                         else
                         {
-                            // Not an occupant at all.
-                            Log.debug("An IQ request was addressed to occupant '{}' of room '{}' by a non-occupant", room.getName(), packet.toXML());
-                            sendErrorPacket(packet, PacketError.Condition.not_acceptable, "You are not an occupant of this room.");
+                            // Not an occupant at all. XEP-0410 §3.2 prescribes a 'cancel'-type 'not-acceptable' error, stamped with the room JID in the 'by' attribute.
+                            Log.debug("An IQ request was addressed to occupant '{}' of room '{}' by a non-occupant: {}", toNickname, room.getName(), packet.toXML());
+                            if (packet.getError() == null) {
+                                final IQ reply = IQ.createResultIQ(packet);
+                                reply.setChildElement(packet.getChildElement().createCopy());
+                                reply.setError(PacketError.Condition.not_acceptable);
+                                reply.getError().setType(PacketError.Type.cancel);
+                                reply.getError().setText("You are not an occupant of this room.");
+                                reply.getError().getElement().addAttribute("by", room.getJID().toBareJID());
+                                XMPPServer.getInstance().getPacketRouter().route(reply);
+                            }
                         }
                     }
                     else

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1132,17 +1132,33 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                     if ( toNickname != null )
                     {
                         // User is sending to a room occupant.
-                        final boolean selfPingEnabled = JiveGlobals.getBooleanProperty("xmpp.muc.self-ping.enabled", true);
-                        if ( selfPingEnabled && occupantData != null && toNickname.equals(occupantData.getNickname()) && packet.isRequest()
-                            && packet.getElement().element(QName.get(IQPingHandler.ELEMENT_NAME, IQPingHandler.NAMESPACE)) != null )
+                        if ( occupantData != null && toNickname.equals(occupantData.getNickname()) )
                         {
-                            Log.trace("User '{}' is sending an IQ 'ping' to itself. See XEP-0410: MUC Self-Ping (Schrödinger's Chat).", packet.getFrom());
-                            XMPPServer.getInstance().getPacketRouter().route(IQ.createResultIQ(packet));
+                            final boolean selfPingEnabled = JiveGlobals.getBooleanProperty("xmpp.muc.self-ping.enabled", true);
+
+                            // Addressed to self. Either handle as self-ping, or as a PM to own other resources.
+                            if (selfPingEnabled && packet.isRequest() && packet.getElement().element(QName.get(IQPingHandler.ELEMENT_NAME, IQPingHandler.NAMESPACE)) != null)
+                            {
+                                Log.trace("User '{}' is sending an IQ 'ping' to itself. See XEP-0410: MUC Self-Ping (Schrödinger's Chat).", packet.getFrom());
+                                XMPPServer.getInstance().getPacketRouter().route(IQ.createResultIQ(packet));
+                            }
+                            else
+                            {
+                                Log.trace("User '{}' is sending an IQ stanza to itself (as a PM) with nickname: '{}'.", packet.getFrom(), toNickname);
+                                room.sendPrivatePacket(packet, occupantData);
+                            }
+                        }
+                        else if ( occupantData != null )
+                        {
+                            // Occupant, addressing someone else in the room: a PM.
+                            Log.trace("User '{}' is sending an IQ stanza to another room occupant (as a PM) with nickname: '{}'.", packet.getFrom(), toNickname);
+                            room.sendPrivatePacket(packet, occupantData);
                         }
                         else
                         {
-                            Log.trace("User '{}' is sending an IQ stanza to another room occupant (as a PM) with nickname: '{}'.", packet.getFrom(), toNickname);
-                            room.sendPrivatePacket(packet, occupantData);
+                            // Not an occupant at all.
+                            Log.debug("An IQ request was addressed to occupant '{}' of room '{}' by a non-occupant", room.getName(), packet.toXML());
+                            sendErrorPacket(packet, PacketError.Condition.not_acceptable, "You are not an occupant of this room.");
                         }
                     }
                     else


### PR DESCRIPTION
A XEP-0410 self-ping sent by a user who is no longer an occupant of the room (for instance after being removed by the ghost-detection ping check) was answered incorrectly in two ways. Each is addressed in its own commit; see the commit messages for detail.

The first commit fixes the error text, which claimed "Room requires a password, but none was supplied." even for rooms without a password. The branch that handles IQs addressed to an occupant JID is restructured so that "addressed to self" and "is a ping request" are checked separately, and a sender that is not an occupant at all is rejected directly with accurate text.

The second commit corrects the error's type and adds the 'by' attribute, per XEP-0410 §3.2: the rejection now carries type="cancel" (rather than the condition's RFC 6120 default of 'modify') and names the room JID in by.

The 'not-acceptable' condition itself was already correct and is unchanged, as XEP-0410 prescribes it for a self-ping from a non-occupant.