### PR TITLE
Add PubSub member affiliation support

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/Node.java
@@ -305,6 +305,17 @@ public abstract class Node implements Cacheable, Externalizable {
     }
 
     /**
+     * Adds a new affiliation or updates an existing affiliation of the specified entity JID
+     * to become a member affiliate.
+     *
+     * @param jid the JID of the member.
+     * @return the newly created or modified affiliation to the node.
+     */
+    public NodeAffiliate addMember(JID jid) {
+        return addAffiliation(jid, NodeAffiliate.Affiliation.member);
+    }
+
+    /**
      * Sets that the specified entity is an outcast of the node. Outcast entities are not
      * able to publish or subscribe to the node. Existing subscriptions will be deleted.
      *

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/NodeAffiliate.java
@@ -365,6 +365,10 @@ public class NodeAffiliate implements Cacheable
          */
         publisher,
         /**
+         * A member can subscribe to and retrieve items from whitelist nodes.
+         */
+        member,
+        /**
          * A user with no affiliation can susbcribe to the node.
          */
         none,

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/PubSubEngine.java
@@ -1761,6 +1761,9 @@ public class PubSubEngine
             else if ("publisher".equals(newAffiliation)) {
                 node.addPublisher(owner);
             }
+            else if ("member".equals(newAffiliation)) {
+                node.addMember(owner);
+            }
             else if ("none".equals(newAffiliation)) {
                 node.addNoneAffiliation(owner);
             }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/WhitelistAccess.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/pubsub/models/WhitelistAccess.java
@@ -40,10 +40,13 @@ public class WhitelistAccess extends AccessModel {
         if (node.isAdmin(owner)) {
             return true;
         }
-        // User is in the whitelist if he has an affiliation and it is not of type outcast
+        // Whitelist access requires an explicit privileged affiliation. A "none" affiliation can
+        // linger after a subscription is removed and must not keep granting access.
         NodeAffiliate nodeAffiliate = node.getAffiliate(owner);
-        return nodeAffiliate != null &&
-                nodeAffiliate.getAffiliation() != NodeAffiliate.Affiliation.outcast;
+        return nodeAffiliate != null && (
+                nodeAffiliate.getAffiliation() == NodeAffiliate.Affiliation.member ||
+                nodeAffiliate.getAffiliation() == NodeAffiliate.Affiliation.publisher ||
+                nodeAffiliate.getAffiliation() == NodeAffiliate.Affiliation.owner);
     }
 
     @Override

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/pubsub/models/WhitelistAccessTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/pubsub/models/WhitelistAccessTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.pubsub.models;
+
+import org.jivesoftware.openfire.pubsub.Node;
+import org.jivesoftware.openfire.pubsub.NodeAffiliate;
+import org.junit.jupiter.api.Test;
+import org.xmpp.packet.JID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class WhitelistAccessTest {
+
+    private final WhitelistAccess access = new WhitelistAccess();
+    private final Node node = mock(Node.class);
+    private final NodeAffiliate affiliate = mock(NodeAffiliate.class);
+    private final JID user = new JID("user@example.org");
+
+    @Test
+    void memberCanSubscribe() {
+        when(node.getAffiliate(user)).thenReturn(affiliate);
+        when(affiliate.getAffiliation()).thenReturn(NodeAffiliate.Affiliation.member);
+
+        assertTrue(access.canSubscribe(node, user, user));
+    }
+
+    @Test
+    void noneAffiliationIsNotWhitelisted() {
+        when(node.getAffiliate(user)).thenReturn(affiliate);
+        when(affiliate.getAffiliation()).thenReturn(NodeAffiliate.Affiliation.none);
+
+        assertFalse(access.canSubscribe(node, user, user));
+    }
+}


### PR DESCRIPTION
## Summary

- add the standard PubSub `member` affiliation and support owner affiliation updates to it
- restrict whitelist access to explicit `member`, `publisher`, or `owner` affiliations
- prevent lingering `none` affiliation records from retaining whitelist access
- add focused coverage for member access and stale `none` rejection

## XEP references and rationale

[XEP-0060: Publish-Subscribe](https://xmpp.org/extensions/xep-0060.html) defines the `member` affiliation and recommends support for non-required affiliations. Its whitelist access model specifies that an owner should add an entity to the whitelist by assigning the `member` affiliation. It also defines the corresponding service discovery feature as `http://jabber.org/protocol/pubsub#member-affiliation`.

[XEP-0503: Server-side spaces](https://xmpp.org/extensions/xep-0503.html#discovering-support) builds on XEP-0060 and says that a Spaces service SHOULD implement and advertise `member-affiliation` for better usability.

Openfire previously had no `member` affiliation. Its whitelist implementation instead accepted every stored affiliation except `outcast`. A `none` affiliation record can remain after membership is removed, which caused that entity to continue being treated as whitelisted. Requiring an explicit `member`, `publisher`, or `owner` affiliation aligns whitelist membership with XEP-0060 and makes removal effective.

This core support lets consumers such as the Spaces plugin implement and advertise XEP-0503's `member-affiliation` recommendation truthfully.

## Test plan

- `./mvnw -pl xmppserver '-P!git-info' -Dtest=WhitelistAccessTest test -nsu`
- `git diff --check upstream/main...HEAD`
