### PR TITLE
OF-3363: Fix UserMultiProvider setName

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserMultiProvider.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/user/UserMultiProvider.java
@@ -437,7 +437,7 @@ public abstract class UserMultiProvider implements UserProvider
     @Override
     public void setName(String username, String name) throws UserNotFoundException
     {
-        getUserProvider(username).setEmail(username, name);
+        getUserProvider(username).setName(username, name);
     }
 
     /**


### PR DESCRIPTION
Fixing an obvious copy/paste issue where setName would incorrectly update the email address of a user with the provided name value. Thanks Tijl!