### PR TITLE
ci: Conversations e2e test improvements

### DIFF
--- a/.github/actions/conversationstest-action/action.yml
+++ b/.github/actions/conversationstest-action/action.yml
@@ -61,8 +61,8 @@ runs:
         path: ${{ runner.temp }}/sidecar.log
         retention-days: 7
 
-    - name: Upload maestro artifacts on failure
-      if: failure()
+    - name: Upload maestro artifacts
+      if: always()
       uses: actions/upload-artifact@v7
       with:
         name: maestro-logs

--- a/.github/actions/conversationstest-action/action.yml
+++ b/.github/actions/conversationstest-action/action.yml
@@ -42,7 +42,7 @@ runs:
       with:
         api-level: 34
         arch: x86_64
-        profile: Nexus 6
+        profile: pixel_6
         script: ${{ github.action_path }}/run-tests.sh ${{ inputs.includeTags }}
 
     - name: Upload ADB logcat on failure

--- a/.github/actions/conversationstest-action/action.yml
+++ b/.github/actions/conversationstest-action/action.yml
@@ -41,7 +41,6 @@ runs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 34
-        target: google_apis
         arch: x86_64
         profile: pixel_6
         script: ${{ github.action_path }}/run-tests.sh ${{ inputs.includeTags }}

--- a/.github/actions/conversationstest-action/action.yml
+++ b/.github/actions/conversationstest-action/action.yml
@@ -50,7 +50,7 @@ runs:
       if: failure()
       uses: actions/upload-artifact@v7
       with:
-        name: adb-logcat
+        name: Conversations e2e (${{ inputs.includeTags }}) Android log
         path: adb_logcat.log
         retention-days: 7
 
@@ -58,7 +58,7 @@ runs:
       if: failure()
       uses: actions/upload-artifact@v7
       with:
-        name: sidecar-log
+        name: Conversations e2e (${{ inputs.includeTags }}) Sidecar log
         path: ${{ runner.temp }}/sidecar.log
         retention-days: 7
 
@@ -66,7 +66,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: maestro-logs
+        name: Conversations e2e (${{ inputs.includeTags }}) Maestro logs
         path: ~/.maestro/tests
         retention-days: 7
         include-hidden-files: true

--- a/.github/actions/conversationstest-action/action.yml
+++ b/.github/actions/conversationstest-action/action.yml
@@ -41,6 +41,7 @@ runs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 34
+        target: google_apis
         arch: x86_64
         profile: pixel_6
         script: ${{ github.action_path }}/run-tests.sh ${{ inputs.includeTags }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -389,7 +389,7 @@ jobs:
         if: ${{ failure() && steps.runConversationsTests.conclusion == 'failure' }}
         uses: actions/upload-artifact@v7
         with:
-          name: Conversations Test (${{ matrix.name }}) Openfire logs
+          name: Conversations e2e (${{ matrix.name }}) Openfire logs
           path: distribution/target/distribution-base/logs/openfire.log
 
 

--- a/build/ci/conversations/flows/bind2.yaml
+++ b/build/ci/conversations/flows/bind2.yaml
@@ -66,7 +66,15 @@ onFlowComplete:
 - tapOn:
     id: "key_pos_ime_action"
     optional: true
-    label: Close keyboard, if visible
+    label: Close Google keyboard, if visible
+- runFlow:
+    when:
+      visible:
+        id: keyboard_view
+    commands:
+      - tapOn: Done
+    label: Close AOSP keyboard, if visible
+
 - assertVisible:
     id: "server_info_bind2"
     text: "available"

--- a/build/ci/conversations/flows/bind2.yaml
+++ b/build/ci/conversations/flows/bind2.yaml
@@ -1,4 +1,5 @@
 appId: eu.siacs.conversations
+name: Bind 2
 tags:
     - sasl2
 onFlowStart:

--- a/build/ci/conversations/flows/bind2.yaml
+++ b/build/ci/conversations/flows/bind2.yaml
@@ -63,6 +63,10 @@ onFlowComplete:
 - tapOn: "jane@example.org"
 - tapOn: "More options"
 - tapOn: "Server info"
+- tapOn:
+    id: "key_pos_ime_action"
+    optional: true
+    label: Close keyboard, if visible
 - assertVisible:
     id: "server_info_bind2"
     text: "available"

--- a/build/ci/conversations/flows/cb.yaml
+++ b/build/ci/conversations/flows/cb.yaml
@@ -39,7 +39,9 @@ onFlowStart:
 - runScript:
       file: scripts/checkForLogs.js
       env:
-          PATTERN: 'jane@example\.org.*Authenticating with SASL\/[A-Z0-9-]+-PLUS'
+          # Pinned to SHA-256/512-PLUS. Conversations won't pick it while stronger mechanisms are available.
+          # Just "-PLUS" would silently pass if a regression caused a downgrade back to SHA-1-PLUS.
+          PATTERN: 'jane@example\.org.*Authenticating with SASL\/SCRAM-SHA-(256|512)-PLUS'
 
 - runScript:
       file: scripts/checkForLogs.js

--- a/build/ci/conversations/flows/cb.yaml
+++ b/build/ci/conversations/flows/cb.yaml
@@ -1,4 +1,5 @@
 appId: eu.siacs.conversations
+name: Channel Binding
 tags:
     - demoboot
 onFlowStart:

--- a/build/ci/conversations/flows/sasl2.yaml
+++ b/build/ci/conversations/flows/sasl2.yaml
@@ -1,4 +1,5 @@
 appId: eu.siacs.conversations
+name: SASL2
 tags:
     - sasl2
 onFlowStart:

--- a/build/ci/conversations/flows/simple.yaml
+++ b/build/ci/conversations/flows/simple.yaml
@@ -1,4 +1,5 @@
 appId: eu.siacs.conversations
+name: Basic Login
 tags:
     - demoboot
 onFlowStart:


### PR DESCRIPTION
- Fixes a typo in the device profile
- Normalises the names of generated artifacts
- Produces Maestro log artifacts always (not just on failure)
- Add a `name` to all of the tests, for easier maintenance later
- Small resilience tweak for the Bind2 test, where the keyboard might still be up, hiding important content
- Tighten the regex on the Channel Binding test, since SCRAM-SHA-1-PLUS should never be negotiated between Conversations and Openfire.