### PR TITLE
OF-2534: Expose Bind 2 usage in session details admin console

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1895,6 +1895,11 @@ session.details.hide-extended=Show Less Details
 session.details.show-extended=Show More Details
 session.details.security=Security
 session.details.features=Features & Functionality
+session.details.bind-method=Bind Method
+session.details.bind-method-bind2=Bind 2 (inline, XEP-0386)
+session.details.bind-method-legacy=Resource Binding (legacy IQ)
+session.details.bind2-inline-features=Bind 2 Inline Features
+session.details.negotiated-via-bind2=negotiated via Bind 2
 
 # Session row Page
 

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1756,6 +1756,11 @@ session.details.hide-extended=Toon Minder Details
 session.details.show-extended=Toon Meer Details
 session.details.security=Beveiliging
 session.details.features=Functies & Functionaliteit
+session.details.bind-method=Bindmethode
+session.details.bind-method-bind2=Bind 2 (inline, XEP-0386)
+session.details.bind-method-legacy=Resource-binding (verouderde IQ)
+session.details.bind2-inline-features=Bind 2 inline-functies
+session.details.negotiated-via-bind2=onderhandeld via Bind 2
 
 # Session row Page
 

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiModule.java
@@ -73,6 +73,11 @@ public class CsiModule extends BasicModule
         }
 
         @Override
+        public String getDisplayName() {
+            return "Client State Indication";
+        }
+
+        @Override
         public boolean handleElement(LocalClientSession session, Element bound, Element element) {
             if (element.getName().equals("active")) {
                 session.getCsiManager().activate();

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiModule.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/csi/CsiModule.java
@@ -21,6 +21,8 @@ import org.jivesoftware.openfire.container.BasicModule;
 import org.jivesoftware.openfire.net.Bind2InlineHandler;
 import org.jivesoftware.openfire.net.Bind2Request;
 import org.jivesoftware.openfire.session.LocalClientSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -67,6 +69,8 @@ public class CsiModule extends BasicModule
      */
     static class Bind2CSIHandler implements Bind2InlineHandler
     {
+        private static final Logger Log = LoggerFactory.getLogger(Bind2CSIHandler.class);
+
         @Override
         public String getNamespace() {
             return CsiManager.NAMESPACE;
@@ -78,11 +82,15 @@ public class CsiModule extends BasicModule
         }
 
         @Override
-        public boolean handleElement(LocalClientSession session, Element bound, Element element) {
+        public boolean handleElement(LocalClientSession session, Element bound, Element element)
+        {
             if (element.getName().equals("active")) {
                 session.getCsiManager().activate();
             } else if (element.getName().equals("inactive")) {
                 session.getCsiManager().deactivate();
+            } else {
+                Log.debug("Received unexpected element '{}'; ignoring.", element.getName());
+                return false;
             }
             return true;
         }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/Bind2CarbonsHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/Bind2CarbonsHandler.java
@@ -19,8 +19,16 @@ package org.jivesoftware.openfire.handler;
 import org.dom4j.Element;
 import org.jivesoftware.openfire.net.Bind2InlineHandler;
 import org.jivesoftware.openfire.session.LocalClientSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class Bind2CarbonsHandler implements Bind2InlineHandler {
+/**
+ * Handles inline elements related to Message Carbons during Bind2 requests.
+ */
+public class Bind2CarbonsHandler implements Bind2InlineHandler
+{
+    private static final Logger Log = LoggerFactory.getLogger(Bind2CarbonsHandler.class);
+
     @Override
     public String getNamespace() {
         return "urn:xmpp:carbons:2";
@@ -32,8 +40,14 @@ public class Bind2CarbonsHandler implements Bind2InlineHandler {
     }
 
     @Override
-    public boolean handleElement(LocalClientSession session, Element bound, Element element) {
-        session.setMessageCarbonsEnabled(element.getName().equals("enable"));
+    public boolean handleElement(LocalClientSession session, Element bound, Element element)
+    {
+        final String name = element.getName();
+        if (!"enable".equals(name) && !"disable".equals(name)) {
+            Log.debug("Received unexpected element '{}'; ignoring.", element.getName());
+            return false;
+        }
+        session.setMessageCarbonsEnabled("enable".equals(name));
         return true;
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/Bind2CarbonsHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/Bind2CarbonsHandler.java
@@ -27,6 +27,11 @@ public class Bind2CarbonsHandler implements Bind2InlineHandler {
     }
 
     @Override
+    public String getDisplayName() {
+        return "Message Carbons";
+    }
+
+    @Override
     public boolean handleElement(LocalClientSession session, Element bound, Element element) {
         session.setMessageCarbonsEnabled(element.getName().equals("enable"));
         return true;

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/handler/Bind2StreamManagementHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/handler/Bind2StreamManagementHandler.java
@@ -49,6 +49,11 @@ public class Bind2StreamManagementHandler implements Bind2InlineHandler {
     }
 
     @Override
+    public String getDisplayName() {
+        return "Stream Management";
+    }
+
+    @Override
     public boolean isEnabled() {
         return StreamManager.isStreamManagementActive();
     }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/Bind2InlineHandler.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/Bind2InlineHandler.java
@@ -32,6 +32,15 @@ public interface Bind2InlineHandler {
     String getNamespace();
 
     /**
+     * Gets a human-friendly name for this handler.
+     *
+     * @return a human-friendly name for this handler.
+     */
+    default String getDisplayName() {
+        return getNamespace();
+    }
+
+    /**
      * Process an inline element from a bind2 request.
      *
      * @param bound The "bound" element to add any output to

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/Bind2Request.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/Bind2Request.java
@@ -45,6 +45,13 @@ public class Bind2Request {
     private static final Map<String, Bind2InlineHandler> elementHandlers = new ConcurrentHashMap<>();
 
     /**
+     * The namespaces of inline feature requests that were successfully processed
+     * during {@link #processFeatureRequests}, for observability purposes. Empty until that
+     * method has run.
+     */
+    private Set<String> negotiatedFeatureNamespaces = Collections.emptySet();
+
+    /**
      * Registers a handler for processing inline elements with a specific namespace.
      *
      * Only one handler can be registered for each namespace. Attempting to register a handler for an already registered
@@ -103,6 +110,7 @@ public class Bind2Request {
      */
     public Element processFeatureRequests(LocalClientSession clientSession, Element successElement) {
         Element bound = successElement.addElement(new QName("bound", new Namespace("", NAMESPACE)));
+        final Set<String> succeeded = new LinkedHashSet<>();
 
         for (Element element : featureRequests) {
             String namespace = element.getNamespaceURI();
@@ -110,20 +118,24 @@ public class Bind2Request {
 
             if (handler != null && handler.isEnabled()) {
                 try {
-                    if (!handler.handleElement(clientSession, bound, element)) {
-                        Log.info("Handler for namespace {} failed to process element", namespace);
+                    if (handler.handleElement(clientSession, bound, element)) {
+                        Log.trace("Handler for namespace {} successfully processed element for session: {}", namespace, clientSession);
+                        succeeded.add(namespace);
+                    } else {
+                        Log.info("Handler for namespace {} failed to process element for session: {}", namespace, clientSession);
                         invokeFailureHandler(clientSession, bound, element, null, handler, namespace);
                     }
                 } catch (Exception e) {
-                    Log.warn("Error processing element with namespace: {}", namespace, e);
+                    Log.warn("Error processing element with namespace: {} for session: {}", namespace, clientSession, e);
                     invokeFailureHandler(clientSession, bound, element, e, handler, namespace);
                 }
             } else {
-                Log.debug("No handler registered/enabled for namespace: {}", namespace);
+                Log.debug("No handler registered/enabled for namespace: {} for session: {}", namespace, clientSession);
                 // We don't fail here because there's no obvious way we could fail.
             }
         }
 
+        negotiatedFeatureNamespaces = Collections.unmodifiableSet(succeeded);
         return bound;
     }
 
@@ -145,6 +157,25 @@ public class Bind2Request {
         } catch (Exception ex) {
             Log.warn("Error invoking failure handler after failing to process element with namespace: {}", namespace, ex);
         }
+    }
+
+    /**
+     * Returns the namespaces of inline feature requests that were successfully processed
+     * during {@link #processFeatureRequests}, for observability purposes. Empty until that
+     * method has run.
+     */
+    public Set<String> getNegotiatedFeatureNamespaces() {
+        return negotiatedFeatureNamespaces;
+    }
+
+    /**
+     * Looks up the registered inline handler for a given namespace, if any.
+     *
+     * @param namespace The namespace to look up.
+     * @return An Optional containing the handler, or an empty Optional if no handler is registered for the namespace.
+     */
+    public static Optional<Bind2InlineHandler> getHandler(@Nonnull final String namespace) {
+        return Optional.ofNullable(elementHandlers.get(namespace));
     }
 
     public static Element featureElement() {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/net/SASLAuthentication.java
@@ -238,6 +238,20 @@ public class SASLAuthentication {
     private static final String SASL2_RESUME_REQUEST = "Sasl2.resume-request";
 
     /**
+     * Session Data property name used to record that a session's resource was bound via an inline XEP-0386 Bind 2
+     * request during SASL2 authentication, as opposed to legacy IQ-based binding. Set only once binding has actually
+     * completed successfully; never set for sessions that bind via legacy IQ, and never set when an inline XEP-0198
+     * resume made the inlined bind2 request moot.
+     */
+    public static final String BIND2_USED = "Bind2.used";
+
+    /**
+     * Session Data property name holding the set of XML namespaces of inline feature requests that
+     * were successfully negotiated via a XEP-0386 Bind 2 request, if any.
+     */
+    public static final String BIND2_INLINE_FEATURES = "Bind2.inline-features";
+
+    /**
      * Controls whether the SCRAM mechanisms that are advertised to a client are tailored to the user that is expected
      * to authenticate.
      *
@@ -1046,6 +1060,11 @@ public class SASLAuthentication {
             bind2Request.processFeatureRequests(clientSession, success);
             clientSession.deliverRawText(success.asXML());
             successDelivered = true;
+
+            clientSession.setSessionData(BIND2_USED, Boolean.TRUE);
+            if (!bind2Request.getNegotiatedFeatureNamespaces().isEmpty()) {
+                clientSession.setSessionData(BIND2_INLINE_FEATURES, bind2Request.getNegotiatedFeatureNamespaces());
+            }
 
             SessionEventDispatcher.dispatchEvent(clientSession, SessionEventDispatcher.EventType.resource_bound);
 

--- a/xmppserver/src/main/webapp/session-details.jsp
+++ b/xmppserver/src/main/webapp/session-details.jsp
@@ -40,6 +40,13 @@
 <%@ page import="org.slf4j.LoggerFactory" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ page import="org.jivesoftware.openfire.session.*" %>
+<%@ page import="org.jivesoftware.openfire.net.SASLAuthentication" %>
+<%@ page import="org.jivesoftware.openfire.net.Bind2Request" %>
+<%@ page import="org.jivesoftware.openfire.net.Bind2InlineHandler" %>
+<%@ page import="org.jivesoftware.openfire.streammanagement.StreamManager" %>
+<%@ page import="org.jivesoftware.openfire.csi.CsiManager" %>
+<%@ page import="java.util.Set" %>
+<%@ page import="java.util.Optional" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -138,6 +145,11 @@
 
     pageContext.setAttribute("address", address);
     pageContext.setAttribute("clusteringEnabled", ClusterManager.isClusteringStarted() || ClusterManager.isClusteringStarting() );
+
+    final boolean bind2Used = currentSess instanceof LocalSession && Boolean.TRUE.equals(((LocalSession) currentSess).getSessionData(SASLAuthentication.BIND2_USED));
+
+    @SuppressWarnings("unchecked")
+    final Set<String> bind2FeatureNamespaces = currentSess instanceof LocalSession ? (Set<String>) ((LocalSession) currentSess).getSessionData(SASLAuthentication.BIND2_INLINE_FEATURES) : null;
 %>
 
 <html>
@@ -460,6 +472,39 @@
                     </td>
                 </tr>
                 <% } %>
+                <tr>
+                    <td class="c1">
+                        <fmt:message key="session.details.bind-method"/>:
+                    </td>
+                    <td>
+                        <% if (bind2Used) { %>
+                        <fmt:message key="session.details.bind-method-bind2"/>
+                        <% } else { %>
+                        <fmt:message key="session.details.bind-method-legacy"/>
+                        <% } %>
+                    </td>
+                </tr>
+                <% if (bind2Used && bind2FeatureNamespaces != null && !bind2FeatureNamespaces.isEmpty()) { %>
+                <tr>
+                    <td class="c1">
+                        <fmt:message key="session.details.bind2-inline-features"/>:
+                    </td>
+                    <td>
+                        <%
+                            final StringBuilder bind2FeatureNames = new StringBuilder();
+                            for (final String featureNamespace : new TreeSet<>(bind2FeatureNamespaces)) {
+                                final Optional<Bind2InlineHandler> featureHandler = Bind2Request.getHandler(featureNamespace);
+                                final String featureDisplayName = featureHandler.map(Bind2InlineHandler::getDisplayName).orElse(featureNamespace);
+                                if (!bind2FeatureNames.isEmpty()) {
+                                    bind2FeatureNames.append(", ");
+                                }
+                                bind2FeatureNames.append(featureDisplayName);
+                            }
+                        %>
+                        <%= StringUtils.escapeHTMLTags(bind2FeatureNames.toString()) %>
+                    </td>
+                </tr>
+                <% } %>
                 <% if (currentSess instanceof LocalSession && ((LocalSession) currentSess).getSessionData("ChannelBindingType") != null) { %>
                 <tr>
                     <td class="c1">
@@ -470,6 +515,91 @@
                     </td>
                 </tr>
                 <% } %>
+            </tbody>
+        </table>
+    </div>
+
+    <br>
+
+    <div class="jive-table">
+        <table style="width: 100%">
+            <thead>
+                <tr>
+                    <th colspan="2">
+                        <fmt:message key="session.details.features"/>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <% if (currentSess instanceof LocalClientSession) {
+                    LocalClientSession s = (LocalClientSession)currentSess; %>
+                <tr>
+                    <td class="c1">
+                        <fmt:message key="session.details.sm-status"/>:
+                    </td>
+                    <td>
+                        <%
+                            if (s.isDetached()) {
+                        %><fmt:message key="session.details.sm-detached"/><%
+                    } else if (s.getStreamManager().isEnabled()) {
+                        if (s.getStreamManager().getResume()) {
+                    %><fmt:message key="session.details.sm-resume"/><%
+                    } else {
+                    %><fmt:message key="session.details.sm-enabled"/><%
+                        }
+                    } else {
+                    %><fmt:message key="session.details.sm-disabled"/><%
+                        }
+                        if (bind2Used && bind2FeatureNamespaces != null && bind2FeatureNamespaces.contains(StreamManager.NAMESPACE_V3)) {
+                    %>
+                        <span class="jive-description"> (<fmt:message key="session.details.negotiated-via-bind2"/>)</span>
+                        <% } %>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="c1">
+                        <fmt:message key="session.details.csi-status"/>:
+                    </td>
+                    <td>
+                        <% if (s.getCsiManager().isActive()) { %>
+                        <fmt:message key="session.details.csi-active"/>
+                        <% } else { %>
+                        <fmt:message key="session.details.csi-inactive"/>
+                        (<fmt:message key="session.details.csi-delayed-stanzas"/>: <%= s.getCsiManager().getDelayQueueSize() %>)
+                        <% } %>
+                        <% if (bind2Used && bind2FeatureNamespaces != null && bind2FeatureNamespaces.contains(CsiManager.NAMESPACE)) { %>
+                        <span class="jive-description"> (<fmt:message key="session.details.negotiated-via-bind2"/>)</span>
+                        <% } %>
+                    </td>
+                </tr>
+                <% } %>
+                <tr>
+                    <td class="c1">
+                        <fmt:message key="session.details.cc-status"/>:
+                    </td>
+                    <td>
+                        <% if (currentSess.isMessageCarbonsEnabled()) { %>
+                        <fmt:message key="session.details.cc-enabled" />
+                        <% } else { %>
+                        <fmt:message key="session.details.cc-disabled" />
+                        <% } %>
+                        <% if (bind2Used && bind2FeatureNamespaces != null && bind2FeatureNamespaces.contains("urn:xmpp:carbons:2")) { %>
+                        <span class="jive-description"> (<fmt:message key="session.details.negotiated-via-bind2"/>)</span>
+                        <% } %>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="c1">
+                        <fmt:message key="session.details.flomr-status"/>:
+                    </td>
+                    <td>
+                        <% if (currentSess.isOfflineFloodStopped()) { %>
+                        <fmt:message key="session.details.flomr-enabled" />
+                        <% } else { %>
+                        <fmt:message key="session.details.flomr-disabled" />
+                        <% } %>
+                    </td>
+                </tr>
             </tbody>
         </table>
     </div>
@@ -507,82 +637,6 @@
         </table>
     </div>
     <%  } %>
-
-    <br>
-
-    <div class="jive-table">
-        <table style="width: 100%">
-            <thead>
-                <tr>
-                    <th colspan="2">
-                        <fmt:message key="session.details.features"/>
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                <% if (currentSess instanceof LocalClientSession) {
-                    LocalClientSession s = (LocalClientSession)currentSess; %>
-                <tr>
-                    <td class="c1">
-                        <fmt:message key="session.details.sm-status"/>:
-                    </td>
-                    <td>
-                        <%
-                            if (s.isDetached()) {
-                        %><fmt:message key="session.details.sm-detached"/><%
-                    } else if (s.getStreamManager().isEnabled()) {
-                        if (s.getStreamManager().getResume()) {
-                    %><fmt:message key="session.details.sm-resume"/><%
-                    } else {
-                    %><fmt:message key="session.details.sm-enabled"/><%
-                        }
-                    } else {
-                    %><fmt:message key="session.details.sm-disabled"/><%
-                        }
-                    %>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="c1">
-                        <fmt:message key="session.details.csi-status"/>:
-                    </td>
-                    <td>
-                        <% if (s.getCsiManager().isActive()) { %>
-                        <fmt:message key="session.details.csi-active"/>
-                        <% } else { %>
-                        <fmt:message key="session.details.csi-inactive"/>
-                        (<fmt:message key="session.details.csi-delayed-stanzas"/>: <%= s.getCsiManager().getDelayQueueSize() %>)
-                        <% } %>
-                    </td>
-                </tr>
-                <% } %>
-                <tr>
-                    <td class="c1">
-                        <fmt:message key="session.details.cc-status"/>:
-                    </td>
-                    <td>
-                        <% if (currentSess.isMessageCarbonsEnabled()) { %>
-                        <fmt:message key="session.details.cc-enabled" />
-                        <% } else { %>
-                        <fmt:message key="session.details.cc-disabled" />
-                        <% } %>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="c1">
-                        <fmt:message key="session.details.flomr-status"/>:
-                    </td>
-                    <td>
-                        <% if (currentSess.isOfflineFloodStopped()) { %>
-                        <fmt:message key="session.details.flomr-enabled" />
-                        <% } else { %>
-                        <fmt:message key="session.details.flomr-disabled" />
-                        <% } %>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
 
 <%
     final EntityCapabilities caps = XMPPServer.getInstance().getEntityCapabilitiesManager().getEntityCapabilities(address);


### PR DESCRIPTION
Records, on the client session, whether resource binding for that session happened via an inline XEP-0386 Bind 2 request (as opposed to legacy IQ-based binding), and which inline feature requests (SM, CSI, Carbons) were successfully negotiated as part of it.

Surfaces this on session-details.jsp: a new "Bind Method" row, a "Bind 2 Inline Features" row listing negotiated features by their handler's display name, and inline "(negotiated via Bind 2)" annotations next to the affected Stream Management, CSI, and Message Carbons status rows.

<img width="1708" height="1347" alt="image" src="https://github.com/user-attachments/assets/aa268eac-f5c7-40d8-b807-10b81b7fa9da" />
