### PR TITLE
OF-2535: Offer SASL EXTERNAL and dialback on inbound directTLS S2S connections

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -189,22 +189,11 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
                     features.add(starttls);
                 }
 
-                if (ServerDialback.isEnabled()) {
-                    // Also offer server dialback (when TLS is not required). Server dialback may be offered
-                    // after TLS has been negotiated and a self-signed certificate is being used
-                    final Element dialback = DocumentHelper.createElement(QName.get("dialback", "urn:xmpp:features:dialback"));
-                    dialback.addElement("errors");
-                    features.add(dialback);
-                }
-
-                if (!ConnectionSettings.Server.STREAM_LIMITS_ADVERTISEMENT_DISABLED.getValue()) {
-                    final Element limits = DocumentHelper.createElement(QName.get("limits", "urn:xmpp:stream-limits:0"));
-                    limits.addElement("max-bytes").addText(String.valueOf(XMLLightweightParser.XMPP_PARSER_BUFFER_SIZE.getValue()));
-                    final Duration timeout = ConnectionSettings.Server.IDLE_TIMEOUT_PROPERTY.getValue();
-                    if (!timeout.isNegative() && !timeout.isZero()) {
-                        limits.addElement("idle-seconds").addText(String.valueOf(timeout.toSeconds()));
-                    }
-                    features.add(limits);
+                // Always delegate the rest (SASL, dialback, limits) to the single feature builder. It self-guards on
+                // session.isEncrypted(), so this is correct whether we're still plaintext (STARTTLS not yet negotiated)
+                // or already encrypted (directTLS, or STARTTLS post-negotiation calling this same method separately).
+                for (Element feature : session.getAvailableStreamFeatures()) {
+                    features.add(feature);
                 }
             } else {
                 Log.debug("Don't offer stream-features to pre-1.0 servers, as it confuses them. Sending features to Openfire < 3.7.1 confuses it too - OF-443)");
@@ -436,17 +425,9 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
             compression.addElement("method").addText("zlib");
             result.add(compression);
         }
-        
-        // Offer server dialback if using self-signed certificates and no authentication has been done yet
-        boolean usingSelfSigned;
-        final Certificate[] chain = conn.getLocalCertificates();
-        if (chain == null || chain.length == 0) {
-            usingSelfSigned = true;
-        } else {
-            usingSelfSigned = CertificateManager.isSelfSignedCertificate((X509Certificate) chain[0]);
-        }
-        
-        if (usingSelfSigned && ServerDialback.isEnabledForSelfSigned() && validatedDomains.isEmpty()) {
+
+        // Offer server dialback whenever it's enabled and no domain has validated yet.
+        if (ServerDialback.isEnabled() && validatedDomains.isEmpty()) {
             final Element dialback = DocumentHelper.createElement(QName.get("dialback", "urn:xmpp:features:dialback"));
             dialback.addElement("errors");
             result.add(dialback);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/LocalIncomingServerSession.java
@@ -426,8 +426,8 @@ public class LocalIncomingServerSession extends LocalServerSession implements In
             result.add(compression);
         }
 
-        // Offer server dialback whenever it's enabled and no domain has validated yet.
-        if (ServerDialback.isEnabled() && validatedDomains.isEmpty()) {
+        // Offer server dialback whenever it's enabled outright, or enabled as a fallback for self-signed certificates, as long as no domain has validated yet.
+        if ((ServerDialback.isEnabled() || ServerDialback.isEnabledForSelfSigned()) && validatedDomains.isEmpty()) {
             final Element dialback = DocumentHelper.createElement(QName.get("dialback", "urn:xmpp:features:dialback"));
             dialback.addElement("errors");
             result.add(dialback);


### PR DESCRIPTION
LocalIncomingServerSession#createSession() built its own inline stream features (STARTTLS, dialback, limits) for the very first response on an inbound server-to-server connection. The advertisement of SASL mechanisms was unconditionally removed from this code as part of OF-2535 refactoring (in 389902fa59a07ba9bed8f7692e83b0c9acc82171).

For STARTTLS connections this was masked, as a second, correct feature set is sent by getAvailableStreamFeatures() which was used only after TLS negotiation completes.

For non-STARTTLS (DirectTLS) connections however, createSession()'s response was the only feature set they ever received: no SASL mechanisms were advertised anymore

Peers that require SASL EXTERNAL (and do not support dialback) could therefore not authenticate inbound over directTLS. They close the stream with an error like: 'No viable authentication method offered'.

With this commit, `createSession()` now always delegate feature-building (SASL, dialback, stream limits) to `getAvailableStreamFeatures()`. Only the STARTTLS offer itself remains specific to the pre-TLS plaintext branch, since directTLS connections are encrypted before this method runs and must not re-offer STARTTLS.

The solution reduces code complexity, and makes this implementation more consistent with the implementation used for client sessions.

This also broadens the dialback condition in getAvailableStreamFeatures() from "only when using a self-signed certificate" to "whenever server dialback is enabled and no domain has validated yet", matching pre-regression behavior. This is a deliberate policy choice, not an oversight: offering both dialback and SASL EXTERNAL together is not a security downgrade, since the peer chooses which mechanism to use. This now applies uniformly to directTLS and post-STARTTLS-negotiation sessions alike.