### PR TITLE
OF-3365: Fix client session table

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -1859,6 +1859,7 @@ session.details.version=Client Version
 session.details.if_presence=Presence (if authenticated)
 session.details.clientip=Client IP
 session.details.close_connect=Close Connection
+session.details.session_detail_current_index=Session {0}
 session.details.session_detail=Current session details above.
 session.details.back_button=Back to Summary
 session.details.node=Cluster Node

--- a/i18n/src/main/resources/openfire_i18n_nl.properties
+++ b/i18n/src/main/resources/openfire_i18n_nl.properties
@@ -1720,6 +1720,7 @@ session.details.version=Client Versie
 session.details.if_presence=Status informatie (indien aangemeld)
 session.details.clientip=Client IP
 session.details.close_connect=Verbinding verbreken
+session.details.session_detail_current_index=Sessie {0}
 session.details.session_detail=Informatie over de huidige sessie staat hierboven.
 session.details.back_button=Terug naar overzicht
 session.details.node=Node

--- a/xmppserver/src/main/webapp/session-details.jsp
+++ b/xmppserver/src/main/webapp/session-details.jsp
@@ -125,11 +125,8 @@
     }
 
     // See if there are multiple sessions for this user:
-    Collection<ClientSession> sessions = null;
-    int sessionCount = sessionManager.getSessionCount(address.getNode());
-    if (!isAnonymous && sessionCount > 1) {
-        sessions = sessionManager.getSessions(address);
-    }
+    final Collection<ClientSession> sessions = sessionManager.getSessions(isAnonymous ? address : address.asBareJID());
+    final int sessionCount = sessions.size();
 
     // Number dateFormatter for all numbers on this page:
     NumberFormat numFormatter = NumberFormat.getNumberInstance();
@@ -667,39 +664,41 @@
         <th nowrap><fmt:message key="session.details.close_connect" /></th>
     </tr>
 
-    <%  int count = 0;
+    <%  pageContext.setAttribute("showName", true);
+        pageContext.setAttribute("showResource", false);
+        pageContext.setAttribute("showVersion", true);
+        pageContext.setAttribute("showClusterNode", true);
+        pageContext.setAttribute("showStatus", true);
+        pageContext.setAttribute("showPresence", true);
+        pageContext.setAttribute("showRxTx", true);
+        pageContext.setAttribute("showIp", true);
+
+        int count = 0;
+        int currentIndex = 0;
         String linkURL = "session-details.jsp";
         for (ClientSession sess : sessions) {
             count++;
             boolean current = sess.getAddress().equals(address);
+            if (current) {
+                currentIndex = count;
+            }
     %>
         <%@ include file="session-row.jspf" %>
 
-    <%  } %>
+    <%  }
+        pageContext.setAttribute("currentIndex", currentIndex);
+        %>
 
     </table>
     </div>
 
     <br>
 
-    <table>
-    <tr>
-        <td style="width: 1%; white-space: nowrap">
-
-            <div class="jive-table">
-            <table>
-            <tr class="jive-current"><td><img src="images/blank.gif" width="12" height="12" alt=""></td></tr>
-            </table>
-            </div>
-
-        </td>
-        <td>
-
-            &nbsp; = <fmt:message key="session.details.session_detail" />
-
-        </td>
-    </tr>
-    </table>
+    <span class="jive-current">
+        <fmt:message key="session.details.session_detail_current_index">
+            <fmt:param><fmt:formatNumber value="${currentIndex}" /></fmt:param>
+        </fmt:message>
+    </span> = <fmt:message key="session.details.session_detail" />
 
 <%  } %>
 


### PR DESCRIPTION
Fixes the rendering of data on the table below the client session details, showing all sessions for the same user.

I've also replaced the stale background-color-based legend with style-based indicator.

<img width="1628" height="1266" alt="image" src="https://github.com/user-attachments/assets/993ffa02-9f6b-416d-89ab-5eec8a798669" />
