### PR TITLE
Minor updates to Jetty, Mysql and Log4j to appease static analyzers

### DIFF
--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -142,4 +142,13 @@
         <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/(mortbay\-)?apache\-(el|jsp)@.*$</packageUrl>
         <cpe>cpe:/a:mortbay_jetty:jetty</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        mortbay-apache-jsp is Apache Tomcat's Jasper JSP engine rebundled for Jetty, with the servlet container stripped out. These CVEs affect Catalina (RewriteValve), Tomcat clustering (EncryptInterceptor) and the examples webapp - none of which are present in this artifact. Verified against jar contents. Openfire uses Jetty, not Tomcat, as its HTTP server. See https://igniterealtime.atlassian.net/browse/OF-3349
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/mortbay-apache-jsp@.*$</packageUrl>
+        <cve>CVE-2026-59083</cve>
+        <cve>CVE-2026-59084</cve>
+        <cve>CVE-2026-66299</cve>
+    </suppress>
 </suppressions>

--- a/.dependency-check-suppressions.xml
+++ b/.dependency-check-suppressions.xml
@@ -69,35 +69,35 @@
         <notes><![CDATA[
         Ignore a CVE regarding Tomcat clustering, which isn't used in Openfire.
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/(mortbay\-)?apache\-(el|jsp)@.*$</packageUrl>
         <cve>CVE-2022-29885</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
         Rapid Reset was fixed in Jetty 10.0.18, which brings in this dependency.
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/(mortbay\-)?apache\-(el|jsp)@.*$</packageUrl>
         <cve>CVE-2023-44487</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
         Openfire doesn't persist sessions via Tomcat FileStore (or anything else, beyond preferences)
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/(mortbay\-)?apache\-(el|jsp)@.*$</packageUrl>
         <cve>CVE-2022-23181</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
         Openfire doesn't make use of the example webapp in Tomcat
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/(mortbay\-)?apache\-(el|jsp)@.*$</packageUrl>
         <cve>CVE-2022-34305</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
         Openfire doesn't use the ROOT webapp. Additional testing on 2023-11-13 against 7a53b23e565cdf06a541af82560a6c49d6c9d2ae.
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/(mortbay\-)?apache\-(el|jsp)@.*$</packageUrl>
         <cve>CVE-2023-41080</cve>
     </suppress>
     <suppress>
@@ -116,30 +116,30 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-        Suppress eclipse:jetty issues for apache-jsp - this is Apache Tomcat's Jasper JSP engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server.
+        Suppress eclipse:jetty issues for the Jasper artifacts - this is Apache Tomcat's Jasper JSP/EL engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server. Confirmed by the Jetty project: https://github.com/jetty/jetty.project/discussions/15541
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/(mortbay\-)?apache\-(el|jsp)@.*$</packageUrl>
         <cpe>cpe:/a:eclipse:jetty</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-        Suppress jetty:jetty issues for apache-jsp - this is Apache Tomcat's Jasper JSP engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server.
+        Suppress jetty:jetty issues for the Jasper artifacts - this is Apache Tomcat's Jasper JSP/EL engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server.
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/(mortbay\-)?apache\-(el|jsp)@.*$</packageUrl>
         <cpe>cpe:/a:jetty:jetty</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-        Suppress mortbay:jetty issues for apache-jsp - this is Apache Tomcat's Jasper JSP engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server.
+        Suppress mortbay:jetty issues for the Jasper artifacts - this is Apache Tomcat's Jasper JSP/EL engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server.
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/(mortbay\-)?apache\-(el|jsp)@.*$</packageUrl>
         <cpe>cpe:/a:mortbay:jetty</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-        Suppress mortbay_jetty:jetty issues for apache-jsp - this is Apache Tomcat's Jasper JSP engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server.
+        Suppress mortbay_jetty:jetty issues for the Jasper artifacts - this is Apache Tomcat's Jasper JSP/EL engine (org.mortbay.jasper), rebundled for use by Jetty, NOT the Jetty HTTP server.
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/apache\-jsp@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.mortbay\.jasper/(mortbay\-)?apache\-(el|jsp)@.*$</packageUrl>
         <cpe>cpe:/a:mortbay_jetty:jetty</cpe>
     </suppress>
 </suppressions>

--- a/build/ci/updater/pom.xml
+++ b/build/ci/updater/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
-      <version>9.7.0</version>
+      <version>26.7.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.protobuf</groupId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -124,7 +124,7 @@
         <!-- Versions -->
         <openfire.version>5.2.0-SNAPSHOT</openfire.version>
         <!-- Note; the following jetty.version should be identical to the jetty.version in xmppserver/pom.xml -->
-        <jetty.version>12.0.35</jetty.version>
+        <jetty.version>12.0.37</jetty.version>
     </properties>
 
     <profiles>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -123,7 +123,7 @@
 
         <!-- Versions -->
         <openfire.version>5.2.0-SNAPSHOT</openfire.version>
-        <!-- Note; the following jetty.version should be identical to the jetty.version in xmppserver/pom.xml -->
+        <!-- Note; the following jetty.version should be identical to the jetty.version in the pom.xml that is in the root of the project. -->
         <jetty.version>12.0.38</jetty.version>
     </properties>
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -124,7 +124,7 @@
         <!-- Versions -->
         <openfire.version>5.2.0-SNAPSHOT</openfire.version>
         <!-- Note; the following jetty.version should be identical to the jetty.version in xmppserver/pom.xml -->
-        <jetty.version>12.0.37</jetty.version>
+        <jetty.version>12.0.38</jetty.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 
         <!-- Versions -->
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
-        <jetty.version>12.0.37</jetty.version>
+        <jetty.version>12.0.38</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <netty.version>4.2.16.Final</netty.version>
         <bouncycastle.version>1.84</bouncycastle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 
         <!-- Versions -->
         <!-- Note; the following jetty.version should be identical to the jetty.version in plugins/pom.xml -->
-        <jetty.version>12.0.35</jetty.version>
+        <jetty.version>12.0.37</jetty.version>
         <standard-taglib.version>1.2.5</standard-taglib.version>
         <netty.version>4.2.16.Final</netty.version>
         <bouncycastle.version>1.84</bouncycastle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <bouncycastle.version>1.84</bouncycastle.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <log4j.version>2.26.0</log4j.version>
+        <log4j.version>2.26.1</log4j.version>
         <ojdbc.version>23.26.2.0.0</ojdbc.version>
     </properties>
 

--- a/xmppserver/pom.xml
+++ b/xmppserver/pom.xml
@@ -459,7 +459,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>9.7.0</version>
+            <version>26.7.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
This updates both components to the latest patch-level release of the branch that Openfire is already using, which resolves reported vulnerabilities.

There is no indication these issues create a practical vulnerability in Openfire itself, but upgrading to non-affected versions is an easy change that takes away all doubt.