### PR TITLE
OF-2534: Prevent duplicate Bind2 handler registrations

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiModule.java
@@ -22,9 +22,51 @@ import org.jivesoftware.openfire.net.Bind2InlineHandler;
 import org.jivesoftware.openfire.net.Bind2Request;
 import org.jivesoftware.openfire.session.LocalClientSession;
 
-public class CsiModule extends BasicModule {
-    static class Bind2CSIHandler implements Bind2InlineHandler {
 
+/**
+ * The CsiModule provides functionality for managing Client State Indication (CSI) within an XMPP server.
+ *
+ * This module interacts with incoming bind2 requests and processes inline elements related to client state activation
+ * and deactivation. It registers a handler for handling CSI-specific operations during the start of the module and
+ * unregisters it during the module's stop operation.
+ */
+public class CsiModule extends BasicModule
+{
+    private Bind2CSIHandler bind2CSIHandler;
+
+    /**
+     * Create a basic module with the given name.
+     */
+    public CsiModule() {
+        super("Client State Indication");
+    }
+
+    @Override
+    public synchronized void start() throws IllegalStateException {
+        super.start();
+        final Bind2CSIHandler localHandler = new Bind2CSIHandler();
+        Bind2Request.registerElementHandler(localHandler);
+        bind2CSIHandler = localHandler; // Only dereference any previous handler after registration succeeds, otherwise that previous handler can never be removed again.
+    }
+
+    @Override
+    public synchronized void stop() {
+        super.stop();
+        if (bind2CSIHandler != null) {
+            Bind2Request.unregisterElementHandler(bind2CSIHandler);
+            bind2CSIHandler = null;
+        }
+    }
+
+    /**
+     * Handles inline elements related to Client State Indication (CSI) during bind2 requests.
+     *
+     * Implements the {@link Bind2InlineHandler} interface to integrate with the bind2 inline element handling
+     * mechanism. Acts as a bridge between the bind2 processing flow and the specific functionalities of the
+     * Client State Indication module.
+     */
+    static class Bind2CSIHandler implements Bind2InlineHandler
+    {
         @Override
         public String getNamespace() {
             return CsiManager.NAMESPACE;
@@ -39,24 +81,5 @@ public class CsiModule extends BasicModule {
             }
             return true;
         }
-    }
-    private static final Bind2CSIHandler handler = new Bind2CSIHandler();
-    /**
-     * <p>Create a basic module with the given name.</p>
-     */
-    public CsiModule() {
-        super("Client State Indication");
-    }
-
-    @Override
-    public void start() throws IllegalStateException {
-        super.start();
-        Bind2Request.registerElementHandler(handler);
-    }
-
-    @Override
-    public void stop() {
-        Bind2Request.unregisterElementHandler(handler);
-        super.stop();
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiModule.java
@@ -56,7 +56,7 @@ public class CsiModule extends BasicModule {
 
     @Override
     public void stop() {
-        Bind2Request.unregisterElementHandler(handler.getNamespace());
+        Bind2Request.unregisterElementHandler(handler);
         super.stop();
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQMessageCarbonsHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQMessageCarbonsHandler.java
@@ -38,6 +38,7 @@ public final class IQMessageCarbonsHandler extends IQHandler implements ServerFe
     private static final String NAMESPACE = "urn:xmpp:carbons:2";
 
     private IQHandlerInfo info;
+    private Bind2CarbonsHandler bind2Handler;
 
     public IQMessageCarbonsHandler() {
         super("XEP-0280: Message Carbons");
@@ -83,12 +84,13 @@ public final class IQMessageCarbonsHandler extends IQHandler implements ServerFe
     @Override
     public void start() throws IllegalStateException {
         super.start();
-        Bind2Request.registerElementHandler(new Bind2CarbonsHandler());
+        bind2Handler = new Bind2CarbonsHandler();
+        Bind2Request.registerElementHandler(bind2Handler);
     }
 
     @Override
     public void stop() {
         super.stop();
-        Bind2Request.unregisterElementHandler("urn:xmpp:carbons:2");
+        Bind2Request.unregisterElementHandler(bind2Handler);
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQMessageCarbonsHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/IQMessageCarbonsHandler.java
@@ -82,15 +82,19 @@ public final class IQMessageCarbonsHandler extends IQHandler implements ServerFe
     }
 
     @Override
-    public void start() throws IllegalStateException {
+    public synchronized void start() throws IllegalStateException {
         super.start();
-        bind2Handler = new Bind2CarbonsHandler();
-        Bind2Request.registerElementHandler(bind2Handler);
+        final Bind2CarbonsHandler localHandler = new Bind2CarbonsHandler();
+        Bind2Request.registerElementHandler(localHandler);
+        bind2Handler = localHandler; // Only dereference any previous handler after registration succeeds, otherwise that previous handler can never be removed again.
     }
 
     @Override
-    public void stop() {
+    public synchronized void stop() {
         super.stop();
-        Bind2Request.unregisterElementHandler(bind2Handler);
+        if (bind2Handler != null) {
+            Bind2Request.unregisterElementHandler(bind2Handler);
+            bind2Handler = null;
+        }
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/Bind2Request.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/Bind2Request.java
@@ -42,44 +42,56 @@ public class Bind2Request {
     private static final Logger Log = LoggerFactory.getLogger(Bind2Request.class);
     
     // Add a map to store registered handlers by namespace
-    private static final Map<String, Bind2InlineHandler> elementHandlers = 
-        new ConcurrentHashMap<>();
-        
+    private static final Map<String, Bind2InlineHandler> elementHandlers = new ConcurrentHashMap<>();
+
     /**
      * Registers a handler for processing inline elements with a specific namespace.
      *
+     * Only one handler can be registered for each namespace. Attempting to register a handler for an already registered
+     * namespace will result in an IllegalStateException.
+     *
      * @param handler The handler to register
      */
-    public static void registerElementHandler(Bind2InlineHandler handler) {
-        if (handler == null) {
-            throw new NullPointerException("Handler cannot be null");
-        }
-        String namespace = handler.getNamespace();
+    public static void registerElementHandler(@Nonnull final Bind2InlineHandler handler)
+    {
+        final String namespace = handler.getNamespace();
         if (namespace == null || namespace.isEmpty()) {
             throw new IllegalArgumentException("Handler namespace cannot be null or empty");
         }
-        
-        elementHandlers.put(namespace, handler);
-        if (Log.isDebugEnabled()) {
-            Log.debug("Registered inline element handler for namespace: {}", namespace);
+
+        if (elementHandlers.putIfAbsent(namespace, handler) != null) {
+            throw new IllegalStateException("An inline element handler is already registered for namespace: " + namespace);
         }
+
+        Log.debug("Registered inline element handler for namespace: {}", namespace);
     }
 
     /**
-     * Unregisters a handler for a specific namespace.
+     * Unregisters an inline element handler associated with a specific namespace.
      *
-     * @param namespace The namespace of the handler to remove
-     * @return The removed handler, or null if none was registered for this namespace
+     * This method removes the handler previously registered for processing inline elements
+     * with the specified namespace. If no handler is registered for the given namespace or
+     * if the provided handler does not match the currently registered handler, no action
+     * will be performed.
+     *
+     * @param handler The inline element handler to unregister. Must not be null and must provide a valid namespace.
+     * @return {@code true} if the handler was successfully unregistered, {@code false} otherwise.
+     * @throws IllegalArgumentException if the handler's namespace is {@code null} or empty.
      */
-    public static Bind2InlineHandler unregisterElementHandler(String namespace) {
+    public static boolean unregisterElementHandler(@Nonnull final Bind2InlineHandler handler)
+    {
+        final String namespace = handler.getNamespace();
+
         if (namespace == null || namespace.isEmpty()) {
-            throw new IllegalArgumentException("Namespace cannot be null or empty");
+            throw new IllegalArgumentException("Handler namespace cannot be null or empty");
         }
-        
-        Bind2InlineHandler removed = elementHandlers.remove(namespace);
-        if (removed != null && Log.isDebugEnabled()) {
+
+        boolean removed = elementHandlers.remove(namespace, handler);
+
+        if (removed) {
             Log.debug("Unregistered inline element handler for namespace: {}", namespace);
         }
+
         return removed;
     }
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/Bind2Request.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/Bind2Request.java
@@ -69,10 +69,11 @@ public class Bind2Request {
     /**
      * Unregisters an inline element handler associated with a specific namespace.
      *
-     * This method removes the handler previously registered for processing inline elements
-     * with the specified namespace. If no handler is registered for the given namespace or
-     * if the provided handler does not match the currently registered handler, no action
-     * will be performed.
+     * This method removes a registration using handler equality, not just namespace matching. As a result, an
+     * invocation must retain the exact handler instance they registered.
+     *
+     * If no handler is registered for the given namespace or if the provided handler does not match the currently
+     * registered handler, no action will be performed.
      *
      * @param handler The inline element handler to unregister. Must not be null and must provide a valid namespace.
      * @return {@code true} if the handler was successfully unregistered, {@code false} otherwise.

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/net/Bind2InlineHandlerTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/net/Bind2InlineHandlerTest.java
@@ -17,135 +17,158 @@
 package org.jivesoftware.openfire.net;
 
 import org.dom4j.Element;
-import org.dom4j.DocumentHelper;
-import org.junit.jupiter.api.BeforeEach;
+import org.jivesoftware.openfire.session.LocalClientSession;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.AfterEach;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Tests for the Bind2InlineHandler registration and processing functionality.
  */
 public class Bind2InlineHandlerTest {
 
-    private Bind2InlineHandler mockHandler;
-    private Element mockBoundElement;
-    private Element mockFeatureElement;
-
-    @BeforeEach
-    public void setUp() {
-        mockHandler = mock(Bind2InlineHandler.class);
-        mockBoundElement = DocumentHelper.createElement("bound");
-        mockFeatureElement = DocumentHelper.createElement("feature");
-        mockFeatureElement.addNamespace("test", "http://test.namespace");
-    }
-
-    @AfterEach
-    public void tearDown() {
-        // Clean up any registered handlers to avoid test interference
-        Bind2Request.unregisterElementHandler("http://test.namespace");
-    }
-
     @Test
     public void testRegisterElementHandler() {
-        // Setup
-        when(mockHandler.getNamespace()).thenReturn("http://test.namespace");
+        Bind2InlineHandler handler = new TestBind2InlineHandler("urn:xmpp:test:0");
 
-        // Execute
-        assertDoesNotThrow(() -> Bind2Request.registerElementHandler(mockHandler));
+        assertDoesNotThrow(
+            () -> Bind2Request.registerElementHandler(handler),
+            "A handler should be registered when its namespace is not already registered"
+        );
 
-        // Verify registration was successful by attempting to unregister
-        Bind2InlineHandler removed = Bind2Request.unregisterElementHandler("http://test.namespace");
-        assertNotNull(removed);
-        assertEquals(mockHandler, removed);
+        assertTrue(
+            Bind2Request.unregisterElementHandler(handler),
+            "The registered handler should be removable using the same handler instance"
+        );
     }
 
     @Test
-    public void testRegisterNullHandler() {
-        // Execute & Verify
-        assertThrows(NullPointerException.class, () -> 
-            Bind2Request.registerElementHandler(null));
+    public void testRegisterElementHandlerRejectsNullNamespace() {
+        Bind2InlineHandler handler = new TestBind2InlineHandler(null);
+
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> Bind2Request.registerElementHandler(handler),
+            "Registering a handler without a namespace should fail"
+        );
     }
 
     @Test
-    public void testRegisterHandlerWithNullNamespace() {
-        // Setup
-        when(mockHandler.getNamespace()).thenReturn(null);
+    public void testRegisterElementHandlerRejectsEmptyNamespace() {
+        Bind2InlineHandler handler = new TestBind2InlineHandler("");
 
-        // Execute & Verify
-        assertThrows(IllegalArgumentException.class, () -> 
-            Bind2Request.registerElementHandler(mockHandler));
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> Bind2Request.registerElementHandler(handler),
+            "Registering a handler with an empty namespace should fail"
+        );
     }
 
     @Test
-    public void testRegisterHandlerWithEmptyNamespace() {
-        // Setup
-        when(mockHandler.getNamespace()).thenReturn("");
+    public void testUnregisterElementHandlerRejectsNullNamespace() {
+        Bind2InlineHandler handler = new TestBind2InlineHandler(null);
 
-        // Execute & Verify
-        assertThrows(IllegalArgumentException.class, () -> 
-            Bind2Request.registerElementHandler(mockHandler));
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> Bind2Request.unregisterElementHandler(handler),
+            "Unregistering a handler without a namespace should fail"
+        );
     }
 
     @Test
-    public void testUnregisterElementHandler() {
-        // Setup
-        when(mockHandler.getNamespace()).thenReturn("http://test.namespace");
-        Bind2Request.registerElementHandler(mockHandler);
+    public void testUnregisterElementHandlerRejectsEmptyNamespace() {
+        Bind2InlineHandler handler = new TestBind2InlineHandler("");
 
-        // Execute
-        Bind2InlineHandler removed = Bind2Request.unregisterElementHandler("http://test.namespace");
-
-        // Verify
-        assertNotNull(removed);
-        assertEquals(mockHandler, removed);
-        
-        // Verify it's actually gone
-        Bind2InlineHandler removedAgain = Bind2Request.unregisterElementHandler("http://test.namespace");
-        assertNull(removedAgain);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> Bind2Request.unregisterElementHandler(handler),
+            "Unregistering a handler with an empty namespace should fail"
+        );
     }
 
     @Test
-    public void testUnregisterNonExistentHandler() {
-        // Execute
-        Bind2InlineHandler removed = Bind2Request.unregisterElementHandler("http://nonexistent.namespace");
+    public void testRegisterElementHandlerRejectsDuplicateNamespace() {
+        String namespace = "urn:xmpp:test:0";
+        Bind2InlineHandler firstHandler = new TestBind2InlineHandler(namespace);
+        Bind2InlineHandler secondHandler = new TestBind2InlineHandler(namespace);
 
-        // Verify
-        assertNull(removed);
-    }
-
-    @Test
-    public void testUnregisterWithNullNamespace() {
-        // Execute & Verify
-        assertThrows(IllegalArgumentException.class, () -> 
-            Bind2Request.unregisterElementHandler(null));
-    }
-
-    @Test
-    public void testUnregisterWithEmptyNamespace() {
-        // Execute & Verify
-        assertThrows(IllegalArgumentException.class, () -> 
-            Bind2Request.unregisterElementHandler(""));
-    }
-
-    @Test
-    public void testReplaceHandler() {
-        // Setup
-        Bind2InlineHandler firstHandler = mock(Bind2InlineHandler.class);
-        Bind2InlineHandler secondHandler = mock(Bind2InlineHandler.class);
-        when(firstHandler.getNamespace()).thenReturn("http://test.namespace");
-        when(secondHandler.getNamespace()).thenReturn("http://test.namespace");
-
-        // Execute
         Bind2Request.registerElementHandler(firstHandler);
-        Bind2Request.registerElementHandler(secondHandler); // Should replace first
 
-        Bind2InlineHandler retrieved = Bind2Request.unregisterElementHandler("http://test.namespace");
+        try {
+            assertThrows(
+                IllegalStateException.class,
+                () -> Bind2Request.registerElementHandler(secondHandler),
+                "Registering a second handler for an existing namespace should fail"
+            );
 
-        // Verify
-        assertEquals(secondHandler, retrieved);
-        assertNotEquals(firstHandler, retrieved);
+            assertTrue(
+                Bind2Request.unregisterElementHandler(firstHandler),
+                "The original handler should remain registered after duplicate registration fails"
+            );
+
+            assertFalse(
+                Bind2Request.unregisterElementHandler(secondHandler),
+                "The rejected handler should never be registered"
+            );
+        } finally {
+            Bind2Request.unregisterElementHandler(firstHandler);
+            Bind2Request.unregisterElementHandler(secondHandler);
+        }
+    }
+
+    @Test
+    public void testUnregisterElementHandlerRequiresRegisteredHandler() {
+        String namespace = "urn:xmpp:test:0";
+        Bind2InlineHandler registeredHandler = new TestBind2InlineHandler(namespace);
+        Bind2InlineHandler otherHandler = new TestBind2InlineHandler(namespace);
+
+        Bind2Request.registerElementHandler(registeredHandler);
+
+        try {
+            assertFalse(
+                Bind2Request.unregisterElementHandler(otherHandler),
+                "A handler that is not registered should not remove the registered handler"
+            );
+
+            assertTrue(
+                Bind2Request.unregisterElementHandler(registeredHandler),
+                "The actually registered handler should still be removable"
+            );
+        } finally {
+            Bind2Request.unregisterElementHandler(registeredHandler);
+            Bind2Request.unregisterElementHandler(otherHandler);
+        }
+    }
+
+    @Test
+    public void testUnregisterElementHandlerReturnsFalseForUnregisteredHandler() {
+        Bind2InlineHandler handler = new TestBind2InlineHandler("urn:xmpp:test:0");
+
+        assertFalse(
+            Bind2Request.unregisterElementHandler(handler),
+            "Unregistering a handler that was never registered should return false"
+        );
+    }
+
+    private static class TestBind2InlineHandler implements Bind2InlineHandler
+    {
+        private final String namespace;
+
+        private TestBind2InlineHandler(String namespace) {
+            this.namespace = namespace;
+        }
+
+        @Override
+        public String getNamespace() {
+            return namespace;
+        }
+
+        @Override
+        public boolean handleElement(LocalClientSession clientSession, Element bound, Element element) {
+            return true;
+        }
     }
 }

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/net/Bind2RequestProcessingTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/net/Bind2RequestProcessingTest.java
@@ -97,9 +97,8 @@ public class Bind2RequestProcessingTest {
 
     @AfterEach
     public void tearDown() {
-        Bind2Request.unregisterElementHandler("http://test1.namespace");
-        Bind2Request.unregisterElementHandler("http://test2.namespace");
-        Bind2Request.unregisterElementHandler("http://unhandled.namespace");
+        Bind2Request.unregisterElementHandler(mockHandler1);
+        Bind2Request.unregisterElementHandler(mockHandler2);
     }
 
     // -------------------------------------------------------------------------
@@ -289,7 +288,7 @@ public class Bind2RequestProcessingTest {
     public void testFeatureElementAfterUnregisteringHandler() {
         Bind2Request.registerElementHandler(mockHandler1);
         Bind2Request.registerElementHandler(mockHandler2);
-        Bind2Request.unregisterElementHandler("http://test1.namespace");
+        Bind2Request.unregisterElementHandler(mockHandler1);
 
         Element feature = Bind2Request.featureElement();
 


### PR DESCRIPTION
Prevent duplicate Bind2 inline handler registrations by rejecting attempts to register an already-used namespace.

Unregistration now requires the original handler instance, preventing one component from accidentally removing another component’s handler.