### PR TITLE
OF-3364: Fix getMaxMessages() reporting unlimited for default-type rooms

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -319,6 +319,21 @@ public class HistoryStrategy implements Externalizable {
         } finally {
             lock.unlock();
         }
+    }
+
+    /**
+     * Resolves this strategy to the one whose settings are actually in effect: if this strategy's type is
+     * {@link Type#defaulType}, walks up the parent chain until a strategy with a concrete type (or no parent) is found.
+     * Returns this instance if its type is not defaulType, or if it has no parent to defer to.
+     *
+     * @return The strategy instance whose type/maxNumber values should be treated as authoritative.
+     */
+    HistoryStrategy resolveEffective() {
+        HistoryStrategy strategy = this;
+        while (strategy.type == Type.defaulType && strategy.parent != null) {
+            strategy = strategy.parent;
+        }
+        return strategy;
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
@@ -124,7 +124,7 @@ public class HistoryStrategy implements Externalizable {
             maxNumber = DEFAULT_MAX_NUMBER;
         }
         else {
-            type = Type.defaulType;
+            type = Type.defaultType;
             maxNumber = parent.getMaxNumber();
         }
     }
@@ -312,14 +312,14 @@ public class HistoryStrategy implements Externalizable {
 
     /**
      * Resolves this strategy to the one whose settings are actually in effect: if this strategy's type is
-     * {@link Type#defaulType}, walks up the parent chain until a strategy with a concrete type (or no parent) is found.
-     * Returns this instance if its type is not defaulType, or if it has no parent to defer to.
+     * {@link Type#defaultType}, walks up the parent chain until a strategy with a concrete type (or no parent) is found.
+     * Returns this instance if its type is not defaultType, or if it has no parent to defer to.
      *
      * @return The strategy instance whose type/maxNumber values should be treated as authoritative.
      */
     HistoryStrategy resolveEffective() {
         HistoryStrategy strategy = this;
-        while (strategy.type == Type.defaulType && strategy.parent != null) {
+        while (strategy.type == Type.defaultType && strategy.parent != null) {
             strategy = strategy.parent;
         }
         return strategy;
@@ -387,7 +387,7 @@ public class HistoryStrategy implements Externalizable {
      * Strategy type.
      */
     public enum Type {
-        defaulType, none, all, number;
+        defaultType, none, all, number;
     }
 
     /**
@@ -404,7 +404,7 @@ public class HistoryStrategy implements Externalizable {
         }
         catch (Exception e) {
             if (parent != null) {
-                type = Type.defaulType;
+                type = Type.defaultType;
             }
             else {
                 type = Type.number;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/HistoryStrategy.java
@@ -205,16 +205,9 @@ public class HistoryStrategy implements Externalizable {
         }
 
         // get the conditions based on default or not
-        final Type strategyType;
-        final int strategyMaxNumber;
-        if (type == Type.defaulType && parent != null) {
-            strategyType = parent.getType();
-            strategyMaxNumber = parent.getMaxNumber();
-        }
-        else {
-            strategyType = type;
-            strategyMaxNumber = maxNumber;
-        }
+        final HistoryStrategy effective = resolveEffective();
+        final Type strategyType = effective.getType();
+        final int strategyMaxNumber = effective.getMaxNumber();
 
         final Lock lock = MUC_HISTORY_CACHE.getLock(roomJID);
         lock.lock();
@@ -238,11 +231,7 @@ public class HistoryStrategy implements Externalizable {
     }
 
     boolean isHistoryEnabled() {
-        Type strategyType = type;
-        if (type == Type.defaulType && parent != null) {
-            strategyType = parent.getType();
-        }
-        return strategyType != HistoryStrategy.Type.none;
+        return resolveEffective().getType() != Type.none;
     }
 
     /**

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MUCRoomHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software, 2016-2025 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2016-2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -324,8 +324,9 @@ public final class MUCRoomHistory implements Externalizable {
      * @return The maximum number of historic messages to keep for this room, or -1.
      */
     public int getMaxMessages() {
-        return switch (historyStrategy.getType()) {
-            case number -> historyStrategy.getMaxNumber();
+        final HistoryStrategy effective = historyStrategy.resolveEffective();
+        return switch (effective.getType()) {
+            case number -> effective.getMaxNumber();
             case none -> 0;
             default -> -1;
         };


### PR DESCRIPTION
MUCRoomHistory.getMaxMessages() switched on the room's own HistoryStrategy type, which is always 'defaulType' (sic) for rooms that inherit their history settings. This caused the method to always return -1 (unlimited) for such rooms, regardless of the parent's actual configured maximum.

Add HistoryStrategy.resolveEffective() to walk up the parent chain to the strategy whose settings are actually in effect, and use it in getMaxMessages() so the correct type and maxNumber are reported.