### PR TITLE
Fix invitations by regular occupants in members-only rooms

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImpl.java
@@ -1021,7 +1021,7 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
                 // Add the user as a member of the room if the room is members only
                 if (room.isMembersOnly())
                 {
-                    room.addMember(jid, null, preExistingOccupantData.getAffiliation());
+                    addInviteeAsMember(room, jid, preExistingOccupantData);
                 }
 
                 // Send the invitation to the invitee
@@ -1043,6 +1043,19 @@ public class MultiUserChatServiceImpl implements Component, MultiUserChatService
             Log.debug("Rejecting invitation message from occupant '{}' in room '{}': The user being invited does not have access to the room.", packet.getFrom(), room.getName(), e);
             sendErrorPacket(packet, PacketError.Condition.not_acceptable, "The user being invited does not have access to the room.");
         }
+    }
+
+    static void addInviteeAsMember(
+        @Nonnull final MUCRoom room,
+        @Nonnull final JID invitee,
+        @Nonnull final MUCOccupant inviter ) throws ForbiddenException, ConflictException
+    {
+        // An invitation that is allowed by the room grants membership on behalf of the room. Using the inviter's
+        // affiliation here would reject regular members even when the room explicitly allows occupants to invite.
+        final Affiliation actorAffiliation = room.canOccupantsInvite()
+            ? room.getSelfRepresentation().getAffiliation()
+            : inviter.getAffiliation();
+        room.addMember(invitee, null, actorAffiliation);
     }
 
     /**

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImplTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/muc/spi/MultiUserChatServiceImplTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.muc.spi;
+
+import org.jivesoftware.openfire.muc.Affiliation;
+import org.jivesoftware.openfire.muc.MUCOccupant;
+import org.jivesoftware.openfire.muc.MUCRoom;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.xmpp.packet.JID;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MultiUserChatServiceImplTest
+{
+    @Mock
+    private MUCRoom room;
+
+    @Mock
+    private MUCOccupant inviter;
+
+    @Mock
+    private MUCOccupant roomSelfOccupant;
+
+    @Test
+    public void testAddInviteeAsMemberUsesRoomAffiliationWhenOccupantInvitesAreAllowed() throws Exception
+    {
+        final JID invitee = new JID("invitee@example.org");
+        when(room.canOccupantsInvite()).thenReturn(true);
+        when(room.getSelfRepresentation()).thenReturn(roomSelfOccupant);
+        when(roomSelfOccupant.getAffiliation()).thenReturn(Affiliation.owner);
+
+        MultiUserChatServiceImpl.addInviteeAsMember(room, invitee, inviter);
+
+        verify(room).addMember(invitee, null, Affiliation.owner);
+    }
+
+    @Test
+    public void testAddInviteeAsMemberUsesInviterAffiliationWhenOccupantInvitesAreDisallowed() throws Exception
+    {
+        final JID invitee = new JID("invitee@example.org");
+        when(room.canOccupantsInvite()).thenReturn(false);
+        when(inviter.getAffiliation()).thenReturn(Affiliation.member);
+
+        MultiUserChatServiceImpl.addInviteeAsMember(room, invitee, inviter);
+
+        verify(room).addMember(invitee, null, Affiliation.member);
+    }
+}


### PR DESCRIPTION
## Problem

A regular room occupant can pass the invitation authorization check when `muc#roomconfig_allowinvites` is enabled. In a members-only room, Openfire then tries to add the invitee as a member using the inviter's `member` affiliation. `MUCRoom.addMember` requires an admin or owner affiliation, which rejects the invitation with `forbidden`.

## Change

When occupant invitations are enabled, add the invitee on behalf of the room, whose self-representation has owner affiliation. When occupant invitations are disabled, retain the inviter's affiliation so the existing admin/owner permission check remains in effect. The actual inviter JID and affiliation are still passed to `sendInvitation`.

Add regression coverage for both configuration states.

## Testing

- `mvnw.cmd -pl xmppserver -am -Dtest=MultiUserChatServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvnw.cmd -pl xmppserver -am test` (2068 tests, 0 failures, 0 errors, 3 skipped)