### PR TITLE
OF-3353: Correctly parse standalone stream:-prefixed stanzas (e.g. <stream:error>)

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/StanzaHandler.java
@@ -198,7 +198,7 @@ public abstract class StanzaHandler {
 
         Element doc;
         final Set<Namespace> namespaces = connection.getAdditionalNamespaces();
-        if (namespaces.isEmpty()) {
+        if (namespaces.isEmpty() && !stanza.startsWith("<stream:")) {
             doc = reader.read(new StringReader(stanza)).getRootElement();
         } else {
             // When the peer defined namespace prefixes on the 'stream' element, other than the default namespaces, then


### PR DESCRIPTION
StanzaHandler#processStanza() 'rewraps' incoming data with a dummy XML element, declaring known namespaces, to prevent XML parsing issues. It rewrapped incoming data with the stream namespace declaration when connection.getAdditionalNamespaces() was non-empty. That set never includes the stream namespace itself (it's explicitly excluded when captured), so it stays empty for any peer that didn't declare some other prefixed namespace (e.g. dialback's xmlns:db) on its stream header.

A peer in that situation sending a standalone stream:-prefixed element, such as a closing <stream:error>, was parsed via the fast, unwrapped path with no binding for the 'stream' prefix anywhere, causing:

  XmlPullParserException: could not determine namespace bound to element prefix stream (position: START_DOCUMENT ...)

and an unhandled-exception connection close, instead of the intended handling in process().

Route stanzas starting with '<stream:' through the existing namespace-rewrapping branch regardless of whether any other prefixed namespace was captured; that branch already adds the stream namespace declaration when it's not otherwise present.